### PR TITLE
Added get_transaction method to HistoryStore.

### DIFF
--- a/blockchain-albatross/src/blockchain/wrappers.rs
+++ b/blockchain-albatross/src/blockchain/wrappers.rs
@@ -178,7 +178,7 @@ impl Blockchain {
         txn_option: Option<&Transaction>,
     ) -> Option<HistoryTreeChunk> {
         self.history_store
-            .get_chunk(epoch_number, chunk_size, chunk_index, txn_option)
+            .prove_chunk(epoch_number, chunk_size, chunk_index, txn_option)
     }
 
     /// Returns the current staking contract.

--- a/blockchain-albatross/src/history_store/extended_transaction.rs
+++ b/blockchain-albatross/src/history_store/extended_transaction.rs
@@ -67,6 +67,32 @@ impl ExtendedTransaction {
 
         (transactions, inherents)
     }
+
+    /// Checks if the extended transaction is an inherent.
+    pub fn is_inherent(&self) -> bool {
+        match self.data {
+            ExtTxData::Basic(_) => false,
+            ExtTxData::Inherent(_) => true,
+        }
+    }
+
+    /// Unwraps the extended transaction and returns a reference to the underlying basic transaction.
+    pub fn unwrap_basic(&self) -> &BlockchainTransaction {
+        if let ExtTxData::Basic(ref tx) = self.data {
+            tx
+        } else {
+            unreachable!()
+        }
+    }
+
+    /// Unwraps the extended transaction and returns a reference to the underlying inherent.
+    pub fn unwrap_inherent(&self) -> &Inherent {
+        if let ExtTxData::Inherent(ref tx) = self.data {
+            tx
+        } else {
+            unreachable!()
+        }
+    }
 }
 
 impl MMRHash<HistoryTreeHash> for ExtendedTransaction {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #22.

## What's in this pull request?

- Adds a method to HistoryStore that allows us to get a transaction by its hash. This is needed for the RPC server.