### PR TITLE
Show correct validator ID for pBFT proposals

### DIFF
--- a/validator/src/validator_network.rs
+++ b/validator/src/validator_network.rs
@@ -474,6 +474,8 @@ impl ValidatorNetwork {
             return Ok(());
         }
 
+        debug!("pBFT proposal by validator {}: {}", signed_proposal.signer_idx, block_hash);
+
         let validator_id = match state.validator_id {
             Some(validator_id) => validator_id,
             None => {
@@ -481,8 +483,6 @@ impl ValidatorNetwork {
                 return Ok(())
             },
         };
-
-        debug!("pBFT proposal by validator {}: {}", validator_id, block_hash);
 
         let pbft = PbftState::new(
             block_hash.clone(),


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

The debug message should actually print the block proposer and not the ID of the node printing the message