### PR TITLE
Fix nimiq-utils building for some features

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -21,22 +21,22 @@ atomic = { version = "0.4", optional = true }
 
 clear_on_drop = { version = "0.2", optional = true }
 futures = { version = "0.1", optional = true }
+hex = { version = "0.4", optional = true }
+libp2p = { version = "0.39", optional = true }
 log = { version = "0.4", optional = true }
 parking_lot = { version = "0.9", optional = true }
 rand = { version = "0.7", optional = true }
 rand_core = { version = "0.5", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.1", optional = true }
 tokio-02 = { package = "tokio", version = "1.9", features = ["sync"], optional = true }
 tokio-stream = "0.1"
-serde = { version = "1.0", features = ["derive"], optional = true }
-libp2p = { version = "0.39", optional = true }
-hex = { version = "0.4", optional = true }
-thiserror = { version = "1.0", optional = true }
 
 beserial = { path = "../beserial", optional = true }
 beserial_derive = { path = "../beserial/beserial_derive", optional = true }
-nimiq-database = { path = "../database"}
 nimiq-collections = { path = "../collections", optional = true }
+nimiq-database = { path = "../database"}
 nimiq-hash = { path = "../hash", optional = true }
 
 [dev-dependencies]
@@ -46,24 +46,24 @@ nimiq-keys = { path = "../keys" }
 [features]
 crc = []
 otp = ["beserial", "clear_on_drop", "nimiq-hash", "rand"]
-key-store = ["thiserror", "beserial"]
+key-store = ["beserial", "log", "thiserror"]
 iterators = []
 locking = ["futures", "parking_lot"]
-merkle = ["beserial", "beserial_derive", "nimiq-hash", "math", "nimiq-collections/bitset"]
+merkle = ["beserial", "beserial_derive", "math", "nimiq-collections/bitset", "nimiq-hash"]
 mutable-once = []
-observer = ["tokio-02"]
+observer = ["log", "tokio-02"]
 time = ["atomic"]
-timers = ["futures", "parking_lot", "tokio", "log"]
+timers = ["futures", "log", "parking_lot", "tokio"]
 unique-ptr = []
-tagged-signing = ["hex", "beserial", "beserial_derive"]
+tagged-signing = ["beserial", "beserial_derive", "hex"]
 throttled-queue = ["nimiq-collections"]
 rate-limit = []
 unique-id = []
 # Compiles this package with all features.
-all = ["otp", "crc", "key-store", "iterators", "locking", "merkle", "mutable-once", "observer", "time", "timers", "unique-ptr", "throttled-queue", "rate-limit", "unique-id", "math"]
+all = ["crc", "iterators", "key-store", "locking", "math", "merkle", "mutable-once", "observer", "otp", "rate-limit", "throttled-queue", "time", "timers", "unique-id", "unique-ptr"]
 # Compiles this package with the features needed for the nimiq client.
 full-nimiq = ["crc", "iterators", "key-store", "locking", "merkle", "mutable-once", "observer", "time", "timers", "unique-ptr"]
 math = []
 key-rng = ["rand"]
-hash-rng = ["rand_core", "nimiq-hash"]
+hash-rng = ["nimiq-hash", "rand_core",]
 serde-derive = ["serde"]

--- a/utils/src/file_store.rs
+++ b/utils/src/file_store.rs
@@ -20,7 +20,7 @@ impl FileStore {
     }
 
     pub fn load<T: Deserialize>(&self) -> Result<T, Error> {
-        log::debug!("Reading from: {}", self.path.display());
+        debug!("Reading from: {}", self.path.display());
         let file = OpenOptions::new().read(true).open(&self.path)?;
         let mut buf_reader = BufReader::new(file);
         let item = Deserialize::deserialize(&mut buf_reader)?;


### PR DESCRIPTION
Fix the building of `nimiq-utils` when building for the features
`key-store` and `observer`.
Add cosmetical changes to the `Cargo.toml` to list depedencies
in alphabetical order.

This closes #307.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.