### PR TITLE
Improves storage/calculation of leaf indexes for blocks in the History Store

### DIFF
--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -87,8 +87,8 @@ impl Handle<BatchSetInfo> for RequestBatchSet {
             // Leaf indices are 0 based thus the + 1
             let history_len = blockchain
                 .history_store
-                // TODO Refactor get_last_leaf_index_of_block
                 .get_last_leaf_index_of_block(block.header.block_number, None)
+                .expect("Can't find block number in the History Store!")
                 + 1;
             BatchSetInfo {
                 block: Some(block),


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?
This PR changes the way block numbers are stored in the History Store. Previously we had a database with block numbers as keys and leaf hashes as values (the database supported duplicate keys evidently). This was horribly inefficient since the block number was stored for every single transaction and the leaf hash was also stored even though it already was stored in two other databases. Furthermore, calculating the last leaf index for a given block (which is a necessary method for us) was also very inefficient and getting the transactions for a block returned the transactions out of order.
Now that database was substituted with one still with the block numbers as keys but with the last leaf index for that block as values. This reduces the size of the database (only one entry per block), simplifies the method to get the last leaf index for a block (evidently, now it's just a database read) and getting the transactions for a block now returns them in order.
