### PR TITLE
RPC: get extended transactions/inherent by batch

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -5,7 +5,7 @@ use nimiq_account::Account;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 
-use crate::types::{Block, OrLatest, SlashedSlots, Slot, Stakes, Transaction};
+use crate::types::{Block, ExtendedTransaction, OrLatest, SlashedSlots, Slot, Stakes, Transaction};
 
 #[cfg_attr(
     feature = "proxy",
@@ -48,6 +48,11 @@ pub trait BlockchainInterface {
         &mut self,
         hash: Blake2bHash,
     ) -> Result<Transaction, Self::Error>;
+
+    async fn get_transactions_by_block_number(
+        &mut self,
+        block_number: u32,
+    ) -> Result<Vec<ExtendedTransaction>, Self::Error>;
 
     async fn get_transaction_receipt(&mut self, hash: Blake2bHash) -> Result<(), Self::Error>;
 

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -54,6 +54,12 @@ pub trait BlockchainInterface {
         block_number: u32,
     ) -> Result<Vec<ExtendedTransaction>, Self::Error>;
 
+    async fn get_transactions_by_batch_number(
+        &mut self,
+        batch_number: u32,
+        epoch_number: u32,
+    ) -> Result<Vec<ExtendedTransaction>, Self::Error>;
+
     async fn get_transactions_by_epoch_number(
         &mut self,
         epoch_number: u32,

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -54,6 +54,11 @@ pub trait BlockchainInterface {
         block_number: u32,
     ) -> Result<Vec<ExtendedTransaction>, Self::Error>;
 
+    async fn get_transactions_by_epoch_number(
+        &mut self,
+        epoch_number: u32,
+    ) -> Result<Vec<ExtendedTransaction>, Self::Error>;
+
     async fn get_transaction_receipt(&mut self, hash: Blake2bHash) -> Result<(), Self::Error>;
 
     async fn list_stakes(&mut self) -> Result<Stakes, Self::Error>;

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -10,6 +10,7 @@ use std::{
 use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
+use nimiq_account::InherentType;
 use nimiq_block_albatross::{TendermintProof, ViewChangeProof};
 use nimiq_blockchain_albatross::{AbstractBlockchain, Blockchain};
 use nimiq_bls::{CompressedPublicKey, CompressedSignature};
@@ -311,6 +312,46 @@ impl Transaction {
             proof: transaction.proof,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Inherent {
+    pub ty: u8,
+
+    pub block_number: u32,
+
+    pub timestamp: u64,
+
+    pub target: Address,
+
+    pub value: Coin,
+
+    #[serde(with = "crate::serde_helpers::hex")]
+    pub data: Vec<u8>,
+}
+
+impl Inherent {
+    pub fn from_inherent(
+        inherent: nimiq_account::Inherent,
+        block_number: u32,
+        timestamp: u64,
+    ) -> Self {
+        Inherent {
+            ty: inherent.ty as u8,
+            block_number,
+            timestamp,
+            target: inherent.target,
+            value: inherent.value,
+            data: inherent.data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExtendedTransaction {
+    Transaction(Transaction),
+    Inherent(Inherent),
 }
 
 impl Block {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -329,6 +329,8 @@ pub struct Inherent {
 
     #[serde(with = "crate::serde_helpers::hex")]
     pub data: Vec<u8>,
+
+    pub hash: Blake2bHash,
 }
 
 impl Inherent {
@@ -337,6 +339,8 @@ impl Inherent {
         block_number: u32,
         timestamp: u64,
     ) -> Self {
+        let hash = inherent.hash();
+
         Inherent {
             ty: inherent.ty as u8,
             block_number,
@@ -344,6 +348,7 @@ impl Inherent {
             target: inherent.target,
             value: inherent.value,
             data: inherent.data,
+            hash,
         }
     }
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -231,7 +231,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         epoch_number: u32,
     ) -> Result<Vec<ExtendedTransaction>, Error> {
-        // Get all the extended transactions that correspond to this block.
+        // Get all the extended transactions that correspond to this epoch.
         let extended_tx_vec = self
             .blockchain
             .history_store

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -174,22 +174,55 @@ impl BlockchainInterface for BlockchainDispatcher {
             .into_iter()
             .enumerate()
             .map(|(_, extended_tx)| {
-                    if extended_tx.is_inherent() {
-                        ExtendedTransaction::Inherent(Inherent::from_inherent(
-                            extended_tx.unwrap_inherent().clone(),
-                            extended_tx.block_number,
-                            extended_tx.block_time,
-                        ))
-                    } else {
-                        let transaction = extended_tx.unwrap_basic();
-                        ExtendedTransaction::Transaction(Transaction::from_blockchain(
-                            transaction.clone(),
-                            extended_tx.block_number,
-                            extended_tx.block_time,
-                            self.blockchain.block_number(),
-                        ))
-                    }
-                })
+                if extended_tx.is_inherent() {
+                    ExtendedTransaction::Inherent(Inherent::from_inherent(
+                        extended_tx.unwrap_inherent().clone(),
+                        extended_tx.block_number,
+                        extended_tx.block_time,
+                    ))
+                } else {
+                    let transaction = extended_tx.unwrap_basic();
+                    ExtendedTransaction::Transaction(Transaction::from_blockchain(
+                        transaction.clone(),
+                        extended_tx.block_number,
+                        extended_tx.block_time,
+                        self.blockchain.block_number(),
+                    ))
+                }
+            })
+            .collect::<Vec<ExtendedTransaction>>())
+    }
+
+    async fn get_transactions_by_epoch_number(
+        &mut self,
+        epoch_number: u32,
+    ) -> Result<Vec<ExtendedTransaction>, Error> {
+        // Get all the extended transactions that correspond to this block.
+        let extended_tx_vec = self
+            .blockchain
+            .history_store
+            .get_epoch_transactions(epoch_number, None);
+
+        Ok(extended_tx_vec
+            .into_iter()
+            .enumerate()
+            .map(|(_, extended_tx)| {
+                if extended_tx.is_inherent() {
+                    ExtendedTransaction::Inherent(Inherent::from_inherent(
+                        extended_tx.unwrap_inherent().clone(),
+                        extended_tx.block_number,
+                        extended_tx.block_time,
+                    ))
+                } else {
+                    let transaction = extended_tx.unwrap_basic();
+                    ExtendedTransaction::Transaction(Transaction::from_blockchain(
+                        transaction.clone(),
+                        extended_tx.block_number,
+                        extended_tx.block_time,
+                        self.blockchain.block_number(),
+                    ))
+                }
+            })
             .collect::<Vec<ExtendedTransaction>>())
     }
 


### PR DESCRIPTION
## What's in this pull request?

New RPC method that sends the extended transactions for a given batch.
