### PR TITLE
Implement RPC transaction create/send methods for validator actions

### DIFF
--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -106,4 +106,120 @@ pub trait ConsensusInterface {
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Self::Error>;
+
+    async fn create_new_validator_transaction(
+        &mut self,
+        wallet: Address,
+        reward_address: Address,
+        validator_secret_key: String,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_new_validator_transaction(
+        &mut self,
+        wallet: Address,
+        reward_address: Address,
+        validator_secret_key: String,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
+
+    async fn create_update_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        new_reward_address: Option<Address>,
+        old_validator_secret_key: String,
+        new_validator_secret_key: Option<String>,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_update_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        new_reward_address: Option<Address>,
+        old_validator_secret_key: String,
+        new_validator_secret_key: Option<String>,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
+
+    async fn create_retire_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        validator_secret_key: String,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_retire_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        validator_secret_key: String,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
+
+    async fn create_reactivate_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        validator_secret_key: String,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_reactivate_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        validator_secret_key: String,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
+
+    async fn create_drop_validator_transaction(
+        &mut self,
+        validator_id: ValidatorId,
+        recipient: Address,
+        validator_secret_key: String,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_drop_validator_transaction(
+        &mut self,
+        validator_id: ValidatorId,
+        recipient: Address,
+        validator_secret_key: String,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
+
+    async fn create_unpark_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        validator_secret_key: String,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_unpark_validator_transaction(
+        &mut self,
+        wallet: Address,
+        validator_id: ValidatorId,
+        validator_secret_key: String,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
 }

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -53,6 +53,26 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Self::Error>;
 
+    async fn create_rededicate_transaction(
+        &mut self,
+        wallet: Address,
+        from_validator_id: ValidatorId,
+        to_validator_id: ValidatorId,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Self::Error>;
+
+    async fn send_rededicate_transaction(
+        &mut self,
+        wallet: Address,
+        from_validator_id: ValidatorId,
+        to_validator_id: ValidatorId,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Self::Error>;
+
     async fn create_retire_transaction(
         &mut self,
         wallet: Address,

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -151,6 +151,52 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
+    async fn create_rededicate_transaction(
+        &mut self,
+        wallet: Address,
+        from_validator_id: ValidatorId,
+        to_validator_id: ValidatorId,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<String, Error> {
+        let transaction = TransactionBuilder::new_rededicate_stake(
+            None,
+            &self.get_wallet_keypair(&wallet)?,
+            &from_validator_id,
+            &to_validator_id,
+            value,
+            fee,
+            self.validity_start_height(validity_start_height),
+            self.network_id(),
+        );
+
+        Ok(transaction_to_hex_string(&transaction))
+    }
+
+    async fn send_rededicate_transaction(
+        &mut self,
+        wallet: Address,
+        from_validator_id: ValidatorId,
+        to_validator_id: ValidatorId,
+        value: Coin,
+        fee: Coin,
+        validity_start_height: ValidityStartHeight,
+    ) -> Result<Blake2bHash, Error> {
+        let raw_tx = self
+            .create_rededicate_transaction(
+                wallet,
+                from_validator_id,
+                to_validator_id,
+                value,
+                fee,
+                validity_start_height,
+            )
+            .await
+            .unwrap();
+        self.send_raw_transaction(raw_tx).await
+    }
+
     async fn create_retire_transaction(
         &mut self,
         wallet: Address,

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -107,16 +107,11 @@ impl ConsensusInterface for ConsensusDispatcher {
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Error> {
-        let transaction = TransactionBuilder::new_simple(
-            &self.get_wallet_keypair(&wallet)?,
-            recipient,
-            value,
-            fee,
-            self.validity_start_height(validity_start_height),
-            self.network_id(),
-        );
-
-        self.push_transaction(transaction).await
+        let raw_tx = self
+            .create_basic_transaction(wallet, recipient, value, fee, validity_start_height)
+            .await
+            .unwrap();
+        self.send_raw_transaction(raw_tx).await
     }
 
     async fn create_stake_transaction(
@@ -148,17 +143,11 @@ impl ConsensusInterface for ConsensusDispatcher {
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Error> {
-        let transaction = TransactionBuilder::new_stake(
-            None,
-            &self.get_wallet_keypair(&wallet)?,
-            &validator_id,
-            value,
-            fee,
-            self.validity_start_height(validity_start_height),
-            self.network_id(),
-        );
-
-        self.push_transaction(transaction).await
+        let raw_tx = self
+            .create_stake_transaction(wallet, validator_id, value, fee, validity_start_height)
+            .await
+            .unwrap();
+        self.send_raw_transaction(raw_tx).await
     }
 
     async fn create_retire_transaction(
@@ -190,17 +179,11 @@ impl ConsensusInterface for ConsensusDispatcher {
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Error> {
-        let transaction = TransactionBuilder::new_retire(
-            None,
-            &self.get_wallet_keypair(&wallet)?,
-            &validator_id,
-            value,
-            fee,
-            self.validity_start_height(validity_start_height),
-            self.network_id(),
-        );
-
-        self.push_transaction(transaction).await
+        let raw_tx = self
+            .create_retire_transaction(wallet, validator_id, value, fee, validity_start_height)
+            .await
+            .unwrap();
+        self.send_raw_transaction(raw_tx).await
     }
 
     async fn create_reactivate_transaction(
@@ -232,17 +215,11 @@ impl ConsensusInterface for ConsensusDispatcher {
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Error> {
-        let transaction = TransactionBuilder::new_reactivate(
-            None,
-            &self.get_wallet_keypair(&wallet)?,
-            &validator_id,
-            value,
-            fee,
-            self.validity_start_height(validity_start_height),
-            self.network_id(),
-        );
-
-        self.push_transaction(transaction).await
+        let raw_tx = self
+            .create_reactivate_transaction(wallet, validator_id, value, fee, validity_start_height)
+            .await
+            .unwrap();
+        self.send_raw_transaction(raw_tx).await
     }
 
     async fn create_unstake_transaction(
@@ -274,16 +251,10 @@ impl ConsensusInterface for ConsensusDispatcher {
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Error> {
-        let transaction = TransactionBuilder::new_unstake(
-            None,
-            &self.get_wallet_keypair(&wallet)?,
-            recipient,
-            value,
-            fee,
-            self.validity_start_height(validity_start_height),
-            self.network_id(),
-        );
-
-        self.push_transaction(transaction).await
+        let raw_tx = self
+            .create_unstake_transaction(wallet, recipient, value, fee, validity_start_height)
+            .await
+            .unwrap();
+        self.send_raw_transaction(raw_tx).await
     }
 }

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -536,7 +536,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract);
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address));
         recipient.stake(validator_id, None);
 
         let mut builder = Self::new();
@@ -569,15 +571,14 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract.clone());
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address.clone()));
         recipient.rededicate_stake(from_validator_id, to_validator_id);
 
         let mut builder = Self::new();
         builder
-            .with_sender(fill_in_staking_contract_address(
-                staking_contract,
-                network_id,
-            ))
+            .with_sender(staking_contract_address)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient.generate().unwrap())
             .with_value(value)
@@ -605,15 +606,14 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract.clone());
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address.clone()));
         recipient.retire_stake(validator_id);
 
         let mut builder = Self::new();
         builder
-            .with_sender(fill_in_staking_contract_address(
-                staking_contract,
-                network_id,
-            ))
+            .with_sender(staking_contract_address)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient.generate().unwrap())
             .with_value(value)
@@ -641,15 +641,14 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract.clone());
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address.clone()));
         recipient.reactivate_stake(validator_id);
 
         let mut builder = Self::new();
         builder
-            .with_sender(fill_in_staking_contract_address(
-                staking_contract,
-                network_id,
-            ))
+            .with_sender(staking_contract_address)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient.generate().unwrap())
             .with_value(value)
@@ -680,14 +679,13 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
         let recipient = Recipient::new_basic(recipient);
 
         let mut builder = Self::new();
         builder
-            .with_sender(fill_in_staking_contract_address(
-                staking_contract,
-                network_id,
-            ))
+            .with_sender(staking_contract_address)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient)
             .with_value(value)
@@ -735,7 +733,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract);
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address));
         recipient.create_validator(validator_key_pair, reward_address);
 
         let mut builder = Self::new();
