### PR TITLE
tokio-compat client and metrics-server

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,9 +18,12 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"
+futures_1 = { version = "0.1", package = "futures" }
 log = "0.4"
-tokio = "0.1"
+tokio = { version = "0.2", features = ["time"] }
+tokio_1 = { version = "0.1", package = "tokio" }
+tokio-compat = "0.1"
 
 [dependencies.nimiq-lib]
 path = "../lib"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -7,9 +7,9 @@ extern crate nimiq_lib as nimiq;
 use std::convert::TryFrom;
 use std::time::Duration;
 
-use futures::{future, Future, Stream, IntoFuture};
+use futures::{FutureExt, StreamExt};
+use futures_1::IntoFuture;
 use tokio;
-use tokio::timer::Interval;
 
 use nimiq::prelude::*;
 use nimiq::config::config::ProtocolConfig;
@@ -48,88 +48,76 @@ fn main_inner() -> Result<(), Error> {
 
     // We need to instantiate the client when the tokio runtime is already alive, so we use
     // a lazy future for it.
-    tokio::run(
-        // TODO: Return this from `Client::into_future()`
-        future::lazy(move || {
-            // TODO: This is the initialization future
+    tokio_compat::run_std(async move {
+        // Clone those now, because we pass ownership of config to Client
+        let protocol_config = config.protocol.clone();
+        let rpc_config = config.rpc_server.clone();
+        let metrics_config = config.metrics_server.clone();
+        let ws_rpc_config = config.ws_rpc_server.clone();
 
-            // Clone those now, because we pass ownership of config to Client
-            let protocol_config = config.protocol.clone();
-            let rpc_config = config.rpc_server.clone();
-            let metrics_config = config.metrics_server.clone();
-            let ws_rpc_config = config.ws_rpc_server.clone();
+        // Create client from config
+        info!("Initializing client");
+        let client: Client = Client::try_from(config)?;
+        client.initialize()?;
 
-            // Create client from config
-            info!("Initializing client");
-            let client: Client = Client::try_from(config)?;
-            client.initialize()?;
+        // Initialize RPC server
+        if let Some(rpc_config) = rpc_config {
+            use nimiq::extras::rpc_server::initialize_rpc_server;
+            let rpc_server = initialize_rpc_server(&client, rpc_config)
+                .expect("Failed to initialize RPC server");
+            tokio_1::spawn(rpc_server.into_future());
+        }
 
-            // Initialize RPC server
-            if let Some(rpc_config) = rpc_config {
-                use nimiq::extras::rpc_server::initialize_rpc_server;
-                let rpc_server = initialize_rpc_server(&client, rpc_config)
-                    .expect("Failed to initialize RPC server");
-                tokio::spawn(rpc_server.into_future());
-            }
-
-            // Initialize metrics server
-            if let Some(mut metrics_config) = metrics_config {
-                // FIXME: Use network TLS settings here
-                if metrics_config.tls_credentials.is_none() {
-                    if let ProtocolConfig::Wss{ tls_credentials, .. } = protocol_config {
-                        metrics_config.tls_credentials = Some(tls_credentials);
-                    }
+        // Initialize metrics server
+        if let Some(mut metrics_config) = metrics_config {
+            // FIXME: Use network TLS settings here
+            if metrics_config.tls_credentials.is_none() {
+                if let ProtocolConfig::Wss { tls_credentials, .. } = protocol_config {
+                    metrics_config.tls_credentials = Some(tls_credentials);
                 }
-
-                // FIXME
-                unimplemented!("Can't run std::future::Future with the Tokio we currently use here");
-                //tokio::spawn(client.metrics_server(metrics_config));
             }
+            tokio::spawn(client.clone().metrics_server(metrics_config));
+        }
 
-            // Initialize Websocket RPC server
-            // TODO: Configuration
-            if let Some(ws_rpc_config) = ws_rpc_config {
-                use nimiq::extras::ws_rpc_server::initialize_ws_rcp_server;
-                let ws_rpc_server = initialize_ws_rcp_server(&client, ws_rpc_config)
-                    .expect("Failed to initialize websocket RPC server");
-                tokio::spawn(ws_rpc_server.into_future());
+        // Initialize Websocket RPC server
+        // TODO: Configuration
+        if let Some(ws_rpc_config) = ws_rpc_config {
+            use nimiq::extras::ws_rpc_server::initialize_ws_rcp_server;
+            let ws_rpc_server = initialize_ws_rcp_server(&client, ws_rpc_config)
+                .expect("Failed to initialize websocket RPC server");
+            tokio_1::spawn(ws_rpc_server.into_future());
+        }
+
+        // Initialize network stack and connect
+        info!("Connecting to network");
+
+        client.connect()?;
+
+        // The Nimiq client is now running and we can access it trough the `client` object.
+
+        // Periodically show some info
+        let mut statistics_interval = config_file.log.statistics;
+        let mut show_statistics = true;
+        if statistics_interval == 0 {
+            statistics_interval = 10;
+            show_statistics = false;
+        }
+
+        let mut interval = tokio::time::interval(Duration::from_secs(statistics_interval));
+        while let Some(_) = interval.next().await {
+            if show_statistics {
+                let peer_count = client.network().connections.peer_count();
+                let head = client.blockchain().head().clone();
+                info!("Head: #{} - {}, Peers: {}", head.block_number(), head.hash(), peer_count);
             }
+        }
 
-            // Initialize network stack and connect
-            info!("Connecting to network");
-
-            client.connect()?;
-
-            // The Nimiq client is now running and we can access it trough the `client` object.
-
-            // TODO: RPC server and metrics server need to be instantiated here
-            Ok(client)
-        })
-            .and_then(move |client| {
-                // NOTE: This is the "monitor" future, which keeps the Client object alive.
-
-                let mut statistics_interval = config_file.log.statistics;
-                let mut show_statistics = true;
-                if statistics_interval == 0 {
-                    statistics_interval = 10;
-                    show_statistics = false;
-                }
-
-                // Run this periodically and optionally show some info
-                Interval::new_interval(Duration::from_secs(statistics_interval))
-                    .map_err(|e| panic!("Timer failed: {}", e))
-                    .for_each(move |_| {
-
-                        if show_statistics {
-                            let peer_count = client.network().connections.peer_count();
-                            let head = client.blockchain().head().clone();
-                            info!("Head: #{} - {}, Peers: {}", head.block_number(), head.hash(), peer_count);
-                        }
-
-                        future::ok::<(), Error>(())
-                    })
-            })
-            .map_err(|e: Error| warn!("{}", e)));
+        Ok(())
+    }.map(|res: Result<(), Error>| {
+        if let Err(e) = res {
+            log_error_cause_chain(&e);
+        }
+    }));
 
     Ok(())
 }

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -65,11 +65,11 @@ impl TryFrom<ClientConfig> for ClientInner {
             ProtocolConfig::Ws { host, port } => {
                 NetworkConfig::new_ws_network_config(host, port, false, config.reverse_proxy)
             },
-            ProtocolConfig::Wss { host, port, pkcs12_key_file, pkcs12_passphrase } => {
-                let pkcs12_key_file = pkcs12_key_file.to_str()
-                    .unwrap_or_else(|| panic!("Failed to convert path to PKCS#12 key file to string: {}", pkcs12_key_file.display()))
+            ProtocolConfig::Wss { host, port, tls_credentials } => {
+                let key_file = tls_credentials.key_file.to_str()
+                    .unwrap_or_else(|| panic!("Failed to convert path to PKCS#12 key file to string: {}", tls_credentials.key_file.display()))
                     .to_string();
-                NetworkConfig::new_wss_network_config(host, port, false, pkcs12_key_file, pkcs12_passphrase)
+                NetworkConfig::new_wss_network_config(host, port, false, key_file, tls_credentials.passphrase)
             }
         };
 

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -56,6 +56,24 @@ impl Default for ConsensusConfig {
 }
 
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct PKCS12Credentials {
+    /// Path to your PKCS#12 key file, that contains private key and certificate.
+    ///
+    /// # Notes
+    ///
+    /// Only PKCS#12 is supported right now, but it is planned to move away from this and use
+    /// the PEM format for certificate and private key.
+    ///
+    pub key_file: PathBuf,
+
+    /// PKCS#12 is always encrypted, therefore you must provide a password for Nimiq to be able
+    /// to access your SSL private key.
+    ///
+    pub passphrase: String,
+}
+
+
 /// Contains which protocol to use and the configuration needed for that protocol.
 ///
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -92,19 +110,8 @@ pub enum ProtocolConfig {
         ///
         port: u16,
 
-        /// Path to your PKCS#12 key file, that contains private key and certificate.
-        ///
-        /// # Notes
-        ///
-        /// Only PKCS#12 is supported right now, but it is planned to move away from this and use
-        /// the PEM format for certificate and private key.
-        ///
-        pkcs12_key_file: PathBuf,
-
-        /// PKCS#12 is always encrypted, therefore you must provide a password for Nimiq to be able
-        /// to access your SSL private key.
-        ///
-        pkcs12_passphrase: String,
+        /// The PKCS#12 key file and its password
+        tls_credentials: PKCS12Credentials,
     },
 
     /// Accept incoming connections over WebRTC
@@ -439,6 +446,9 @@ pub struct MetricsServerConfig {
     /// If specified, require HTTP basic auth with these credentials
     #[builder(setter(strip_option))]
     pub credentials: Option<Credentials>,
+
+    /// If specified, use this to encrypt the metrics server
+    pub tls_credentials: Option<PKCS12Credentials>,
 }
 
 /// Client configuration
@@ -635,8 +645,10 @@ impl ClientConfigBuilder {
         self.protocol(ProtocolConfig::Wss {
             host: host.into(),
             port: port.into().unwrap_or(consts::WS_DEFAULT_PORT),
-            pkcs12_key_file: pkcs12_key_file.into(),
-            pkcs12_passphrase: pkcs12_passphrase.into(),
+            tls_credentials: PKCS12Credentials {
+                key_file: pkcs12_key_file.into(),
+                passphrase: pkcs12_passphrase.into(),
+            },
         })
     }
 
@@ -718,8 +730,10 @@ impl ClientConfigBuilder {
                         .ok_or_else(|| Error::config_error("Hostname not set."))?,
                     port: config_file.network.port.clone()
                         .unwrap_or(consts::WS_DEFAULT_PORT),
-                    pkcs12_key_file: PathBuf::from(tls.identity_file),
-                    pkcs12_passphrase: tls.identity_password,
+                    tls_credentials: PKCS12Credentials {
+                        key_file: PathBuf::from(tls.identity_file),
+                        passphrase: tls.identity_password,
+                    },
                 }
             },
             config_file::Protocol::Rtc => ProtocolConfig::Rtc,
@@ -834,6 +848,7 @@ impl ClientConfigBuilder {
                     bind_to,
                     port: metrics_config.port.unwrap_or(consts::METRICS_DEFAULT_PORT),
                     credentials,
+                    tls_credentials: None, // TODO
                 }));
             }
         }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -13,6 +13,8 @@ use consensus::Error as ConsensusError;
 use validator::error::Error as ValidatorError;
 #[cfg(feature="rpc-server")]
 use rpc_server::error::Error as RpcServerError;
