### PR TITLE
Refactor some test utilities into its own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
   "rpc-interface",
   "rpc-server",
   "tendermint",
+  "test-utils",
   "tools",
   "transaction-builder",
   "utils",

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -37,6 +37,7 @@ nimiq-vrf = { path = "../vrf" }
 
 [dev-dependencies]
 nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-test-utils = { path = "../test-utils" }
 
 [features]
 default = []

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -1,139 +1,18 @@
 use std::sync::Arc;
 
 use beserial::Deserialize;
-use nimiq_block::{
-    Block, BlockError, ForkProof, MacroBlock, MacroBody, MacroHeader, MultiSignature,
-    SignedViewChange, TendermintIdentifier, TendermintProof, TendermintStep, TendermintVote,
-    ViewChange, ViewChangeProof,
-};
+use nimiq_block::{Block, BlockError, ForkProof};
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushError, PushResult};
-use nimiq_bls::{AggregateSignature, KeyPair, SecretKey};
-use nimiq_collections::BitSet;
+use nimiq_bls::{KeyPair, SecretKey};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
-use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_mempool::{Mempool, MempoolConfig};
-use nimiq_nano_primitives::pk_tree_construct;
 use nimiq_primitives::policy;
-use nimiq_primitives::policy::{SLOTS, TWO_THIRD_SLOTS};
+use nimiq_test_utils::blockchain::{
+    fill_micro_blocks, sign_macro_block, sign_view_change, SECRET_KEY,
+};
 use nimiq_vrf::VrfSeed;
