### PR TITLE
Implement getTransactionByHash RPC method

### DIFF
--- a/blockchain-albatross/src/history_store/history_store.rs
+++ b/blockchain-albatross/src/history_store/history_store.rs
@@ -408,7 +408,7 @@ impl HistoryStore {
 
     /// Gets an extended transaction by its hash. Note that this hash is the leaf hash (see MMRHash)
     /// of the transaction, not a simple Blake2b hash of the transaction.
-    fn get_extended_tx(
+    pub fn get_extended_tx(
         &self,
         hash: &Blake2bHash,
         txn_option: Option<&Transaction>,
@@ -426,7 +426,7 @@ impl HistoryStore {
     }
 
     /// Gets a leaf hash from the hash of its transaction (only basic, no inherents!).
-    fn get_leaf_hash(
+    pub fn get_leaf_hash(
         &self,
         hash: &Blake2bHash,
         txn_option: Option<&Transaction>,

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -5,7 +5,7 @@ use nimiq_account::Account;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 
-use crate::types::{Block, OrLatest, SlashedSlots, Slot, Stakes};
+use crate::types::{Block, OrLatest, SlashedSlots, Slot, Stakes, Transaction};
 
 #[cfg_attr(
     feature = "proxy",
@@ -44,7 +44,10 @@ pub trait BlockchainInterface {
 
     async fn get_raw_transaction_info(&mut self, raw_tx: String) -> Result<(), Self::Error>;
 
-    async fn get_transaction_by_hash(&mut self, hash: Blake2bHash) -> Result<(), Self::Error>;
+    async fn get_transaction_by_hash(
+        &mut self,
+        hash: Blake2bHash,
+    ) -> Result<Transaction, Self::Error>;
 
     async fn get_transaction_receipt(&mut self, hash: Blake2bHash) -> Result<(), Self::Error>;
 

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -264,15 +264,11 @@ impl From<nimiq_block_albatross::ForkProof> for ForkProof {
 pub struct Transaction {
     pub hash: Blake2bHash,
 
-    pub block_hash: Blake2bHash,
-
     pub block_number: u32,
 
     pub timestamp: u64,
 
     pub confirmations: u32,
-
-    pub transaction_index: usize,
 
     pub from: Address,
 
@@ -296,19 +292,15 @@ pub struct Transaction {
 impl Transaction {
     pub fn from_blockchain(
         transaction: nimiq_transaction::Transaction,
-        transaction_index: usize,
-        block_hash: &Blake2bHash,
         block_number: u32,
         timestamp: u64,
         head_height: u32,
     ) -> Self {
         Transaction {
             hash: transaction.hash(),
-            block_hash: block_hash.clone(),
             block_number,
             timestamp,
             confirmations: head_height.saturating_sub(block_number),
-            transaction_index,
             from: transaction.sender,
             to: transaction.recipient,
             value: transaction.value,
@@ -381,8 +373,6 @@ impl Block {
                                     .map(|(index, tx)| {
                                         Transaction::from_blockchain(
                                             tx,
-                                            index,
-                                            &block_hash,
                                             block_number,
                                             timestamp,
                                             head_height,

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -288,6 +288,9 @@ pub struct Transaction {
     pub flags: u8,
 
     pub validity_start_height: u32,
+
+    #[serde(with = "crate::serde_helpers::hex")]
+    pub proof: Vec<u8>,
 }
 
 impl Transaction {
@@ -313,6 +316,7 @@ impl Transaction {
             flags: transaction.flags.bits() as u8,
             data: transaction.data,
             validity_start_height: transaction.validity_start_height,
+            proof: transaction.proof,
         }
     }
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -130,7 +130,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         let extended_tx = self
             .blockchain
             .history_store
-            .get_extended_transaction_by_transaction_hash(&hash, None)
+            .get_ext_tx_by_hash(&hash, None)
             .ok_or(Error::TransactionNotFound(hash))?;
 
         let block_number = extended_tx.block_number;

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -133,23 +133,12 @@ impl BlockchainInterface for BlockchainDispatcher {
             .get_ext_tx_by_hash(&hash, None)
             .ok_or(Error::TransactionNotFound(hash))?;
 
-        let block_number = extended_tx.block_number;
-        // let timestamp = extended_tx.block_time;
-
-        let block = self
-            .blockchain
-            .get_block_at(block_number, false, None)
-            .ok_or(Error::BlockNotFound(block_number.into()))?;
-
         let transaction = extended_tx.unwrap_basic(); // Because we found the extended_tx above, this cannot be None
 
         Ok(Transaction::from_blockchain(
             transaction.clone(),
-            // TODO: Get transaction index from block
-            0,
-            &block.hash(),
-            block.block_number(),
-            block.timestamp(),
+            extended_tx.block_number,
+            extended_tx.block_time,
             self.blockchain.block_number(),
         ))
     }

--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use nimiq_hash::Blake2bHash;
 use nimiq_jsonrpc_core::RpcError;
 use nimiq_keys::Address;
 use nimiq_rpc_interface::types::BlockNumberOrHash;
@@ -47,6 +48,9 @@ pub enum Error {
 
     #[error("Transaction rejected: {0:?}")]
     TransactionRejected(nimiq_mempool::ReturnCode),
+
+    #[error("Transaction not found: {0}")]
+    TransactionNotFound(Blake2bHash),
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
This PR implements the RPC `getTransactionByHash` method. However, to be able to include block information in the result, such as block_number, confirmations, block_time, the RPC method does not use the exposed `history_store.get_transaction`, as that function loses the block information from the `ExtendedTransaction` struct and only returns the transaction itself.

@brunoffranca Please let me know if this is approach is correct, or if the block information can be retrieved differently.

### TODO
- Find the `transaction_index` from the block, to include in the result
- Should this method also return mempool transactions?