### PR TITLE
Unpark validator automatically

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -82,7 +82,12 @@ impl TryFrom<ClientConfig> for ClientInner {
         // Initialize peer key
         config.storage.init_key_store(&mut network_config)?;
 
-        // Load validator key (before we give away ownership of the storage config
+        // Load transaction key (before we give away ownership of the storage config)
+        #[cfg(feature="validator")]
+        let transaction_key = config.storage.transaction_key()
+            .expect("Failed to load transaction key");
+
+        // Load validator key (before we give away ownership of the storage config)
         #[cfg(feature="validator")]
         let validator_key = config.storage.validator_key()
             .expect("Failed to load validator key");
@@ -114,7 +119,7 @@ impl TryFrom<ClientConfig> for ClientInner {
 
         #[cfg(feature="validator")]
         let validator = config.validator.map(|_config| {
-            Validator::new(Arc::clone(&consensus), validator_key)
+            Validator::new(Arc::clone(&consensus), validator_key, transaction_key)
         }).transpose()?;
 
         Ok(ClientInner {

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -52,6 +52,8 @@ pub struct ConfigFile {
     #[serde(default)]
     pub peer_key_file: Option<String>,
     #[serde(default)]
+    pub transaction: Option<TransactionSettings>,
+    #[serde(default)]
     pub validator: Option<ValidatorSettings>,
 }
 
@@ -528,6 +530,12 @@ impl From<MempoolFilterSettings> for MempoolRules {
             recipient_balance: f.recipient_balance,
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TransactionSettings {
+    pub key_file: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -33,12 +33,14 @@ nimiq-consensus = { path = "../consensus", version = "0.1" }
 nimiq-database = { path = "../database", version = "0.1", features = ["full-nimiq"] }
 nimiq-handel = { path = "../handel", version = "0.1" }
 nimiq-hash = { path = "../hash", version = "0.1" }
+nimiq-keys = { path = "../keys", version = "0.1" }
 nimiq-macros = { path = "../macros", version = "0.1" }
 nimiq-mempool = { path = "../mempool", version = "0.1" }
 nimiq-messages = { path = "../messages", version = "0.1" }
 nimiq-network = { path = "../network", version = "0.1" }
 nimiq-network-primitives = { path = "../network-primitives", version = "0.1", features = ["networks", "time"] }
 nimiq-primitives = { path = "../primitives", version = "0.1" }
+nimiq-transaction-builder = { path = "../transaction-builder", version = "0.1" }
 nimiq-utils = { path = "../utils", version = "0.1", features = ["observer", "timers", "mutable-once", "throttled-queue", "rate-limit"] }
 
 [features]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -21,6 +21,8 @@ extern crate nimiq_primitives as primitives;
 extern crate nimiq_blockchain_albatross as blockchain_albatross;
 extern crate nimiq_blockchain_base as blockchain_base;
 extern crate nimiq_block_production_albatross as block_production_albatross;
+extern crate nimiq_keys as keys;
+extern crate nimiq_transaction_builder as transaction_builder;
 
 pub mod validator;
 pub mod validator_network;


### PR DESCRIPTION
This PR enables validators to recognize when they are parked and, if they are, allows them to send an unpark signalling transaction.