### PR TITLE
Fix get_slot_at when the chain head is at a macro block

### DIFF
--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -1764,13 +1764,27 @@ impl Blockchain {
         };
 
         // Gets slots collection from either the cached ones, or from the macro block.
+        // Note: We need to handle the case where `state.block_number()` is at a macro block (so `state.current_slots`
+        // was already updated by it, pushing this epoch's slots to `state.previous_slots` and deleting previous'
+        // epoch's slots).
         let slots_owned;
         let slots = if policy::epoch_at(state.block_number()) == policy::epoch_at(block_number) {
-            state
-                .current_slots
-                .as_ref()
-                .expect("Missing current epoch's slots")
-        } else if policy::epoch_at(state.block_number()) == policy::epoch_at(block_number) + 1 {
+            if policy::is_macro_block_at(state.block_number()) {
+                state.previous_slots.as_ref().unwrap_or_else(|| {
+                    panic!(
+                        "Missing epoch's slots for block {}.{}",
+                        block_number, view_number
+                    )
+                })
+            } else {
+                state
+                    .current_slots
+                    .as_ref()
+                    .expect("Missing current epoch's slots")
+            }
+        } else if !policy::is_macro_block_at(state.block_number())
+            && policy::epoch_at(state.block_number()) == policy::epoch_at(block_number) + 1
+        {
             state.previous_slots.as_ref().unwrap_or_else(|| {
                 panic!(
                     "Missing previous epoch's slots for block {}.{}",


### PR DESCRIPTION
This code change was intended for #155, but it seems the problem is more complex than initially understood. Since the code change is still relevant, I'm creating this new PR for it, so that we can discuss and fix the original issue there.

This PR makes sure that the correct slot is returned by `get_slot_at()` in the edge case where a macro block was accepted and the slot requested is in the same epoch (i.e. a block number equal or less than the macro block's). Under this scenario, the correct slots to use would be `state.previous_slots` instead of `state.current_slots` (which was overwritten by the macro block when it was accepted).