### PR TITLE
Fix deadlock detection

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,7 +31,7 @@ human-panic = { version = "1.0", optional = true }
 lazy_static = "1.4"
 log = "0.4"
 log-panics = { version = "2.0", features = ["with-backtrace"], optional = true }
-parking_lot = { version = "0.7", features = ["deadlock_detection"], optional = true }
+parking_lot = { version = "0.9", features = ["deadlock_detection"], optional = true }
 paw = "1.0"
 rand = "0.7"
 rand04_compat = "0.1"


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

The version for `parking_lot` in `nimiq-lib` didn't match the version used everywhere else. Therefore the deadlock detection wasn't enabled anywhere.