### PR TITLE
Hex string peer key support on config file

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -73,6 +73,7 @@ impl ClientInner {
         // Load identity keypair from file store
         let identity_keypair = config.storage.identity_keypair()?;
         log::info!("Identity public key: {:?}", identity_keypair.public());
+        log::info!("PeerId: {:}", identity_keypair.public().into_peer_id().to_base58());
 
         // Generate peer contact from identity keypair and services/protocols
         let mut peer_contact = PeerContact::new(

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -73,7 +73,10 @@ impl ClientInner {
         // Load identity keypair from file store
         let identity_keypair = config.storage.identity_keypair()?;
         log::info!("Identity public key: {:?}", identity_keypair.public());
-        log::info!("PeerId: {:}", identity_keypair.public().into_peer_id().to_base58());
+        log::info!(
+            "PeerId: {:}",
+            identity_keypair.public().into_peer_id().to_base58()
+        );
 
         // Generate peer contact from identity keypair and services/protocols
         let mut peer_contact = PeerContact::new(
@@ -112,7 +115,7 @@ impl ClientInner {
 
         // Load validator key (before we give away ownership of the storage config)
         #[cfg(feature = "validator")]
-        let validator_key = config.storage.validator_key()?;
+        let validator_key = config.storage.validator_keypair()?;
 
         // Open database
         let environment = config.storage.database(

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -117,6 +117,7 @@ impl ConfigFile {
 #[serde(deny_unknown_fields)]
 pub struct NetworkSettings {
     pub peer_key_file: Option<String>,
+    pub peer_key: Option<String>,
 
     #[serde(default)]
     pub listen_addresses: Vec<String>,

--- a/scripts/docker_config.sh
+++ b/scripts/docker_config.sh
@@ -27,6 +27,7 @@ function optional () {
 echo '[network]'
 required min_peers NIMIQ_MIN_PEERS number
 required peer_key_file NIMIQ_PEER_KEY_FILE string
+optional peer_key NIMIQ_PEER_KEY string
 
 echo "listen_addresses = ["
 addr=($LISTEN_ADDRESSES)


### PR DESCRIPTION
Currently the peer key is either loaded from a file or created from scratch if that fails. This PR introduces support so that the peer key can also be specified as a hex string in the config file.