### PR TITLE
Replace Box::into_raw_non_null(...) with NonNull:from(Box::leak(...))

### DIFF
--- a/collections/src/lib.rs
+++ b/collections/src/lib.rs
@@ -1,5 +1,4 @@
 // Required for LinkedList.
-#![feature(box_into_raw_non_null)]
 #![feature(specialization)]
 
 #[cfg(feature = "bitset")]

--- a/collections/src/linked_list.rs
+++ b/collections/src/linked_list.rs
@@ -135,7 +135,7 @@ impl<T> LinkedList<T> {
         unsafe {
             node.next = self.head;
             node.prev = None;
-            let node = Some(Box::into_raw_non_null(node));
+            let node = Some(NonNull::from(Box::leak(node)));
 
             match self.head {
                 None => self.tail = node,
@@ -170,7 +170,7 @@ impl<T> LinkedList<T> {
         unsafe {
             node.next = None;
             node.prev = self.tail;
-            let node = Some(Box::into_raw_non_null(node));
+            let node = Some(NonNull::from(Box::leak(node)));
 
             match self.tail {
                 None => self.head = node,
@@ -902,11 +902,11 @@ impl<'a, T> IterMut<'a, T> {
                     Some(prev) => prev,
                 };
 
-                let node = Some(Box::into_raw_non_null(Box::new(Node {
+                let node = Some(NonNull::from(Box::leak(Box::new(Node {
                     next: Some(head),
                     prev: Some(prev),
                     element,
-                })));
+                }))));
 
                 prev.as_mut().next = node;
                 head.as_mut().prev = node;


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Replaces `Box::into_raw_non_null(...)` with `NonNull:from(Box::leak(...))` so that the ci can run again.