### PR TITLE
Remove macro_use lines, optimize imports

### DIFF
--- a/block-production-albatross/src/lib.rs
+++ b/block-production-albatross/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate log;
-
 extern crate nimiq_block_albatross as block;
 extern crate nimiq_blockchain_albatross as blockchain;
 extern crate nimiq_blockchain_base as blockchain_base;
@@ -22,7 +19,7 @@ use block::ForkProof;
 use block::MicroJustification;
 use blockchain::blockchain::Blockchain;
 use blockchain_base::AbstractBlockchain;
-use bls::bls12_381::{CompressedSignature, KeyPair};
+use bls::bls12_381::KeyPair;
 use database::WriteTransaction;
 use hash::{Blake2bHash, Hash};
 use mempool::Mempool;

--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -16,7 +16,7 @@ use block::{Block, BlockError, BlockHeader, BlockType, ForkProof, MacroBlock, Ma
 use blockchain_base::{AbstractBlockchain, BlockchainError, Direction};
 #[cfg(feature = "metrics")]
 use blockchain_base::chain_metrics::BlockchainMetrics;
-use bls::bls12_381::{CompressedSignature, PublicKey};
+use bls::bls12_381::PublicKey;
 use collections::bitset::BitSet;
 use database::{Environment, ReadTransaction, Transaction, WriteTransaction};
 use hash::{Blake2bHash, Hash};

--- a/blockchain-albatross/src/reward_registry/mod.rs
+++ b/blockchain-albatross/src/reward_registry/mod.rs
@@ -3,7 +3,6 @@ mod reward_pot;
 
 use std::borrow::Cow;
 use std::io;
-use std::io::Write;
 use std::sync::Arc;
 
 use failure::Fail;
@@ -14,12 +13,11 @@ use collections::bitset::BitSet;
 use database::{AsDatabaseBytes, Database, DatabaseFlags, Environment, FromDatabaseValue,
                ReadTransaction, Transaction, WriteTransaction};
 use database::cursor::{ReadCursor, WriteCursor};
-use hash::{Blake2bHasher, Hasher};
 use primitives::coin::Coin;
 use primitives::policy;
 use primitives::slot::{Slots, Slot, SlotIndex};
 use transaction::Transaction as BlockchainTransaction;
-use vrf::{VrfRng, VrfUseCase};
+use vrf::VrfUseCase;
 
 use crate::chain_store::ChainStore;
 use crate::reward_registry::reward_pot::RewardPot;

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -23,8 +23,7 @@ paw = "1.0"
 rand = "0.7"
 rand04_compat = "0.1"
 rand_chacha = "0.2"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 shellfn = "0.1"
 simple_logger = "1.0"
 structopt = { version = "0.3", features = ["paw"] }

--- a/build-tools/src/devnet/docker.rs
+++ b/build-tools/src/devnet/docker.rs
@@ -39,22 +39,22 @@ impl Docker {
 mod docker_cmd {
     use failure::Error;
 
-    #[shell]
+    #[shellfn::shell]
     pub fn build<P: ToString>(env_dir: P) -> Result<(), Error> { r#"
         docker-compose -f $ENV_DIR/docker-compose.yml build
     "# }
 
-    #[shell]
+    #[shellfn::shell]
     pub fn up<P: ToString>(env_dir: P) -> Result<impl Iterator<Item=Result<String, Error>>, Error> {
         "docker-compose -f $ENV_DIR/docker-compose.yml up | tee $ENV_DIR/build/validators.log"
     }
 
-    #[shell]
+    #[shellfn::shell]
     pub fn down<P: ToString>(env_dir: P) -> Result<(), Error> {
         "docker-compose -f $ENV_DIR/docker-compose.yml down"
     }
 
-    #[shell]
+    #[shellfn::shell]
     pub fn prune() -> Result<(), Error> {
         "docker image prune -f"
     }

--- a/build-tools/src/devnet/main.rs
+++ b/build-tools/src/devnet/main.rs
@@ -1,12 +1,7 @@
-extern crate structopt;
-extern crate paw;
 #[macro_use]
 extern crate log;
 #[macro_use]
-extern crate shellfn;
-#[macro_use]
 extern crate failure;
-extern crate ctrlc;
 
 mod docker;
 
@@ -16,11 +11,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::fs::{canonicalize, remove_file};
 
+use docker::Docker;
+use failure::Error;
 use log::Level;
 use structopt::StructOpt;
-use failure::Error;
-
-use docker::Docker;
 
 
 #[derive(Debug, StructOpt)]
@@ -32,7 +26,7 @@ struct Args {
 }
 
 
-#[shell]
+#[shellfn::shell]
 // NOTE: env_dir needs to be absolute
 fn build_client<S: ToString>(env_dir: S) -> Result<impl Iterator<Item=Result<String, Error>>, Error> { r#"
     mkdir -p $ENV_DIR/build/

--- a/build-tools/src/lib.rs
+++ b/build-tools/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde_derive;
 
 extern crate nimiq_bls as bls;
 extern crate nimiq_block_albatross as block_albatross;

--- a/consensus/src/accounts_chunk_cache.rs
+++ b/consensus/src/accounts_chunk_cache.rs
@@ -18,6 +18,7 @@ use blockchain_base::{AbstractBlockchain, BlockchainEvent};
 use database::Environment;
 use database::ReadTransaction;
 use hash::Blake2bHash;
+use macros::upgrade_weak;
 use utils::mutable_once::MutableOnce;
 
 pub type SerializedChunk = Vec<u8>;

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -11,6 +11,7 @@ use rand::thread_rng;
 
 use blockchain_base::{AbstractBlockchain, BlockchainEvent};
 use database::Environment;
+use macros::upgrade_weak;
 use mempool::{Mempool, MempoolEvent, MempoolConfig};
 use network::{Network, NetworkConfig, NetworkEvent, Peer};
 use network_primitives::networks::NetworkId;

--- a/consensus/src/consensus_agent/mod.rs
+++ b/consensus/src/consensus_agent/mod.rs
@@ -10,6 +10,7 @@ use beserial::Serialize;
 use block_base::Block;
 use blockchain_base::{AbstractBlockchain, PushError, PushResult};
 use hash::Blake2bHash;
+use macros::upgrade_weak;
 use mempool::{Mempool, ReturnCode};
 use network::connection::close_type::CloseType;
 use network::Peer;

--- a/consensus/src/consensus_agent/sync.rs
+++ b/consensus/src/consensus_agent/sync.rs
@@ -12,6 +12,7 @@ use block_base::{Block, BlockError};
 use blockchain_albatross::Blockchain as AlbatrossBlockchain;
 use blockchain_base::{AbstractBlockchain, PushError, PushResult};
 use hash::Blake2bHash;
+use macros::upgrade_weak;
 use network::connection::close_type::CloseType;
 use network::peer::Peer;
 use network_messages::{EpochTransactionsMessage, GetBlocksDirection, GetBlocksMessage, GetEpochTransactionsMessage};

--- a/consensus/src/inventory.rs
+++ b/consensus/src/inventory.rs
@@ -12,6 +12,7 @@ use blockchain_base::{AbstractBlockchain, Direction, PushError, PushResult};
 use collections::{LimitHashSet, UniqueLinkedList};
 use collections::queue::Queue;
 use hash::{Blake2bHash, Hash};
+use macros::upgrade_weak;
 use mempool::{Mempool, ReturnCode};
 use network::connection::close_type::CloseType;
 use network::Peer;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate nimiq_macros as macros;
 
 extern crate nimiq_block_albatross as block_albatross;
 extern crate nimiq_block_base as block_base;
@@ -11,6 +9,7 @@ extern crate nimiq_blockchain_base as blockchain_base;
 extern crate nimiq_collections as collections;
 extern crate nimiq_database as database;
 extern crate nimiq_hash as hash;
+extern crate nimiq_macros as macros;
 extern crate nimiq_mempool as mempool;
 extern crate nimiq_messages as network_messages;
 extern crate nimiq_network as network;

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1,12 +1,11 @@
 #[macro_use]
-extern crate bitflags;
-#[macro_use]
 extern crate log;
 
 use std::borrow::Cow;
 use std::io;
 use std::ops::Deref;
 
+use bitflags::bitflags;
 use lmdb_zero;
 
 use crate::cursor::{ReadCursor, WriteCursor as WriteCursorTrait};

--- a/fixed-unsigned/benches/fixed_unsigned.rs
+++ b/fixed-unsigned/benches/fixed_unsigned.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-#[macro_use]
-extern crate lazy_static;
+use lazy_static::lazy_static;
 
 use std::str::FromStr;
 use criterion::{Criterion, Benchmark};

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Weak};
 use std::fmt;
 
+use macros::upgrade_weak;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use futures::{future, Future};
 

--- a/handel/src/lib.rs
+++ b/handel/src/lib.rs
@@ -15,8 +15,6 @@ extern crate log;
 extern crate tokio;
 extern crate rand;
 extern crate parking_lot;
-#[macro_use]
-extern crate lazy_static;
 
 extern crate beserial;
 #[macro_use]
@@ -25,7 +23,6 @@ extern crate nimiq_bls as bls;
 extern crate nimiq_collections as collections;
 extern crate nimiq_hash as hash;
 extern crate nimiq_utils as utils;
-#[macro_use]
 extern crate nimiq_macros as macros;
 
 

--- a/handel/src/verifier.rs
+++ b/handel/src/verifier.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use futures::{future, Future};
 use futures::future::FutureResult;
 use futures_cpupool::{CpuPool, CpuFuture};
+use lazy_static::lazy_static;
 
 use hash::Blake2bHash;
 use bls::bls12_381::AggregatePublicKey;

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate nimiq_macros as macros;
-
 pub mod hmac;
 pub mod pbkdf2;
 pub mod sha512;
@@ -11,6 +8,7 @@ use libargon2_sys::argon2d_hash;
 use sha2::{Sha256, Sha512, Digest};
 use beserial::{Serialize, Deserialize};
 use hex::FromHex;
+use nimiq_macros::{add_hex_io_fns_typed_arr, create_typed_array};
 
 use std::cmp::Ordering;
 use std::fmt::{Debug, Error, Formatter};

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -1,5 +1,6 @@
 use crate::PublicKey;
-use crate::hash::{Blake2bHash, Blake2bHasher, Hasher};
+use hash::{Blake2bHash, Blake2bHasher, Hasher, hash_typed_array};
+use macros::{add_hex_io_fns_typed_arr, create_typed_array};
 use std::convert::From;
 use std::char;
 use std::io;

--- a/keys/src/lib.rs
+++ b/keys/src/lib.rs
@@ -2,9 +2,7 @@
 extern crate beserial_derive;
 #[macro_use]
 extern crate failure;
-#[macro_use]
 extern crate nimiq_hash as hash;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_utils as utils;
 

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -1,9 +1,10 @@
-
 use std::convert::TryFrom;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::net::IpAddr;
 
+use derive_builder::Builder;
+use enum_display_derive::Display;
 use url::Url;
 
 #[cfg(feature="validator")]

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -10,6 +10,7 @@ use log::LevelFilter;
 use url::Url;
 use hex::FromHex;
 use failure::Fail;
+use serde_derive::Deserialize;
 
 use network_primitives::{address, protocol};
 use network_primitives::address::peer_uri::PeerUriError;

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -5,6 +5,7 @@ use colored::Colorize;
 use failure::Fail;
 use fern::colors::{Color, ColoredLevelConfig};
 use fern::{Dispatch, log_file};
+use lazy_static::lazy_static;
 use log::{Level, LevelFilter, SetLoggerError};
 
 use crate::error::Error;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,15 +1,7 @@
 #[macro_use]
-extern crate derive_builder;
-#[macro_use]
 extern crate failure;
 #[macro_use]
-extern crate enum_display_derive;
-#[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate lazy_static;
 
 extern crate nimiq_network as network;
 extern crate nimiq_consensus as consensus;

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -3,8 +3,6 @@
 
 #[macro_use]
 extern crate beserial_derive;
-#[macro_use]
-extern crate bitflags;
 extern crate nimiq_account as account;
 extern crate nimiq_block as block;
 extern crate nimiq_block_albatross as block_albatross;
@@ -13,7 +11,6 @@ extern crate nimiq_bls as bls;
 extern crate nimiq_handel as handel;
 extern crate nimiq_hash as hash;
 extern crate nimiq_keys as keys;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_network_primitives as network_primitives;
 extern crate nimiq_transaction as transaction;
@@ -30,12 +27,14 @@ use rand::rngs::OsRng;
 
 use account::Account;
 use beserial::{Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength, SerializingError, uvar, WriteBytesExt};
+use bitflags::bitflags;
 use block::{Block, BlockHeader};
 use block::proof::ChainProof;
 use block_albatross::{Block as BlockAlbatross, BlockHeader as BlockHeaderAlbatross, ForkProof, PbftCommitMessage, PbftPrepareMessage, SignedPbftProposal, ViewChange, ViewChangeProof};
 use handel::update::LevelUpdateMessage;
 use hash::Blake2bHash;
 use keys::{Address, KeyPair, PublicKey, Signature};
+use macros::create_typed_array;
 use network_primitives::address::{PeerAddress, PeerId};
 use network_primitives::protocol::ProtocolFlags;
 use network_primitives::services::ServiceFlags;

--- a/mnemonic/src/lib.rs
+++ b/mnemonic/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate nimiq_hash as hash;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_utils as utils;
 
@@ -13,6 +12,7 @@ use unicode_normalization::UnicodeNormalization;
 
 use hash::{Hasher, Sha256Hasher};
 use hash::pbkdf2::{compute_pbkdf2_sha512, Pbkdf2Error};
+use macros::{add_hex_io_fns_typed_arr, create_typed_array};
 use utils::bit_vec::IntoChunkedBitVecIterator;
 use utils::crc::Crc8Computer;
 

--- a/network-primitives/src/lib.rs
+++ b/network-primitives/src/lib.rs
@@ -15,10 +15,7 @@ extern crate nimiq_hash as hash;
 extern crate nimiq_bls as bls;
 extern crate nimiq_block_albatross as block_albatross;
 extern crate nimiq_account as account;
-#[macro_use]
-extern crate nimiq_hash_derive;
-#[macro_use]
-extern crate lazy_static;
+extern crate nimiq_hash_derive as hash_derive;
 
 #[cfg(feature = "address")]
 pub mod address;

--- a/network-primitives/src/networks.rs
+++ b/network-primitives/src/networks.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use keys::PublicKey;
 use hex::FromHex;
 use account::AccountsList;
+use lazy_static::lazy_static;
 
 
 #[derive(Clone, Debug)]

--- a/network-primitives/src/validator_info.rs
+++ b/network-primitives/src/validator_info.rs
@@ -4,6 +4,7 @@ use beserial::{Serialize, Deserialize};
 use block_albatross::signed::{SignedMessage, PREFIX_VALIDATOR_INFO, Message};
 use bls::bls12_381::CompressedPublicKey;
 use hash::SerializeContent;
+use hash_derive::SerializeContent;
 
 use crate::address::peer_address::PeerAddress;
 

--- a/network/src/address/peer_address_book.rs
+++ b/network/src/address/peer_address_book.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant, SystemTime};
 
+use macros::upgrade_weak;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use rand::{Rng, rngs::OsRng};
 

--- a/network/src/connection/connection_pool.rs
+++ b/network/src/connection/connection_pool.rs
@@ -8,6 +8,7 @@ use parking_lot::{ReentrantMutex, RwLock, RwLockReadGuard};
 
 use blockchain_base::AbstractBlockchain;
 use collections::SparseVec;
+use macros::upgrade_weak;
 use network_messages::SignalMessage;
 use network_primitives::address::net_address::{NetAddress, NetAddressType};
 use network_primitives::address::peer_address::PeerAddress;

--- a/network/src/connection/network_agent.rs
+++ b/network/src/connection/network_agent.rs
@@ -10,6 +10,7 @@ use rand::{Rng, rngs::OsRng};
 
 use beserial::Serialize;
 use blockchain_base::AbstractBlockchain;
+use macros::upgrade_weak;
 use network_messages::*;
 use network_primitives::address::peer_address::PeerAddress;
 use network_primitives::address::PeerId;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -3,7 +3,6 @@ extern crate log;
 
 #[macro_use]
 extern crate beserial_derive;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_messages as network_messages;
 extern crate nimiq_network_primitives as network_primitives;

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use atomic::Atomic;
 use atomic::Ordering;
+use macros::upgrade_weak;
 use parking_lot::RwLock;
 use parking_lot::RwLockReadGuard;
 use rand::Rng;

--- a/primitives/account/src/staking_contract.rs
+++ b/primitives/account/src/staking_contract.rs
@@ -6,14 +6,11 @@ use std::sync::Arc;
 
 use beserial::{Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength, SerializingError, WriteBytesExt};
 use bls::bls12_381::CompressedPublicKey as BlsPublicKey;
-use bls::bls12_381::CompressedSignature as BlsSignature;
-use hash::Blake2bHash;
 use keys::Address;
 use primitives::{policy, coin::Coin};
 use primitives::slot::{Slots, SlotsBuilder};
 use transaction::{SignatureProof, Transaction};
 use transaction::account::staking_contract::{StakingTransactionData, StakingTransactionType};
-use utils::hash_rng::HashRng;
 use vrf::{VrfSeed, VrfUseCase, AliasMethod};
 
 use crate::{Account, AccountError, AccountTransactionInteraction, AccountType};

--- a/primitives/block-albatross/src/block.rs
+++ b/primitives/block-albatross/src/block.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 use block_base;
 use hash::{Blake2bHash, Hash, SerializeContent};
+use hash_derive::SerializeContent;
 use primitives::networks::NetworkId;
 use transaction::Transaction;
 use vrf::VrfSeed;

--- a/primitives/block-albatross/src/lib.rs
+++ b/primitives/block-albatross/src/lib.rs
@@ -9,7 +9,6 @@ extern crate nimiq_block_base as block_base;
 extern crate nimiq_bls as bls;
 extern crate nimiq_collections as collections;
 extern crate nimiq_hash as hash;
-#[macro_use]
 extern crate nimiq_hash_derive as hash_derive;
 extern crate nimiq_keys as keys;
 extern crate nimiq_primitives as primitives;

--- a/primitives/block-albatross/src/macro_block.rs
+++ b/primitives/block-albatross/src/macro_block.rs
@@ -5,7 +5,6 @@ use std::io;
 use failure::Fail;
 
 use beserial::{Deserialize, Serialize};
-use bls::bls12_381::CompressedSignature;
 use collections::bitset::BitSet;
 use hash::{Blake2bHash, Hash, SerializeContent};
 use primitives::slot::{Slots, ValidatorSlots, StakeSlots};

--- a/primitives/block-albatross/src/micro_block.rs
+++ b/primitives/block-albatross/src/micro_block.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 
 use beserial::{Deserialize, Serialize};
 use hash::{Hash, Blake2bHash, SerializeContent};
+use hash_derive::SerializeContent;
 use primitives::networks::NetworkId;
 use bls::bls12_381::CompressedSignature;
 use transaction::Transaction;

--- a/primitives/block-albatross/src/pbft.rs
+++ b/primitives/block-albatross/src/pbft.rs
@@ -1,6 +1,7 @@
 use beserial::{Deserialize, Serialize};
 use bls::bls12_381::PublicKey;
 use hash::{Blake2bHash, SerializeContent};
+use hash_derive::SerializeContent;
 use primitives::slot::ValidatorSlots;
 
 use crate::ViewChangeProof;

--- a/primitives/block-albatross/src/view_change.rs
+++ b/primitives/block-albatross/src/view_change.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use beserial::{Deserialize, Serialize};
 
 use hash::SerializeContent;
+use hash_derive::SerializeContent;
 use super::signed;
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, SerializeContent, Hash)]

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -8,7 +8,6 @@ extern crate nimiq_account as account;
 extern crate nimiq_block_base as block_base;
 extern crate nimiq_hash as hash;
 extern crate nimiq_keys as keys;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_primitives as primitives;
 extern crate nimiq_transaction as transaction;

--- a/primitives/block/src/target.rs
+++ b/primitives/block/src/target.rs
@@ -6,6 +6,7 @@ use num_bigint::BigUint;
 use beserial::{Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength, SerializingError, WriteBytesExt};
 use fixed_unsigned::types::FixedUnsigned10;
 use hash::Argon2dHash;
+use macros::create_typed_array;
 use primitives::policy;
 
 /// Compact Target (represented internally as `u32`)

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use beserial::{Deserialize, Serialize};
+use enum_display_derive::Display;
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Display)]
 #[repr(u8)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,16 +3,8 @@ extern crate beserial_derive;
 #[cfg(feature = "failure")]
 #[macro_use]
 extern crate failure;
