### PR TITLE
Shorten nimiq dependencies and remove more path dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,8 @@ nimiq-hash = { path = "hash" }
 nimiq-hash_derive = { path = "hash/hash_derive" }
 nimiq-keys = { path = "keys" }
 nimiq-key-derivation = { path = "key-derivation" }
-nimiq-lib = { path = "lib"}
+nimiq-lib = { path = "lib" }
+nimiq-lib2 = { path = "lib2" }
 nimiq-macros = { path = "macros" }
 nimiq-mempool = { path = "mempool" }
 nimiq-messages = { path = "messages"}

--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -18,12 +18,12 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 hex = "0.3"
-beserial = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
+beserial = "0.1"
+nimiq-keys = "0.1"
 nimiq-primitives = { features = ["coin", "networks", "policy"], version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-block = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
+nimiq-hash = "0.1"
+nimiq-account = "0.1"
+nimiq-block = "0.1"
+nimiq-transaction = "0.1"
 nimiq-database = { features = ["full-nimiq"], version = "0.1" }
-nimiq-tree-primitives = { version = "0.1" }
+nimiq-tree-primitives = "0.1"

--- a/accounts/tree-primitives/Cargo.toml
+++ b/accounts/tree-primitives/Cargo.toml
@@ -18,11 +18,11 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 hex = "0.3"
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-account = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-keys = "0.1"
+nimiq-hash = "0.1"
+nimiq-account = "0.1"
 
 [dev-dependencies]
 nimiq-primitives = { version = "0.1", features = ["coin"] }

--- a/beserial/beserial_derive/Cargo.toml
+++ b/beserial/beserial_derive/Cargo.toml
@@ -23,4 +23,4 @@ proc-macro = true
 proc-macro2 = "0.4"
 syn = { version = "0.15", features = ["extra-traits"] }
 quote = "0.6"
-beserial = { version = "0.1" }
+beserial = "0.1"

--- a/block-production-albatross/Cargo.toml
+++ b/block-production-albatross/Cargo.toml
@@ -17,23 +17,23 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-beserial = { version = "0.1" }
-nimiq-block-albatross = { version = "0.1" }
-nimiq-blockchain-albatross = { version = "0.1" }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-bls = { version = "0.1" }
-nimiq-collections = { version = "0.1" }
-nimiq-database = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-mempool = { version = "0.1" }
+beserial = "0.1"
+nimiq-block-albatross = "0.1"
+nimiq-blockchain-albatross = "0.1"
+nimiq-blockchain-base = "0.1"
+nimiq-bls = "0.1"
+nimiq-collections = "0.1"
+nimiq-database = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-mempool = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks"] }
-nimiq-primitives = { version = "0.1" }
+nimiq-primitives = "0.1"
 log = "0.4"
 
 [dev-dependencies]
 hex = "0.3"
-nimiq-account = { version = "0.1" }
-nimiq-database = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-collections = { version = "0.1" }
+nimiq-account = "0.1"
+nimiq-database = "0.1"
+nimiq-transaction = "0.1"
+nimiq-collections = "0.1"

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -17,16 +17,16 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-beserial = { version = "0.1" }
-nimiq-block = { version = "0.1" }
-nimiq-blockchain = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-mempool = { version = "0.1" }
+beserial = "0.1"
+nimiq-block = "0.1"
+nimiq-blockchain = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-mempool = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks"] }
 
 [dev-dependencies]
-nimiq-account = { version = "0.1" }
-nimiq-database = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
+nimiq-account = "0.1"
+nimiq-database = "0.1"
+nimiq-primitives = "0.1"
+nimiq-transaction = "0.1"

--- a/blockchain-albatross/Cargo.toml
+++ b/blockchain-albatross/Cargo.toml
@@ -19,28 +19,28 @@ failure = "0.1"
 hex = "0.3"
 log = "0.4"
 parking_lot = "0.9"
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-fixed-unsigned = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-accounts = { version = "0.1" }
-nimiq-block-albatross = { version = "0.1" }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-collections = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+fixed-unsigned = "0.1"
+nimiq-account = "0.1"
+nimiq-accounts = "0.1"
+nimiq-block-albatross = "0.1"
+nimiq-blockchain-base = "0.1"
+nimiq-collections = "0.1"
 nimiq-bls = { version = "0.1", features = ["beserial"] }
 nimiq-database = { version = "0.1", features = ["full-nimiq"] }
-nimiq-keys = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
+nimiq-keys = "0.1"
+nimiq-hash = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks", "time"] }
-nimiq-primitives = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-tree-primitives = { version = "0.1" }
+nimiq-primitives = "0.1"
+nimiq-transaction = "0.1"
+nimiq-tree-primitives = "0.1"
 nimiq-utils = { version = "0.1", features = ["observer", "unique-ptr", "iterators"] }
 
 [dev-dependencies]
 atomic = "0.4"
 rand = "0.6"
-nimiq-block-production-albatross = { version = "0.1" }
+nimiq-block-production-albatross = "0.1"
 
 [features]
 default = ["transaction-store"]

--- a/blockchain-base/Cargo.toml
+++ b/blockchain-base/Cargo.toml
@@ -19,16 +19,16 @@ maintenance = { status = "experimental" }
 [dependencies]
 failure = "0.1"
 parking_lot = "0.9"
-beserial = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-block-base = { version = "0.1" }
-nimiq-database = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-network-primitives = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-tree-primitives = { version = "0.1" }
+beserial = "0.1"
+nimiq-account = "0.1"
+nimiq-block-base = "0.1"
+nimiq-database = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-network-primitives = "0.1"
+nimiq-primitives = "0.1"
+nimiq-transaction = "0.1"
+nimiq-tree-primitives = "0.1"
 nimiq-utils = { version = "0.1", features = ["observer"] }
 [features]
 metrics = []

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -21,21 +21,21 @@ parking_lot = "0.9"
 log = "0.4"
 hex = "0.3"
 failure = "0.1"
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-block = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-accounts = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-keys = "0.1"
+nimiq-primitives = "0.1"
+nimiq-account = "0.1"
+nimiq-block = "0.1"
+nimiq-transaction = "0.1"
+nimiq-hash = "0.1"
+nimiq-accounts = "0.1"
 nimiq-database = { version = "0.1", features = ["full-nimiq"] }
-nimiq-tree-primitives = { version = "0.1" }
-fixed-unsigned = { version = "0.1" }
+nimiq-tree-primitives = "0.1"
+fixed-unsigned = "0.1"
 nimiq-utils = { version = "0.1", features = ["observer", "unique-ptr", "iterators"] }
 nimiq-network-primitives = { version = "0.1", features = ["networks", "time"] }
-nimiq-blockchain-base = { version = "0.1" }
+nimiq-blockchain-base = "0.1"
 
 [dev-dependencies]
 atomic = "0.4"

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 pairing = { git = "https://github.com/paberr/librustzcash" }
 group = { git = "https://github.com/paberr/librustzcash" }
 ff = { git = "https://github.com/paberr/librustzcash" }
-nimiq-hash = { path = "../hash" }
+nimiq-hash = "0.1"
 rand = "0.6"
 rand04_compat = "0.1"
 rand_chacha = "0.1"

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -16,14 +16,14 @@ path = "src/devnet/main.rs"
 nimiq-bls = { version = "0.1", optional = true }
 nimiq-block = { version = "0.1", optional = true }
 nimiq-block-albatross = { version = "0.1", optional = true }
-nimiq-collections = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-accounts = { version = "0.1" }
+nimiq-collections = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-primitives = "0.1"
+nimiq-account = "0.1"
+nimiq-accounts = "0.1"
 nimiq-database = { version = "0.1", features = ["account"] }
-beserial = { version = "0.1" }
+beserial = "0.1"
 lazy_static = "1.3"
 rand = "0.6"
 rand04_compat = "0.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,19 +37,19 @@ directories = "1.0"
 failure = "0.1"
 human-panic = { version = "1.0", optional = true }
 log-panics = { version = "2.0", features = ["with-backtrace"] }
-nimiq-database = { version = "0.1" }
-nimiq-network = { version = "0.1" }
+nimiq-database = "0.1"
+nimiq-network = "0.1"
 nimiq-primitives = { version = "0.1", features = ["networks", "coin"] }
-nimiq-network-primitives = { version = "0.1" }
+nimiq-network-primitives = "0.1"
 nimiq-rpc-server = { version = "0.1", optional = true }
 nimiq-metrics-server = { version = "0.1", optional = true }
-nimiq-mempool = { version = "0.1" }
-nimiq-lib = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-utils = { version = "0.1" }
-nimiq-consensus = { version = "0.1" }
-nimiq-bls = { version = "0.1" }
-beserial = { version = "0.1" }
+nimiq-mempool = "0.1"
+nimiq-lib = "0.1"
+nimiq-keys = "0.1"
+nimiq-utils = "0.1"
+nimiq-consensus = "0.1"
+nimiq-bls = "0.1"
+beserial = "0.1"
 
 [features]
 default = ["all"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -24,20 +24,20 @@ weak-table = "0.2"
 failure = "0.1"
 futures = "0.1"
 tokio = "0.1"
-beserial = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-macros = { version = "0.1" }
-nimiq-block-base = { version = "0.1" }
+beserial = "0.1"
+nimiq-hash = "0.1"
+nimiq-macros = "0.1"
+nimiq-block-base = "0.1"
 nimiq-blockchain = { version = "0.1", features = ["transaction-store"] }
 nimiq-blockchain-albatross = { version = "0.1", features = ["transaction-store"] }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-mempool = { version = "0.1" }
-nimiq-collections = { version = "0.1" }
+nimiq-blockchain-base = "0.1"
+nimiq-transaction = "0.1"
+nimiq-mempool = "0.1"
+nimiq-collections = "0.1"
 nimiq-primitives = { version = "0.1", features = ["policy"] }
-nimiq-messages = { version = "0.1" }
+nimiq-messages = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks", "time"] }
-nimiq-network = { version = "0.1" }
+nimiq-network = "0.1"
 nimiq-database = { version = "0.1", features = ["full-nimiq"] }
 nimiq-utils = { version = "0.1", features = ["observer", "timers", "mutable-once", "throttled-queue", "rate-limit", "merkle", "math"] }
-nimiq-block-albatross = { version = "0.1" }
+nimiq-block-albatross = "0.1"

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = "0.9"
 tempdir = "0.3"
 rand = "0.6"
 bitflags = "1.0"
-beserial = { version = "0.1" }
+beserial = "0.1"
 nimiq-hash = { version = "0.1", optional = true }
 nimiq-keys = { version = "0.1", optional = true }
 nimiq-utils = { version = "0.1", features = ["otp"], optional = true }

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-bls = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-bls = "0.1"
 nimiq-collections = { version = "0.1", features = ["bitset"] }
-nimiq-hash = { version = "0.1" }
+nimiq-hash = "0.1"
 nimiq-utils = { version = "0.1", features = ["math", "mutable-once", "observer", "timers"] }
-nimiq-macros = { version = "0.1" }
+nimiq-macros = "0.1"
 futures = "0.1"
 futures-cpupool = "0.1"
 stopwatch = "0.0"

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -21,6 +21,6 @@ blake2-rfc = "0.2"
 hex = "0.3"
 sha2 = "0.8"
 byteorder = "1.2"
-beserial = { version = "0.1" }
-nimiq-macros = { version = "0.1" }
-libargon2-sys = { version = "0.1" }
+beserial = "0.1"
+nimiq-macros = "0.1"
+libargon2-sys = "0.1"

--- a/key-derivation/Cargo.toml
+++ b/key-derivation/Cargo.toml
@@ -19,9 +19,9 @@ maintenance = { status = "experimental" }
 [dependencies]
 regex = "1"
 byteorder = "1.2"
-beserial = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
+beserial = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
 
 [dev-dependencies]
 hex = "0.3"

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = "0.8"
 rand = "0.6"
 hex = "0.3"
 failure = "0.1"
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-macros = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-hash = "0.1"
+nimiq-macros = "0.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,13 +21,13 @@ futures = "0.1"
 failure = "0.1"
 lazy_static = "1.2"
 log = "0.4"
-nimiq-network = { version = "0.1" }
-nimiq-consensus = { version = "0.1" }
-nimiq-database = { version = "0.1" }
+nimiq-network = "0.1"
+nimiq-consensus = "0.1"
+nimiq-database = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["all"] }
 nimiq-primitives = { version = "0.1", features = ["networks"] }
-nimiq-mempool = { version = "0.1" }
-nimiq-utils = { version = "0.1" }
+nimiq-mempool = "0.1"
+nimiq-utils = "0.1"
 nimiq-validator = { version = "0.1", optional = true }
 nimiq-bls = { version = "0.1", optional = true }
 

--- a/lib2/Cargo.toml
+++ b/lib2/Cargo.toml
@@ -29,16 +29,30 @@ directories = "1.0"
 enum-display-derive = "0.1"
 rand = "0.6"
 rand04_compat = "0.1"
-nimiq-network = { version = "0.1" }
-nimiq-consensus = { version = "0.1" }
-nimiq-database = { version = "0.1" }
+serde = "1.0"
+serde_derive = "1.0"
+toml = "0.5"
+url = "1.7"
+hex = "0.3"
+structopt = "0.3"
+lazy_static = "1.4"
+chrono = "0.4"
+fern = { version = "0.5", features = ["colored"], optional = true }
+colored = { version = "1.7", optional = true }
+parking_lot = { version = "0.7", features = ["deadlock_detection"], optional = true }
+log-panics = { version = "2.0", features = ["with-backtrace"], optional = true }
+human-panic = { version = "1.0", optional = true }
+nimiq-network = "0.1"
+nimiq-consensus = "0.1"
+nimiq-database = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["all"] }
 nimiq-primitives = { version = "0.1", features = ["networks"] }
