### PR TITLE
Fix dead-lock by running event handler in seperate thread

### DIFF
--- a/blockchain-base/src/lib.rs
+++ b/blockchain-base/src/lib.rs
@@ -109,7 +109,7 @@ pub trait AbstractBlockchain<'env>: Sized + Send + Sync {
     fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk>;
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BlockchainEvent<BL: Block> {
     Extended(Blake2bHash),
     Rebranched(Vec<(Blake2bHash, BL)>, Vec<(Blake2bHash, BL)>),


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes issue #11.

## What's in this pull request?

The blockchain event handler in `Validator` might do a lot of work, which also e.g. acquires the `Blockchain::push_lock`. All handlers that do more than just simple state changes should be run in a separate thread anyway.

With this fix, in the particular case described in #11, the validator will have to wait for all the blockchain event handlers to have finished and the `push_lock` to be release before it can produce another block.