+#[cfg(feature="metrics-server")]
+use metrics_server::error::Error as MetricsServerError;
 
 
 #[derive(Debug, Fail)]
@@ -46,8 +48,12 @@ pub enum Error {
     #[fail(display = "RPC server error: {}", _0)]
     RpcServer(#[cause] RpcServerError),
 
+    #[cfg(feature="metrics-server")]
+    #[fail(display = "Metrics server error: {}", _0)]
+    MetricsServer(#[cause] MetricsServerError),
+
     #[fail(display = "Logger error: {}", _0)]
-    Logging(#[cause] SetLoggerError)
+    Logging(#[cause] SetLoggerError),
 }
 
 impl Error {
@@ -118,6 +124,13 @@ impl From<ValidatorError> for Error {
 impl From<RpcServerError> for Error {
     fn from(e: RpcServerError) -> Self {
         Self::RpcServer(e)
+    }
+}
+
+#[cfg(feature="metrics-server")]
+impl From<MetricsServerError> for Error {
+    fn from(e: MetricsServerError) -> Self {
+        Self::MetricsServer(e)
     }
 }
 

--- a/lib/src/extras/metrics_server.rs
+++ b/lib/src/extras/metrics_server.rs
@@ -9,7 +9,9 @@ use metrics_server::metrics::AlbatrossChainMetrics;
 
 
 impl Client {
-    pub async fn metrics_server(&self, config: MetricsServerConfig) -> Result<(), Error> {
+    pub async fn metrics_server(self, config: MetricsServerConfig) -> Result<(), Error> {
+        let consensus = self.consensus();
+
         let tls = config.tls_credentials
             .ok_or_else(|| Error::config_error("TLS credentials for metrics server missing."))?;
         let key_file = tls.key_file.to_str()
@@ -29,7 +31,7 @@ impl Client {
             password,
             key_file,
             &tls.passphrase,
-            self.consensus()
+            consensus,
         ).await?;
 
         Ok(())

--- a/lib/src/extras/metrics_server.rs
+++ b/lib/src/extras/metrics_server.rs
@@ -1,30 +1,37 @@
-use metrics_server::MetricsServer;
-use metrics_server::error::Error;
-use metrics_server::AlbatrossChainMetrics;
+use std::net::Ipv4Addr;
 
 use crate::config::config::MetricsServerConfig;
 use crate::client::Client;
-use crate::config::consts::default_bind;
+use crate::error::Error;
+
+use metrics_server::metrics_server;
+use metrics_server::metrics::AlbatrossChainMetrics;
 
 
-pub fn initialize_metrics_server(client: &Client, config: MetricsServerConfig, pkcs12_key_file: &str, pkcs12_passphrase: &str) -> Result<MetricsServer, Error> {
-    let ip = config.bind_to.unwrap_or_else(default_bind);
-    info!("Initializing metrics server: {}:{}", ip, config.port);
+impl Client {
+    pub async fn metrics_server(&self, config: MetricsServerConfig) -> Result<(), Error> {
+        let tls = config.tls_credentials
+            .ok_or_else(|| Error::config_error("TLS credentials for metrics server missing."))?;
+        let key_file = tls.key_file.to_str()
+            .ok_or_else(|| Error::config_error(format!("Invalid key file path: {}", tls.key_file.display())))?;
 
-    let (username, password) = if let Some(credentials) = config.credentials {
-        (Some(credentials.username), Some(credentials.password))
-    } else {
-        warn!("No password set for metrics server!");
-        (None, None)
-    };
+        let (username, password) = if let Some(credentials) = config.credentials {
+            (Some(credentials.username), Some(credentials.password))
+        }
+        else {
+            (None, None)
+        };
 
-     Ok(MetricsServer::new::<_, AlbatrossChainMetrics>(
-        ip,
-        config.port,
-        username,
-        password,
-        pkcs12_key_file,
-        pkcs12_passphrase,
-        client.consensus()
-    )?)
+        metrics_server::<_, AlbatrossChainMetrics>(
+            config.bind_to.unwrap_or_else(|| Ipv4Addr::new(127, 0, 0, 1).into()),
+            config.port,
+            username,
+            password,
+            key_file,
+            &tls.passphrase,
+            self.consensus()
+        ).await?;
+
+        Ok(())
+    }
 }

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -19,12 +19,12 @@ maintenance = { status = "experimental" }
 [dependencies]
 base64 = "0.10"
 failure = "0.1"
-futures = "0.1"
-hyper = "0.12"
+futures = "0.3"
+hyper = "0.13"
 log = "0.4"
 native-tls = "0.2"
-tokio = "0.1"
-tokio-tls = "0.2"
+tokio = { version = "0.2", features = ["tcp"] }
+tokio-tls = "0.3"
 
 beserial = { path = "../beserial", version = "0.1" }
 nimiq-block = { path = "../primitives/block", version = "0.1" }

--- a/metrics-server/src/error.rs
+++ b/metrics-server/src/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     IoError(#[cause] IoError),
     #[fail(display = "{}", _0)]
     NativeTlsError(#[cause] NativeTlsError),
+    #[fail(display = "{}", _0)]
+    HyperError(#[cause] hyper::Error),
 }
 
 impl From<IoError> for Error {
@@ -19,5 +21,11 @@ impl From<IoError> for Error {
 impl From<NativeTlsError> for Error {
     fn from(e: NativeTlsError) -> Self {
         Error::NativeTlsError(e)
+    }
+}
+
+impl From<hyper::Error> for Error {
+    fn from(e: hyper::Error) -> Self {
+        Error::HyperError(e)
     }
 }

--- a/metrics-server/src/metrics/mod.rs
+++ b/metrics-server/src/metrics/mod.rs
@@ -1,3 +1,7 @@
 pub(crate) mod chain;
 pub(crate) mod mempool;
 pub(crate) mod network;
+
+pub use self::chain::{AlbatrossChainMetrics, NimiqChainMetrics};
+pub use self::mempool::MempoolMetrics;
+pub use self::network::NetworkMetrics;


### PR DESCRIPTION
Two commits by @jgraef cherry-picked to latest albatross: 3ca84fa3d070f940052c0488e1c86ecae7e14535 and 7125b4275cd2f0c29d9a238af4e10d8c00e7fd01

## What's in this pull request?

 - Makes the `client` crate use the tokio-0.2 runtime, providing backwards-compatibility via tokio-compat. (Read more: https://tokio.rs/blog/2019-12-compat/)
 - Upgrades the metrics-server to tokio-0.2

The code looks good to me and `nimiq-devnet devnet-environments/test-two-validators` also works.