### PR TITLE
Switch from failure to thiserror

### DIFF
--- a/consensus-albatross/Cargo.toml
+++ b/consensus-albatross/Cargo.toml
@@ -17,7 +17,6 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-failure = "0.1"
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.9"
@@ -26,6 +25,7 @@ rand = "0.7"
 tokio = { version = "0.2", features = ["full"] }
 weak-table = "0.2"
 async-trait = "0.1"
+thiserror = "1.0"
 
 beserial = { path = "../beserial", version = "0.1" }
 beserial_derive = { path = "../beserial/beserial_derive", version = "0.1" }

--- a/consensus-albatross/src/error.rs
+++ b/consensus-albatross/src/error.rs
@@ -1,23 +1,19 @@
-use failure::Fail;
+use thiserror::Error;
 
 use blockchain_albatross::BlockchainError;
 
-#[derive(Fail, Debug)]
+
+#[derive(Debug, Error)]
 pub enum Error {
-    #[fail(display = "{}", _0)]
-    BlockchainError(#[cause] BlockchainError),
+    #[error("{0}")]
+    BlockchainError(#[from] BlockchainError),
 }
 
-impl From<BlockchainError> for Error {
-    fn from(e: BlockchainError) -> Self {
-        Error::BlockchainError(e)
-    }
-}
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Error)]
 pub enum SyncError {
-    #[fail(display = "Other")]
+    #[error("Other")]
     Other,
-    #[fail(display = "No valid sync target found")]
+    #[error("No valid sync target found")]
     NoValidSyncTarget,
 }


### PR DESCRIPTION
This switches from using `failure` to `thiserror` for error handling in `nimiq-consensus-albatross`.
