### PR TITLE
New reward

### DIFF
--- a/block-production-albatross/src/lib.rs
+++ b/block-production-albatross/src/lib.rs
@@ -20,15 +20,10 @@ use block::{
     Block, MacroBlock, MacroExtrinsics, MacroHeader, MicroBlock, MicroExtrinsics, MicroHeader,
     PbftProposal, ViewChangeProof, ViewChanges,
 };
-use block::{
-    Block, MacroBlock, MacroExtrinsics, MacroHeader, MicroBlock, MicroExtrinsics, MicroHeader,
-    PbftProposal, ViewChangeProof, ViewChanges,
-};
 use blockchain::blockchain::Blockchain;
 use blockchain::reward_registry::SlashedSetSelector;
-use blockchain::reward_registry::SlashedSetSelector;
 use blockchain_base::AbstractBlockchain;
-use bls::bls12_381::KeyPair;
+use bls::KeyPair;
 use database::WriteTransaction;
 use hash::{Blake2bHash, Hash};
 use mempool::Mempool;

--- a/block-production-albatross/src/lib.rs
+++ b/block-production-albatross/src/lib.rs
@@ -20,10 +20,15 @@ use block::{
     Block, MacroBlock, MacroExtrinsics, MacroHeader, MicroBlock, MicroExtrinsics, MicroHeader,
     PbftProposal, ViewChangeProof, ViewChanges,
 };
+use block::{
+    Block, MacroBlock, MacroExtrinsics, MacroHeader, MicroBlock, MicroExtrinsics, MicroHeader,
+    PbftProposal, ViewChangeProof, ViewChanges,
+};
 use blockchain::blockchain::Blockchain;
 use blockchain::reward_registry::SlashedSetSelector;
+use blockchain::reward_registry::SlashedSetSelector;
 use blockchain_base::AbstractBlockchain;
-use bls::KeyPair;
+use bls::bls12_381::KeyPair;
 use database::WriteTransaction;
 use hash::{Blake2bHash, Hash};
 use mempool::Mempool;
