### PR TITLE
Prepare accounts tree with generic parameter

### DIFF
--- a/accounts/src/accounts.rs
+++ b/accounts/src/accounts.rs
@@ -12,13 +12,12 @@ use tree_primitives::accounts_tree_chunk::AccountsTreeChunk;
 
 use crate::tree::AccountsTree;
 
-
 type ReceiptsMap<'a> = HashMap<u16, &'a Vec<u8>>;
 
 #[derive(Debug)]
 pub struct Accounts {
     env: Environment,
-    tree: AccountsTree,
+    tree: AccountsTree<Account>,
 }
 
 impl Accounts {
@@ -41,14 +40,14 @@ impl Accounts {
         }.unwrap_or(Account::INITIAL)
     }
 
-    pub fn get_chunk(&self, prefix: &str, size: usize, txn_option: Option<&db::Transaction>) -> Option<AccountsTreeChunk> {
+    pub fn get_chunk(&self, prefix: &str, size: usize, txn_option: Option<&db::Transaction>) -> Option<AccountsTreeChunk<Account>> {
         match txn_option {
             Some(txn) => self.tree.get_chunk(txn, prefix, size),
             None => self.tree.get_chunk(&ReadTransaction::new(&self.env), prefix, size),
         }
     }
 
-    pub fn get_accounts_proof(&self, txn: &db::Transaction, addresses: &[Address]) -> AccountsProof {
+    pub fn get_accounts_proof(&self, txn: &db::Transaction, addresses: &[Address]) -> AccountsProof<Account> {
         self.tree.get_accounts_proof(txn, addresses)
     }
 

--- a/accounts/tree-primitives/src/accounts_tree_chunk.rs
+++ b/accounts/tree-primitives/src/accounts_tree_chunk.rs
@@ -1,3 +1,4 @@
+use account::AccountsTreeLeave;
 use beserial::{Deserialize, Serialize};
 use hash::Blake2bHash;
 
@@ -5,14 +6,14 @@ use crate::accounts_proof::AccountsProof;
 use crate::accounts_tree_node::AccountsTreeNode;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AccountsTreeChunk {
+pub struct AccountsTreeChunk<A: AccountsTreeLeave> {
     #[beserial(len_type(u16))]
-    pub nodes: Vec<AccountsTreeNode>,
-    pub proof: AccountsProof,
+    pub nodes: Vec<AccountsTreeNode<A>>,
+    pub proof: AccountsProof<A>,
 }
 
-impl AccountsTreeChunk {
-    pub fn new(nodes: Vec<AccountsTreeNode>, proof: AccountsProof) -> AccountsTreeChunk {
+impl<A: AccountsTreeLeave> AccountsTreeChunk<A> {
+    pub fn new(nodes: Vec<AccountsTreeNode<A>>, proof: AccountsProof<A>) -> AccountsTreeChunk<A> {
         AccountsTreeChunk { nodes, proof }
     }
 
@@ -40,10 +41,10 @@ impl AccountsTreeChunk {
     pub fn is_empty(&self) -> bool { false }
 
     #[inline]
-    pub fn head(&self) -> &AccountsTreeNode { self.nodes.get(0).unwrap_or_else(|| self.tail()) }
+    pub fn head(&self) -> &AccountsTreeNode<A> { self.nodes.get(0).unwrap_or_else(|| self.tail()) }
 
     #[inline]
-    pub fn terminal_nodes(&self) -> Vec<&AccountsTreeNode> {
+    pub fn terminal_nodes(&self) -> Vec<&AccountsTreeNode<A>> {
         let mut vec = Vec::with_capacity(self.len());
         for node in &self.nodes {
             vec.push(node)
@@ -53,7 +54,7 @@ impl AccountsTreeChunk {
     }
 
     #[inline]
-    pub fn tail(&self) -> &AccountsTreeNode { self.proof.nodes().get(0).unwrap() }
+    pub fn tail(&self) -> &AccountsTreeNode<A> { self.proof.nodes().get(0).unwrap() }
 
     pub fn root(&self) -> Blake2bHash { self.proof.root_hash() }
 

--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -1565,7 +1565,7 @@ impl AbstractBlockchain for Blockchain {
     }
 
     #[allow(unused_variables)]
-    fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof> {
+    fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof<Account>> {
         unimplemented!()
     }
 
@@ -1600,7 +1600,7 @@ impl AbstractBlockchain for Blockchain {
         unimplemented!()
     }
 
-    fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk> {
+    fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk<Account>> {
         self.state.read().accounts.get_chunk(prefix, size, txn_option)
     }
 

--- a/blockchain-base/src/lib.rs
+++ b/blockchain-base/src/lib.rs
@@ -87,7 +87,7 @@ pub trait AbstractBlockchain: Sized + Send + Sync {
     fn contains(&self, hash: &Blake2bHash, include_forks: bool) -> bool;
 
 
-    fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof>;
+    fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof<Account>>;
 
     fn get_transactions_proof(&self, block_hash: &Blake2bHash, addresses: &HashSet<Address>) -> Option<TransactionsProof>;
 
@@ -109,7 +109,7 @@ pub trait AbstractBlockchain: Sized + Send + Sync {
     // TODO Why do we need this? Remove if possible.
     fn head_hash_from_store(&self, txn: &ReadTransaction) -> Option<Blake2bHash>;
 
-    fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk>;
+    fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk<Account>>;
 
     // TODO: Currently, we can implement request responses in the ConsensusAgent only for *both* protocols, which is why AbstractBlockchain needs to support this.
     fn get_epoch_transactions(&self, epoch: u32, txn_option: Option<&Transaction>) -> Option<Vec<BlockchainTransaction>>;

--- a/blockchain/src/blockchain/mod.rs
+++ b/blockchain/src/blockchain/mod.rs
@@ -777,7 +777,7 @@ impl AbstractBlockchain for Blockchain {
         self.contains(hash, include_forks)
     }
 
-    fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof> {
+    fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof<Account>> {
         self.get_accounts_proof(block_hash, addresses)
     }
 
@@ -809,7 +809,7 @@ impl AbstractBlockchain for Blockchain {
         self.head_hash_from_store(txn)
     }
 
-    fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk> {
+    fn get_accounts_chunk(&self, prefix: &str, size: usize, txn_option: Option<&Transaction>) -> Option<AccountsTreeChunk<Account>> {
         self.state.read().accounts.get_chunk(prefix, size, txn_option)
     }
 

--- a/blockchain/src/blockchain/transaction_proofs.rs
+++ b/blockchain/src/blockchain/transaction_proofs.rs
@@ -1,11 +1,12 @@
 use std::collections::HashSet;
 
+use account::Account;
 use database::ReadTransaction;
 use hash::Blake2bHash;
 use hash::Hash;
 use keys::Address;
-use tree_primitives::accounts_proof::AccountsProof;
 use transaction::TransactionsProof;
+use tree_primitives::accounts_proof::AccountsProof;
 use utils::merkle::Blake2bMerkleProof;
 
 use crate::Blockchain;
@@ -31,7 +32,7 @@ impl Blockchain {
         })
     }
 
-    pub fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof> {
+    pub fn get_accounts_proof(&self, block_hash: &Blake2bHash, addresses: &[Address]) -> Option<AccountsProof<Account>> {
         let state = self.state.read();
         // We only support accounts proofs for the head hash.
         if block_hash != &state.head_hash {

--- a/database/src/traits/accounts.rs
+++ b/database/src/traits/accounts.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::io;
 
 use beserial::{Deserialize, Serialize};
+use nimiq_account::{AccountsTreeLeave, Receipts};
 use nimiq_tree_primitives::accounts_tree_node::AccountsTreeNode;
 use nimiq_tree_primitives::address_nibbles::AddressNibbles;
-use nimiq_account::Receipts;
 
 use crate::{AsDatabaseBytes, FromDatabaseValue, IntoDatabaseValue};
 
@@ -16,7 +16,7 @@ impl AsDatabaseBytes for AddressNibbles {
     }
 }
 
-impl IntoDatabaseValue for AccountsTreeNode {
+impl<A: AccountsTreeLeave> IntoDatabaseValue for AccountsTreeNode<A> {
     fn database_byte_size(&self) -> usize {
         self.serialized_size()
     }
@@ -26,7 +26,7 @@ impl IntoDatabaseValue for AccountsTreeNode {
     }
 }
 
-impl FromDatabaseValue for AccountsTreeNode {
+impl<A: AccountsTreeLeave> FromDatabaseValue for AccountsTreeNode<A> {
     fn copy_from_database(bytes: &[u8]) -> io::Result<Self> where Self: Sized {
         let mut cursor = io::Cursor::new(bytes);
         Ok(Deserialize::deserialize(&mut cursor)?)

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -37,6 +37,7 @@ nimiq-macros = "0.1"
 nimiq-network-primitives = { version = "0.1", features = ["networks", "subscription", "version"] }
 nimiq-tree-primitives = "0.1"
 nimiq-transaction = "0.1"
+nimiq-account = "0.1"
 nimiq-utils = { version = "0.1", features = ["observer", "crc", "time"] }
 nimiq-handel = "0.1"
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -7,6 +7,7 @@ extern crate beserial_derive;
 extern crate bitflags;
 #[macro_use]
 extern crate enum_display_derive;
+extern crate nimiq_account as account;
 extern crate nimiq_block as block;
 extern crate nimiq_block_albatross as block_albatross;
 extern crate nimiq_block_base as block_base;
@@ -29,6 +30,7 @@ use parking_lot::RwLock;
 use rand::Rng;
 use rand::rngs::OsRng;
 
+use account::Account;
 use beserial::{Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength, SerializingError, uvar, WriteBytesExt};
 use block::{Block, BlockHeader};
 use block::proof::ChainProof;
@@ -723,7 +725,7 @@ impl InvVector {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TxMessage {
     pub transaction: Transaction,
-    pub accounts_proof: Option<AccountsProof>,
+    pub accounts_proof: Option<AccountsProof<Account>>,
 }
 impl TxMessage {
     pub fn new(transaction: Transaction) -> Message {
@@ -952,11 +954,11 @@ pub struct GetAccountsProofMessage {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountsProofMessage {
     pub block_hash: Blake2bHash,
-    pub proof: Option<AccountsProof>,
+    pub proof: Option<AccountsProof<Account>>,
 }
 
 impl AccountsProofMessage {
-    pub fn new(block_hash: Blake2bHash, proof: Option<AccountsProof>) -> Message {
+    pub fn new(block_hash: Blake2bHash, proof: Option<AccountsProof<Account>>) -> Message {
         Message::AccountsProof(Box::new(AccountsProofMessage {
             block_hash,
             proof,
@@ -976,7 +978,7 @@ pub struct GetAccountsTreeChunkMessage {
 #[derive(Clone, Debug)]
 pub enum AccountsTreeChunkData {
     Serialized(Vec<u8>),
-    Structured(AccountsTreeChunk),
+    Structured(AccountsTreeChunk<Account>),
 }
 
 impl AccountsTreeChunkData {

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -68,6 +68,10 @@ macro_rules! invoke_account_instance {
     }
 }
 
+pub trait AccountsTreeLeave: Serialize + Deserialize + Clone {
+    fn is_initial(&self) -> bool;
+}
+
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub enum Account {
     Basic(BasicAccount),
@@ -101,13 +105,6 @@ impl Account {
         }
     }
 
-    pub fn is_initial(&self) -> bool {
-        match *self {
-            Account::Basic(ref account) => account.balance == Coin::ZERO,
-            _ => false
-        }
-    }
-
     pub fn is_to_be_pruned(&self) -> bool {
         match *self {
             Account::Basic(_) | Account::Staking(_) => false,
@@ -131,6 +128,15 @@ impl Account {
             Err(AccountError::InsufficientFunds {balance, needed: value})
         } else {
             Ok(())
+        }
+    }
+}
+
+impl AccountsTreeLeave for Account {
+    fn is_initial(&self) -> bool {
+        match *self {
+            Account::Basic(ref account) => account.balance == Coin::ZERO,
+            _ => false
         }
     }
 }

--- a/validator/src/validator_agent.rs
+++ b/validator/src/validator_agent.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::cmp::Ordering;
 use std::fmt;
 use std::time::Duration;
 


### PR DESCRIPTION
This is a preparation step for the UTXO tree accounts.
It does simply introduce the generic parameter and a corresponding trait, but does not change logic at all.