-nimiq-mempool = { version = "0.1" }
-nimiq-utils = { version = "0.1" }
+nimiq-mempool = "0.1"
+nimiq-utils = "0.1"
 nimiq-validator = { version = "0.1", optional = true }
 nimiq-bls = { version = "0.1", optional = true }
-nimiq-blockchain-albatross = { version = "0.1" }
+nimiq-blockchain-albatross = "0.1"
+nimiq-keys = "0.1"
 
 [features]
 default = ["filestorage", "validator"]

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -19,20 +19,20 @@ maintenance = { status = "experimental" }
 [dependencies]
 log = "0.4"
 parking_lot = "0.9"
-beserial = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-block-base = { version = "0.1" }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-collections = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
+beserial = "0.1"
+nimiq-account = "0.1"
+nimiq-block-base = "0.1"
+nimiq-blockchain-base = "0.1"
+nimiq-collections = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
 nimiq-primitives = { version = "0.1", features = ["coin", "networks"] }
-nimiq-transaction = { version = "0.1" }
+nimiq-transaction = "0.1"
 nimiq-utils = { version = "0.1", features = ["observer", "timers", "mutable-once"] }
 
 [dev-dependencies]
 hex = "0.3"
-nimiq-block = { version = "0.1" }
-nimiq-blockchain = { version = "0.1" }
-nimiq-database = { version = "0.1" }
-nimiq-network-primitives = { version = "0.1" }
+nimiq-block = "0.1"
+nimiq-blockchain = "0.1"
+nimiq-database = "0.1"
+nimiq-network-primitives = "0.1"

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -25,20 +25,20 @@ log = "0.4"
 parking_lot = "0.9"
 rand = "0.6"
 enum-display-derive = "0.1"
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-block = { version = "0.1" }
-nimiq-block-albatross = { version = "0.1" }
-nimiq-block-base = { version = "0.1" }
-nimiq-bls = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-macros = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-block = "0.1"
+nimiq-block-albatross = "0.1"
+nimiq-block-base = "0.1"
+nimiq-bls = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-macros = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks", "subscription", "version"] }
-nimiq-tree-primitives = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
+nimiq-tree-primitives = "0.1"
+nimiq-transaction = "0.1"
 nimiq-utils = { version = "0.1", features = ["observer", "crc", "time"] }
