### PR TITLE
Update the balances of the active validators list used for selecting slots

### DIFF
--- a/primitives/account/src/account.rs
+++ b/primitives/account/src/account.rs
@@ -282,7 +282,7 @@ impl AccountInherentInteraction for Account {
     ) -> Result<Option<Vec<u8>>, AccountError> {
         // If the inherent target is the staking contract then we forward it to the staking contract
         // right here.
-        if &Address::from_any_str(STAKING_CONTRACT_ADDRESS).unwrap() == &inherent.target {
+        if Address::from_any_str(STAKING_CONTRACT_ADDRESS).unwrap() == inherent.target {
             return StakingContract::commit_inherent(
                 accounts_tree,
                 db_txn,
@@ -318,7 +318,7 @@ impl AccountInherentInteraction for Account {
     ) -> Result<(), AccountError> {
         // If the inherent target is the staking contract then we forward it to the staking contract
         // right here.
-        if &Address::from_any_str(STAKING_CONTRACT_ADDRESS).unwrap() == &inherent.target {
+        if Address::from_any_str(STAKING_CONTRACT_ADDRESS).unwrap() == inherent.target {
             return StakingContract::revert_inherent(
                 accounts_tree,
                 db_txn,

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -1,7 +1,3 @@
-use crate::{
-    Account, AccountError, AccountInherentInteraction, AccountTransactionInteraction, Inherent,
-    Receipt, Receipts,
-};
 use nimiq_database::{
     Environment, ReadTransaction, Transaction as DBTransaction, WriteTransaction,
 };
@@ -9,6 +5,11 @@ use nimiq_hash::Blake2bHash;
 use nimiq_transaction::{Transaction, TransactionFlags};
 use nimiq_trie::key_nibbles::KeyNibbles;
 use nimiq_trie::trie::MerkleRadixTrie;
+
+use crate::{
+    Account, AccountError, AccountInherentInteraction, AccountTransactionInteraction, Inherent,
+    Receipt, Receipts,
+};
 
 /// An alias for the accounts tree.
 pub type AccountsTrie = MerkleRadixTrie<Account>;

--- a/primitives/account/src/accounts_list.rs
+++ b/primitives/account/src/accounts_list.rs
@@ -1,8 +1,9 @@
 use std::convert::TryFrom;
 
-use crate::Account;
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 use nimiq_trie::key_nibbles::KeyNibbles;
+
+use crate::Account;
 
 /// A small wrapper over a list of accounts with keys. This is only used to have method
 /// of serializing and deserializing the genesis accounts.

--- a/primitives/account/src/basic_account.rs
+++ b/primitives/account/src/basic_account.rs
@@ -1,5 +1,6 @@
 use beserial::{Deserialize, Serialize};
 use nimiq_database::WriteTransaction;
+use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
 use nimiq_transaction::Transaction;
 use nimiq_trie::key_nibbles::KeyNibbles;
@@ -7,7 +8,6 @@ use nimiq_trie::key_nibbles::KeyNibbles;
 use crate::inherent::{Inherent, InherentType};
 use crate::interaction_traits::{AccountInherentInteraction, AccountTransactionInteraction};
 use crate::{Account, AccountError, AccountsTrie};
-use nimiq_primitives::account::AccountType;
 
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]

--- a/primitives/account/src/staking_contract/mod.rs
+++ b/primitives/account/src/staking_contract/mod.rs
@@ -12,12 +12,12 @@ use nimiq_primitives::slots::{Validators, ValidatorsBuilder};
 use nimiq_primitives::{coin::Coin, policy};
 use nimiq_trie::key_nibbles::KeyNibbles;
 use nimiq_vrf::{AliasMethod, VrfSeed, VrfUseCase};
-
-use crate::{Account, AccountsTrie};
-
 pub use receipts::*;
 pub use staker::Staker;
 pub use validator::Validator;
+
+use crate::{Account, AccountsTrie};
+
 mod receipts;
 mod staker;
 mod traits;

--- a/primitives/account/src/staking_contract/staker.rs
+++ b/primitives/account/src/staking_contract/staker.rs
@@ -94,6 +94,11 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, balance)?;
+            if validator.inactivity_flag.is_none() {
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
             validator.num_stakers += 1;
 
             // All checks passed, not allowed to fail from here on!
@@ -183,6 +188,11 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, staker.active_stake)?;
+            if validator.inactivity_flag.is_none() {
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
             validator.num_stakers -= 1;
 
             // All checks passed, not allowed to fail from here on!
@@ -271,6 +281,11 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, value)?;
+            if validator.inactivity_flag.is_none() {
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
 
             // All checks passed, not allowed to fail from here on!
 
@@ -349,6 +364,11 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, value)?;
+            if validator.inactivity_flag.is_none() {
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
 
             // All checks passed, not allowed to fail from here on!
 
@@ -434,6 +454,14 @@ impl StakingContract {
             // Update it.
             old_validator.balance =
                 Account::balance_sub(old_validator.balance, staker.active_stake)?;
+            if old_validator.inactivity_flag.is_none() {
+                // Get the staking contract main and update it.
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(old_validator_address.clone(), old_validator.balance);
+            }
             old_validator.num_stakers -= 1;
 
             // Re-add the validator entry.
@@ -470,6 +498,13 @@ impl StakingContract {
             // Update it.
             new_validator.balance =
                 Account::balance_add(new_validator.balance, staker.active_stake)?;
+            if new_validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(new_validator_address.clone(), new_validator.balance);
+            }
             new_validator.num_stakers += 1;
 
             // Re-add the validator entry.
@@ -548,6 +583,13 @@ impl StakingContract {
             // Update it.
             new_validator.balance =
                 Account::balance_sub(new_validator.balance, staker.active_stake)?;
+            if new_validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(new_validator_address.clone(), new_validator.balance);
+            }
             new_validator.num_stakers -= 1;
 
             // Re-add the validator entry.
@@ -591,6 +633,13 @@ impl StakingContract {
             // Update it.
             old_validator.balance =
                 Account::balance_add(old_validator.balance, staker.active_stake)?;
+            if old_validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(old_validator_address.clone(), old_validator.balance);
+            }
             old_validator.num_stakers += 1;
 
             // Re-add the validator entry.
@@ -680,6 +729,13 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, value)?;
+            if validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
 
             // All checks passed, not allowed to fail from here on!
 
@@ -749,6 +805,13 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, value)?;
+            if validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
 
             // Re-add the validator entry.
             trace!(
@@ -814,6 +877,13 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, value)?;
+            if validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
 
             // Re-add the validator entry.
             trace!(
@@ -878,6 +948,13 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, value)?;
+            if validator.inactivity_flag.is_none() {
+                let mut staking_contract =
+                    StakingContract::get_staking_contract(accounts_tree, db_txn);
+                staking_contract
+                    .active_validators
+                    .insert(validator_address.clone(), validator.balance);
+            }
 
             // Re-add the validator entry.
             trace!(
@@ -1061,6 +1138,13 @@ impl StakingContract {
 
                 // Update it.
                 validator.balance = Account::balance_sub(validator.balance, value)?;
+                if validator.inactivity_flag.is_none() {
+                    let mut staking_contract =
+                        StakingContract::get_staking_contract(accounts_tree, db_txn);
+                    staking_contract
+                        .active_validators
+                        .insert(validator_address.clone(), validator.balance);
+                }
 
                 // Re-add the validator entry.
                 trace!(
@@ -1148,6 +1232,13 @@ impl StakingContract {
                 };
 
                 validator.balance = Account::balance_add(validator.balance, value)?;
+                if validator.inactivity_flag.is_none() {
+                    let mut staking_contract =
+                        StakingContract::get_staking_contract(accounts_tree, db_txn);
+                    staking_contract
+                        .active_validators
+                        .insert(validator_address.clone(), validator.balance);
+                }
 
                 trace!(
                     "Trying to put validator with address {} in the accounts tree.",

--- a/primitives/account/src/staking_contract/staker.rs
+++ b/primitives/account/src/staking_contract/staker.rs
@@ -94,11 +94,13 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, balance)?;
+
             if validator.inactivity_flag.is_none() {
                 staking_contract
                     .active_validators
                     .insert(validator_address.clone(), validator.balance);
             }
+
             validator.num_stakers += 1;
 
             // All checks passed, not allowed to fail from here on!
@@ -188,11 +190,13 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, staker.active_stake)?;
+
             if validator.inactivity_flag.is_none() {
                 staking_contract
                     .active_validators
                     .insert(validator_address.clone(), validator.balance);
             }
+
             validator.num_stakers -= 1;
 
             // All checks passed, not allowed to fail from here on!
@@ -281,6 +285,7 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, value)?;
+
             if validator.inactivity_flag.is_none() {
                 staking_contract
                     .active_validators
@@ -364,6 +369,7 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, value)?;
+
             if validator.inactivity_flag.is_none() {
                 staking_contract
                     .active_validators
@@ -416,6 +422,9 @@ impl StakingContract {
         staker_address: &Address,
         delegation: Option<Address>,
     ) -> Result<UpdateStakerReceipt, AccountError> {
+        // Get the staking contract main.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -454,14 +463,13 @@ impl StakingContract {
             // Update it.
             old_validator.balance =
                 Account::balance_sub(old_validator.balance, staker.active_stake)?;
+
             if old_validator.inactivity_flag.is_none() {
-                // Get the staking contract main and update it.
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(old_validator_address.clone(), old_validator.balance);
             }
+
             old_validator.num_stakers -= 1;
 
             // Re-add the validator entry.
@@ -498,13 +506,13 @@ impl StakingContract {
             // Update it.
             new_validator.balance =
                 Account::balance_add(new_validator.balance, staker.active_stake)?;
+
             if new_validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(new_validator_address.clone(), new_validator.balance);
             }
+
             new_validator.num_stakers += 1;
 
             // Re-add the validator entry.
@@ -546,6 +554,15 @@ impl StakingContract {
             Account::StakingStaker(staker),
         );
 
+        // Save the staking contract.
+        trace!("Trying to put staking contract in the accounts tree.");
+
+        accounts_tree.put(
+            db_txn,
+            &StakingContract::get_key_staking_contract(),
+            Account::Staking(staking_contract),
+        );
+
         Ok(receipt)
     }
 
@@ -556,6 +573,9 @@ impl StakingContract {
         staker_address: &Address,
         receipt: UpdateStakerReceipt,
     ) -> Result<(), AccountError> {
+        // Get the staking contract main.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -583,13 +603,13 @@ impl StakingContract {
             // Update it.
             new_validator.balance =
                 Account::balance_sub(new_validator.balance, staker.active_stake)?;
+
             if new_validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(new_validator_address.clone(), new_validator.balance);
             }
+
             new_validator.num_stakers -= 1;
 
             // Re-add the validator entry.
@@ -633,13 +653,13 @@ impl StakingContract {
             // Update it.
             old_validator.balance =
                 Account::balance_add(old_validator.balance, staker.active_stake)?;
+
             if old_validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(old_validator_address.clone(), old_validator.balance);
             }
+
             old_validator.num_stakers += 1;
 
             // Re-add the validator entry.
@@ -681,6 +701,15 @@ impl StakingContract {
             Account::StakingStaker(staker),
         );
 
+        // Save the staking contract.
+        trace!("Trying to put staking contract in the accounts tree.");
+
+        accounts_tree.put(
+            db_txn,
+            &StakingContract::get_key_staking_contract(),
+            Account::Staking(staking_contract),
+        );
+
         Ok(())
     }
 
@@ -694,6 +723,9 @@ impl StakingContract {
         value: Coin,
         block_height: u32,
     ) -> Result<RetireStakerReceipt, AccountError> {
+        // Get the staking contract main.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -729,9 +761,8 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, value)?;
+
             if validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(validator_address.clone(), validator.balance);
@@ -764,6 +795,15 @@ impl StakingContract {
             Account::StakingStaker(staker),
         );
 
+        // Save the staking contract.
+        trace!("Trying to put staking contract in the accounts tree.");
+
+        accounts_tree.put(
+            db_txn,
+            &StakingContract::get_key_staking_contract(),
+            Account::Staking(staking_contract),
+        );
+
         Ok(receipt)
     }
 
@@ -775,6 +815,9 @@ impl StakingContract {
         value: Coin,
         receipt: RetireStakerReceipt,
     ) -> Result<(), AccountError> {
+        // Get the staking contract main.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -805,9 +848,8 @@ impl StakingContract {
 
             // Update it.
             validator.balance = Account::balance_add(validator.balance, value)?;
+
             if validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(validator_address.clone(), validator.balance);
@@ -837,6 +879,15 @@ impl StakingContract {
             Account::StakingStaker(staker),
         );
 
+        // Save the staking contract.
+        trace!("Trying to put staking contract in the accounts tree.");
+
+        accounts_tree.put(
+            db_txn,
+            &StakingContract::get_key_staking_contract(),
+            Account::Staking(staking_contract),
+        );
+
         Ok(())
     }
 
@@ -848,6 +899,9 @@ impl StakingContract {
         staker_address: &Address,
         value: Coin,
     ) -> Result<(), AccountError> {
+        // Get the staking contract main.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -878,8 +932,6 @@ impl StakingContract {
             // Update it.
             validator.balance = Account::balance_add(validator.balance, value)?;
             if validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(validator_address.clone(), validator.balance);
@@ -909,6 +961,15 @@ impl StakingContract {
             Account::StakingStaker(staker),
         );
 
+        // Save the staking contract.
+        trace!("Trying to put staking contract in the accounts tree.");
+
+        accounts_tree.put(
+            db_txn,
+            &StakingContract::get_key_staking_contract(),
+            Account::Staking(staking_contract),
+        );
+
         Ok(())
     }
 
@@ -919,6 +980,9 @@ impl StakingContract {
         staker_address: &Address,
         value: Coin,
     ) -> Result<(), AccountError> {
+        // Get the staking contract main.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -949,8 +1013,6 @@ impl StakingContract {
             // Update it.
             validator.balance = Account::balance_sub(validator.balance, value)?;
             if validator.inactivity_flag.is_none() {
-                let mut staking_contract =
-                    StakingContract::get_staking_contract(accounts_tree, db_txn);
                 staking_contract
                     .active_validators
                     .insert(validator_address.clone(), validator.balance);
@@ -978,6 +1040,15 @@ impl StakingContract {
             db_txn,
             &StakingContract::get_key_staker(staker_address),
             Account::StakingStaker(staker),
+        );
+
+        // Save the staking contract.
+        trace!("Trying to put staking contract in the accounts tree.");
+
+        accounts_tree.put(
+            db_txn,
+            &StakingContract::get_key_staking_contract(),
+            Account::Staking(staking_contract),
         );
 
         Ok(())
@@ -1105,6 +1176,9 @@ impl StakingContract {
         from_active_balance: bool,
         value: Coin,
     ) -> Result<Option<DropStakerReceipt>, AccountError> {
+        // Get the staking contract.
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         // Get the staker and check if it exists.
         let mut staker = match StakingContract::get_staker(accounts_tree, db_txn, staker_address) {
             None => {
@@ -1138,9 +1212,8 @@ impl StakingContract {
 
                 // Update it.
                 validator.balance = Account::balance_sub(validator.balance, value)?;
+
                 if validator.inactivity_flag.is_none() {
-                    let mut staking_contract =
-                        StakingContract::get_staking_contract(accounts_tree, db_txn);
                     staking_contract
                         .active_validators
                         .insert(validator_address.clone(), validator.balance);
@@ -1162,9 +1235,7 @@ impl StakingContract {
             staker.inactive_stake = Account::balance_sub(staker.inactive_stake, value)?;
         }
 
-        // Get the staking contract and update it.
-        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
-
+        // Update and store the staking contract.
         staking_contract.balance = Account::balance_sub(staking_contract.balance, value)?;
 
         trace!("Trying to put staking contract in the accounts tree.");
@@ -1203,6 +1274,8 @@ impl StakingContract {
         value: Coin,
         receipt_opt: Option<DropStakerReceipt>,
     ) -> Result<(), AccountError> {
+        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
+
         let mut staker = match receipt_opt {
             Some(receipt) => {
                 StakingContract::revert_drop_staker(accounts_tree, db_txn, staker_address, receipt)?
@@ -1233,8 +1306,6 @@ impl StakingContract {
 
                 validator.balance = Account::balance_add(validator.balance, value)?;
                 if validator.inactivity_flag.is_none() {
-                    let mut staking_contract =
-                        StakingContract::get_staking_contract(accounts_tree, db_txn);
                     staking_contract
                         .active_validators
                         .insert(validator_address.clone(), validator.balance);
@@ -1265,8 +1336,6 @@ impl StakingContract {
             &StakingContract::get_key_staker(staker_address),
             Account::StakingStaker(staker),
         );
-
-        let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
 
         staking_contract.balance = Account::balance_add(staking_contract.balance, value)?;
 

--- a/primitives/account/src/staking_contract/traits.rs
+++ b/primitives/account/src/staking_contract/traits.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use beserial::{Deserialize, Serialize};
 use nimiq_collections::BitSet;
 use nimiq_database::WriteTransaction;
+use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::policy;
 use nimiq_primitives::slots::SlashedSlot;
@@ -15,7 +16,6 @@ use crate::interaction_traits::{AccountInherentInteraction, AccountTransactionIn
 use crate::staking_contract::receipts::DropValidatorReceipt;
 use crate::staking_contract::SlashReceipt;
 use crate::{Account, AccountError, AccountsTrie, Inherent, InherentType, StakingContract};
-use nimiq_keys::Address;
 
 /// We need to distinguish between two types of transactions:
 /// 1. Incoming transactions, which include:

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -3,10 +3,8 @@ use std::convert::TryFrom;
 use nimiq_account::{Accounts, Inherent, InherentType};
 use nimiq_account::{Receipt, Receipts};
 use nimiq_database::volatile::VolatileEnvironment;
-
 use nimiq_database::WriteTransaction;
 use nimiq_keys::Address;
-
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_transaction::Transaction;

--- a/primitives/account/tests/basic_account.rs
+++ b/primitives/account/tests/basic_account.rs
@@ -67,16 +67,13 @@ fn basic_transfer_works() {
     );
 
     assert_eq!(
-        accounts_tree
-            .get(&mut db_txn, &key_sender)
-            .unwrap()
-            .balance(),
+        accounts_tree.get(&db_txn, &key_sender).unwrap().balance(),
         Coin::from_u64_unchecked(899)
     );
 
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &key_recipient)
+            .get(&db_txn, &key_recipient)
             .unwrap()
             .balance(),
         Coin::from_u64_unchecked(1100)
@@ -118,16 +115,13 @@ fn basic_transfer_works() {
     );
 
     assert_eq!(
-        accounts_tree
-            .get(&mut db_txn, &key_sender)
-            .unwrap()
-            .balance(),
+        accounts_tree.get(&db_txn, &key_sender).unwrap().balance(),
         Coin::from_u64_unchecked(1000)
     );
 
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &key_recipient)
+            .get(&db_txn, &key_recipient)
             .unwrap()
             .balance(),
         Coin::from_u64_unchecked(1000)
@@ -160,11 +154,11 @@ fn create_and_prune_works() {
         Ok(None)
     );
 
-    assert_eq!(accounts_tree.get(&mut db_txn, &key_sender), None);
+    assert_eq!(accounts_tree.get(&db_txn, &key_sender), None);
 
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &key_recipient)
+            .get(&db_txn, &key_recipient)
             .unwrap()
             .balance(),
         Coin::from_u64_unchecked(999)
@@ -182,14 +176,11 @@ fn create_and_prune_works() {
     );
 
     assert_eq!(
-        accounts_tree
-            .get(&mut db_txn, &key_sender)
-            .unwrap()
-            .balance(),
+        accounts_tree.get(&db_txn, &key_sender).unwrap().balance(),
         Coin::from_u64_unchecked(1000)
     );
 
-    assert_eq!(accounts_tree.get(&mut db_txn, &key_recipient), None);
+    assert_eq!(accounts_tree.get(&db_txn, &key_recipient), None);
 }
 
 fn init_tree(accounts_tree: &AccountsTrie, db_txn: &mut WriteTransaction) {

--- a/primitives/account/tests/htlc_contract.rs
+++ b/primitives/account/tests/htlc_contract.rs
@@ -38,7 +38,7 @@ fn create_serialized_contract() {
     let mut bytes: Vec<u8> = Vec::with_capacity(contract.serialized_size());
     contract.serialize(&mut bytes).unwrap();
     println!("{}", hex::encode(bytes));
-    assert!(false);
+    panic!();
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn it_can_create_contract_from_transaction() {
     HashedTimeLockedContract::create(&accounts_tree, &mut db_txn, &transaction, 0, 0);
 
     match accounts_tree.get(
-        &mut db_txn,
+        &db_txn,
         &KeyNibbles::from(&transaction.contract_creation_address()),
     ) {
         Some(Account::HTLC(htlc)) => {
@@ -188,7 +188,7 @@ fn it_can_create_contract_from_transaction() {
             assert_eq!(htlc.hash_count, 2);
             assert_eq!(htlc.timeout, 1000);
         }
-        _ => assert!(false),
+        _ => panic!(),
     }
 }
 
@@ -503,7 +503,7 @@ fn it_can_apply_and_revert_valid_transaction() {
         .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[0u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[0u8; 20][..]))
             .unwrap()
             .balance(),
         0.try_into().unwrap()
@@ -519,7 +519,7 @@ fn it_can_apply_and_revert_valid_transaction() {
     .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[0u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[0u8; 20][..]))
             .unwrap(),
         Account::HTLC(start_contract.clone())
     );
@@ -543,7 +543,7 @@ fn it_can_apply_and_revert_valid_transaction() {
         .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[0u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[0u8; 20][..]))
             .unwrap()
             .balance(),
         0.try_into().unwrap()
@@ -559,7 +559,7 @@ fn it_can_apply_and_revert_valid_transaction() {
     .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[0u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[0u8; 20][..]))
             .unwrap(),
         Account::HTLC(start_contract.clone())
     );
@@ -580,7 +580,7 @@ fn it_can_apply_and_revert_valid_transaction() {
         .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[0u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[0u8; 20][..]))
             .unwrap()
             .balance(),
         0.try_into().unwrap()
@@ -596,7 +596,7 @@ fn it_can_apply_and_revert_valid_transaction() {
     .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[0u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[0u8; 20][..]))
             .unwrap(),
         Account::HTLC(start_contract)
     );

--- a/primitives/account/tests/vesting_contract.rs
+++ b/primitives/account/tests/vesting_contract.rs
@@ -32,7 +32,7 @@ fn create_serialized_contract() {
     let mut bytes: Vec<u8> = Vec::with_capacity(contract.serialized_size());
     contract.serialize(&mut bytes).unwrap();
     println!("{}", hex::encode(bytes));
-    assert!(false);
+    panic!();
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn it_can_create_contract_from_transaction() {
     VestingContract::create(&accounts_tree, &mut db_txn, &transaction, 0, 0);
 
     match accounts_tree.get(
-        &mut db_txn,
+        &db_txn,
         &KeyNibbles::from(&transaction.contract_creation_address()),
     ) {
         Some(Account::Vesting(contract)) => {
@@ -175,7 +175,7 @@ fn it_can_create_contract_from_transaction() {
             assert_eq!(contract.step_amount, 100.try_into().unwrap());
             assert_eq!(contract.total_amount, 100.try_into().unwrap());
         }
-        _ => assert!(false),
+        _ => panic!(),
     }
 
     let mut data: Vec<u8> = Vec::with_capacity(Address::SIZE + 24);
@@ -190,7 +190,7 @@ fn it_can_create_contract_from_transaction() {
     VestingContract::create(&accounts_tree, &mut db_txn, &transaction, 0, 0);
 
     match accounts_tree.get(
-        &mut db_txn,
+        &db_txn,
         &KeyNibbles::from(&transaction.contract_creation_address()),
     ) {
         Some(Account::Vesting(contract)) => {
@@ -201,7 +201,7 @@ fn it_can_create_contract_from_transaction() {
             assert_eq!(contract.step_amount, 50.try_into().unwrap());
             assert_eq!(contract.total_amount, 100.try_into().unwrap());
         }
-        _ => assert!(false),
+        _ => panic!(),
     }
 
     let mut data: Vec<u8> = Vec::with_capacity(Address::SIZE + 32);
@@ -217,7 +217,7 @@ fn it_can_create_contract_from_transaction() {
     VestingContract::create(&accounts_tree, &mut db_txn, &transaction, 0, 0);
 
     match accounts_tree.get(
-        &mut db_txn,
+        &db_txn,
         &KeyNibbles::from(&transaction.contract_creation_address()),
     ) {
         Some(Account::Vesting(contract)) => {
@@ -228,7 +228,7 @@ fn it_can_create_contract_from_transaction() {
             assert_eq!(contract.step_amount, 50.try_into().unwrap());
             assert_eq!(contract.total_amount, 150.try_into().unwrap());
         }
-        _ => assert!(false),
+        _ => panic!(),
     }
 
     // Invalid data
@@ -361,7 +361,7 @@ fn it_can_apply_and_revert_valid_transaction() {
     VestingContract::commit_outgoing_transaction(&accounts_tree, &mut db_txn, &tx, 1, 200).unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[1u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[1u8; 20][..]))
             .unwrap()
             .balance(),
         800.try_into().unwrap()
@@ -370,7 +370,7 @@ fn it_can_apply_and_revert_valid_transaction() {
         .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[1u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[1u8; 20][..]))
             .unwrap(),
         Account::Vesting(start_contract)
     );
@@ -393,7 +393,7 @@ fn it_can_apply_and_revert_valid_transaction() {
     VestingContract::commit_outgoing_transaction(&accounts_tree, &mut db_txn, &tx, 1, 200).unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[1u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[1u8; 20][..]))
             .unwrap()
             .balance(),
         800.try_into().unwrap()
@@ -402,7 +402,7 @@ fn it_can_apply_and_revert_valid_transaction() {
         .unwrap();
     assert_eq!(
         accounts_tree
-            .get(&mut db_txn, &KeyNibbles::from(&[1u8; 20][..]))
+            .get(&db_txn, &KeyNibbles::from(&[1u8; 20][..]))
             .unwrap(),
         Account::Vesting(start_contract)
     );


### PR DESCRIPTION
Through the community developer Jake I was made aware that the `listStakes` RPC method does not display validators' actual balance (including stakes), but only the deposit (same for all validators). This RPC method simply returns the `staking_contract.active_validators` list.

This PR makes sure to update the balances stored in the staking contract's `active_validators` list, **the balances of which are used to select validator slots in election blocks**:

https://github.com/nimiq/core-rs-albatross/blob/8047d57271adcec389f930bd530f716bee16ce5a/primitives/account/src/staking_contract/mod.rs#L285-L288

This approach demonstrated in this PR is only meant to show the idea, it's not the final implementation (way too much repetition). I just want to make sure that this is actually needed.