### PR TITLE
Remove const_int_pow feature flag

### DIFF
--- a/nano-sync/src/lib.rs
+++ b/nano-sync/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![feature(const_int_pow)]
 
 // Re-export big-endian serialization of algebra types.
 pub use nimiq_bls::compression;


### PR DESCRIPTION
const_int_pow was stabilized in Rust 1.50.0
https://github.com/rust-lang/rust/pull/76829