### PR TITLE
Override the right profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ members = [
   "ws-rpc-server",
 ]
 
-[profile.test.package.nimiq-bls]
+[profile.dev.package.nimiq-bls]
 opt-level = 3
 
-[profile.test.package.nimiq-nano-sync]
+[profile.dev.package.nimiq-nano-sync]
 opt-level = 3


### PR DESCRIPTION
The test profile is only used to compile the code of the tests, not the code under test, so we actually want to override the dev profile to make tests go faster.