### PR TITLE
Fix error message on client.toml absence

### DIFF
--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -100,7 +100,7 @@ impl ConfigFile {
         let path = paths::home().join("client.toml");
         if !path.exists() {
             let msg = format!(
-                "Config file not found. Please create one. An example config file can be found at: {}",
+                "Config file not found at {}. An example config file can be found at lib/src/config/config_file/client.example.toml",
                 path.display()
             );
             log::warn!("{}", msg);

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -100,8 +100,9 @@ impl ConfigFile {
         let path = paths::home().join("client.toml");
         if !path.exists() {
             let msg = format!(
-                "Config file not found at {}. An example config file can be found at lib/src/config/config_file/client.example.toml",
-                path.display()
+                "Config file not found. Please create one at {} or specify a location using -c path/to/config.toml, see the example config file at {}",
+                path.display(),
+                path_example.display(),
             );
             log::warn!("{}", msg);
             return Err(Error::config_error(&msg));


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?
This fixes the error message that occurs when `client.toml` isn't found. Before, it incorrectly referred to the location where the config file was searched for as where an example was. This fixes it so it correctly labels the expected config location, and includes a reference to the actual example config.