### PR TITLE
Give up read lock in all if branches

### DIFF
--- a/consensus/src/inventory.rs
+++ b/consensus/src/inventory.rs
@@ -574,6 +574,10 @@ impl<P: ConsensusProtocol + 'static> InventoryAgent<P> {
             warn!("We're not subscribed to this transaction from {} - discarding and closing the channel", self.peer.peer_address());
             self.peer.channel.close(CloseType::ReceivedTransactionNotMatchingOurSubscription);
         }
+        else {
+            // Give up read lock.
+            drop(state);
+        }
 
         // Mark object as received.
         self.on_object_received(&vector);


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.

#### This fixes issue #106 .

## What's in this pull request?

`InventoryAgent::on_tx` has a read-lock on the state. If the agent is currently unsubscribed it didn't drop the state lock before calling `self.on_object_received`. This pull request fixes that.