@@ -222,7 +227,7 @@ impl BlockProducer {
 
         let mut inherents = self
             .blockchain
-            .finalize_last_epoch(&self.blockchain.state(), &header);
+            .finalize_previous_epoch(&self.blockchain.state(), &header);
 
         // Add slashes for view changes.
         let view_changes = ViewChanges::new(

--- a/blockchain-albatross/src/blockchain.rs
+++ b/blockchain-albatross/src/blockchain.rs
@@ -1955,7 +1955,7 @@ impl Blockchain {
         // Remember the number of eligible slots that a validator had (that was able to accept the inherent)
         let mut num_eligible_slots_for_accepted_inherent = Vec::new();
 
-        // Remember the total amount of reward must be burned. The reward for a slot is burned
+        // Remember that the total amount of reward must be burned. The reward for a slot is burned
         // either because the slot was slashed or because the corresponding validator was unable to
         // accept the inherent.
         let mut burned_reward = Coin::ZERO;

--- a/blockchain-albatross/src/lib.rs
+++ b/blockchain-albatross/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate beserial_derive;
 #[macro_use]
 extern crate log;
-
 extern crate nimiq_account as account;
 extern crate nimiq_accounts as accounts;
 extern crate nimiq_block_albatross as block;
@@ -19,10 +18,10 @@ extern crate nimiq_tree_primitives as tree_primitives;
 extern crate nimiq_utils as utils;
 extern crate nimiq_vrf as vrf;
 
+pub use blockchain::{Blockchain, ForkEvent};
+
 pub mod blockchain;
 pub mod chain_info;
 pub mod chain_store;
 pub mod reward_registry;
 pub mod transaction_cache;
-
-pub use blockchain::{Blockchain, ForkEvent};

--- a/blockchain-albatross/src/reward_registry/mod.rs
+++ b/blockchain-albatross/src/reward_registry/mod.rs
@@ -31,7 +31,7 @@ pub struct SlashRegistry {
     reward_pot: RewardPot,
 }
 
-// TODO Better error messages
+// TODO: Better error messages
 #[derive(Debug, Fail)]
 pub enum SlashPushError {
     #[fail(display = "Redundant fork proofs in block")]
@@ -66,7 +66,7 @@ struct BlockDescriptor {
     prev_epoch_state: BitSet,
 }
 
-// TODO Pass in active validator set + seed through parameters
+// TODO: Pass in active validator set + seed through parameters
 //      or always load from chain store?
 impl SlashRegistry {
     const SLASH_REGISTRY_DB_NAME: &'static str = "SlashRegistry";
@@ -151,8 +151,10 @@ impl SlashRegistry {
 
         // Lookup slash state.
         let mut cursor = txn.cursor(&self.slash_registry_db);
+
         // Move cursor to first entry with a block number >= ours (or end of the database).
         let _: Option<(u32, BlockDescriptor)> = cursor.seek_range_key(&block_number);
+
         // Then move cursor back by one.
         let last_change: Option<(u32, BlockDescriptor)> = cursor.prev();
 

--- a/blockchain-albatross/src/reward_registry/mod.rs
+++ b/blockchain-albatross/src/reward_registry/mod.rs
@@ -1,5 +1,3 @@
-mod reward_pot;
-
 use std::borrow::Cow;
 use std::io;
 use std::sync::Arc;
@@ -18,11 +16,13 @@ use primitives::coin::Coin;
 use primitives::policy;
 use primitives::slot::{Slot, SlotIndex, Slots};
 use transaction::Transaction as BlockchainTransaction;
+use vrf::rng::Rng;
 use vrf::VrfUseCase;
 
 use crate::chain_store::ChainStore;
 use crate::reward_registry::reward_pot::RewardPot;
-use vrf::rng::Rng;
+
+mod reward_pot;
 
 pub struct SlashRegistry {
     env: Environment,

--- a/blockchain-albatross/src/reward_registry/reward_pot.rs
+++ b/blockchain-albatross/src/reward_registry/reward_pot.rs
@@ -1,10 +1,21 @@
+use std::convert::TryInto;
+
 use block::{MacroBlock, MicroBlock};
 use database::{Database, Environment, ReadTransaction, WriteTransaction};
 use primitives::coin::Coin;
 use primitives::policy;
-use std::convert::TryInto;
 use transaction::Transaction as BlockchainTransaction;
 
+/// This struct is meant to calculate and keep track of the rewards for the current and previous
+/// epochs. We need to remember the reward for the previous epoch because we only distribute rewards
+/// for a given epoch on the subsequent epoch.
+/// It also keeps track of the current supply, which is defined as all the coins that were ever
+/// created (even if those coins were later burned), at the time of the last macro block (the end of
+/// the previous epoch). We need the current supply in order to calculate the coinbase for the
+/// rewards.
+/// Finally, it also stores the timestamp and the supply of when the genesis block was created. We
+/// need both these values to calculate the supply at any given time, which in turn we need to
+/// calculate the coinbase.
 pub struct RewardPot {
     env: Environment,
     reward_pot: Database,

--- a/blockchain-albatross/src/reward_registry/reward_pot.rs
+++ b/blockchain-albatross/src/reward_registry/reward_pot.rs
@@ -180,7 +180,7 @@ impl RewardPot {
         txn.put(&self.reward_pot, Self::CURRENT_REWARD_KEY, &current_reward);
     }
 
-    /// Rollbacks the RewardPot database for a micro block. It takes the whole micro block as input
+    /// Rolls back the RewardPot database for a micro block. It takes the whole micro block as input
     /// since we need all the transactions in it.
     /// This function is used for normal block syncing.
     pub(super) fn revert_micro_block(&self, block: &MicroBlock, txn: &mut WriteTransaction) {

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 curve25519-dalek = "1.0.2"
-ed25519-dalek = "1.0.0-pre.3"
+ed25519-dalek = "=1.0.0-pre.3"
 data-encoding = "2.1"
 failure = "0.1"
 hex = "0.4"

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -117,6 +117,15 @@ impl Address {
             .or_else(|_| Address::from_str(s))
             .map_err(|_| AddressParseError::UnknownFormat)
     }
+
+    /// Returns the "burn address". This is an address for which it is extremely unlikely (basically
+    /// impossible) that anyone knows the corresponding private key. Consequently this address can
+    /// be used to "burn" coins (and is regularly used by Team Nimiq to do so).
+    /// To be clear, it's IMPOSSIBLE for ANYONE to use the funds sent to this address.
+    pub fn burn_address() -> Address {
+        // We use unwrap here because we know this will not produce an error.
+        Self::from_user_friendly_address("NQ07 0000 0000 0000 0000 0000 0000 0000 0000").unwrap()
+    }
 }
 
 impl From<Blake2bHash> for Address {

--- a/primitives/account/src/staking_contract/mod.rs
+++ b/primitives/account/src/staking_contract/mod.rs
@@ -121,7 +121,7 @@ impl StakingContract {
 
         debug!("Select validators: num_slots = {}", policy::SLOTS);
 
-        // NOTE: `active_stake_sorted` is sorted from highest to lowest stake. `LookupTable`
+        // NOTE: `active_validators_sorted` is sorted from highest to lowest stake. `LookupTable`
         // expects the reverse ordering.
         for validator in self.active_validators_sorted.iter() {
             potential_validators.push(Arc::clone(validator));

--- a/primitives/block-albatross/tests/mod.rs
+++ b/primitives/block-albatross/tests/mod.rs
@@ -89,6 +89,7 @@ fn it_can_convert_macro_block_into_slots() {
         justification: None,
         extrinsics: Some(MacroExtrinsics {
             slashed_set: BitSet::new(),
+            extra_data: vec![],
         }),
     };
 


### PR DESCRIPTION
This PR handles several things related to the way rewards are calculated and distributed:

- Rewards are now divided among all validators. But the rewards for misbehaving validators are burned. This fixes #89.
- The reward remainder is given to a single random validator. Previously it was randomly divided among all validators but this is unnecessary since the remainder is always very small.
- Added the new supply curve to the policy file.
- Changed RewardPot to use the new supply curve and also simplified the way rewards are calculated. Now micro block rewards consist only of the transaction fees and macro block rewards consist only of the coinbase.
- Added the field `extra_data` to MacroBlock. This was necessary in order to encode the genesis supply into the genesis block, but it might also be useful for other purposes.
- Added some documentation all-around.

Checklist:
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

