### PR TITLE
Serialize only HashSets that have ordering

### DIFF
--- a/beserial/src/lib.rs
+++ b/beserial/src/lib.rs
@@ -310,12 +310,16 @@ impl<T, H> DeserializeWithLength for HashSet<T, H>
 }
 
 impl<T, H> SerializeWithLength for HashSet<T, H>
-    where T: Serialize + std::cmp::Eq + std::hash::Hash,
+    where T: Serialize + std::cmp::Eq + std::hash::Hash + std::cmp::Ord,
           H: BuildHasher
 {
     fn serialize<S: Serialize + num::FromPrimitive, W: WriteBytesExt>(&self, writer: &mut W) -> Result<usize, SerializingError> {
         let mut size = S::from_usize(self.len()).unwrap().serialize(writer)?;
-        for t in self {
+
+        let mut v = self.iter().collect::<Vec<&T>>();
+        v.sort_unstable();
+
+        for t in v {
             size += t.serialize(writer)?;
         }
         Ok(size)

--- a/beserial/tests/hashsets.rs
+++ b/beserial/tests/hashsets.rs
@@ -4,7 +4,7 @@ use beserial::{Deserialize, DeserializeWithLength, Serialize, SerializeWithLengt
 #[test]
 fn it_correctly_serializes_and_deserializes_hashsets() {
     fn reserialize<T>(s: HashSet<T>) -> HashSet<T>
-    where T: Serialize + Deserialize + std::cmp::Eq + std::hash::Hash
+        where T: Serialize + Deserialize + std::cmp::Eq + std::hash::Hash + std::cmp::Ord
     {
         let mut v = Vec::with_capacity(64);
         SerializeWithLength::serialize::<u16, Vec<u8>>(&s, &mut v).unwrap();


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

Got an `AccountsHashMismatch` when there are more than two stakes parked. The parking sets are `HashSets` and the implementation of `Serialize` serialized them in arbitrary order. This caused the hash to be non-deterministic.

Even though there are cases where you might want to serialize a `HashSet` where the ordering doesn't matter, to avoid future errors, we constrained the `Serialize` implementation over types that are `Ord` and it sorts them before serializing.
