### PR TITLE
Fix building of nimiq-primitives with feature coin

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.2"
 
 [features]
 all = ["coin", "account", "policy", "networks", "slots"]
-coin = ["hex", "thiserror", "num-traits", "regex"]
+coin = ["hex", "lazy_static", "thiserror", "num-traits", "regex"]
 account = ["hex", "thiserror"]
 policy = ["num-bigint", "num-traits", "parking_lot", "lazy_static"]
 networks = ["thiserror"]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "account", feature = "networks", feature = "slots"))]
 #[macro_use]
 extern crate beserial_derive;
 


### PR DESCRIPTION
Fix the building of the crate `nimiq-primitives` with the feature
`coin`.
Remove a warning when building the crate for every feature except
`account`, `networks` or `slots` related to the unused `macro_use`
of `beserial_derive`.

This closes #310.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.