### PR TITLE
const_int_pow is not a feature anymore

### DIFF
--- a/nano-sync/src/lib.rs
+++ b/nano-sync/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![feature(const_int_pow)]
 
 // Re-export big-endian serialization of algebra types.
 pub use nimiq_bls::compression;


### PR DESCRIPTION
With the current nightly compiler the feature `const_int_pow` doesn't exist anymore.