### PR TITLE
WIP: Method to get a fingerprint string for a validator public key

### DIFF
--- a/bls/src/bls12_381/mod.rs
+++ b/bls/src/bls12_381/mod.rs
@@ -7,7 +7,7 @@ use pairing::Engine;
 
 #[cfg(feature = "beserial")]
 use beserial::Serialize;
-use hash::Hash;
+use hash::{Hash, Blake2bHash};
 
 use super::{
     AggregatePublicKey as GenericAggregatePublicKey,
@@ -143,6 +143,15 @@ impl PublicKey {
 #[derive(Clone)]
 pub struct CompressedPublicKey {
     pub(crate) p_pub: G2Compressed,
+}
+
+impl CompressedPublicKey {
+    pub fn fingerprint(&self) -> String {
+        let mut hash = self.p_pub.as_ref().hash::<Blake2bHash>().to_hex();
+        hash.truncate(8);
+        hash.shrink_to_fit();
+        hash
+    }
 }
 
 impl fmt::Debug for CompressedPublicKey {


### PR DESCRIPTION
I think there is a good use-case for when we need a shorter identifier for validators. The public key is 96 bytes after all.

I can still improve this PR by having the fingerprint method just return a Blake2bHash. This can then easily be converted to a hexadecimal representation anyway and would totally suffice.