-#[macro_use]
-extern crate log;
-#[cfg(feature = "lazy_static")]
-#[macro_use]
-extern crate lazy_static;
 #[cfg(feature = "nimiq-macros")]
 extern crate nimiq_macros;
-#[cfg(feature = "enum-display-derive")]
-#[macro_use]
-extern crate enum_display_derive;
 
 #[cfg(feature = "coin")]
 pub mod coin;

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use num_traits::pow;
 use parking_lot::RwLock;

--- a/primitives/tests/coin/mod.rs
+++ b/primitives/tests/coin/mod.rs
@@ -1,4 +1,5 @@
 use beserial::{Serialize, Deserialize, SerializingError};
+use lazy_static::lazy_static;
 use primitives::coin::{Coin, CoinParseError};
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;

--- a/primitives/tests/mod.rs
+++ b/primitives/tests/mod.rs
@@ -1,7 +1,4 @@
 extern crate nimiq_primitives as primitives;
-#[cfg(feature = "lazy_static")]
-#[macro_use]
-extern crate lazy_static;
 #[cfg(feature = "fixed-unsigned")]
 extern crate fixed_unsigned;
 

--- a/primitives/transaction/src/account/htlc_contract.rs
+++ b/primitives/transaction/src/account/htlc_contract.rs
@@ -1,9 +1,11 @@
 use std::fmt::Display;
 
 use beserial::{Deserialize, Serialize};
