### PR TITLE
WIP: Fix timer issues

### DIFF
--- a/consensus/src/consensus_agent/mod.rs
+++ b/consensus/src/consensus_agent/mod.rs
@@ -459,6 +459,7 @@ impl<P: ConsensusProtocol + 'static> ConsensusAgent<P> {
 
     fn out_of_sync(&self) {
         self.timers.clear_delay(&ConsensusAgentTimer::ResyncThrottle);
+        self.timers.clear_delay(&ConsensusAgentTimer::Mempool);
 
         self.state.write().synced = false;
 


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes issue #102.

## What's in this pull request?

# `ConsensusAgent`

When the consensus agent finishes a sync, it sets a timer to request the mempool of the peer. This fix also clears the timer when the agent goes out of sync.

# `InventoryManager`

There is a duplicate timer issue when requesting an inventory vector:
```
logs/devnet_validator.4.ul1icdeypqka9t8nergz7fmo0.log: 2019-12-16 21:28:41.574 ERROR timers               | Duplicate delay for key Request(InvVector { ty: Transaction, hash: c2b4a4d11e7c22e2ff8e1a60ac82969ddaeb5757f0083a519f4e977258136cb7 })
```

TODO: Fix this