### PR TITLE
Prevent integer underflow

### DIFF
--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -261,8 +261,8 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
         }
 
         match ip {
-            IpNetwork::V4(..) => self.limits.ipv4_count -= 1,
-            IpNetwork::V6(..) => self.limits.ipv6_count -= 1,
+            IpNetwork::V4(..) => self.limits.ipv4_count = self.limits.ipv4_count.saturating_sub(1),
+            IpNetwork::V6(..) => self.limits.ipv6_count = self.limits.ipv6_count.saturating_sub(1),
         };
     }
 


### PR DESCRIPTION
I received this log and panic in the external client when I force-quit all 4 Docker nodes. There might be another root cause, feel free to ignore this PR and fix it properly :)

```
 2021-05-08 01:29:28 INFO  nimiq_client         | Consensus established: true - Head: #1077 - 02b9021e60faff72a3e7972ccea21ae1c51aeecd0b0e15eca9d19bc6c85ff6b6, Peers: 4
 2021-05-08 01:29:32 INFO  behaviour            | Connection closed: peer_id=PeerId("12D3KooWHsCjTvcUVT9pyJZ57o6kmVCaTtN84gNgtXco7HFeGQi7"), connection_id=ConnectionId(TaskId(1)), connected_point=Dialer { address: "/ip4/7.0.0.5/tcp/8443/ws" }
 2021-05-08 01:29:32 INFO  behaviour            | Connection closed: peer_id=PeerId("12D3KooWESd1NiMYeuDNJhp3Dpn4AASeWu4ZtmFdLz4iVmk7wvgu"), connection_id=ConnectionId(TaskId(0)), connected_point=Dialer { address: "/dns4/seed1.nimiq.local/tcp/8443/ws" }
 2021-05-08 01:29:32 INFO  behaviour            | Connection closed: peer_id=PeerId("12D3KooWKFgQo9imZcYqKsP15TdqygV8DcemSZzcmJE2L9LXFBVD"), connection_id=ConnectionId(TaskId(2)), connected_point=Dialer { address: "/ip4/7.0.0.4/tcp/8443/ws" }

 2021-05-08 01:29:34 ERROR panic                | thread 'async-std/runtime' panicked at 'attempt to subtract with overflow': network-libp2p/src/connection_pool/behaviour.rs:264
   0: log_panics::init::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/log-panics-2.0.0/src/lib.rs:52:25
   1: std::panicking::rust_panic_with_hook
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/std/src/panicking.rs:595:17
   2: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/std/src/panicking.rs:495:13
   3: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/std/src/sys_common/backtrace.rs:141:18
   4: rust_begin_unwind
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/std/src/panicking.rs:493:5
   5: core::panicking::panic_fmt
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/core/src/panicking.rs:92:14
   6: core::panicking::panic
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/core/src/panicking.rs:50:5
   7: <nimiq_network_libp2p::connection_pool::behaviour::ConnectionPoolBehaviour as libp2p_swarm::behaviour::NetworkBehaviour>::inject_connection_closed
             at network-libp2p/src/connection_pool/behaviour.rs:264:34
   8: <nimiq_network_libp2p::behaviour::NimiqBehaviour as libp2p_swarm::behaviour::NetworkBehaviour>::inject_connection_closed
             at network-libp2p/src/behaviour.rs:93:10
   9: libp2p_swarm::ExpandedSwarm<TBehaviour,TInEvent,TOutEvent,THandler>::poll_next_event
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-swarm-0.27.2/src/lib.rs:549:21
  10: libp2p_swarm::ExpandedSwarm<TBehaviour,TInEvent,TOutEvent,THandler>::next_event::{{closure}}::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-swarm-0.27.2/src/lib.rs:475:35
  11: <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.14/src/future/poll_fn.rs:55:9
  12: libp2p_swarm::ExpandedSwarm<TBehaviour,TInEvent,TOutEvent,THandler>::next_event::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-swarm-0.27.2/src/lib.rs:475:9
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  14: <futures_util::future::future::fuse::Fuse<Fut> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.14/src/future/future/fuse.rs:86:37
  15: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:120:9
  16: futures_util::future::future::FutureExt::poll_unpin
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.14/src/future/future/mod.rs:562:9
  17: nimiq_network_libp2p::network::Network::swarm_task::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.14/src/async_await/select_mod.rs:326:13
  18: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:269:13
  19: nimiq_network_libp2p::network::Network::swarm_task::{{closure}}::{{closure}}::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.14/src/async_await/select_mod.rs:326:13
  20: <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.14/src/future/poll_fn.rs:55:9
  21: nimiq_network_libp2p::network::Network::swarm_task::{{closure}}::{{closure}}
             at network-libp2p/src/network.rs:247:17
  22: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  23: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.25/src/instrument.rs:151:9
  24: nimiq_network_libp2p::network::Network::swarm_task::{{closure}}
             at network-libp2p/src/network.rs:245:9
  25: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  26: <async_std::task::builder::SupportTaskLocals<F> as core::future::future::Future>::poll::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:199:17
  27: async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/task_locals_wrapper.rs:60:13
  28: std::thread::local::LocalKey<T>::try_with
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:376:16
  29: std::thread::local::LocalKey<T>::with
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:352:9
  30: async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/task_locals_wrapper.rs:55:9
  31: <async_std::task::builder::SupportTaskLocals<F> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:197:13
  32: async_executor::Executor::spawn::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-executor-1.4.1/src/lib.rs:144:13
  33: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  34: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:120:9
  35: async_task::raw::RawTask<F,T,S>::run
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-task-4.0.3/src/raw.rs:489:20
  36: async_task::runnable::Runnable::run
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-task-4.0.3/src/runnable.rs:309:18
  37: async_executor::Executor::run::{{closure}}::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-executor-1.4.1/src/lib.rs:235:21
  38: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  39: <futures_lite::future::Or<F1,F2> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-lite-1.11.3/src/future.rs:529:33
  40: async_executor::Executor::run::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-executor-1.4.1/src/lib.rs:242:9
  41: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  42: <futures_lite::future::Or<F1,F2> as core::future::future::Future>::poll
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-lite-1.11.3/src/future.rs:529:33
  43: async_io::driver::block_on
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-io-1.4.1/src/driver.rs:142:33
  44: async_global_executor::reactor::block_on::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/reactor.rs:3:18
  45: async_global_executor::reactor::block_on
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/reactor.rs:12:5
  46: async_global_executor::threading::thread_main_loop::{{closure}}::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/threading.rs:95:17
  47: std::thread::local::LocalKey<T>::try_with
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:376:16
  48: std::thread::local::LocalKey<T>::with
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:352:9
  49: async_global_executor::threading::thread_main_loop::{{closure}}
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/threading.rs:89:13
  50: std::panicking::try::do_call
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:379:40
  51: __rust_try
  52: std::panicking::try
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:343:19
  53: std::panic::catch_unwind
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:431:14
  54: async_global_executor::threading::thread_main_loop
             at /home/soeren/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/threading.rs:88:12
  55: core::ops::function::FnOnce::call_once
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
  56: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs:125:18
  57: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:481:17
  58: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:344:9
  59: std::panicking::try::do_call
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:379:40
  60: __rust_try
  61: std::panicking::try
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:343:19
  62: std::panic::catch_unwind
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:431:14
  63: std::thread::Builder::spawn_unchecked::{{closure}}
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:480:30
  64: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /home/soeren/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
  65: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/alloc/src/boxed.rs:1546:9
      <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/alloc/src/boxed.rs:1546:9
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/716394d6581b60c75cfdd88b8e5b876f2db88b62/library/std/src/sys/unix/thread.rs:71:17
  66: start_thread
  67: __clone

```