### PR TITLE
Remove send_update from push_contribution

### DIFF
--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -119,8 +119,9 @@ impl<P: Protocol + fmt::Debug> Aggregation<P> {
             self.check_final_signature();
 
             // send level 0
-            let level = self.levels.get(0).expect("Level 0 missing");
-            self.send_update(contribution.as_multisig(), level, self.config.peer_count);
+            // This will be done by check_completed level
+            //let level = self.levels.get(0).expect("Level 0 missing");
+            //self.send_update(contribution.as_multisig(), level, self.config.peer_count);
         }
         else {
             error!("Contribution already exists");


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

`Aggregation::push_contribution` did send an update for the first level explicitely. But `Aggregation::check_completed_level` will do this anyway. So I removed the extra call to `Aggregation::send_update`.