### PR TITLE
Add RPC validator signalling methods

### DIFF
--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -63,7 +63,7 @@ pub fn initialize_rpc_server(client: &Client, config: RpcServerConfig) -> Result
     let wallet_manager = Arc::clone(&wallet_handler.unlocked_wallets);
     handler.add_module(wallet_handler);
 
-    let mempool_handler = MempoolAlbatrossHandler::new(client.mempool(), Some(wallet_manager));
+    let mempool_handler = MempoolAlbatrossHandler::new(client.mempool(), client.validator(), Some(wallet_manager));
     handler.add_module(mempool_handler);
 
     Ok(rpc_server)

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -46,6 +46,7 @@ nimiq-network = { path = "../network", version = "0.1", features = ["metrics"] }
 nimiq-network-primitives = { path = "../network-primitives", version = "0.1" }
 nimiq-primitives = { path = "../primitives", version = "0.1" }
 nimiq-transaction = { path = "../primitives/transaction", version = "0.1" }
+nimiq-transaction-builder = { path = "../transaction-builder", version = "0.1" }
 nimiq-utils = { path = "../utils", version = "0.1", features = ["merkle", "time", "otp"] }
 nimiq-validator = { path = "../validator", version = "0.1", optional = true}
 nimiq-wallet = { path = "../wallet", version = "0.1" }

--- a/rpc-server/src/handlers/mempool_albatross.rs
+++ b/rpc-server/src/handlers/mempool_albatross.rs
@@ -232,6 +232,64 @@ impl MempoolAlbatrossHandler {
         self.generic.push_transaction(tx)
     }
 
+    /// Unpark validator
+    /// Parameters:
+    /// - sender_address: NIM address used to create this transaction
+    /// - validator_key: Public key of validator (BLS)
+    /// - fee: Fee for transaction in Luna
+    pub(crate) fn unpark_validator(&self, params: &[JsonValue]) -> Result<JsonValue, JsonValue> {
+        // Make sure a validator object is available
+        let validator = self.validator.as_ref().ok_or_else(|| object! {"message" => "No validator configured"})?;
+
+        let sender_address = Self::parse_address(params.get(0).unwrap_or(&Null), "sender")?;
+        let validator_key = params.get(1)
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| object! {"message" => "Invalid validator key"})
+            .and_then(|it| hex::decode(it)
+                .map_err(|_| object! {"message" => "Validator key must be hex-encoded"}))
+            .and_then(|it| CompressedPublicKey::deserialize_from_vec(&it)
+                .map_err(|_| object! {"message" => "Invalid public key"}))?;
+        let fee = params.get(2)
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0)
+            .try_into()
+            .map_err(|e| object! {"message" => format!("Invalid fee: {}", e)})?;
+
+        let network_id = self.mempool.network_id();
+        let staking_contract = NetworkInfo::from_network_id(network_id)
+            .validator_registry_address().unwrap();
+
+        let staking_data = IncomingStakingTransactionData::UnparkValidator {
+            validator_key,
+            signature: CompressedSignature::default(), // Placeholder for real signature
+        };
+
+        let mut tx = Transaction::new_signalling(
+            sender_address, AccountType::Basic,    // sender
+            staking_contract.clone(), AccountType::Staking, // recipient
+            Coin::ZERO, fee,                       // amount, fee
+            staking_data.serialize_to_vec(),       // data
+            self.mempool.current_height(),         // validity_start_height
+            network_id,                            // network_id
+        );
+
+        let signature = validator.validator_key.sign(&tx).compress();
+        tx.data = IncomingStakingTransactionData::set_validator_signature_on_data(
+            &tx.data, signature
+        ).unwrap();
+
+        // debug!("Transaction data: {:#?}", IncomingStakingTransactionData::deserialize(&mut tx.data)?);
+
+        let unlocked_wallets = self.unlocked_wallets.as_ref()
+            .ok_or_else(|| object! {"message" => "No wallets"})?;
+        let unlocked_wallets = unlocked_wallets.read();
+        let wallet_account = unlocked_wallets.get(&tx.sender)
+            .ok_or_else(|| object! {"message" => "Sender account is locked"})?;
+        wallet_account.sign_transaction(&mut tx);
+
+        self.generic.push_transaction(tx)
+    }
+
     /// Stakes NIM
     /// Parameters:
     /// - sender_address: NIM address used to deduct funds from
