### PR TITLE
Implemented non-naive validator discovery

### DIFF
--- a/bls/src/bls12_381/mod.rs
+++ b/bls/src/bls12_381/mod.rs
@@ -9,7 +9,7 @@ use failure::Fail;
 
 #[cfg(feature = "beserial")]
 use beserial::{Serialize, Deserialize};
-use hash::Hash;
+use hash::{Hash, HashOutput};
 
 use super::{
     AggregatePublicKey as GenericAggregatePublicKey,
@@ -241,7 +241,7 @@ impl fmt::Display for Signature {
 
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "CompressedSignature({})", self.compress().to_hex())
+        write!(f, "Signature({})", &::hex::encode(self.compress().as_ref()))
     }
 }
 

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -217,20 +217,21 @@ impl<P: ConsensusProtocol> Consensus<P> {
             },
         }
 
-        // Don't relay blocks if we are not synced yet.
-        if !state.established {
-            let height = self.blockchain.head_height();
-            if height % 100 == 0 {
-                info!("Now at block #{}", height);
-            }
-            return;
-        } else {
-            info!("Now at block #{}", self.blockchain.head_height());
+        // print block height
+        let height = self.blockchain.head_height();
+        if height % 100 == 0 {
+            info!("Now at block #{}", height);
+        }
+        else {
+            debug!("Now at block #{}", height);
         }
 
-        for agent in state.agents.values() {
-            for &block in blocks.iter() {
-                agent.relay_block(block);
+        // Only relay blocks if we are synced up.
+        if state.established {
+            for agent in state.agents.values() {
+                for &block in blocks.iter() {
+                    agent.relay_block(block);
+                }
             }
         }
     }

--- a/consensus/src/consensus_agent/mod.rs
+++ b/consensus/src/consensus_agent/mod.rs
@@ -379,7 +379,7 @@ impl<P: ConsensusProtocol + 'static> ConsensusAgent<P> {
                 }
             }
             Ok(PushResult::Known) => {
-                debug!("Known block {} from {}", hash, self.peer.peer_address());
+                trace!("Known block {} from {}", hash, self.peer.peer_address());
             }
             Err(PushError::Orphan) => {
                 self.on_orphan_block(hash);

--- a/network-primitives/src/validator_info.rs
+++ b/network-primitives/src/validator_info.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::hash::Hasher;
 
 use beserial::{Serialize, Deserialize};
 use block_albatross::signed::{SignedMessage, PREFIX_VALIDATOR_INFO, Message};
@@ -10,7 +11,7 @@ use crate::address::peer_address::PeerAddress;
 
 
 /// Information regarding an (maybe active) validator
-#[derive(Clone, Debug, Serialize, Deserialize, SerializeContent)]
+#[derive(Clone, Debug, Serialize, Deserialize, SerializeContent, Eq)]
 pub struct ValidatorInfo {
     /// The validator's public key (BLS12-381)
     pub public_key: CompressedPublicKey,

--- a/network/src/connection/close_type.rs
+++ b/network/src/connection/close_type.rs
@@ -75,6 +75,10 @@ pub enum CloseType {
 
     ManualPeerBan = 190,
 
+    EmptyValidatorInfo = 131,
+    InvalidPublicKeyInValidatorInfo = 132,
+    InvalidSignatureInValidatorInfo = 133,
+
     // Fail Close Types
 
     ClosedByRemote = 200,


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

Improved validator discovery:

 * Only verify `ValidatorInfo`s that are unknown.
 * Ban peers for incorrect `ValidatorInfo` messages
 * Send `ValidatorInfo`s to other peers when they connect, or when an epoch starts.
 * When sending, filter out `ValidatorInfo`s that are already known by that peer,
 * Immediately connect to all known active validators

## FixMe

 * I think we're connecting to all active validators even if we're not active. I will open an issue to fix this. In the meantime this is not a big problem.