+use enum_display_derive::Display;
 use hash::{Blake2bHasher, Hasher, Sha256Hasher};
 use hex::FromHex;
 use keys::Address;
+use macros::{add_hex_io_fns_typed_arr, create_typed_array};
 use primitives::account::AccountType;
 
 use crate::{Transaction, TransactionError, TransactionFlags};

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -1,16 +1,10 @@
-extern crate beserial;
 #[macro_use]
 extern crate beserial_derive;
 #[macro_use]
-extern crate bitflags;
-#[macro_use]
 extern crate log;
-#[macro_use]
-extern crate enum_display_derive;
 extern crate nimiq_bls as bls;
 extern crate nimiq_hash as hash;
 extern crate nimiq_keys as keys;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_primitives as primitives;
 extern crate nimiq_utils as utils;
@@ -19,6 +13,7 @@ use std::cmp::{Ord, Ordering};
 use std::io;
 use std::sync::Arc;
 
+use bitflags::bitflags;
 use failure::Fail;
 
 use beserial::{Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength, SerializingError, WriteBytesExt};

--- a/rpc-server/src/handlers/block_production_albatross.rs
+++ b/rpc-server/src/handlers/block_production_albatross.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use std::string::ToString;
 
-use json::JsonValue;
+use json::{JsonValue, object};
 
 use validator::validator::Validator;
 

