### PR TITLE
Get transactions and inherents by block and batch

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -5,7 +5,9 @@ use nimiq_account::Account;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 
-use crate::types::{Block, OrLatest, SlashedSlots, Slot, Stakes, Transaction};
+use crate::types::{
+    Block, ExtendedTransactions, OrLatest, SlashedSlots, Slot, Stakes, Transaction,
+};
 
 #[cfg_attr(
     feature = "proxy",
@@ -48,6 +50,11 @@ pub trait BlockchainInterface {
         &mut self,
         hash: Blake2bHash,
     ) -> Result<Transaction, Self::Error>;
+
+    async fn get_transactions_by_block_number(
+        &mut self,
+        block_number: u32,
+    ) -> Result<ExtendedTransactions, Self::Error>;
 
     async fn get_transaction_receipt(&mut self, hash: Blake2bHash) -> Result<(), Self::Error>;
 

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -6,7 +6,7 @@ use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 
 use crate::types::{
-    Block, ExtendedTransactions, OrLatest, SlashedSlots, Slot, Stakes, Transaction,
+    Block, ExtendedTransactions, Inherent, OrLatest, SlashedSlots, Slot, Stakes, Transaction,
 };
 
 #[cfg_attr(
@@ -55,6 +55,11 @@ pub trait BlockchainInterface {
         &mut self,
         block_number: u32,
     ) -> Result<ExtendedTransactions, Self::Error>;
+
+    async fn get_batch_inherents(
+        &mut self,
+        batch_number: u32,
+    ) -> Result<Vec<Inherent>, Self::Error>;
 
     async fn get_transaction_receipt(&mut self, hash: Blake2bHash) -> Result<(), Self::Error>;
 

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -313,6 +313,52 @@ impl Transaction {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Inherent {
+    pub ty: u8,
+
+    pub block_number: u32,
+
+    pub timestamp: u64,
+
+    pub target: Address,
+
+    pub value: Coin,
+
+    #[serde(with = "crate::serde_helpers::hex")]
+    pub data: Vec<u8>,
+
+    pub hash: Blake2bHash,
+}
+
+impl Inherent {
+    pub fn from_transaction(
+        inherent: nimiq_account::Inherent,
+        block_number: u32,
+        timestamp: u64,
+    ) -> Self {
+        let hash = inherent.hash();
+
+        Inherent {
+            ty: inherent.ty as u8,
+            block_number,
+            timestamp,
+            target: inherent.target,
+            value: inherent.value,
+            data: inherent.data,
+            hash,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtendedTransactions {
+    pub transactions: Vec<Transaction>,
+
+    pub inherents: Vec<Inherent>,
+}
+
 impl Block {
     pub fn from_block(
         blockchain: &Blockchain,

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -196,6 +196,25 @@ impl BlockchainInterface for BlockchainDispatcher {
         })
     }
 
+    async fn get_batch_inherents(&mut self, batch_number: u32) -> Result<Vec<Inherent>, Error> {
+        let extended_tx_vec = self
+            .blockchain
+            .history_store
+            .get_block_transactions(policy::macro_block_of(batch_number), None);
+
+        Ok(extended_tx_vec
+            .into_iter()
+            .map(|inherent| {
+                Inherent::from_transaction(
+                    // Because we get the ext_txs of a macro block, all of them must be inherents
+                    inherent.unwrap_inherent().clone(),
+                    inherent.block_number,
+                    inherent.block_time,
+                )
+            })
+            .collect())
+    }
+
     async fn list_stakes(&mut self) -> Result<Stakes, Error> {
         let staking_contract = self.blockchain.get_staking_contract();
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

(I cancelled the pr-checks, as they are the same as the push-checks, as this branch is on top of `albatross`.)

#### Replaces #248 

## What's in this pull request?

Two new methods: `getTransactionsByBlockNumber` to get all blockchain transactions and inherents for a block, and a `getBatchInherents` method that takes the batch number and returns only the inherents of its macro block.

Two questions @brunoffranca:
1. Are inherents only included in macro blocks? E.g. the slashing inherents, are they only in the macro blocks at the end of batches?
2. Since the second method `getBatchInherents` returns the same content as `getTransactionsByBlockNumber` for macro blocks (if question 1 is answered with "yes"), do you think it is unnecessary? If one knows the batch number to give to the batch-inherents method, one would also know the macro block number and can use the txs-by-block-number method.