### PR TITLE
nimiq-bls: Print proof of knowledge

### DIFF
--- a/tools/src/bls/main.rs
+++ b/tools/src/bls/main.rs
@@ -16,4 +16,8 @@ fn main() {
     println!("# Secret Key:");
     println!();
     println!("{}", hex::encode(secret_key.serialize_to_vec()));
+    println!();
+    println!("# Proof Of Knowledge:");
+    println!();
+    println!("{}", hex::encode(&secret_key.sign(&public_key).compress()));
 }


### PR DESCRIPTION
Only usage of `nimiq-bls` I know of is in scripts/devnet_create.py but it's not affected by the changes.