### PR TITLE
Added extra-traits feature to syn dependency

### DIFF
--- a/beserial/beserial_derive/Cargo.toml
+++ b/beserial/beserial_derive/Cargo.toml
@@ -21,6 +21,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "0.4"
-syn = "0.15"
+syn = { version = "0.15", features = ["extra-traits"] }
 quote = "0.6"
 beserial = { path = "..", version = "0.1" }


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes issue #13.

## What's in this pull request?

This add the feature flag `extra-traits` to the `syn` dependencies for `bererial_derive` as that's needed to debug print `syn::attr::Meta`.
