### PR TITLE
RPC server: Add peer_public_key method

### DIFF
--- a/rpc-server/src/handlers/network.rs
+++ b/rpc-server/src/handlers/network.rs
@@ -184,6 +184,14 @@ impl<P: ConsensusProtocol + 'static> NetworkHandler<P> {
             "tx" => network_connection.map(|conn| conn.metrics().bytes_sent().into()).unwrap_or(Null)
         }
     }
+
+    /// Returns the peer state for a single peer.
+    /// Parameters: None
+    ///
+    /// The return value is a string, the peer public key.
+    pub(crate) fn peer_public_key(&self, params: &[JsonValue]) -> Result<JsonValue, JsonValue> {
+        Ok(self.network.network_config.key_pair().public.to_hex().into())
+    }
 }
 
 impl<P: ConsensusProtocol + 'static> Module for NetworkHandler<P> {
@@ -192,5 +200,6 @@ impl<P: ConsensusProtocol + 'static> Module for NetworkHandler<P> {
         "syncing" => syncing,
         "peerList" => peer_list,
         "peerState" => peer_state,
+        "peerPublicKey" => peer_public_key,
     }
 }


### PR DESCRIPTION
`peer_public_key` takes no arguments and returns the peer public key as a hex string.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

To generate a seed list from a swarm of auto-generated validators, I need some way to get the peer public key from RPC.

Maybe we should create a `peer_config` call though and include more information like peer ID.