### PR TITLE
Parallelized pk_tree_construct

### DIFF
--- a/blockchain-albatross/src/blockchain/blockchain.rs
+++ b/blockchain-albatross/src/blockchain/blockchain.rs
@@ -78,6 +78,7 @@ impl Blockchain {
     ) -> Result<Self, BlockchainError> {
         let chain_store = Arc::new(ChainStore::new(env.clone()));
         let history_store = Arc::new(HistoryStore::new(env.clone()));
+
         Ok(match chain_store.get_head(None) {
             Some(head_hash) => Blockchain::load(
                 env,
@@ -200,14 +201,8 @@ impl Blockchain {
             chain_store.get_block(&election_head.header.parent_election_hash, true, None);
 
         let last_slots = match prev_block {
-            Some(Block::Macro(prev_election_block)) => {
-                if prev_election_block.is_election_block() {
-                    prev_election_block.get_validators().unwrap()
-                } else {
-                    return Err(BlockchainError::InconsistentState);
-                }
-            }
-            None => Validators::default(),
+            Some(Block::Macro(prev_election_block)) => prev_election_block.get_validators(),
+            None => None,
             _ => return Err(BlockchainError::InconsistentState),
         };
 
@@ -229,10 +224,9 @@ impl Blockchain {
                 election_head,
                 election_head_hash,
                 current_slots: Some(current_slots),
-                previous_slots: Some(last_slots),
+                previous_slots: last_slots,
             }),
             push_lock: Mutex::new(()),
-
             #[cfg(feature = "metrics")]
             metrics: BlockchainMetrics::default(),
             genesis_supply,

--- a/bls/src/pedersen.rs
+++ b/bls/src/pedersen.rs
@@ -107,8 +107,7 @@ pub fn pedersen_generators(number: usize) -> Vec<G1Projective> {
 /// s = b_0 * 2^0 + b_1 * 2^1 + ... + b_750 * 2^750 + b_751 * 2^751
 /// We then calculate the commitment like so:
 /// H = G_0 + s_1 * G_1 + ... + s_n * G_n
-/// where G_0 is a sum generator that is used to avoid that the sum starts at zero (which is
-/// problematic because the ZK circuits used in nano-sync can't handle addition with zero).
+/// where G_0 is a generator that is used as a blinding factor.
 pub fn pedersen_hash(input: Vec<bool>, generators: Vec<G1Projective>) -> G1Projective {
     // Check that the input can be stored using the available generators.
     assert!((generators.len() - 1) * POINT_CAPACITY >= input.len());

--- a/nano-blockchain/Cargo.toml
+++ b/nano-blockchain/Cargo.toml
@@ -23,6 +23,6 @@ nimiq-tree-primitives = { path = "../accounts/tree-primitives" }
 nimiq-utils = { path = "../utils", features = ["time"] }
 
 [dev-dependencies]
-rand = "0.8.0"
+rand = "^0.8"
 
 nimiq-block-production-albatross = { path = "../block-production-albatross", features = ["test-utils"] }

--- a/nano-primitives/Cargo.toml
+++ b/nano-primitives/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 num-traits = "0.2"
+rayon = "^1.5"
 
 ark-ec = "^0.2"
 ark-mnt4-753 = "^0.2"
@@ -19,3 +20,7 @@ ark-groth16 = "^0.2"
 
 nimiq-bls = { path = "../bls", version = "0.1" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }
+
+[dev-dependencies]
+rand = "0.8"
+ark-std = "^0.2"

--- a/nano-primitives/src/merkle_tree.rs
+++ b/nano-primitives/src/merkle_tree.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 
 use ark_mnt6_753::G1Projective;
+use rayon::prelude::*;
 
 use nimiq_bls::{
     pedersen::{pedersen_generators, pedersen_hash},
@@ -42,40 +43,40 @@ pub fn merkle_tree_construct(inputs: Vec<Vec<bool>>) -> Vec<u8> {
     let generators = pedersen_generators(generators_needed);
 
     // Calculate the Pedersen hashes for the leaves.
-    let mut nodes = Vec::new();
+    let mut nodes: Vec<G1Projective> = inputs
+        .par_iter()
+        .map(|bits| pedersen_hash(bits.clone(), generators.clone()))
+        .collect();
 
-    for input in inputs {
-        let hash = pedersen_hash(input, generators.clone());
-        nodes.push(hash);
-    }
-
-    // Calculate the rest of the tree
-    let mut next_nodes = Vec::new();
-
+    // Process each level of nodes.
     while nodes.len() > 1 {
-        // Process each level of nodes.
-        for j in 0..nodes.len() / 2 {
-            let mut bytes = Vec::new();
+        // Serialize all the child nodes.
+        let bits: Vec<bool> = nodes
+            .par_iter()
+            .map(|node| bytes_to_bits(&serialize_g1_mnt6(&node)))
+            .flatten()
+            .collect();
 
-            // Serialize the left node.
-            bytes.extend_from_slice(serialize_g1_mnt6(nodes[2 * j]).as_ref());
+        // Chunk the bits into the number of parent nodes.
+        let mut chunks = Vec::new();
 
-            // Serialize the right node.
-            bytes.extend_from_slice(serialize_g1_mnt6(nodes[2 * j + 1]).as_ref());
-
-            // Calculate the parent node.
-            let bits = bytes_to_bits(&bytes);
-            let parent_node = pedersen_hash(bits, generators.clone());
-
-            next_nodes.push(parent_node);
+        for i in 0..nodes.len() / 2 {
+            chunks.push(bits[2 * i..2 * i + 1].to_vec());
         }
-        nodes.clear();
 
+        // Calculate the parent nodes.
+        let mut next_nodes: Vec<G1Projective> = chunks
+            .par_iter()
+            .map(|bits| pedersen_hash(bits.clone(), generators.clone()))
+            .collect();
+
+        // Clear the child nodes and add the parent nodes.
+        nodes.clear();
         nodes.append(&mut next_nodes);
     }
 
     // Serialize the root node.
-    let bytes = serialize_g1_mnt6(nodes[0]);
+    let bytes = serialize_g1_mnt6(&nodes[0]);
 
     Vec::from(bytes.as_ref())
 }
@@ -135,9 +136,9 @@ pub fn merkle_tree_verify(
         // Serialize the left and right nodes.
         let mut bytes = Vec::new();
 
-        bytes.extend_from_slice(serialize_g1_mnt6(left_node).as_ref());
+        bytes.extend_from_slice(serialize_g1_mnt6(&left_node).as_ref());
 
-        bytes.extend_from_slice(serialize_g1_mnt6(right_node).as_ref());
+        bytes.extend_from_slice(serialize_g1_mnt6(&right_node).as_ref());
 
         let bits = bytes_to_bits(&bytes);
 
@@ -146,7 +147,7 @@ pub fn merkle_tree_verify(
     }
 
     // Serialize the root node.
-    let bytes = serialize_g1_mnt6(result);
+    let bytes = serialize_g1_mnt6(&result);
 
     let reference = Vec::from(bytes.as_ref());
 
@@ -226,10 +227,10 @@ pub fn merkle_tree_prove(inputs: Vec<Vec<bool>>, path: Vec<bool>) -> Vec<G1Proje
             }
 
             // Serialize the left node.
-            bytes.extend_from_slice(serialize_g1_mnt6(nodes[2 * j]).as_ref());
+            bytes.extend_from_slice(serialize_g1_mnt6(&nodes[2 * j]).as_ref());
 
             // Serialize the right node.
-            bytes.extend_from_slice(serialize_g1_mnt6(nodes[2 * j + 1]).as_ref());
+            bytes.extend_from_slice(serialize_g1_mnt6(&nodes[2 * j + 1]).as_ref());
 
             // Calculate the parent node.
             let bits = bytes_to_bits(&bytes);

--- a/nano-primitives/src/pk_tree.rs
+++ b/nano-primitives/src/pk_tree.rs
@@ -1,4 +1,5 @@
 use ark_mnt6_753::G2Projective;
+use rayon::prelude::*;
 
 use nimiq_bls::utils::bytes_to_bits;
 use nimiq_primitives::policy::SLOTS;
@@ -15,9 +16,6 @@ pub const PK_TREE_BREADTH: usize = 2_usize.pow(PK_TREE_DEPTH as u32);
 /// This function is meant to calculate the public key tree "off-circuit". Generating the public key
 /// tree with this function guarantees that it is compatible with the ZK circuit.
 pub fn pk_tree_construct(public_keys: Vec<G2Projective>) -> Vec<u8> {
-    // FIXME This computation is too slow ATM. Disable it for the time being.
-    return Default::default();
-
     // Checking that the number of public keys is equal to the number of validator slots.
     assert_eq!(public_keys.len(), SLOTS as usize);
 
@@ -25,13 +23,11 @@ pub fn pk_tree_construct(public_keys: Vec<G2Projective>) -> Vec<u8> {
     assert_eq!(public_keys.len() % PK_TREE_BREADTH, 0);
 
     // Serialize the public keys into bits.
-    let mut bytes = Vec::new();
-
-    for pk in public_keys {
-        bytes.extend_from_slice(&serialize_g2_mnt6(pk));
-    }
-
-    let bits = bytes_to_bits(&bytes);
+    let bits: Vec<bool> = public_keys
+        .par_iter()
+        .map(|pk| bytes_to_bits(&serialize_g2_mnt6(&pk)))
+        .flatten()
+        .collect();
 
     // Chunk the bits into the number of leaves.
     let mut inputs = Vec::new();

--- a/nano-primitives/src/serialize.rs
+++ b/nano-primitives/src/serialize.rs
@@ -5,28 +5,28 @@ use ark_mnt6_753::{G1Projective as MNT6G1Projective, G2Projective as MNT6G2Proje
 use nimiq_bls::compression::BeSerialize;
 
 /// Serializes a G1 point in the MNT4-753 curve.
-pub fn serialize_g1_mnt4(point: MNT4G1Projective) -> [u8; 95] {
+pub fn serialize_g1_mnt4(point: &MNT4G1Projective) -> [u8; 95] {
     let mut buffer = [0u8; 95];
     BeSerialize::serialize(&point.into_affine(), &mut &mut buffer[..]).unwrap();
     buffer
 }
 
 /// Serializes a G2 point in the MNT4-753 curve.
-pub fn serialize_g2_mnt4(point: MNT4G2Projective) -> [u8; 190] {
+pub fn serialize_g2_mnt4(point: &MNT4G2Projective) -> [u8; 190] {
     let mut buffer = [0u8; 190];
     BeSerialize::serialize(&point.into_affine(), &mut &mut buffer[..]).unwrap();
     buffer
 }
 
 /// Serializes a G1 point in the MNT6-753 curve.
-pub fn serialize_g1_mnt6(point: MNT6G1Projective) -> [u8; 95] {
+pub fn serialize_g1_mnt6(point: &MNT6G1Projective) -> [u8; 95] {
     let mut buffer = [0u8; 95];
     BeSerialize::serialize(&point.into_affine(), &mut &mut buffer[..]).unwrap();
     buffer
 }
 
 /// Serializes a G2 point in the MNT6-753 curve.
-pub fn serialize_g2_mnt6(point: MNT6G2Projective) -> [u8; 285] {
+pub fn serialize_g2_mnt6(point: &MNT6G2Projective) -> [u8; 285] {
     let mut buffer = [0u8; 285];
     BeSerialize::serialize(&point.into_affine(), &mut &mut buffer[..]).unwrap();
     buffer

--- a/nano-primitives/src/state_commitment.rs
+++ b/nano-primitives/src/state_commitment.rs
@@ -1,9 +1,9 @@
 use ark_mnt6_753::G2Projective;
 
+use nimiq_bls::pedersen::{pedersen_generators, pedersen_hash};
 use nimiq_bls::utils::bytes_to_bits;
 
 use crate::{pk_tree_construct, serialize_g1_mnt6};
-use nimiq_bls::pedersen::{pedersen_generators, pedersen_hash};
 
 /// This gadget is meant to calculate the "state commitment" off-circuit, which is simply a commitment,
 /// for a given block, of the block number concatenated with the header hash concatenated with the
@@ -43,7 +43,7 @@ pub fn state_commitment(
     let hash = pedersen_hash(bits, generators);
 
     // Serialize the Pedersen hash.
-    let bytes = serialize_g1_mnt6(hash);
+    let bytes = serialize_g1_mnt6(&hash);
 
     Vec::from(bytes.as_ref())
 }

--- a/nano-primitives/src/vk_commitment.rs
+++ b/nano-primitives/src/vk_commitment.rs
@@ -2,10 +2,10 @@ use ark_ec::AffineCurve;
 use ark_groth16::VerifyingKey;
 use ark_mnt6_753::MNT6_753;
 
-use crate::{serialize_g1_mnt6, serialize_g2_mnt6};
+use nimiq_bls::pedersen::{pedersen_generators, pedersen_hash};
 use nimiq_bls::utils::bytes_to_bits;
 
-use nimiq_bls::pedersen::{pedersen_generators, pedersen_hash};
+use crate::{serialize_g1_mnt6, serialize_g2_mnt6};
 
 /// This function is meant to calculate a commitment off-circuit for a verifying key of a SNARK in the
 /// MNT6-753 curve. This means we can open this commitment inside of a circuit in the MNT4-753 curve
@@ -17,16 +17,16 @@ pub fn vk_commitment(vk: VerifyingKey<MNT6_753>) -> Vec<u8> {
     // Serialize the verifying key into bits.
     let mut bytes: Vec<u8> = vec![];
 
-    bytes.extend_from_slice(serialize_g1_mnt6(vk.alpha_g1.into_projective()).as_ref());
+    bytes.extend_from_slice(serialize_g1_mnt6(&vk.alpha_g1.into_projective()).as_ref());
 
-    bytes.extend_from_slice(serialize_g2_mnt6(vk.beta_g2.into_projective()).as_ref());
+    bytes.extend_from_slice(serialize_g2_mnt6(&vk.beta_g2.into_projective()).as_ref());
 
-    bytes.extend_from_slice(serialize_g2_mnt6(vk.gamma_g2.into_projective()).as_ref());
+    bytes.extend_from_slice(serialize_g2_mnt6(&vk.gamma_g2.into_projective()).as_ref());
 
-    bytes.extend_from_slice(serialize_g2_mnt6(vk.delta_g2.into_projective()).as_ref());
+    bytes.extend_from_slice(serialize_g2_mnt6(&vk.delta_g2.into_projective()).as_ref());
 
     for i in 0..vk.gamma_abc_g1.len() {
-        bytes.extend_from_slice(serialize_g1_mnt6(vk.gamma_abc_g1[i].into_projective()).as_ref());
+        bytes.extend_from_slice(serialize_g1_mnt6(&vk.gamma_abc_g1[i].into_projective()).as_ref());
     }
 
     let bits = bytes_to_bits(&bytes);
@@ -43,7 +43,7 @@ pub fn vk_commitment(vk: VerifyingKey<MNT6_753>) -> Vec<u8> {
     let hash = pedersen_hash(bits, generators);
 
     // Serialize the Pedersen commitment.
-    let bytes = serialize_g1_mnt6(hash);
+    let bytes = serialize_g1_mnt6(&hash);
 
     Vec::from(bytes.as_ref())
 }

--- a/nano-sync/src/gadgets/mnt4/merkle_tree.rs
+++ b/nano-sync/src/gadgets/mnt4/merkle_tree.rs
@@ -254,13 +254,13 @@ mod tests {
 
             if path[i] {
                 bits.extend_from_slice(
-                    bytes_to_bits(serialize_g1_mnt6(other_node).as_ref()).as_ref(),
+                    bytes_to_bits(serialize_g1_mnt6(&other_node).as_ref()).as_ref(),
                 );
-                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(node).as_ref()).as_ref());
+                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(&node).as_ref()).as_ref());
             } else {
-                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(node).as_ref()).as_ref());
+                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(&node).as_ref()).as_ref());
                 bits.extend_from_slice(
-                    bytes_to_bits(serialize_g1_mnt6(other_node).as_ref()).as_ref(),
+                    bytes_to_bits(serialize_g1_mnt6(&other_node).as_ref()).as_ref(),
                 );
             }
 
@@ -270,7 +270,7 @@ mod tests {
         }
 
         // Create root.
-        let root = serialize_g1_mnt6(node).to_vec();
+        let root = serialize_g1_mnt6(&node).to_vec();
         let root_bits = bytes_to_bits(&root);
 
         // Verify Merkle proof using the primitive version.
@@ -341,13 +341,13 @@ mod tests {
 
             if path[i] {
                 bits.extend_from_slice(
-                    bytes_to_bits(serialize_g1_mnt6(other_node).as_ref()).as_ref(),
+                    bytes_to_bits(serialize_g1_mnt6(&other_node).as_ref()).as_ref(),
                 );
-                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(node).as_ref()).as_ref());
+                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(&node).as_ref()).as_ref());
             } else {
-                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(node).as_ref()).as_ref());
+                bits.extend_from_slice(bytes_to_bits(serialize_g1_mnt6(&node).as_ref()).as_ref());
                 bits.extend_from_slice(
-                    bytes_to_bits(serialize_g1_mnt6(other_node).as_ref()).as_ref(),
+                    bytes_to_bits(serialize_g1_mnt6(&other_node).as_ref()).as_ref(),
                 );
             }
 

--- a/nano-sync/src/gadgets/mnt4/serialize.rs
+++ b/nano-sync/src/gadgets/mnt4/serialize.rs
@@ -85,7 +85,7 @@ mod tests {
         let g1_point_var = G1Var::new_witness(cs.clone(), || Ok(g1_point)).unwrap();
 
         // Serialize using the primitive version.
-        let primitive_bytes = serialize_g1_mnt6(g1_point);
+        let primitive_bytes = serialize_g1_mnt6(&g1_point);
         let primitive_bits = bytes_to_bits(&primitive_bytes);
 
         // Serialize using the gadget version.
@@ -113,7 +113,7 @@ mod tests {
         let g2_point_var = G2Var::new_witness(cs.clone(), || Ok(g2_point)).unwrap();
 
         // Serialize using the primitive version.
-        let primitive_bytes = serialize_g2_mnt6(g2_point);
+        let primitive_bytes = serialize_g2_mnt6(&g2_point);
         let primitive_bits = bytes_to_bits(&primitive_bytes);
 
         // Serialize using the gadget version.

--- a/nano-sync/src/gadgets/mnt4/y_to_bit.rs
+++ b/nano-sync/src/gadgets/mnt4/y_to_bit.rs
@@ -92,7 +92,7 @@ mod tests {
                 .unwrap();
 
             // Serialize using the primitive version and get the first bit (which is the y flag).
-            let bytes = serialize_g1_mnt6(g1_point);
+            let bytes = serialize_g1_mnt6(&g1_point);
             let bits = bytes_to_bits(&bytes);
             let primitive_y_bit = bits[0];
 
@@ -125,7 +125,7 @@ mod tests {
                 .unwrap();
 
             // Serialize using the primitive version and get the first bit (which is the y flag).
-            let bytes = serialize_g2_mnt6(g2_point);
+            let bytes = serialize_g2_mnt6(&g2_point);
             let bits = bytes_to_bits(&bytes);
             let primitive_y_bit = bits[0];
 

--- a/nano-sync/src/gadgets/mnt6/serialize.rs
+++ b/nano-sync/src/gadgets/mnt6/serialize.rs
@@ -85,7 +85,7 @@ mod tests {
         let g1_point_var = G1Var::new_witness(cs.clone(), || Ok(g1_point)).unwrap();
 
         // Serialize using the primitive version.
-        let primitive_bytes = serialize_g1_mnt4(g1_point);
+        let primitive_bytes = serialize_g1_mnt4(&g1_point);
         let primitive_bits = bytes_to_bits(&primitive_bytes);
 
         // Serialize using the gadget version.
@@ -113,7 +113,7 @@ mod tests {
         let g2_point_var = G2Var::new_witness(cs.clone(), || Ok(g2_point)).unwrap();
 
         // Serialize using the primitive version.
-        let primitive_bytes = serialize_g2_mnt4(g2_point);
+        let primitive_bytes = serialize_g2_mnt4(&g2_point);
         let primitive_bits = bytes_to_bits(&primitive_bytes);
 
         // Serialize using the gadget version.

--- a/nano-sync/src/gadgets/mnt6/y_to_bit.rs
+++ b/nano-sync/src/gadgets/mnt6/y_to_bit.rs
@@ -86,7 +86,7 @@ mod tests {
                 .unwrap();
 
             // Serialize using the primitive version and get the first bit (which is the y flag).
-            let bytes = serialize_g1_mnt4(g1_point);
+            let bytes = serialize_g1_mnt4(&g1_point);
             let bits = bytes_to_bits(&bytes);
             let primitive_y_bit = bits[0];
 
@@ -119,7 +119,7 @@ mod tests {
                 .unwrap();
 
             // Serialize using the primitive version and get the first bit (which is the y flag).
-            let bytes = serialize_g2_mnt4(g2_point);
+            let bytes = serialize_g2_mnt4(&g2_point);
             let bits = bytes_to_bits(&bytes);
             let primitive_y_bit = bits[0];
 

--- a/nano-sync/src/nano_zkp/prove.rs
+++ b/nano-sync/src/nano_zkp/prove.rs
@@ -62,7 +62,7 @@ impl NanoZKP {
         let mut bytes = Vec::new();
 
         for i in 0..initial_pks.len() {
-            bytes.extend_from_slice(&serialize_g2_mnt6(initial_pks[i]));
+            bytes.extend_from_slice(&serialize_g2_mnt6(&initial_pks[i]));
         }
 
         let bits = bytes_to_bits(&bytes);
@@ -305,11 +305,11 @@ impl NanoZKP {
             }
         }
 
-        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(agg_pk));
+        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(&agg_pk));
 
         let hash = pedersen_hash(agg_pk_bits, pedersen_generators(5));
 
-        let agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(hash));
+        let agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Get the relevant chunk of the signer's bitmap.
         let signer_bitmap_chunk = &signer_bitmap[position * SLOTS as usize / PK_TREE_BREADTH
@@ -415,11 +415,11 @@ impl NanoZKP {
             }
         }
 
-        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(agg_pk));
+        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(&agg_pk));
 
         let hash = pedersen_hash(agg_pk_bits, pedersen_generators(5));
 
-        let left_agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(hash));
+        let left_agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Calculate the right aggregate public key commitment.
         let mut agg_pk = G2MNT6::zero();
@@ -432,11 +432,11 @@ impl NanoZKP {
             }
         }
 
-        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(agg_pk));
+        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(&agg_pk));
 
         let hash = pedersen_hash(agg_pk_bits, pedersen_generators(5));
 
-        let right_agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(hash));
+        let right_agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Get the relevant chunk of the signer's bitmap.
         let signer_bitmap_chunk = &signer_bitmap[position * SLOTS as usize
@@ -561,11 +561,11 @@ impl NanoZKP {
             agg_pk += chunk;
         }
 
-        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(agg_pk));
+        let agg_pk_bits = bytes_to_bits(&serialize_g2_mnt6(&agg_pk));
 
         let hash = pedersen_hash(agg_pk_bits, pedersen_generators(5));
 
-        let agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(hash));
+        let agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Get the relevant chunk of the signer's bitmap.
         let signer_bitmap_chunk = &signer_bitmap[position * SLOTS as usize


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?
Parallelized pk_tree_construct and merkle_tree_construct using Rayon.  Previously, with 512 public keys as input, pk_tree_construct took 4.9s in release mode. Now, with the same 512 keys and also in release mode, it takes 1.35s.