### PR TITLE
Remove slashing of stake and instead park slashed validators

### DIFF
--- a/block-production-albatross/tests/mod.rs
+++ b/block-production-albatross/tests/mod.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use beserial::Deserialize;
-use nimiq_block_albatross::{Block, BlockError, ForkProof, MacroBlock, MacroExtrinsics, PbftCommitMessage, PbftPrepareMessage, PbftProofBuilder, PbftProposal, SignedPbftCommitMessage, SignedPbftPrepareMessage, SignedViewChange, ViewChange, ViewChangeProof, ViewChangeProofBuilder};
-use nimiq_block_albatross::signed::SignedMessage;
+use nimiq_block_albatross::{Block, ForkProof, MacroBlock, MacroExtrinsics, PbftCommitMessage, PbftPrepareMessage, PbftProofBuilder, PbftProposal, SignedPbftCommitMessage, SignedPbftPrepareMessage, SignedViewChange, ViewChange, ViewChangeProof, ViewChangeProofBuilder};
 use nimiq_block_production_albatross::BlockProducer;
-use nimiq_blockchain_albatross::blockchain::{Blockchain, PushError, PushResult};
+use nimiq_blockchain_albatross::blockchain::{Blockchain, PushResult};
 use nimiq_blockchain_base::AbstractBlockchain;
 use nimiq_bls::{KeyPair, SecretKey};
 use nimiq_bls::bls12_381::lazy::LazyPublicKey;

