### PR TITLE
Add rotating_trace_log configuration to docker_config.sh

### DIFF
--- a/scripts/docker_config.sh
+++ b/scripts/docker_config.sh
@@ -66,6 +66,13 @@ entry file /home/nimiq/nimiq.log.pipe string
 optional statistics NIMIQ_LOG_STATISTICS number
 optional file NIMIQ_LOG_FILE string
 
+if [[ "$ROTATING_LOG_ENABLED" == "true" ]]; then
+    echo '[log.rotating_trace_log]'
+    optional path ROTATING_LOG_PATH string
+    optional size ROTATING_LOG_SIZE number
+    optional file_count ROTATING_LOG_FILE_COUNT number
+fi
+
 echo '[validator]'
 optional validator_key_file VALIDATOR_KEY_FILE string
 optional validator_key VALIDATOR_KEY string


### PR DESCRIPTION
This change adds the option to enable and configure rotating trace log in docker using environment variables