### PR TITLE
Use RwLock for LazyPublicKey

### DIFF
--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::vec::IntoIter;
 
 
-use parking_lot::{MappedMutexGuard, MappedRwLockReadGuard, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
+use parking_lot::{MappedRwLockReadGuard, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
 
 use account::{Account, Inherent, InherentType};
 use account::inherent::AccountInherentInteraction;
@@ -339,7 +339,7 @@ impl Blockchain {
         Some(validators)
     }
 
-    pub fn verify_block_header(&self, header: &BlockHeader, view_change_proof: OptionalCheck<&ViewChangeProof>, intended_slot_owner: &MappedMutexGuard<PublicKey>, txn_opt: Option<&Transaction>) -> Result<(), PushError> {
+    pub fn verify_block_header(&self, header: &BlockHeader, view_change_proof: OptionalCheck<&ViewChangeProof>, intended_slot_owner: &MappedRwLockReadGuard<PublicKey>, txn_opt: Option<&Transaction>) -> Result<(), PushError> {
         // Check if the block's immediate predecessor is part of the chain.
         let prev_info_opt = self.chain_store.get_chain_info(&header.parent_hash(), false, txn_opt);
         if prev_info_opt.is_none() {

--- a/validator/src/signature_aggregation/voting.rs
+++ b/validator/src/signature_aggregation/voting.rs
@@ -88,7 +88,8 @@ impl ValidatorRegistry {
 impl IdentityRegistry for ValidatorRegistry {
     fn public_key(&self, id: usize) -> Option<PublicKey> {
         self.validators.read().get_public_key(id)
-            .and_then(|pubkey| pubkey.uncompressed())
+            .and_then(|pubkey| pubkey.uncompress()
+                .map(|c| c.clone()))
     }
 }
 


### PR DESCRIPTION
 - Remove LazyPublicKey::uncompress()
 - Use UpgradableRwLock instead of Mutex for LazyPublicKey cache

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #67 