--- a/blockchain-albatross/src/reward_registry/reward_pot.rs
+++ b/blockchain-albatross/src/reward_registry/reward_pot.rs
@@ -56,7 +56,7 @@ impl RewardPot {
     }
 
     pub(super) fn commit_micro_block(&self, block: &MicroBlock, txn: &mut WriteTransaction) {
-        // The total reward of a block is composed of the block reward, transaction fees and slashes.
+        // The total reward of a block is composed of the block reward and transaction fees.
         let mut reward = RewardPot::reward_for_micro_block(block);
 
         // Add to current reward pot of epoch.
@@ -65,7 +65,7 @@ impl RewardPot {
     }
 
     pub(super) fn revert_micro_block(&self, block: &MicroBlock, txn: &mut WriteTransaction) {
-        // The total reward of a block is composed of the block reward, transaction fees and slashes.
+        // The total reward of a block is composed of the block reward and transaction fees.
         let mut reward = Coin::from_u64_unchecked(txn.get(&self.reward_pot, Self::CURRENT_EPOCH_KEY).unwrap_or(0));
 
         // Add to current reward pot of epoch.

--- a/blockchain-albatross/tests/macro_block_sync.rs
+++ b/blockchain-albatross/tests/macro_block_sync.rs
@@ -2,17 +2,14 @@ use std::sync::Arc;
 
 use beserial::Deserialize;
 use nimiq_bls::{KeyPair, SecretKey};
-use nimiq_bls::bls12_381::lazy::LazyPublicKey;
 use nimiq_block_production_albatross::BlockProducer;
-use nimiq_block_albatross::{Block, ForkProof, MacroBlock, MacroExtrinsics, PbftProposal, PbftProofBuilder, PbftPrepareMessage, PbftCommitMessage, SignedPbftPrepareMessage, SignedPbftCommitMessage, ViewChange, ViewChangeProof, ViewChangeProofBuilder, SignedViewChange};
+use nimiq_block_albatross::{Block, MacroBlock, PbftProposal, PbftProofBuilder, PbftPrepareMessage, PbftCommitMessage, SignedPbftPrepareMessage, SignedPbftCommitMessage};
 use nimiq_blockchain_albatross::blockchain::{Blockchain, PushResult};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_network_primitives::{networks::NetworkId};
 use nimiq_primitives::policy;
 use nimiq_blockchain_base::AbstractBlockchain;
-use nimiq_block_albatross::signed::SignedMessage;
-use nimiq_primitives::slot::ValidatorSlots;
 use nimiq_blockchain_base::Direction;
 
 /// Secret key of validator. Tests run with `network-primitives/src/genesis/unit-albatross.toml`
@@ -61,7 +58,7 @@ fn produce_macro_blocks(num_macro: usize, producer: &BlockProducer, blockchain: 
         fill_micro_blocks(producer, blockchain);
 
         let next_block_height = blockchain.head_height() + 1;
-        let (proposal, extrinsics) = producer.next_macro_block_proposal(1565713920000 + next_block_height as u64 * 2000, 0u32, None);
+        let (proposal, _extrinsics) = producer.next_macro_block_proposal(1565713920000 + next_block_height as u64 * 2000, 0u32, None);
 
         let block = sign_macro_block(proposal);
         assert_eq!(blockchain.push_block(Block::Macro(block), true), Ok(PushResult::Extended));

--- a/blockchain-albatross/tests/signed.rs
+++ b/blockchain-albatross/tests/signed.rs
@@ -4,9 +4,7 @@ extern crate nimiq_primitives as primitives;
 extern crate beserial;
 extern crate nimiq_hash as hash;
 
-use std::iter::FromIterator;
-
-use block_albatross::{ViewChangeProof, ViewChange, ViewChangeProofBuilder, SignedViewChange, PbftPrepareMessage, SignedPbftCommitMessage, PbftCommitMessage};
+use block_albatross::{ViewChange, ViewChangeProofBuilder, SignedViewChange, PbftPrepareMessage, SignedPbftCommitMessage, PbftCommitMessage};
 use bls::bls12_381::KeyPair;
 use primitives::policy;
 use block_albatross::signed::Message;
@@ -38,7 +36,7 @@ fn test_view_change_single_signature() {
 
     // verify view change proof
     let validators = ValidatorSlots::new(vec![ValidatorSlotBand::new(LazyPublicKey::from(key_pair.public), policy::SLOTS)]);
-    view_change_proof.verify(&view_change, &validators, policy::TWO_THIRD_SLOTS);
+    view_change_proof.verify(&view_change, &validators, policy::TWO_THIRD_SLOTS).unwrap();
 }
 
 #[test]

--- a/bls/src/bls12_381/mod.rs
+++ b/bls/src/bls12_381/mod.rs
@@ -290,6 +290,20 @@ impl AsRef<[u8]> for CompressedSignature {
     }
 }
 
+impl AsMut<[u8]> for CompressedSignature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.s.as_mut()
+    }
+}
+
+impl Default for CompressedSignature {
+    fn default() -> Self {
+        CompressedSignature {
+            s: G1Compressed::empty(),
+        }
+    }
+}
+
 impl CompressedSignature {
     pub const SIZE: usize = 48;
 

--- a/build-tools/src/genesis/albatross/mod.rs
+++ b/build-tools/src/genesis/albatross/mod.rs
@@ -21,7 +21,6 @@ use database::WriteTransaction;
 use hash::{Blake2bHash, Blake2bHasher, Hash, Hasher};
 use keys::Address;
 use primitives::coin::Coin;
-use primitives::policy;
 
 mod config;
 
@@ -174,7 +173,7 @@ impl GenesisBuilder {
 
         // generate slot allocation from staking contract
         let slots = staking_contract
-            .select_validators(&pre_genesis_seed.compress(), policy::SLOTS, policy::MAX_CONSIDERED as usize);
+            .select_validators(&pre_genesis_seed.compress());
         debug!("Slots: {:#?}", slots);
 
         // extrinsics

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -28,8 +28,8 @@ nimiq-keys = "0.1"
 nimiq-transaction = "0.1"
 nimiq-primitives = { version = "0.1", features = ["coin", "policy", "validators"] }
 nimiq-bls = "0.1"
-nimiq-collections = "0.1"
+nimiq-utils = { version = "0.1", features = ["hash-rng"] }
+rand = "0.7"
 
 [dev-dependencies]
 hex = "0.4"
-rand = "0.7"

--- a/primitives/account/src/basic_account.rs
+++ b/primitives/account/src/basic_account.rs
@@ -19,7 +19,7 @@ impl AccountTransactionInteraction for BasicAccount {
         Err(AccountError::InvalidForRecipient)
     }
 
-    fn check_incoming_transaction(&self, _transaction: &Transaction, _block_height: u32) -> Result<(), AccountError> {
+    fn check_incoming_transaction(_transaction: &Transaction, _block_height: u32) -> Result<(), AccountError> {
         Ok(())
     }
 
@@ -57,25 +57,25 @@ impl AccountTransactionInteraction for BasicAccount {
 }
 
 impl AccountInherentInteraction for BasicAccount {
-    fn check_inherent(&self, inherent: &Inherent) -> Result<(), AccountError> {
+    fn check_inherent(&self, inherent: &Inherent, _block_height: u32) -> Result<(), AccountError> {
         match inherent.ty {
             InherentType::Reward => Ok(()),
-            InherentType::Slash => Err(AccountError::InvalidInherent),
+            _ => Err(AccountError::InvalidInherent),
         }
     }
 
-    fn commit_inherent(&mut self, inherent: &Inherent) -> Result<Option<Vec<u8>>, AccountError> {
-        self.check_inherent(inherent)?;
+    fn commit_inherent(&mut self, inherent: &Inherent, block_height: u32) -> Result<Option<Vec<u8>>, AccountError> {
+        self.check_inherent(inherent, block_height)?;
         self.balance = Account::balance_add(self.balance, inherent.value)?;
         Ok(None)
     }
 
-    fn revert_inherent(&mut self, inherent: &Inherent, receipt: Option<&Vec<u8>>) -> Result<(), AccountError> {
+    fn revert_inherent(&mut self, inherent: &Inherent, block_height: u32, receipt: Option<&Vec<u8>>) -> Result<(), AccountError> {
         if receipt.is_some() {
             return Err(AccountError::InvalidReceipt);
         }
 
-        self.check_inherent(inherent)?;
+        self.check_inherent(inherent, block_height)?;
         self.balance = Account::balance_sub(self.balance, inherent.value)?;
         Ok(())
     }

--- a/primitives/account/src/htlc_contract.rs
+++ b/primitives/account/src/htlc_contract.rs
@@ -55,7 +55,7 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
         Ok(HashedTimeLockedContract::new(balance, data.sender, data.recipient, data.hash_algorithm, data.hash_root, data.hash_count, data.timeout, transaction.value))
     }
 
-    fn check_incoming_transaction(&self, _transaction: &Transaction, _block_height: u32) -> Result<(), AccountError> {
+    fn check_incoming_transaction(_transaction: &Transaction, _block_height: u32) -> Result<(), AccountError> {
         Err(AccountError::InvalidForRecipient)
     }
 
@@ -148,15 +148,15 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
 }
 
 impl AccountInherentInteraction for HashedTimeLockedContract {
-    fn check_inherent(&self, _inherent: &Inherent) -> Result<(), AccountError> {
+    fn check_inherent(&self, _inherent: &Inherent, _block_height: u32) -> Result<(), AccountError> {
         Err(AccountError::InvalidInherent)
     }
 
-    fn commit_inherent(&mut self, _inherent: &Inherent) -> Result<Option<Vec<u8>>, AccountError> {
+    fn commit_inherent(&mut self, _inherent: &Inherent, _block_height: u32) -> Result<Option<Vec<u8>>, AccountError> {
         Err(AccountError::InvalidInherent)
     }
 
-    fn revert_inherent(&mut self, _inherent: &Inherent, _receipt: Option<&Vec<u8>>) -> Result<(), AccountError> {
+    fn revert_inherent(&mut self, _inherent: &Inherent, _block_height: u32, _receipt: Option<&Vec<u8>>) -> Result<(), AccountError> {
         Err(AccountError::InvalidInherent)
     }
 }

--- a/primitives/account/src/inherent.rs
+++ b/primitives/account/src/inherent.rs
@@ -7,6 +7,22 @@ use crate::AccountError;
 pub enum InherentType {
     Reward,
     Slash,
+    FinalizeEpoch,
+}
+
+impl InherentType {
+    /// Inherents can either be applied before transactions in a block or after them.
+    /// In most cases, they will be applied after the transactions.
+    /// An exception are slash transactions that park a staker.
+    /// Following transactions should be able to unpark that staker, which is why slash inherents
+    /// are applied before transactions.
+    #[inline]
+    pub fn is_pre_transactions(&self) -> bool {
+        match self {
+            InherentType::Slash => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -17,11 +33,18 @@ pub struct Inherent {
     pub data: Vec<u8>,
 }
 
+impl Inherent {
+    #[inline]
+    pub fn is_pre_transactions(&self) -> bool {
+        self.ty.is_pre_transactions()
+    }
+}
+
 pub trait AccountInherentInteraction: Sized {
-    fn check_inherent(&self, inherent: &Inherent) -> Result<(), AccountError>;
+    fn check_inherent(&self, inherent: &Inherent, block_height: u32) -> Result<(), AccountError>;
 
-    fn commit_inherent(&mut self, inherent: &Inherent) -> Result<Option<Vec<u8>>, AccountError>;
+    fn commit_inherent(&mut self, inherent: &Inherent, block_height: u32) -> Result<Option<Vec<u8>>, AccountError>;
 
-    fn revert_inherent(&mut self, inherent: &Inherent, receipt: Option<&Vec<u8>>) -> Result<(), AccountError>;
+    fn revert_inherent(&mut self, inherent: &Inherent, block_height: u32, receipt: Option<&Vec<u8>>) -> Result<(), AccountError>;
 }
 

--- a/primitives/account/src/vesting_contract.rs
+++ b/primitives/account/src/vesting_contract.rs
@@ -60,7 +60,7 @@ impl AccountTransactionInteraction for VestingContract {
         Ok(VestingContract::new(balance, data.owner, data.start, data.step_blocks, data.step_amount, data.total_amount))
     }
 
-    fn check_incoming_transaction(&self, _transaction: &Transaction, _block_height: u32) -> Result<(), AccountError> {
+    fn check_incoming_transaction(_transaction: &Transaction, _block_height: u32) -> Result<(), AccountError> {
         Err(AccountError::InvalidForRecipient)
     }
 
@@ -106,15 +106,15 @@ impl AccountTransactionInteraction for VestingContract {
 }
 
 impl AccountInherentInteraction for VestingContract {
-    fn check_inherent(&self, _inherent: &Inherent) -> Result<(), AccountError> {
+    fn check_inherent(&self, _inherent: &Inherent, _block_height: u32) -> Result<(), AccountError> {
         Err(AccountError::InvalidInherent)
     }
 
-    fn commit_inherent(&mut self, _inherent: &Inherent) -> Result<Option<Vec<u8>>, AccountError> {
+    fn commit_inherent(&mut self, _inherent: &Inherent, _block_height: u32) -> Result<Option<Vec<u8>>, AccountError> {
         Err(AccountError::InvalidInherent)
     }
 
-    fn revert_inherent(&mut self, _inherent: &Inherent, _receipt: Option<&Vec<u8>>) -> Result<(), AccountError> {
+    fn revert_inherent(&mut self, _inherent: &Inherent, _block_height: u32, _receipt: Option<&Vec<u8>>) -> Result<(), AccountError> {
         Err(AccountError::InvalidInherent)
     }
 }

--- a/primitives/account/tests/htlc_contract.rs
+++ b/primitives/account/tests/htlc_contract.rs
@@ -146,7 +146,7 @@ fn it_does_not_support_incoming_transactions() {
     let mut tx = Transaction::new_basic(Address::from([1u8; 20]), Address::from([2u8; 20]), 1.try_into().unwrap(), 1000.try_into().unwrap(), 1, NetworkId::Dummy);
     tx.recipient_type = AccountType::HTLC;
 
-    assert_eq!(contract.check_incoming_transaction(&tx, 2), Err(AccountError::InvalidForRecipient));
+    assert_eq!(HashedTimeLockedContract::check_incoming_transaction(&tx, 2), Err(AccountError::InvalidForRecipient));
     assert_eq!(contract.commit_incoming_transaction(&tx, 2), Err(AccountError::InvalidForRecipient));
     assert_eq!(contract.revert_incoming_transaction(&tx, 2, None), Err(AccountError::InvalidForRecipient));
 }

--- a/primitives/account/tests/vesting_contract.rs
+++ b/primitives/account/tests/vesting_contract.rs
@@ -186,7 +186,7 @@ fn it_does_not_support_incoming_transactions() {
     let mut tx = Transaction::new_basic(Address::from([1u8; 20]), Address::from([2u8; 20]), 1.try_into().unwrap(), 1000.try_into().unwrap(), 1, NetworkId::Dummy);
     tx.recipient_type = AccountType::Vesting;
 
-    assert_eq!(contract.check_incoming_transaction(&tx, 2), Err(AccountError::InvalidForRecipient));
+    assert_eq!(VestingContract::check_incoming_transaction(&tx, 2), Err(AccountError::InvalidForRecipient));
     assert_eq!(contract.commit_incoming_transaction(&tx, 2), Err(AccountError::InvalidForRecipient));
     assert_eq!(contract.revert_incoming_transaction(&tx, 2, None), Err(AccountError::InvalidForRecipient));
 }

--- a/primitives/block-albatross/src/macro_block.rs
+++ b/primitives/block-albatross/src/macro_block.rs
@@ -8,7 +8,6 @@ use beserial::{Deserialize, Serialize};
 use bls::bls12_381::CompressedSignature;
 use collections::bitset::BitSet;
 use hash::{Blake2bHash, Hash, SerializeContent};
-use primitives::coin::Coin;
 use primitives::slot::{Slots, ValidatorSlots, StakeSlots};
 
 use crate::BlockError;
@@ -50,8 +49,6 @@ pub struct MacroHeader {
 pub struct MacroExtrinsics {
     /// Slots with staker information, i.e. staker address and reward address
     pub stakers: StakeSlots,
-    /// The slash fine for the next epoch.
-    pub slash_fine: Coin,
     /// The final list of slashes from the previous epoch.
     pub slashed_set: BitSet,
 }
@@ -79,13 +76,8 @@ impl TryInto<Slots> for MacroBlock {
 // CHECKME: Check for performance
 impl MacroExtrinsics {
     pub fn from_stake_slots_and_slashed_set(stake_slots: StakeSlots, slashed_set: BitSet) -> Self {
-        // TODO: Slash fine will be removed. Instead of patching it into our Slots struct, we'll
-        //       just set the fine to 0.
-        let slash_fine = Coin::ZERO;
-
         MacroExtrinsics {
             stakers: stake_slots,
-            slash_fine,
             slashed_set,
         }
     }

--- a/primitives/block-albatross/tests/mod.rs
+++ b/primitives/block-albatross/tests/mod.rs
@@ -1,14 +1,12 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::str::FromStr;
 
 use beserial::Deserialize;
 use nimiq_block_albatross::{MacroBlock, MacroExtrinsics, MacroHeader};
-use nimiq_bls::bls12_381::lazy::LazyPublicKey;
 use nimiq_bls::bls12_381::{Signature, CompressedPublicKey};
 use nimiq_collections::bitset::BitSet;
 use nimiq_hash::{Blake2bHasher, Hasher};
 use nimiq_keys::Address;
-use nimiq_primitives::coin::Coin;
 use nimiq_primitives::slot::{Slots, StakeSlots, StakeSlotBand, ValidatorSlots, ValidatorSlotBand};
 
 #[test]
@@ -25,7 +23,7 @@ fn it_can_convert_macro_block_into_slots() {
         (130u16, "abdaf5ac13036550362c2d3c5f1848fd6ab1898c75311381bd022d6a2a7909d526ad7a6aaafbaf8f64f11a3af5f220fa0a150b022394ff5da765016b7e6a2525fbe63c65b2e382989de3ecb04038e24c9f782e7965c2b3ec179c7715ecf7f191"),
     ];
     let validator_slots: ValidatorSlots = slot_allocation.into_iter()
-        .map(|(num_slots, pubkey_str)| { ;
+        .map(|(num_slots, pubkey_str)| {
             let pubkey = CompressedPublicKey::from_str(pubkey_str).unwrap();
             ValidatorSlotBand::new(pubkey, num_slots)
         })
@@ -59,7 +57,6 @@ fn it_can_convert_macro_block_into_slots() {
         justification: None,
         extrinsics: Some(MacroExtrinsics {
             stakers: stake_slots.clone(),
-            slash_fine: Coin::try_from(8u64).unwrap(),
             slashed_set: BitSet::new(),
         }),
     };

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -114,9 +114,6 @@ pub const UNSTAKING_DELAY: u32 = 100; // TODO: Set.
 /// Number of available slots
 pub const SLOTS: u16 = 512;
 
-/// Maximum number of stakes considered for validator selection
-pub const MAX_CONSIDERED: u32 = 10_000;
-
 /// ceil(2/3) of active validators
 // (2 * n + 3) / 3 = ceil(2f + 1) where n = 3f + 1
 pub const TWO_THIRD_SLOTS: u16 = (2 * SLOTS + 3) / 3;

--- a/primitives/src/slot.rs
+++ b/primitives/src/slot.rs
@@ -59,7 +59,6 @@ use bls::bls12_381::lazy::LazyPublicKey;
 use bls::bls12_381::CompressedPublicKey;
 use keys::Address;
 
-use crate::coin::Coin;
 use crate::policy::SLOTS;
 
 
@@ -128,11 +127,6 @@ impl Slots {
             validator_slot: self.validator_slots.get(idx)?.clone(),
             stake_slot: self.stake_slots.get(idx)?.clone(),
         })
-    }
-
-    #[deprecated]
-    pub fn slash_fine(&self) -> Coin {
-        Coin::ZERO
     }
 
     /// Returns stake slots with first slot number and the corresponding public key of the

--- a/primitives/transaction/src/account/staking_contract.rs
+++ b/primitives/transaction/src/account/staking_contract.rs
@@ -47,6 +47,13 @@ impl AccountTransactionVerification for StakingContractVerifier {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum StakingTransactionType {
+    Retire = 0,
+    Unpark = 1,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StakingTransactionData {
     pub validator_key: BlsPublicKey,


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #9 and #21 .

## What's in this pull request?

Remove slashing of stake and instead park slashed validators
Parking will lead to automatic retirement of the stake after the next epoch
Add unpark transaction to prevent being retired
