### PR TITLE
Bump Bitvec to 0.17

### DIFF
--- a/beserial/Cargo.toml
+++ b/beserial/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-bitvec = { version = "0.15", optional = true }
+bitvec = { version = "0.17", optional = true }
 byteorder = "1.2"
 failure = "0.1"
 num = "0.2"

--- a/beserial/src/bitvec.rs
+++ b/beserial/src/bitvec.rs
@@ -1,4 +1,4 @@
-use bitvec::prelude::{BitVec, Cursor};
+use bitvec::prelude::{BitVec, BitOrder};
 
 use crate::{SerializeWithLength, DeserializeWithLength, Serialize, Deserialize, WriteBytesExt, ReadBytesExt, SerializingError};
 
@@ -10,7 +10,7 @@ fn bits_to_bytes(lhs: usize) -> usize {
 }
 
 
-impl<C: Cursor> SerializeWithLength for BitVec<C, u8> {
+impl<O: BitOrder> SerializeWithLength for BitVec<O, u8> {
     fn serialize<S: Serialize + num::FromPrimitive, W: WriteBytesExt>(&self, writer: &mut W) -> Result<usize, SerializingError> {
         let mut size = 0;
 
@@ -39,7 +39,7 @@ impl<C: Cursor> SerializeWithLength for BitVec<C, u8> {
     }
 }
 
-impl<C: Cursor> DeserializeWithLength for BitVec<C, u8> {
+impl<O: BitOrder> DeserializeWithLength for BitVec<O, u8> {
     fn deserialize_with_limit<D: Deserialize + num::ToPrimitive, R: ReadBytesExt>(reader: &mut R, limit: Option<usize>) -> Result<Self, SerializingError> {
         // Deserialize the number if bits in the BitVec
         let n_bits = D::deserialize(reader)?
@@ -56,7 +56,7 @@ impl<C: Cursor> DeserializeWithLength for BitVec<C, u8> {
         data.resize(n_bytes, 0);
         reader.read_exact(data.as_mut_slice())?;
 
-        let mut bitvec: BitVec<C, u8> = BitVec::from(data);
+        let mut bitvec: BitVec<O, u8> = BitVec::from(data);
         bitvec.resize(n_bits, false);
         Ok(bitvec)
     }

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 bitflags = "1.0"
-bitvec = "0.15"
+bitvec = "0.17"
 byteorder = "1.2"
 hex = "0.4"
 log = "0.4"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-bitvec = "0.15"
+bitvec = "0.17"
 enum-display-derive = { version = "0.1", optional = true }
 failure = { version = "0.1", optional = true}
 hex = { version = "0.4", optional = true }

--- a/primitives/src/slot.rs
+++ b/primitives/src/slot.rs
@@ -51,7 +51,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use bitvec::prelude::BitVec;
-use bitvec::cursor::BigEndian;
+use bitvec::order::Msb0;
 use itertools::Itertools;
 
 use beserial::{Deserialize, Serialize, ReadBytesExt, WriteBytesExt, SerializingError, SerializeWithLength, DeserializeWithLength, uvar};
@@ -538,7 +538,7 @@ impl Serialize for StakeSlots {
         // it as as BitVec, so it only uses 1/8th of that.
         //
         // TODO: Replace with fixed-size BitVec
-        let reward_addresses: BitVec<BigEndian, u8> = BitVec::from_iter(self.iter()
+        let reward_addresses: BitVec<Msb0, u8> = BitVec::from_iter(self.iter()
             .map(|item| item.reward_address_opt.is_some()));
         SerializeWithLength::serialize::<uvar, W>(&reward_addresses, writer)?;
 
@@ -560,7 +560,7 @@ impl Serialize for StakeSlots {
 
         // Size of BitVec that encodes which reward addresses are custom
         // TODO: Replace with fixed-size BitVec
-        let reward_addresses: BitVec<BigEndian, u8> = BitVec::from_iter(self.iter()
+        let reward_addresses: BitVec<Msb0, u8> = BitVec::from_iter(self.iter()
             .map(|item| item.reward_address_opt.is_some()));
         size += SerializeWithLength::serialized_size::<uvar>(&reward_addresses);
 
@@ -583,7 +583,7 @@ impl Deserialize for StakeSlots {
         let allocation = allocation.as_vec();
 
         // Deserialize which reward addresses are set
-        let reward_addresses: BitVec = DeserializeWithLength::deserialize::<uvar, R>(reader)?;
+        let reward_addresses: BitVec<Msb0, u8> = DeserializeWithLength::deserialize::<uvar, R>(reader)?;
 
         // Deserialize addresses
         let mut slot_addresses = Vec::with_capacity(num_slot_addresses);
@@ -591,7 +591,7 @@ impl Deserialize for StakeSlots {
         for (i, num_slots) in allocation.into_iter().enumerate() {
             let staker_address: Address = Deserialize::deserialize(reader)?;
 
-            let reward_address: Option<Address> = if reward_addresses.get(i).unwrap_or_default() {
+            let reward_address: Option<Address> = if reward_addresses.get(i).copied().unwrap_or_default() {
                 let address = Deserialize::deserialize(reader)?;
                 if address == staker_address {
                     // This is an invalid encoding, as it needlessly bloats the block chain
@@ -668,7 +668,7 @@ impl fmt::Debug for SlotIndexTable {
 /// A compressed representation of repeated objects. This is used to encode the slot allocation
 /// of something that is a `NumSlotsCollection`
 struct SlotAllocation {
-    bits: BitVec<BigEndian, u8>,
+    bits: BitVec<Msb0, u8>,
 }
 
 impl SlotAllocation {
@@ -706,7 +706,7 @@ impl SlotAllocation {
         let mut total = 0;
 
         for b in &self.bits {
-            if b && count > 0 {
+            if *b && count > 0 {
                 num_slots.push(count);
                 total += count;
                 count = 1;

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -75,6 +75,10 @@ impl From<CompressedSignature> for VrfSeed {
     }
 }
 
+// Disable clippy error because the property "k1 == k2 -> hash(k1) == hash(k2)" is maintained here since PartialEq
+// derivation is based on all fields being equal (see https://doc.rust-lang.org/std/cmp/trait.PartialEq.html#derivable)
+// which implies that `self.signature.as_ref()` would be equal, and thus the hash value of it would be equal too
+#[allow(clippy::derive_hash_xor_eq)]
 impl Hash for VrfSeed {
     fn hash<H: StdHasher>(&self, state: &mut H) {
         self.signature.as_ref().hash(state)


### PR DESCRIPTION
It seems that older-than-current versions of Bitvec had a bug and they were yanked from crates.io (see https://github.com/myrrlyn/bitvec/issues/59).