@@ -393,6 +451,7 @@ impl Module for MempoolAlbatrossHandler {
         "createValidator" => create_validator,
         "retireValidator" => retire_validator,
         "reactivateValidator" => reactivate_validator,
+        "unparkValidator" => unpark_validator,
         "stake" => stake,
         "retire" => retire,
         "unstake" => unstake,

--- a/rpc-server/src/handlers/mempool_albatross.rs
+++ b/rpc-server/src/handlers/mempool_albatross.rs
@@ -51,6 +51,13 @@ impl MempoolAlbatrossHandler {
                 .map_err(|_| object! {"message" => format!("Invalid {} address", kind)}))
     }
 
+    fn get_staking_contract_recipient(&self) -> StakingRecipientBuilder {
+        let staking_contract = NetworkInfo::from_network_id(self.mempool.network_id())
+            .validator_registry_address().unwrap();
+
+        Recipient::new_staking_builder(staking_contract.clone())
+    }
+
     /// Create validator
     /// Parameters:
     /// - sender_address: NIM address used to create this transaction
@@ -132,10 +139,7 @@ impl MempoolAlbatrossHandler {
             .try_into()
             .map_err(|e| object! {"message" => format!("Invalid fee: {}", e)})?;
 
-        let staking_contract = NetworkInfo::from_network_id(self.mempool.network_id())
-            .validator_registry_address().unwrap();
-
-        let mut recipient = Recipient::new_staking_builder(staking_contract.clone());
+        let mut recipient = self.get_staking_contract_recipient();
         recipient.retire_validator(&validator.validator_key.public);
 
         let tx = self.build_validator_signalling_transaction(sender, recipient, fee)?;
@@ -157,10 +161,7 @@ impl MempoolAlbatrossHandler {
             .try_into()
             .map_err(|e| object! {"message" => format!("Invalid fee: {}", e)})?;
 
-        let staking_contract = NetworkInfo::from_network_id(self.mempool.network_id())
-            .validator_registry_address().unwrap();
-
-        let mut recipient = Recipient::new_staking_builder(staking_contract.clone());
+        let mut recipient = self.get_staking_contract_recipient();
         recipient.reactivate_validator(&validator.validator_key.public);
 
         let tx = self.build_validator_signalling_transaction(sender, recipient, fee)?;
@@ -182,10 +183,7 @@ impl MempoolAlbatrossHandler {
             .try_into()
             .map_err(|e| object! {"message" => format!("Invalid fee: {}", e)})?;
 
-        let staking_contract = NetworkInfo::from_network_id(self.mempool.network_id())
-            .validator_registry_address().unwrap();
-
-        let mut recipient = Recipient::new_staking_builder(staking_contract.clone());
+        let mut recipient = self.get_staking_contract_recipient();
         recipient.unpark_validator(&validator.validator_key.public);
 
         let tx = self.build_validator_signalling_transaction(sender, recipient, fee)?;

--- a/rpc-server/src/handlers/mempool_albatross.rs
+++ b/rpc-server/src/handlers/mempool_albatross.rs
@@ -122,6 +122,9 @@ impl MempoolAlbatrossHandler {
     /// - validator_key: Public key of validator (BLS)
     /// - fee: Fee for transaction in Luna
     pub(crate) fn reactivate_validator(&self, params: &[JsonValue]) -> Result<JsonValue, JsonValue> {
+        // Make sure a validator object is available
+        let validator = self.validator.as_ref().ok_or_else(|| object! {"message" => "No validator configured"})?;
+
         let sender_address = Self::parse_address(params.get(0).unwrap_or(&Null), "sender")?;
         let validator_key = params.get(1)
             .and_then(JsonValue::as_str)
@@ -154,7 +157,7 @@ impl MempoolAlbatrossHandler {
             network_id,                            // network_id
         );
 
-        let signature = self.validator.as_ref().unwrap().validator_key.sign(&tx).compress();
+        let signature = validator.validator_key.sign(&tx).compress();
         tx.data = IncomingStakingTransactionData::set_validator_signature_on_data(
             &tx.data, signature
         ).unwrap();


### PR DESCRIPTION
There are lots of validator & staking related methods still missing in the RPC server. Most of them are for signalling transactions, which require a signature of the tx by the validator private key in their transaction data.

To create this signature, the mempool RPC handler needs to get a reference of the client's validator object.

This code here works and I was able to reactivate my validator with it (on first try!) :blush: 

**~~I have done this here without regarding that the validator is an `Option` (because the validator can be disabled in the config). Currently the `Option` is simply `unwrap`ped, which I understand will panic when the option is actually empty. Since I have no idea how to handle Options properly in Rust, I leave that part to the experts~~ :wink:**

### TODO
- [ ] Add comments to explain why we first add an empty signature, maybe refactor variable names?
- [x] Properly handle the `validator` argument as an `Option` (not simply `unwrap()`)
- [ ] Add test(s)?