### PR TITLE
Subscribe to and log consensus events in client

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -292,7 +292,7 @@ impl<N: Network> Consensus<N> {
             // - know the head state of a majority of our peers
             if self.num_agents() >= self.min_peers {
                 if self.block_queue.accepted_block_announcements() >= Self::MIN_BLOCKS_ESTABLISHED {
-                    info!("Consensus established, number of accepted announcements satisfied.");
+                    debug!("Consensus established, number of accepted announcements satisfied.");
                     self.established_flag.swap(true, Ordering::Release);
 
                     // Also stop any other checks.
@@ -307,7 +307,7 @@ impl<N: Network> Consensus<N> {
                         debug!("Trying to establish consensus, checking head request ({} known, {} unknown).", head_request.num_known_blocks, head_request.num_unknown_blocks);
                         // We would like that 2/3 of our peers have a known state.
                         if head_request.num_known_blocks >= 2 * head_request.num_unknown_blocks {
-                            info!("Consensus established, 2/3 of heads known.");
+                            debug!("Consensus established, 2/3 of heads known.");
                             self.established_flag.swap(true, Ordering::Release);
                             return Some(ConsensusEvent::Established);
                         }

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use nimiq_block::Block;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain};
+pub use nimiq_consensus::ConsensusEvent;
 use nimiq_consensus::{Consensus as AbstractConsensus, ConsensusProxy as AbstractConsensusProxy};
 use nimiq_database::Environment;
 use nimiq_genesis::NetworkInfo;


### PR DESCRIPTION
Instead of (ab)using trace/debug logs in the consensus itself (that I changed to info logs in 0cc70d5a7ef7e718e77f30c5268d9b57e937ebdd), use the client to log consensus state changes. This will also be helpful as an example/extension-point for developers that are extending the client to add their own functionality.