-nimiq-handel = { version = "0.1" }
+nimiq-handel = "0.1"
 
 [dev-dependencies]
 nimiq-utils = { version = "0.1", features = ["observer", "crc", "time", "iterators"] }

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -25,9 +25,9 @@ failure = "0.1"
 nimiq-blockchain = { version = "0.1", features = ["metrics"] }
 nimiq-blockchain-base = { version = "0.1", features = ["metrics"] }
 nimiq-blockchain-albatross = { version = "0.1", features = ["metrics"] }
-nimiq-block-albatross = { version = "0.1" }
-nimiq-consensus = { version = "0.1" }
+nimiq-block-albatross = "0.1"
+nimiq-consensus = "0.1"
 nimiq-network = { version = "0.1", features = ["metrics"] }
-nimiq-mempool = { version = "0.1" }
-nimiq-block = { version = "0.1" }
-beserial = { version = "0.1" }
+nimiq-mempool = "0.1"
+nimiq-block = "0.1"
+beserial = "0.1"

--- a/mnemonic/Cargo.toml
+++ b/mnemonic/Cargo.toml
@@ -20,9 +20,9 @@ maintenance = { status = "experimental" }
 bit-vec = "0.5"
 hex = "0.3"
 unicode-normalization = "0.1"
-nimiq-hash = { version = "0.1" }
-beserial = { version = "0.1" }
-nimiq-macros = { version = "0.1" }
+nimiq-hash = "0.1"
+beserial = "0.1"
+nimiq-macros = "0.1"
 nimiq-utils = { version = "0.1", features = ["bit-vec", "crc"] }
 nimiq-key-derivation = { version = "0.1", optional = true }
 