--- a/rpc-server/src/handlers/block_production_nimiq.rs
+++ b/rpc-server/src/handlers/block_production_nimiq.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use json::{JsonValue, Null};
+use json::{JsonValue, Null, object};
 
 use beserial::{Deserialize, Serialize};
 use block::{Block, BlockHeader};

--- a/rpc-server/src/handlers/blockchain.rs
+++ b/rpc-server/src/handlers/blockchain.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use json::{Array, JsonValue, Null};
+use json::{Array, JsonValue, Null, object};
 
 use block_base::{Block, BlockHeader};
 use blockchain_base::AbstractBlockchain;

--- a/rpc-server/src/handlers/blockchain_albatross.rs
+++ b/rpc-server/src/handlers/blockchain_albatross.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::convert::TryInto;
 use std::sync::Arc;
 
-use json::{JsonValue, Null};
+use json::{JsonValue, Null, object};
 
 use block_albatross::{Block, ForkProof, signed};
 use account::Account;
@@ -120,7 +120,7 @@ impl BlockchainAlbatrossHandler {
     pub(crate) fn get_slot_at(&self, params: &[JsonValue]) -> Result<JsonValue, JsonValue> {
         // Parse block number argument
         let block_number = params.get(0)
-            .ok_or_else(||object!{"message" => "First argument must be block number"})
+            .ok_or_else(|| object!{"message" => "First argument must be block number"})
             .and_then(|n| self.generic.parse_block_number(n))?;
 
         // Check if it's not a macro block

--- a/rpc-server/src/handlers/blockchain_nimiq.rs
+++ b/rpc-server/src/handlers/blockchain_nimiq.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use json::{JsonValue, Null};
+use json::{JsonValue, Null, object};
 
 use beserial::{Deserialize, Serialize};
 use block::Block;

--- a/rpc-server/src/handlers/mempool.rs
+++ b/rpc-server/src/handlers/mempool.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use json::{Array, JsonValue, Null};
+use json::{Array, JsonValue, Null, object};
 use json::object::Object;
 use parking_lot::RwLock;
 

--- a/rpc-server/src/handlers/mempool_albatross.rs
+++ b/rpc-server/src/handlers/mempool_albatross.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use beserial::{Deserialize, Serialize};
-use json::{JsonValue, Null};
+use json::{JsonValue, Null, object};
 use parking_lot::RwLock;
 
 use blockchain_albatross::Blockchain;

--- a/rpc-server/src/handlers/network.rs
+++ b/rpc-server/src/handlers/network.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use json::{Array, JsonValue, Null};
+use json::{Array, JsonValue, Null, object};
 
 use blockchain_base::AbstractBlockchain;
 use consensus::{ConsensusProtocol, Consensus};

--- a/rpc-server/src/handlers/wallet.rs
+++ b/rpc-server/src/handlers/wallet.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use hex;
-use json::{JsonValue, Null};
+use json::{JsonValue, Null, object};
 use parking_lot::RwLock;
 
 use beserial::{Deserialize, Serialize};

--- a/rpc-server/src/jsonrpc.rs
+++ b/rpc-server/src/jsonrpc.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use futures::{future, Future, IntoFuture, stream::Stream};
 use hyper::{Body, Method, Request, Response, StatusCode};
 use hyper::header::HeaderValue;
-use json::{Array, JsonValue, Null};
+use json::{Array, JsonValue, Null, array, object};
 
 use crate::error::AuthenticationError;
 

--- a/rpc-server/src/lib.rs
+++ b/rpc-server/src/lib.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate json;
-
-#[macro_use]
 extern crate log;
 extern crate nimiq_account as account;
 extern crate nimiq_block as block;
@@ -27,7 +24,7 @@ use std::sync::Arc;
 
 use futures::future::Future;
 use hyper::Server;
-use json::JsonValue;
+use json::{JsonValue, object};
 
 use crate::error::Error;
 pub use crate::handler::Handler;

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-extern crate clap;
-extern crate failure;
-extern crate hex;
-extern crate beserial;
 extern crate nimiq_transaction as transaction;
 extern crate nimiq_keys as keys;
 extern crate nimiq_primitives as primitives;
@@ -11,7 +6,7 @@ use std::io::stdin;
 use std::process::exit;
 use std::str::FromStr;
 use failure::Fail;
-use clap::{App, Arg};
+use clap::{App, Arg, crate_version, crate_authors, crate_description};
 use keys::{PrivateKey, KeyPair, Address};
 use transaction::Transaction;
 use beserial::{Serialize, Deserialize};

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -2,7 +2,6 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate nimiq_macros as macros;
 extern crate nimiq_handel as handel;
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -32,6 +32,7 @@ use blockchain_base::BlockchainEvent;
 use bls::bls12_381::KeyPair;
 use consensus::{AlbatrossConsensusProtocol, Consensus, ConsensusEvent};
 use hash::{Blake2bHash, Hash};
+use macros::upgrade_weak;
 use network_primitives::networks::NetworkInfo;
 use network_primitives::validator_info::{SignedValidatorInfo, ValidatorInfo};
 use utils::mutable_once::MutableOnce;

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use byteorder::{WriteBytesExt, ReadBytesExt, BigEndian};
 
-use hash::{Blake2bHash, Blake2bHasher, Hasher, HashOutput};
+use hash::{Blake2bHash, Blake2bHasher, Hasher};
 use beserial::{Serialize, Deserialize};
 use bls::bls12_381::{CompressedSignature, PublicKey, SecretKey};
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,8 +1,5 @@
-extern crate hex;
-
 #[macro_use]
 extern crate beserial_derive;
-extern crate beserial;
 extern crate nimiq_keys as keys;
 extern crate nimiq_key_derivation as key_derivation;
 extern crate nimiq_primitives as primitives;

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate lazy_static;
+use lazy_static::lazy_static;
 
 extern crate beserial;
 extern crate nimiq_wallet as wallet;

--- a/ws-rpc-server/src/lib.rs
+++ b/ws-rpc-server/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate json;
 
 extern crate nimiq_consensus as consensus;
 extern crate nimiq_utils as utils;
@@ -23,7 +21,7 @@ use tokio::net::{TcpListener};
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::{Message, Error as WsError};
 use parking_lot::RwLock;
-use json::JsonValue;
+use json::{JsonValue, object};
 
 use utils::unique_id::UniqueId;
 use consensus::{Consensus, AlbatrossConsensusProtocol};


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs. (including script/test_features.py)
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Since Rust Edition 2018, most macros can be imported via `use`.
This PR switches most macro imports from  `#[macro_use]` to `use`