-
-/// Secret key of validator. Tests run with `genesis/src/genesis/unit-albatross.toml`
-const SECRET_KEY: &str =
-    "196ffdb1a8acc7cbd76a251aeac0600a1d68b3aba1eba823b5e4dc5dbdcdc730afa752c05ab4f6ef8518384ad514f403c5a088a22b17bf1bc14f8ff8decc2a512c0a200f68d7bdf5a319b30356fe8d1d75ef510aed7a8660968c216c328a0000";
-
-// Fill epoch with micro blocks
-fn fill_micro_blocks(producer: &BlockProducer, blockchain: &Arc<Blockchain>) {
-    let init_height = blockchain.block_number();
-    let macro_block_number = policy::macro_block_after(init_height + 1);
-    for i in (init_height + 1)..macro_block_number {
-        let last_micro_block = producer.next_micro_block(
-            blockchain.time.now() + i as u64 * 1000,
-            0,
-            None,
-            vec![],
-            vec![0x42],
-        );
-        assert_eq!(
-            blockchain.push(Block::Micro(last_micro_block)),
-            Ok(PushResult::Extended)
-        );
-    }
-    assert_eq!(blockchain.block_number(), macro_block_number - 1);
-}
-
-fn sign_macro_block(header: MacroHeader, body: Option<MacroBody>) -> MacroBlock {
-    let keypair =
-        KeyPair::from(SecretKey::deserialize_from_vec(&hex::decode(SECRET_KEY).unwrap()).unwrap());
-
-    // Calculate block hash.
-    let block_hash = header.hash::<Blake2bHash>();
-
-    // Calculate the validator Merkle root (used in the nano sync).
-    let validator_merkle_root =
-        pk_tree_construct(vec![keypair.public_key.public_key; SLOTS as usize]);
-
-    // Create the precommit tendermint vote.
-    let precommit = TendermintVote {
-        proposal_hash: Some(block_hash),
-        id: TendermintIdentifier {
-            block_number: header.block_number,
-            round_number: 0,
-            step: TendermintStep::PreCommit,
-        },
-        validator_merkle_root,
-    };
-
-    // Create signed precommit.
-    let signed_precommit = keypair.secret_key.sign(&precommit);
-
-    // Create signers Bitset.
-    let mut signers = BitSet::new();
-    for i in 0..TWO_THIRD_SLOTS {
-        signers.insert(i as usize);
-    }
-
-    // Create multisignature.
-    let multisig = MultiSignature {
-        signature: AggregateSignature::from_signatures(&*vec![
-            signed_precommit;
-            TWO_THIRD_SLOTS as usize
-        ]),
-        signers,
-    };
-
-    // Create Tendermint proof.
-    let tendermint_proof = TendermintProof {
-        round: 0,
-        sig: multisig,
-    };
-
-    // Create and return the macro block.
-    MacroBlock {
-        header,
-        body,
-        justification: Some(tendermint_proof),
-    }
-}
-
-fn sign_view_change(
-    prev_seed: VrfSeed,
-    block_number: u32,
-    new_view_number: u32,
-) -> ViewChangeProof {
-    let keypair =
-        KeyPair::from(SecretKey::deserialize_from_vec(&hex::decode(SECRET_KEY).unwrap()).unwrap());
-
-    // Create the view change.
-    let view_change = ViewChange {
-        block_number,
-        new_view_number,
-        prev_seed,
-    };
-
-    // Sign the view change.
-    let signed_view_change =
-        SignedViewChange::from_message(view_change, &keypair.secret_key, 0).signature;
-
-    // Create signers Bitset.
-    let mut signers = BitSet::new();
-    for i in 0..TWO_THIRD_SLOTS {
-        signers.insert(i as usize);
-    }
-
-    // Create multisignature.
-    let multisig = MultiSignature {
-        signature: AggregateSignature::from_signatures(&*vec![
-            signed_view_change;
-            TWO_THIRD_SLOTS as usize
-        ]),
-        signers,
-    };
-
-    // Create and return view change proof.
-    ViewChangeProof { sig: multisig }
-}
 
 #[test]
 fn it_can_produce_micro_blocks() {
@@ -234,7 +113,11 @@ fn it_can_produce_macro_blocks() {
         vec![],
     );
 
-    let block = sign_macro_block(macro_block.header, macro_block.body);
+    let block = sign_macro_block(
+        &KeyPair::from(SecretKey::deserialize_from_vec(&hex::decode(SECRET_KEY).unwrap()).unwrap()),
+        macro_block.header,
+        macro_block.body,
+    );
     assert_eq!(
         blockchain.push(Block::Macro(block)),
         Ok(PushResult::Extended)
@@ -262,7 +145,13 @@ fn it_can_produce_election_blocks() {
             vec![0x42],
         );
 
-        let block = sign_macro_block(macro_block.header, macro_block.body);
+        let block = sign_macro_block(
+            &KeyPair::from(
+                SecretKey::deserialize_from_vec(&hex::decode(SECRET_KEY).unwrap()).unwrap(),
+            ),
+            macro_block.header,
+            macro_block.body,
+        );
 
         assert_eq!(
             blockchain.push(Block::Macro(block)),

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -44,6 +44,7 @@ atomic = "0.4"
 
 nimiq-block-production = { path = "../block-production", features = ["test-utils"] }
 nimiq-nano-primitives = { path= "../nano-primitives" }
+nimiq-test-utils = { path= "../test-utils" }
 
 [features]
 metrics = []

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -1,130 +1,16 @@
 use std::sync::Arc;
 
 use beserial::Deserialize;
-use nimiq_block::{
-    Block, MacroBlock, MacroBody, MultiSignature, TendermintIdentifier, TendermintProof,
-    TendermintProposal, TendermintStep, TendermintVote,
-};
 use nimiq_block_production::BlockProducer;
-use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushResult};
-use nimiq_bls::{AggregateSignature, KeyPair, SecretKey};
-use nimiq_collections::bitset::BitSet;
+use nimiq_blockchain::{Blockchain, PushResult};
+use nimiq_bls::{KeyPair, SecretKey};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
-use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
-use nimiq_primitives::policy;
 use nimiq_primitives::policy::{BATCHES_PER_EPOCH, BATCH_LENGTH, EPOCH_LENGTH};
+use nimiq_test_utils::blockchain::produce_macro_blocks;
 
 // Secret key of validator. Tests run with `genesis/src/genesis/unit-albatross.toml`
 const SECRET_KEY: &str = "196ffdb1a8acc7cbd76a251aeac0600a1d68b3aba1eba823b5e4dc5dbdcdc730afa752c05ab4f6ef8518384ad514f403c5a088a22b17bf1bc14f8ff8decc2a512c0a200f68d7bdf5a319b30356fe8d1d75ef510aed7a8660968c216c328a0000";
-
-// Produces a series of macro blocks (and the corresponding batches).
-fn produce_macro_blocks(num_macro: usize, producer: &BlockProducer, blockchain: &Arc<Blockchain>) {
-    for _ in 0..num_macro {
-        fill_micro_blocks(producer, blockchain);
-
-        let slots = blockchain.current_validators().unwrap();
-
-        let next_block_height = (blockchain.block_number() + 1) as u64;
-
-        let macro_block_proposal = producer.next_macro_block_proposal(
-            blockchain.time.now() + next_block_height * 1000,
-            0u32,
-            vec![],
-        );
-
-        let block = sign_macro_block(
-            TendermintProposal {
-                value: macro_block_proposal.header,
-                valid_round: None,
-            },
-            macro_block_proposal.body.unwrap(),
-            MacroBlock::create_pk_tree_root(&slots),
-        );
-
-        assert_eq!(
-            blockchain.push(Block::Macro(block)),
-            Ok(PushResult::Extended)
-        );
-    }
-}
-
-// Fill batch with micro blocks.
-fn fill_micro_blocks(producer: &BlockProducer, blockchain: &Arc<Blockchain>) {
-    let init_height = blockchain.block_number();
-
-    assert!(policy::is_macro_block_at(init_height));
-
-    let macro_block_number = init_height + BATCH_LENGTH;
-
-    for i in (init_height + 1)..macro_block_number {
-        let last_micro_block = producer.next_micro_block(
-            blockchain.time.now() + i as u64 * 1000,
-            0,
-            None,
-            vec![],
-            vec![0x42],
-        );
-
-        assert_eq!(
-            blockchain.push(Block::Micro(last_micro_block)),
-            Ok(PushResult::Extended)
-        );
-    }
-
-    assert_eq!(blockchain.block_number(), macro_block_number - 1);
-}
-
-// Signs a macro block proposal.
-fn sign_macro_block(
-    proposal: TendermintProposal,
-    extrinsics: MacroBody,
-    validator_merkle_root: Vec<u8>,
-) -> MacroBlock {
-    let keypair =
-        KeyPair::from(SecretKey::deserialize_from_vec(&hex::decode(SECRET_KEY).unwrap()).unwrap());
-
-    // Create a TendermintVote instance out of known properties.
-    // round_number is for now fixed at 0 for tests, but it could be anything,
-    // as long as the TendermintProof further down this function does use the same round_number.
-    let vote = TendermintVote {
-        proposal_hash: Some(proposal.value.hash::<Blake2bHash>()),
-        id: TendermintIdentifier {
-            block_number: proposal.value.block_number,
-            step: TendermintStep::PreCommit,
-            round_number: 0,
-        },
-        validator_merkle_root,
-    };
-
-    // create the to-be-signed hash
-    let message_hash = vote.hash::<Blake2sHash>();
-
-    // sign the hash
-    let signature = AggregateSignature::from_signatures(&[keypair
-        .secret_key
-        .sign_hash(message_hash)
-        .multiply(policy::SLOTS)]);
-
-    // create and populate signers BitSet.
-    let mut signers = BitSet::new();
-
-    for i in 0..policy::SLOTS {
-        signers.insert(i as usize);
-    }
-
-    // create the TendermintProof
-    let justification = Some(TendermintProof {
-        round: 0,
-        sig: MultiSignature::new(signature, signers),
-    });
-
-    MacroBlock {
-        header: proposal.value,
-        justification,
-        body: Some(extrinsics),
-    }
-}
 
 // Tests if the basic history sync works. It will try to push a succession of election and checkpoint
 // blocks. It does test if election blocks can be pushed after checkpoint blocks and vice-versa. It

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -49,4 +49,5 @@ simple_logger = "1.0"
 
 nimiq-bls = { path = "../bls" }
 nimiq-network-mock = { path = "../network-mock" }
-nimiq-block-production = { path = "../block-production", features = ["test-utils"] }
+nimiq-block-production = { path = "../block-production"}
+nimiq-test-utils = { path = "../test-utils" }

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -5,7 +5,7 @@ use beserial::Deserialize;
 use futures::{Stream, StreamExt};
 
 use futures::task::{Context, Poll};
-use nimiq_block_production::{test_utils::*, BlockProducer};
+use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain};
 use nimiq_bls::{KeyPair, SecretKey};
 use nimiq_consensus::consensus::Consensus;
@@ -19,6 +19,7 @@ use nimiq_mempool::{Mempool, MempoolConfig};
 use nimiq_network_interface::network::Network;
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_primitives::policy;
+use nimiq_test_utils::blockchain::produce_macro_blocks;
 use std::pin::Pin;
 
 pub struct MockHistorySyncStream<TNetwork: Network> {

--- a/consensus/tests/request_component.rs
+++ b/consensus/tests/request_component.rs
@@ -1,7 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
 use beserial::Deserialize;
-use nimiq_block_production::test_utils::produce_macro_blocks;
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain};
 use nimiq_bls::{KeyPair, SecretKey};
@@ -12,6 +11,7 @@ use nimiq_mempool::{Mempool, MempoolConfig};
 use nimiq_network_interface::network::Network;
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_primitives::networks::NetworkId;
+use nimiq_test_utils::blockchain::produce_macro_blocks;
 
 /// Secret key of validator. Tests run with `network-primitives/src/genesis/unit-albatross.toml`
 const SECRET_KEY: &str =

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nimiq-test-utils"
+version = "0.1.0"
+authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+edition = "2018"
+description = "Test utilities for Nimiq's Rust implementation"
+homepage = "https://nimiq.com"
+repository = "https://github.com/nimiq/core-rs-albatross"
+license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["nimiq", "cryptocurrency", "blockchain"]
+
+[dependencies]
+hex = "0.4"
+
+beserial = { path = "../beserial" }
+nimiq-block = { path = "../primitives/block" }
+nimiq-blockchain = { path = "../blockchain" }
+nimiq-block-production = { path = "../block-production" }
+nimiq-bls = { path = "../bls" }
+nimiq-collections = { path = "../collections" }
+nimiq-hash = { path = "../hash" }
+nimiq-nano-primitives = { path = "../nano-primitives" }
+nimiq-primitives = { path = "../primitives" }
+nimiq-vrf = { path = "../vrf" }

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -1,0 +1,169 @@
+use beserial::Deserialize;
+use std::sync::Arc;
+
+use nimiq_block::{
+    Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SignedViewChange,
+    TendermintIdentifier, TendermintProof, TendermintStep, TendermintVote, ViewChange,
+    ViewChangeProof,
+};
+use nimiq_block_production::BlockProducer;
+use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushResult};
+use nimiq_bls::{AggregateSignature, KeyPair, SecretKey};
+use nimiq_collections::BitSet;
+use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_nano_primitives::pk_tree_construct;
+use nimiq_primitives::policy;
+use nimiq_vrf::VrfSeed;
+
+/// Secret key of validator. Tests run with `genesis/src/genesis/unit-albatross.toml`
+pub const SECRET_KEY: &str = "196ffdb1a8acc7cbd76a251aeac0600a1d68b3aba1eba823b5e4dc5dbdcdc730afa752c05ab4f6ef8518384ad514f403c5a088a22b17bf1bc14f8ff8decc2a512c0a200f68d7bdf5a319b30356fe8d1d75ef510aed7a8660968c216c328a0000";
+
+// Produces a series of macro blocks (and the corresponding batches).
+pub fn produce_macro_blocks(
+    num_macro: usize,
+    producer: &BlockProducer,
+    blockchain: &Arc<Blockchain>,
+) {
+    for _ in 0..num_macro {
+        fill_micro_blocks(producer, blockchain);
+
+        let next_block_height = (blockchain.block_number() + 1) as u64;
+
+        let macro_block_proposal = producer.next_macro_block_proposal(
+            blockchain.time.now() + next_block_height * 1000,
+            0u32,
+            vec![],
+        );
+
+        let block = sign_macro_block(
+            &producer.validator_key,
+            macro_block_proposal.header,
+            macro_block_proposal.body,
+        );
+
+        assert_eq!(
+            blockchain.push(Block::Macro(block)),
+            Ok(PushResult::Extended)
+        );
+    }
+}
+
+// Fill batch with micro blocks.
+pub fn fill_micro_blocks(producer: &BlockProducer, blockchain: &Arc<Blockchain>) {
+    let init_height = blockchain.block_number();
+
+    assert!(policy::is_macro_block_at(init_height));
+
+    let macro_block_number = init_height + policy::BATCH_LENGTH;
+
+    for i in (init_height + 1)..macro_block_number {
+        let last_micro_block = producer.next_micro_block(
+            blockchain.time.now() + i as u64 * 1000,
+            0,
+            None,
+            vec![],
+            vec![0x42],
+        );
+
+        assert_eq!(
+            blockchain.push(Block::Micro(last_micro_block)),
+            Ok(PushResult::Extended)
+        );
+    }
+
+    assert_eq!(blockchain.block_number(), macro_block_number - 1);
+}
+
+// Signs a macro block proposal.
+pub fn sign_macro_block(
+    keypair: &KeyPair,
+    header: MacroHeader,
+    body: Option<MacroBody>,
+) -> MacroBlock {
+    // Calculate block hash.
+    let block_hash = header.hash::<Blake2bHash>();
+
+    // Calculate the validator Merkle root (used in the nano sync).
+    let validator_merkle_root =
+        pk_tree_construct(vec![keypair.public_key.public_key; policy::SLOTS as usize]);
+
+    // Create the precommit tendermint vote.
+    let precommit = TendermintVote {
+        proposal_hash: Some(block_hash),
+        id: TendermintIdentifier {
+            block_number: header.block_number,
+            round_number: 0,
+            step: TendermintStep::PreCommit,
+        },
+        validator_merkle_root,
+    };
+
+    // Create signed precommit.
+    let signed_precommit = keypair.secret_key.sign(&precommit);
+
+    // Create signers Bitset.
+    let mut signers = BitSet::new();
+    for i in 0..policy::TWO_THIRD_SLOTS {
+        signers.insert(i as usize);
+    }
+
+    // Create multisignature.
+    let multisig = MultiSignature {
+        signature: AggregateSignature::from_signatures(&*vec![
+            signed_precommit;
+            policy::TWO_THIRD_SLOTS as usize
+        ]),
+        signers,
+    };
+
+    // Create Tendermint proof.
+    let tendermint_proof = TendermintProof {
+        round: 0,
+        sig: multisig,
+    };
+
+    // Create and return the macro block.
+    MacroBlock {
+        header,
+        body,
+        justification: Some(tendermint_proof),
+    }
+}
+
+pub fn sign_view_change(
+    prev_seed: VrfSeed,
+    block_number: u32,
+    new_view_number: u32,
+) -> ViewChangeProof {
+    let keypair =
+        KeyPair::from(SecretKey::deserialize_from_vec(&hex::decode(SECRET_KEY).unwrap()).unwrap());
+
+    // Create the view change.
+    let view_change = ViewChange {
+        block_number,
+        new_view_number,
+        prev_seed,
+    };
+
+    // Sign the view change.
+    let signed_view_change =
+        SignedViewChange::from_message(view_change, &keypair.secret_key, 0).signature;
+
+    // Create signers Bitset.
+    let mut signers = BitSet::new();
+    for i in 0..policy::TWO_THIRD_SLOTS {
+        signers.insert(i as usize);
+    }
+
+    // Create multisignature.
+    let multisig = MultiSignature {
+        signature: AggregateSignature::from_signatures(&*vec![
+            signed_view_change;
+            policy::TWO_THIRD_SLOTS as usize
+        ]),
+        signers,
+    };
+
+    // Create and return view change proof.
+    ViewChangeProof { sig: multisig }
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod blockchain;

--- a/vrf/src/alias.rs
+++ b/vrf/src/alias.rs
@@ -107,7 +107,7 @@ where
             }
         }
 
-        // Both must be emtpy now
+        // Both must be empty now
         debug_assert!(U_underfull.is_empty() && U_overfull.is_empty());
 
         // Entries that are "underfull" need an entry in the alias table


### PR DESCRIPTION
This PR includes:

- Refactor some test utilities into its own crate
  Refactor some test utilities into its own crate.
  The test-utils crate includes for now these functions:
  - produce_macro_blocks
  - fill_micro_blocks
  - sign_macro_block
  - sign_view_change
- Fix minor typo in the vrf crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