--- a/network-primitives/Cargo.toml
+++ b/network-primitives/Cargo.toml
@@ -29,7 +29,7 @@ beserial_derive = {version = "0.1"}
 nimiq-keys = {version = "0.1" }
 nimiq-hash = {version = "0.1" }
 nimiq-hash_derive = {version = "0.1" }
-nimiq-block = { version = "0.1" }
+nimiq-block = "0.1"
 nimiq-block-albatross = {version = "0.1" }
 nimiq-bls = {version = "0.1" }
 nimiq-transaction = {version = "0.1" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -31,14 +31,14 @@ tokio-tls = "0.2"
 tokio-tungstenite = "0.8"
 tk-listen = "0.2.1"
 url = "1.7"
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-collections = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-macros = { version = "0.1" }
-nimiq-messages = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-blockchain-base = "0.1"
+nimiq-collections = "0.1"
+nimiq-keys = "0.1"
+nimiq-hash = "0.1"
+nimiq-macros = "0.1"
+nimiq-messages = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["all"] }
 nimiq-utils = { version = "0.1", features = ["timers", "key-store", "observer", "mutable-once", "time", "unique-ptr", "iterators", "locking", "rate-limit", "unique-id"] }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,13 +25,13 @@ hex = { version = "0.3", optional = true }
 lazy_static = { version = "1.2", optional = true }
 failure = { version = "0.1", optional = true}
 enum-display-derive = { version = "0.1", optional = true }
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
 nimiq-macros = { version = "0.1", optional = true }
 fixed-unsigned = { version = "0.1", optional = true }
 nimiq-bls = { version = "0.1", features = ["beserial"], optional = true }
 nimiq-keys = { version = "0.1", optional = true }
