### PR TITLE
Introduce rededicate stake transaction

### DIFF
--- a/primitives/account/src/staking_contract/actions/staker.rs
+++ b/primitives/account/src/staking_contract/actions/staker.rs
@@ -57,6 +57,38 @@ impl StakingContract {
         Ok(())
     }
 
+    pub(super) fn rededicate_stake_sender(&mut self, staker_address: Address, value: Coin, from_validator_id: &ValidatorId) -> Result<(), AccountError> {
+        let mut entry = self.remove_validator(from_validator_id).ok_or(AccountError::InvalidForRecipient)?;
+        entry.try_sub_stake(&staker_address, value, AccountError::InvalidForSender);
+        self.restore_validator(entry)?;
+
+        Ok(())
+    }
+
+    pub(super) fn revert_rededicate_stake_sender(&mut self, staker_address: Address, value: Coin, from_validator_id: &ValidatorId) -> Result<(), AccountError> {
+        let mut entry = self.remove_validator(from_validator_id).ok_or(AccountError::InvalidForRecipient)?;
+        entry.try_add_stake(staker_address, value);
+        self.restore_validator(entry)?;
+
+        Ok(())
+    }
+
+    pub(super) fn rededicate_stake_receiver(&mut self, staker_address: Address, value: Coin, to_validator_id: &ValidatorId) -> Result<(), AccountError> {
+        let mut entry = self.remove_validator(to_validator_id).ok_or(AccountError::InvalidForRecipient)?;
+        entry.try_add_stake(staker_address, value);
+        self.restore_validator(entry)?;
+
+        Ok(())
+    }
+
+    pub(super) fn revert_rededicate_stake_receiver(&mut self, staker_address: Address, value: Coin, to_validator_id: &ValidatorId) -> Result<(), AccountError> {
+        let mut entry = self.remove_validator(to_validator_id).ok_or(AccountError::InvalidForRecipient)?;
+        entry.try_sub_stake(&staker_address, value, AccountError::InvalidForSender);
+        self.restore_validator(entry)?;
+
+        Ok(())
+    }
+
     /// Removes stake from the active stake list.
     pub(super) fn retire_sender(&mut self, staker_address: &Address, value: Coin, validator_id: &ValidatorId) -> Result<(), AccountError> {
         let new_balance = Account::balance_sub(self.balance, value)?;

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -560,6 +560,44 @@ fn it_can_apply_unstaking_transaction() {
 }
 
 #[test]
+fn it_can_apply_rededicate_stake_tx() {
+    let validator_id1: ValidatorId = [1u8; 20].into();
+    let validator_id2: ValidatorId = [2u8; 20].into();
+
+    let bls_pair1 = BlsKeyPair::generate_default_csprng();
+    let bls_pair2 = BlsKeyPair::generate_default_csprng();
+
+    let mut contract = make_empty_contract();
+    contract
+        .create_validator(validator_id1.clone(), bls_pair1.public_key.compress(), [1;20].into(), Coin::from_u64_unchecked(0))
+        .unwrap();
+    contract
+        .create_validator(validator_id2.clone(), bls_pair2.public_key.compress(), [2;20].into(), Coin::from_u64_unchecked(0))
+        .unwrap();
+    contract
+        .stake(Address::from(&ed25519_key_pair()), Coin::from_u64_unchecked(150000000), &validator_id1)
+        .unwrap();
+
+
+    let tx_1 = make_self_transaction(SelfStakingTransactionData::RededicateStake{ from_validator_id: validator_id1.clone(), to_validator_id: validator_id2.clone() }, 50000000);
+    assert_eq!(contract.check_outgoing_transaction(&tx_1, 2, 0), Ok(()));
+    assert_eq!(contract.commit_outgoing_transaction(&tx_1, 2, 0), Ok(None));
+    assert_eq!(StakingContract::check_incoming_transaction(&tx_1, 2, 0), Ok(()));
+    assert_eq!(contract.commit_incoming_transaction(&tx_1, 2, 0), Ok(None));
+
+    // initial balance - moved stake - fees
+    assert_eq!(contract.get_validator(&validator_id1).unwrap().balance, Coin::from_u64_unchecked(150000000 - 50000000 - 100));
+    assert_eq!(contract.get_validator(&validator_id2).unwrap().balance, Coin::from_u64_unchecked(50000000));
+
+    // revert transaction
+    assert_eq!(contract.revert_outgoing_transaction(&tx_1, 2, 0, None), Ok(()));
+    assert_eq!(contract.revert_incoming_transaction(&tx_1, 2, 0, None), Ok(()));
+
+    assert_eq!(contract.get_validator(&validator_id1).unwrap().balance, Coin::from_u64_unchecked(150000000));
+    assert_eq!(contract.get_validator(&validator_id2).unwrap().balance, Coin::from_u64_unchecked(0));
+}
+
+#[test]
 fn it_can_verify_inherent() {
     let key_pair = ed25519_key_pair();
     let bls_pair = bls_key_pair();

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -434,6 +434,7 @@ impl Deserialize for OutgoingStakingTransactionProof {
 pub enum SelfStakingTransactionType {
     RetireStake = 0,
     ReactivateStake = 1,
+    RededicateStake = 2,
 }
 
 #[derive(Clone, Debug)]
@@ -441,6 +442,10 @@ pub enum SelfStakingTransactionType {
 pub enum SelfStakingTransactionData {
     RetireStake(ValidatorId),
     ReactivateStake(ValidatorId),
+    RededicateStake {
+        from_validator_id: ValidatorId,
+        to_validator_id: ValidatorId,
+    }
 }
 
 impl SelfStakingTransactionData {
@@ -465,6 +470,11 @@ impl Serialize for SelfStakingTransactionData {
                 size += Serialize::serialize(&SelfStakingTransactionType::ReactivateStake, writer)?;
                 size += Serialize::serialize(validator_id, writer)?;
             }
+            SelfStakingTransactionData::RededicateStake { from_validator_id, to_validator_id } => {
+                size += Serialize::serialize(&SelfStakingTransactionType::RededicateStake, writer)?;
+                size += Serialize::serialize(from_validator_id, writer)?;
+                size += Serialize::serialize(to_validator_id, writer)?;
+            }
         }
         Ok(size)
     }
@@ -479,6 +489,11 @@ impl Serialize for SelfStakingTransactionData {
             SelfStakingTransactionData::ReactivateStake(validator_id) => {
                 size += Serialize::serialized_size(&SelfStakingTransactionType::ReactivateStake);
                 size += Serialize::serialized_size(validator_id);
+            }
+            SelfStakingTransactionData::RededicateStake { from_validator_id, to_validator_id } => {
+                size += Serialize::serialized_size(&SelfStakingTransactionType::RededicateStake);
+                size += Serialize::serialized_size(&from_validator_id);
+                size += Serialize::serialized_size(&to_validator_id);
             }
         }
         size
@@ -498,6 +513,12 @@ impl Deserialize for SelfStakingTransactionData {
                 let validator_id: ValidatorId = Deserialize::deserialize(reader)?;
 
                 Ok(SelfStakingTransactionData::ReactivateStake(validator_id))
+            }
+            SelfStakingTransactionType::RededicateStake => {
+                Ok(SelfStakingTransactionData::RededicateStake {
+                    from_validator_id: Deserialize::deserialize(reader)?,
+                    to_validator_id: Deserialize::deserialize(reader)?,
+                })
             }
         }
     }

--- a/transaction-builder/src/recipient/staking_contract.rs
+++ b/transaction-builder/src/recipient/staking_contract.rs
@@ -188,6 +188,14 @@ impl StakingRecipientBuilder {
         self
     }
 
+    pub fn rededicate_stake(&mut self, from_validator_id: &ValidatorId, to_validator_id: &ValidatorId) -> &mut Self {
+        self.staking_data = Some(StakingTransaction::SelfTransaction(SelfStakingTransactionData::RededicateStake {
+            from_validator_id: from_validator_id.clone(),
+            to_validator_id: to_validator_id.clone(),
+        }));
+        self
+    }
+
     /// This method allows to retire a stake.
     /// This has the effect of removing the stake from the validator with key `validator_key`.
     /// It is a necessary precondition to unstake funds.


### PR DESCRIPTION
The rededicate stake transaction removes stake from one validator and delegates it to another one.