### PR TITLE
Janosch/fix preceding macro block missing

### DIFF
--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -1177,7 +1177,10 @@ impl<'env> Blockchain<'env> {
         } else {
             let macro_block = self.chain_store
                 .get_block_at(policy::macro_block_before(block_number), true, Some(&txn))
-                .unwrap_or_else(|| panic!("Failed to determine slots - preceding macro block not found: block_number={}, view_number={}, state.block_number()={}", block_number, view_number, state.block_number()))
+                .or_else(|| {
+                    warn!("Failed to determine slots - preceding macro block not found: block_number={}, view_number={}, state.block_number()={}", block_number, view_number, state.block_number());
+                    None
+                })?
                 .unwrap_macro();
 
             // Get slots of epoch

--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -1177,7 +1177,7 @@ impl<'env> Blockchain<'env> {
         } else {
             let macro_block = self.chain_store
                 .get_block_at(policy::macro_block_before(block_number), true, Some(&txn))
-                .expect("Failed to determine slots - preceding macro block not found")
+                .unwrap_or_else(|| panic!("Failed to determine slots - preceding macro block not found: block_number={}, view_number={}, state.block_number()={}", block_number, view_number, state.block_number()))
                 .unwrap_macro();
 
             // Get slots of epoch


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes issue:

```
logs/devnet_validator_21.log: ERROR panic                | thread 'tokio-runtime-worker-0' panicked at 'Failed to determine slots - preceding macro block not found: block_number=129, view_number=0, state.block_number()=125': blockchain-albatross/src/blockchain.rs:1182
logs/devnet_validator_21.log-stack backtrace:
logs/devnet_validator_21.log-   0: log_panics::init::{{closure}}
logs/devnet_validator_21.log-   1: std::panicking::rust_panic_with_hook
logs/devnet_validator_21.log-             at src/libstd/panicking.rs:468
logs/devnet_validator_21.log-   2: std::panicking::continue_panic_fmt
logs/devnet_validator_21.log-             at src/libstd/panicking.rs:373
logs/devnet_validator_21.log-   3: std::panicking::begin_panic_fmt
logs/devnet_validator_21.log-             at src/libstd/panicking.rs:328
logs/devnet_validator_21.log-   4: nimiq_blockchain_albatross::blockchain::Blockchain::get_block_producer_at
logs/devnet_validator_21.log-   5: nimiq_blockchain_albatross::blockchain::Blockchain::push_block
logs/devnet_validator_21.log-   6: <nimiq_blockchain_albatross::blockchain::Blockchain as nimiq_blockchain_base::AbstractBlockchain>::push
logs/devnet_validator_21.log-   7: nimiq_consensus::inventory::InventoryAgent<B,MA>::on_block
logs/devnet_validator_21.log-   8: <F as nimiq_utils::observer::PassThroughListener<E>>::on_event
logs/devnet_validator_21.log-   9: nimiq_utils::observer::PassThroughNotifier<E>::notify
logs/devnet_validator_21.log-  10: nimiq_messages::MessageNotifier::notify
logs/devnet_validator_21.log-  11: <F as nimiq_utils::observer::PassThroughListener<E>>::on_event
logs/devnet_validator_21.log-  12: nimiq_utils::observer::PassThroughNotifier<E>::notify
logs/devnet_validator_21.log-  13: <futures::stream::for_each::ForEach<S,F,U> as futures::future::Future>::poll
logs/devnet_validator_21.log-  14: futures::future::chain::Chain<A,B,C>::poll
logs/devnet_validator_21.log-  15: <futures::future::select::Select<A,B> as futures::future::Future>::poll
```

## What's in this pull request?

The orphan check is after we need the block producers, but `get_block_producers_at` assumes that the previous macro block exists.

I removed the `expect` and just return `None` if we don't have the previous macro block yet. Thus the block verification will fail - as it should as it's an orphan anyway.