-nimiq-collections = { version = "0.1" }
+nimiq-collections = "0.1"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -21,14 +21,14 @@ log = "0.4"
 failure = "0.1"
 parking_lot = "0.9"
 lazy_static = "1.3"
-beserial = { path = "../../beserial", version = "0.1" }
-beserial_derive = { path = "../../beserial/beserial_derive", version = "0.1" }
-nimiq-hash = { path = "../../hash", version = "0.1" }
-nimiq-keys = { path = "../../keys", version = "0.1" }
-nimiq-transaction = { path = "../transaction", version = "0.1" }
-nimiq-primitives = { path = "..", version = "0.1", features = ["coin", "policy", "validators"] }
-nimiq-bls = { path = "../../bls", version = "0.1" }
-nimiq-collections = { path = "../../collections" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-transaction = "0.1"
+nimiq-primitives = { version = "0.1", features = ["coin", "policy", "validators"] }
+nimiq-bls = "0.1"
+nimiq-collections = "0.1"
 
 [dev-dependencies]
 hex = "0.3"

--- a/primitives/block-albatross/Cargo.toml
+++ b/primitives/block-albatross/Cargo.toml
@@ -17,20 +17,20 @@ hex = "0.3"
 log = "0.4"
 num-bigint = "0.2"
 failure = "0.1"
-beserial = { path = "../../beserial", version = "0.1" }
-beserial_derive = { path = "../../beserial/beserial_derive", version = "0.1" }
-fixed-unsigned = { path = "../../fixed-unsigned", version = "0.1" }
-nimiq-account = { path = "../account", version = "0.1" }
-nimiq-block-base = { path = "../block-base", version = "0.1" }
-nimiq-bls = { path = "../../bls", version = "0.1", features = ["beserial"]}
-nimiq-collections = { path = "../../collections", version = "0.1", features = ["bitset"] }
-nimiq-hash = { path = "../../hash", version = "0.1" }
-nimiq-hash_derive = { path = "../../hash/hash_derive", version = "0.1" }
-nimiq-keys = { path = "../../keys", version = "0.1" }
-nimiq-macros = { path = "../../macros", version = "0.1" }
-nimiq-primitives = { path = "..", version = "0.1", features = ["policy", "networks"] }
-nimiq-transaction = { path = "../transaction", version = "0.1" }
-nimiq-utils = { path = "../../utils", version = "0.1", features = ["merkle"] }
+beserial = "0.1"
+beserial_derive = "0.1"
+fixed-unsigned = "0.1"
+nimiq-account = "0.1"
+nimiq-block-base = "0.1"
+nimiq-bls = { version = "0.1", features = ["beserial"]}
+nimiq-collections = { version = "0.1", features = ["bitset"] }
+nimiq-hash = "0.1"
+nimiq-hash_derive = "0.1"
+nimiq-keys = "0.1"
+nimiq-macros = "0.1"
+nimiq-primitives = { version = "0.1", features = ["policy", "networks"] }
+nimiq-transaction = "0.1"
+nimiq-utils = { version = "0.1", features = ["merkle"] }
 
 [dev-dependencies]
 num-traits = "0.2"

--- a/primitives/block-base/Cargo.toml
+++ b/primitives/block-base/Cargo.toml
@@ -17,9 +17,9 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-beserial = { path = "../../beserial", version = "0.1" }
-nimiq-hash = { path = "../../hash", version = "0.1" }
-nimiq-transaction = { path = "../transaction", version = "0.1" }
+beserial = "0.1"
+nimiq-hash = "0.1"
+nimiq-transaction = "0.1"
 failure = "0.1"
 
 [dev-dependencies]

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -21,17 +21,17 @@ num-bigint = "0.2"
 log = "0.4"
 hex = "0.3"
 failure = "0.1"
-beserial = { path = "../../beserial", version = "0.1" }
-beserial_derive = { path = "../../beserial/beserial_derive", version = "0.1" }
-fixed-unsigned = { path = "../../fixed-unsigned", version = "0.1" }
-nimiq-block-base = { path = "../block-base", version = "0.1" }
-nimiq-hash = { path = "../../hash", version = "0.1" }
-nimiq-keys = { path = "../../keys", version = "0.1" }
-nimiq-utils = { path = "../../utils", version = "0.1", features = ["merkle"] }
-nimiq-primitives = { path = "..", version = "0.1", features = ["policy", "networks"] }
-nimiq-transaction = { path = "../transaction", version = "0.1" }
-nimiq-account = { path = "../account", version = "0.1" }
-nimiq-macros = { path = "../../macros", version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+fixed-unsigned = "0.1"
+nimiq-block-base = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-utils = { version = "0.1", features = ["merkle"] }
+nimiq-primitives = { version = "0.1", features = ["policy", "networks"] }
+nimiq-transaction = "0.1"
+nimiq-account = "0.1"
+nimiq-macros = "0.1"
 
 [dev-dependencies]
 num-traits = "0.2"

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -16,14 +16,15 @@ bitflags = "1.0"
 hex = "0.3"
 log = "0.4"
 failure = "0.1"
-beserial = { path = "../../beserial", version = "0.1" }
-beserial_derive = { path = "../../beserial/beserial_derive", version = "0.1" }
-nimiq-hash = { path = "../../hash", version = "0.1" }
-nimiq-keys = { path = "../../keys", version = "0.1" }
-nimiq-utils = { path = "../../utils", version = "0.1", features = ["merkle"] }
-nimiq-primitives = { path = "..", version = "0.1", features = ["policy", "networks", "account", "coin"] }
-nimiq-bls = { path = "../../bls", version = "0.1", features = ["beserial"] }
-nimiq-macros = { path = "../../macros", version = "0.1" }
+enum-display-derive = "0.1"
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-utils = { version = "0.1", features = ["merkle"] }
+nimiq-primitives = { version = "0.1", features = ["policy", "networks", "account", "coin"] }
+nimiq-bls = { version = "0.1", features = ["beserial"] }
+nimiq-macros = "0.1"
 
 [dev-dependencies]
 hex = "0.3"

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -25,24 +25,24 @@ hex = "0.3"
 failure = "0.1"
 parking_lot = "0.9"
 base64 = "0.10"
-beserial = { version = "0.1" }
+beserial = "0.1"
 clear_on_drop = { version = "0.2" }
-nimiq-database = { version = "0.1" }
-nimiq-consensus = { version = "0.1" }
-nimiq-blockchain = { version = "0.1" }
-nimiq-blockchain-albatross = { version = "0.1" }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-bls = { version = "0.1" }
-nimiq-mempool = { version = "0.1" }
-nimiq-network = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-network-primitives = { version = "0.1" }
-nimiq-block = { version = "0.1" }
-nimiq-block-albatross = { version = "0.1" }
-nimiq-block-base = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-block-production = { version = "0.1" }
+nimiq-database = "0.1"
+nimiq-consensus = "0.1"
+nimiq-blockchain = "0.1"
+nimiq-blockchain-albatross = "0.1"
+nimiq-blockchain-base = "0.1"
+nimiq-bls = "0.1"
+nimiq-mempool = "0.1"
+nimiq-network = "0.1"
+nimiq-hash = "0.1"
+nimiq-network-primitives = "0.1"
+nimiq-block = "0.1"
+nimiq-block-albatross = "0.1"
+nimiq-block-base = "0.1"
+nimiq-transaction = "0.1"
+nimiq-keys = "0.1"
+nimiq-block-production = "0.1"
 nimiq-utils = { version = "0.1", features = ["merkle", "time", "otp"] }
-nimiq-primitives = { version = "0.1" }
-nimiq-wallet = { version = "0.1" }
+nimiq-primitives = "0.1"
+nimiq-wallet = "0.1"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -23,13 +23,13 @@ name = "nimiq-signtx"
 path = "src/signtx/main.rs"
 
 [dependencies]
-nimiq-bls = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-build-tools = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-beserial = { version = "0.1" }
+nimiq-bls = "0.1"
+nimiq-hash = "0.1"
+nimiq-keys = "0.1"
+nimiq-build-tools = "0.1"
+nimiq-transaction = "0.1"
+nimiq-primitives = "0.1"
+beserial = "0.1"
 log = "0.4"
 simple_logger = "1.0"
 hex = "0.3"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -31,7 +31,7 @@ clear_on_drop = { version = "0.2", optional = true }
 rand = { version = "0.6", optional = true }
 
 [dev-dependencies]
-beserial_derive = { version = "0.1" }
+beserial_derive = "0.1"
 
 [features]
 crc = []

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -13,25 +13,25 @@ travis-ci = { repository = "nimiq/core-rs", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-beserial = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-bls = { version = "0.1" }
-nimiq-consensus = { version = "0.1" }
+beserial = "0.1"
+nimiq-account = "0.1"
+nimiq-bls = "0.1"
+nimiq-consensus = "0.1"
 nimiq-collections = { version = "0.1", features = ["bitset"] }
 nimiq-database = { version = "0.1", features = ["full-nimiq"] }
-nimiq-macros = { version = "0.1" }
-nimiq-mempool = { version = "0.1" }
-nimiq-network = { version = "0.1" }
+nimiq-macros = "0.1"
+nimiq-mempool = "0.1"
+nimiq-network = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks", "time"] }
 nimiq-utils = { version = "0.1", features = ["observer", "timers", "mutable-once", "throttled-queue", "rate-limit"] }
-nimiq-block-albatross = { version = "0.1" }
-nimiq-messages = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-nimiq-blockchain-albatross = { version = "0.1" }
-nimiq-block-production-albatross = { version = "0.1" }
-nimiq-blockchain-base = { version = "0.1" }
-nimiq-handel = { version = "0.1" }
+nimiq-block-albatross = "0.1"
+nimiq-messages = "0.1"
+nimiq-hash = "0.1"
+nimiq-primitives = "0.1"
+nimiq-blockchain-albatross = "0.1"
+nimiq-block-production-albatross = "0.1"
+nimiq-blockchain-base = "0.1"
+nimiq-handel = "0.1"
 hex = { version = "0.3", optional = true }
 failure = "0.1"
 log = "0.4"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -13,14 +13,14 @@ travis-ci = { repository = "nimiq/core-rs", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-beserial = { version = "0.1" }
-beserial_derive = { version = "0.1" }
-nimiq-account = { version = "0.1" }
-nimiq-keys = { version = "0.1" }
-nimiq-key-derivation = { version = "0.1" }
-nimiq-hash = { version = "0.1" }
-nimiq-primitives = { version = "0.1" }
-nimiq-transaction = { version = "0.1" }
+beserial = "0.1"
+beserial_derive = "0.1"
+nimiq-account = "0.1"
+nimiq-keys = "0.1"
+nimiq-key-derivation = "0.1"
+nimiq-hash = "0.1"
+nimiq-primitives = "0.1"
+nimiq-transaction = "0.1"
 nimiq-database = { version = "0.1", features = ["keys"] }
 nimiq-utils = { version = "0.1", features = ["otp"]}
 failure = "0.1"


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes issue #30.

## What's in this pull request?

There were some dependencies still with a `path` attribute. I removed them. I also replaced
```
nimiq-hash = { version = "0.1" }
```
with
```
nimiq-hash = "0.1"
```
