### PR TITLE
Unpark validator automatically

### DIFF
--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -253,3 +253,15 @@ level = "debug"
 #creation_value = 0
 #sender_balance = 0
 #recipient_balance = 0
+
+##############################################################################
+##
+## Configure validator wallet
+##
+###############################################################################
+
+[validator]
+
+# Define
+# If the wallet private 
+#wallet_private_key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -534,4 +534,5 @@ impl From<MempoolFilterSettings> for MempoolRules {
 #[serde(deny_unknown_fields)]
 pub struct ValidatorSettings {
     pub key_file: Option<String>,
+    pub wallet_private_key: Option<String>,
 }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -33,12 +33,14 @@ nimiq-consensus = { path = "../consensus", version = "0.1" }
 nimiq-database = { path = "../database", version = "0.1", features = ["full-nimiq"] }
 nimiq-handel = { path = "../handel", version = "0.1" }
 nimiq-hash = { path = "../hash", version = "0.1" }
+nimiq-keys = { path = "../keys", version = "0.1" }
 nimiq-macros = { path = "../macros", version = "0.1" }
 nimiq-mempool = { path = "../mempool", version = "0.1" }
 nimiq-messages = { path = "../messages", version = "0.1" }
 nimiq-network = { path = "../network", version = "0.1" }
 nimiq-network-primitives = { path = "../network-primitives", version = "0.1", features = ["networks", "time"] }
 nimiq-primitives = { path = "../primitives", version = "0.1" }
+nimiq-transaction-builder = { path = "../transaction-builder", version = "0.1" }
 nimiq-utils = { path = "../utils", version = "0.1", features = ["observer", "timers", "mutable-once", "throttled-queue", "rate-limit"] }
 
 [features]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -21,6 +21,8 @@ extern crate nimiq_primitives as primitives;
 extern crate nimiq_blockchain_albatross as blockchain_albatross;
 extern crate nimiq_blockchain_base as blockchain_base;
 extern crate nimiq_block_production_albatross as block_production_albatross;
+extern crate nimiq_keys as keys;
+extern crate nimiq_transaction_builder as transaction_builder;
 
 pub mod validator;
 pub mod validator_network;

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -32,9 +32,13 @@ use blockchain_base::{AbstractBlockchain, BlockchainEvent};
 use bls::bls12_381::KeyPair;
 use consensus::{AlbatrossConsensusProtocol, Consensus, ConsensusEvent};
 use hash::{Blake2bHash, Hash};
+use keys::Address;
 use macros::upgrade_weak;
 use network_primitives::networks::NetworkInfo;
 use network_primitives::validator_info::{SignedValidatorInfo, ValidatorInfo};
+use primitives::coin::Coin;
+use primitives::policy;
+use transaction_builder::{Recipient, TransactionBuilder};
 use utils::mutable_once::MutableOnce;
 use utils::observer::ListenerHandle;
 use utils::timers::Timers;
@@ -69,6 +73,7 @@ pub struct Validator {
     consensus: Arc<Consensus<AlbatrossConsensusProtocol>>,
     pub validator_network: Arc<ValidatorNetwork>,
     pub validator_key: KeyPair,
+    pub validator_wallet_key: Option<keys::KeyPair>,
 
     timers: Timers<ValidatorTimer>,
 
@@ -97,7 +102,7 @@ impl Validator {
     const BLOCK_TIMEOUT: Duration = Duration::from_secs(10);
     //const PBFT_TIMEOUT: Duration = Duration::from_secs(60);
 
-    pub fn new(consensus: Arc<Consensus<AlbatrossConsensusProtocol>>, validator_key: KeyPair) -> Result<Arc<Self>, Error> {
+    pub fn new(consensus: Arc<Consensus<AlbatrossConsensusProtocol>>, validator_key: KeyPair, validator_wallet_key: Option<keys::KeyPair>) -> Result<Arc<Self>, Error> {
         let compressed_public_key = validator_key.public.compress();
         let info = ValidatorInfo {
             public_key: compressed_public_key,
@@ -118,6 +123,7 @@ impl Validator {
             validator_network,
 
             validator_key,
+            validator_wallet_key,
             timers: Timers::new(),
 
             state: RwLock::new(ValidatorState {
@@ -240,7 +246,7 @@ impl Validator {
         // Therefore we always update here.
         state.view_number = self.blockchain.next_view_number();
 
-        // clear out proposed extrinsics
+        // Clear out proposed extrinsics
         state.proposed_extrinsics.clear();
 
         if state.status == ValidatorStatus::Potential || state.status == ValidatorStatus::Active {
@@ -256,6 +262,37 @@ impl Validator {
             // NOTE: This might take the state lock, so we drop it here
             drop(state);
             self.on_slot_change(SlotChange::NextBlock);
+        }
+
+        if let Some(ref validator_wallet_key) = self.validator_wallet_key {
+            // If we're a parked validator with a wallet key, we signal to unpark automatically.
+            let validator_registry = NetworkInfo::from_network_id(self.blockchain.network_id).validator_registry_address().expect("Albatross consensus always has the address set.");
+
+            if self.is_parked(validator_registry) {
+                let mut recipient = Recipient::new_staking_builder(validator_registry.clone());
+                recipient.unpark_validator(&self.validator_key.public);
+
+                // Send the unpark transaction with a fixed height each epoch in case there's already a pushed unpark transaction.
+                // Note: If the validity window is ever less than an epoch's length, using the last macro block's height would require
+                // handling the case where the last macro block is more blocks away than the validity window inverval, since otherwise
+                // invalid transactions would be created.
+                let validity_start_height = policy::macro_block_before(self.consensus.mempool.current_height());
+
+                let mut tx_builder = TransactionBuilder::new();
+                tx_builder.with_sender(validator_registry.clone())
+                    .with_value(Coin::ZERO)
+                    .with_network_id(self.blockchain.network_id)
+                    .with_validity_start_height(validity_start_height)
+                    .with_recipient(recipient.generate().unwrap());
+
+                let mut proof_builder = tx_builder.generate().unwrap().unwrap_signalling();
+                proof_builder.sign_with_validator_key_pair(&self.validator_key);
+                let mut proof_builder = proof_builder.generate().unwrap().unwrap_basic();
+                proof_builder.sign_with_key_pair(validator_wallet_key);
+                let transaction = proof_builder.generate().unwrap();
+
+                self.consensus.mempool.push_transaction(transaction.clone());
+            }
         }
     }
 
@@ -613,6 +650,18 @@ impl Validator {
 
             // FIXME: Inefficient linear scan.
             contract.active_validators_by_key.contains_key(&public_key)
+        } else {
+            panic!("Validator registry has a wrong account type.");
+        }
+    }
+
+    fn is_parked(&self, validator_registry: &Address) -> bool {
+        let contract = self.blockchain.state().accounts().get(validator_registry, None);
+
+        if let Account::Staking(contract) = contract {
+            let public_key = self.validator_key.public.compress();
+
+            contract.current_epoch_parking.contains(&public_key) || contract.previous_epoch_parking.contains(&public_key)
         } else {
             panic!("Validator registry has a wrong account type.");
         }


### PR DESCRIPTION
Reopened the PR to use my local branch. These changes enable validators to recognize when they are parked and, if they are, allows them to send an unpark signalling transaction.