### PR TITLE
Add code coverage for GH Actions

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,6 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+output-type: lcov
+output-path: ./lcov.info
+prefix-dir: /home/user/build/

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -72,7 +72,23 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --release --all-features
+        args: --all-features
+      # Add flags for gcov
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+    - id: coverage
+      name: Generate coverage  report
+      uses: actions-rs/grcov@v0.1
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ${{ steps.coverage.outputs.report }}
+        fail_ci_if_error: false
+        flags: unittests
+        name: Nimiq code coverage
+        verbose: true
 
   clippy:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Add code coverage for Github Actions.
The workflow stage reuses the test stage, adding flags for
generating coverage and then uploading the results to codecov.io.
This implementation uses grcov in favor of tarpaulin because of
the lack of support of anything different from x86-64 in the
latter.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
