### PR TITLE
fix/seed1 nimiq peerkey not needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - LISTEN_ADDRESSES=/ip4/7.0.0.2/tcp/8443/ws
       - NIMIQ_HOST=seed1.${NETWORK_NAME:?err}
       - NIMIQ_NETWORK=dev-albatross
-      - NIMIQ_PEER_KEY=fe3b33ed720a5d532e27551c3b9aa83d97a27e82c30d87fe1378936890f81ea6
       - NIMIQ_PEER_KEY_FILE=/home/nimiq/.nimiq/peer_key.dat
       - NIMIQ_INSTANT_INBOUND=true
       - NIMIQ_VALIDATOR=validator
@@ -76,7 +75,6 @@ services:
       - NIMIQ_NETWORK=dev-albatross
       - NIMIQ_SEED_NODES=/ip4/7.0.0.2/tcp/8443/ws
       # - NIMIQ_SEED_NODES=ws://seed1.${NETWORK_NAME:?err}:8443/5af4c3f30998573e8d3476cd0e0543bf7adba576ef321342e41c2bccc246c377
-      # - NIMIQ_PEER_KEY=3a55f2b5f7c66a4ce624c8189bb7d6217384ae67c4728591d5458beaab1b226a
       - NIMIQ_PEER_KEY_FILE=/home/nimiq/.nimiq/peer_key.dat
       - NIMIQ_INSTANT_INBOUND=true
       - NIMIQ_VALIDATOR=validator
@@ -107,7 +105,6 @@ services:
       - NIMIQ_NETWORK=dev-albatross
       - NIMIQ_SEED_NODES=/ip4/7.0.0.2/tcp/8443/ws
       # - NIMIQ_SEED_NODES=ws://seed1.${NETWORK_NAME:?err}:8443/5af4c3f30998573e8d3476cd0e0543bf7adba576ef321342e41c2bccc246c377
-      # - NIMIQ_PEER_KEY=3a55f2b5f7c66a4ce624c8189bb7d6217384ae67c4728591d5458beaab1b226a
       - NIMIQ_PEER_KEY_FILE=/home/nimiq/.nimiq/peer_key.dat
       - NIMIQ_INSTANT_INBOUND=true
       - NIMIQ_VALIDATOR=validator
@@ -139,7 +136,6 @@ services:
       - NIMIQ_NETWORK=dev-albatross
       - NIMIQ_SEED_NODES=/ip4/7.0.0.2/tcp/8443/ws
       # - NIMIQ_SEED_NODES=ws://seed1.${NETWORK_NAME:?err}:8443/5af4c3f30998573e8d3476cd0e0543bf7adba576ef321342e41c2bccc246c377
-      # - NIMIQ_PEER_KEY=3a55f2b5f7c66a4ce624c8189bb7d6217384ae67c4728591d5458beaab1b226a
       - NIMIQ_PEER_KEY_FILE=/home/nimiq/.nimiq/peer_key.dat
       - NIMIQ_INSTANT_INBOUND=true
       - NIMIQ_VALIDATOR=validator


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes issue #___.

## What's in this pull request?
remove of nimiq-peer key from seed 1, this made the chain crash.
nimiq-peer key is not needed because its created on startup.
>...
