### PR TITLE
Use fee option for fee when creating tx via RPC

### DIFF
--- a/rpc-server/src/handlers/mempool.rs
+++ b/rpc-server/src/handlers/mempool.rs
@@ -284,8 +284,7 @@ pub(crate) fn obj_to_transaction(obj: &JsonValue, current_height: u32, network_i
         .ok_or_else(|| object! {"message" => "Invalid transaction value"})?)
         .map_err(|_| object! {"message" => "Invalid transaction value"})?;
 
-    // FIXME Wrong fee
-    let fee = Coin::try_from(obj["value"].as_u64()
+    let fee = Coin::try_from(obj["fee"].as_u64()
         .ok_or_else(|| object! {"message" => "Invalid transaction fee"})?)
         .map_err(|_| object! {"message" => "Invalid transaction fee"})?;
 


### PR DESCRIPTION
Somehow, instead of the option parameter `fee`, `value` was used for the fee. Someone even managed to put a `FIXME` comment next to it :smile: 