@@ -791,7 +791,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract);
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address));
         recipient.update_validator(
             validator_id,
             &old_validator_key_pair.public_key,
@@ -850,7 +852,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract);
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address));
         recipient.retire_validator(&validator_id);
 
         let mut builder = Self::new();
@@ -904,7 +908,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract);
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address));
         recipient.reactivate_validator(&validator_id);
 
         let mut builder = Self::new();
@@ -956,14 +962,13 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
         let recipient = Recipient::new_basic(recipient);
 
         let mut builder = Self::new();
         builder
-            .with_sender(fill_in_staking_contract_address(
-                staking_contract,
-                network_id,
-            ))
+            .with_sender(staking_contract_address)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient)
             .with_value(value)
@@ -1011,7 +1016,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Transaction {
-        let mut recipient = Recipient::new_staking_builder(staking_contract);
+        let staking_contract_address =
+            fill_in_staking_contract_address(staking_contract, network_id);
+        let mut recipient = Recipient::new_staking_builder(Some(staking_contract_address));
         recipient.unpark_validator(&validator_id);
 
         let mut builder = Self::new();

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -578,6 +578,7 @@ impl TransactionBuilder {
                 staking_contract,
                 network_id,
             ))
+            .with_sender_type(AccountType::Staking)
             .with_recipient(recipient.generate().unwrap())
             .with_value(value)
             .with_fee(fee)
@@ -586,7 +587,7 @@ impl TransactionBuilder {
 
         let proof_builder = builder.generate().unwrap();
         match proof_builder {
-            TransactionProofBuilder::Basic(mut builder) => {
+            TransactionProofBuilder::StakingSelf(mut builder) => {
                 builder.sign_with_key_pair(&key_pair);
                 builder.generate().unwrap()
             }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

This PR implements all create/send transaction methods to control a validator, also implements the rededicate_stake method for RPC.
