### PR TITLE
Add validator ID to validator public information (for RPC)

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -582,6 +582,8 @@ pub struct Stake {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Validator {
+    pub id: ValidatorId,
+
     pub public_key: CompressedPublicKey,
 
     pub balance: Coin,
@@ -600,6 +602,7 @@ impl Validator {
         _retire_time: Option<u32>,
     ) -> Self {
         Validator {
+            id: validator.id.clone(),
             public_key: validator.validator_key.clone(),
             balance: validator.balance,
             reward_address: validator.reward_address.clone(),


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Effectively add the validator ID to the output of the RPC `listStakes` method.
