### PR TITLE
Remove validator public key merkle root from checkpoint blocks

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -260,9 +260,19 @@ impl BlockProducer {
             None
         };
 
+        // If this is an election block, calculate the validator set for the next epoch.
+        let pk_tree_root = if policy::is_election_block_at(self.blockchain.block_number() + 1) {
+            Some(MacroBlock::create_pk_tree_root(
+                validators.as_ref().unwrap(),
+            ))
+        } else {
+            None
+        };
+
         // Create the body for the macro block.
         let body = MacroBody {
             validators,
+            pk_tree_root,
             lost_reward_set,
             disabled_set,
             transactions: vec![],

--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -222,7 +222,7 @@ impl BlockProducer {
         // Get the state.
         let state = blockchain.state();
 
-        let inherents: Vec<Inherent> = blockchain.create_macro_block_inherents(&state, &header);
+        let inherents: Vec<Inherent> = blockchain.create_macro_block_inherents(state, &header);
 
         // Update the state and add the state root to the header.
         header.state_root = state
@@ -261,7 +261,7 @@ impl BlockProducer {
         };
 
         // If this is an election block, calculate the validator set for the next epoch.
-        let pk_tree_root = if policy::is_election_block_at(self.blockchain.block_number() + 1) {
+        let pk_tree_root = if policy::is_election_block_at(blockchain.block_number() + 1) {
             Some(MacroBlock::create_pk_tree_root(
                 validators.as_ref().unwrap(),
             ))

--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -63,7 +63,8 @@ impl TemporaryBlockProducer {
                 .get_validators_for_epoch(policy::epoch_at(blockchain.block_number() + 1));
             assert!(validators.is_some());
 
-            let validator_merkle_root = MacroBlock::create_pk_tree_root(&validators.unwrap());
+            let validator_merkle_root =
+                MacroBlock::create_pk_tree_root(&validators.unwrap(), height);
 
             Block::Macro(TemporaryBlockProducer::finalize_macro_block(
                 TendermintProposal {

--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -63,9 +63,6 @@ impl TemporaryBlockProducer {
                 .get_validators_for_epoch(policy::epoch_at(blockchain.block_number() + 1));
             assert!(validators.is_some());
 
-            let validator_merkle_root =
-                MacroBlock::create_pk_tree_root(&validators.unwrap(), height);
-
             Block::Macro(TemporaryBlockProducer::finalize_macro_block(
                 TendermintProposal {
                     valid_round: None,

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -120,6 +120,7 @@ impl Blockchain {
             macro_block.hash(),
             macro_block.header.block_number,
             &this.current_validators().unwrap(),
+            body.pk_tree_root.clone(),
         ) {
             warn!("Rejecting block - macro block with bad justification");
             return Err(PushError::InvalidBlock(BlockError::InvalidJustification));

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -81,7 +81,7 @@ impl Blockchain {
         // Check the justification.
         if let Err(e) = Blockchain::verify_block_justification(
             &*this,
-            &block.header(),
+            &block,
             &block.justification(),
             &intended_slot_owner,
             Some(&read_txn),

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
 
 use nimiq_block::{
-    Block, BlockBody, BlockError, BlockHeader, BlockJustification, BlockType, ForkProof, MacroBody,
-    ViewChange,
+    Block, BlockBody, BlockError, BlockHeader, BlockJustification, BlockType, ForkProof,
+    MacroBlock, MacroBody, ViewChange,
 };
 use nimiq_bls::PublicKey;
 use nimiq_database::Transaction as DBtx;
@@ -95,7 +95,7 @@ impl Blockchain {
     //       might be a better way to do this though.
     pub fn verify_block_justification<B: AbstractBlockchain>(
         blockchain: &B,
-        header: &BlockHeader,
+        block: &Block,
         justification_opt: &Option<BlockJustification>,
         intended_slot_owner: &PublicKey,
         txn_opt: Option<&DBtx>,
@@ -116,10 +116,10 @@ impl Blockchain {
                 }
 
                 // Verify the signature on the justification.
-                if !intended_slot_owner.verify_hash(header.hash_blake2s(), &signature.unwrap()) {
+                if !intended_slot_owner.verify_hash(block.hash_blake2s(), &signature.unwrap()) {
                     warn!("Rejecting block - invalid signature for intended slot owner");
 
-                    debug!("Block hash: {}", header.hash());
+                    debug!("Block hash: {}", block.hash());
 
                     debug!("Intended slot owner: {:?}", intended_slot_owner.compress());
                     return Err(PushError::InvalidBlock(BlockError::InvalidJustification));
@@ -127,22 +127,22 @@ impl Blockchain {
 
                 // Check if a view change occurred - if so, validate the proof
                 let prev_info = blockchain
-                    .get_chain_info(header.parent_hash(), false, txn_opt)
+                    .get_chain_info(block.parent_hash(), false, txn_opt)
                     .unwrap();
 
-                let view_number = if policy::is_macro_block_at(header.block_number() - 1) {
+                let view_number = if policy::is_macro_block_at(block.block_number() - 1) {
                     // Reset view number in new batch
                     0
                 } else {
                     prev_info.head.view_number()
                 };
 
-                let new_view_number = header.view_number();
+                let new_view_number = block.view_number();
 
                 if new_view_number < view_number {
                     warn!(
                         "Rejecting block - lower view number {:?} < {:?}",
-                        header.view_number(),
+                        block.view_number(),
                         view_number
                     );
                     return Err(PushError::InvalidBlock(BlockError::InvalidViewNumber));
@@ -158,8 +158,8 @@ impl Blockchain {
                 } else if new_view_number > view_number && justification.view_change_proof.is_some()
                 {
                     let view_change = ViewChange {
-                        block_number: header.block_number(),
-                        new_view_number: header.view_number(),
+                        block_number: block.block_number(),
+                        new_view_number: block.view_number(),
                         prev_seed: prev_info.head.seed().clone(),
                     };
 
@@ -175,11 +175,18 @@ impl Blockchain {
                 }
             }
             BlockJustification::Macro(justification) => {
+                // Check if there's a block body from which to get the pk_tree_root.
+                let pk_tree_root = match block.body() {
+                    Some(body) => body.unwrap_macro().pk_tree_root,
+                    None => None,
+                };
+
                 // If the block is a macro block, verify the Tendermint proof.
                 if !justification.verify(
-                    header.hash(),
-                    header.block_number(),
+                    block.hash(),
+                    block.block_number(),
                     &blockchain.current_validators().unwrap(),
+                    pk_tree_root,
                 ) {
                     warn!("Rejecting block - macro block with bad justification");
                     return Err(PushError::InvalidBlock(BlockError::InvalidJustification));
@@ -376,6 +383,15 @@ impl Blockchain {
                 None
             };
 
+            // Calculate the PK Tree root.
+            let real_pk_tree_root = if macro_block.is_election_block() {
+                Some(MacroBlock::create_pk_tree_root(
+                    real_validators.as_ref().unwrap(),
+                ))
+            } else {
+                None
+            };
+
             // Check the real values against the block.
             if let Some(body) = &macro_block.body {
                 // If we were given a body, then check each value against the corresponding value in
@@ -395,6 +411,11 @@ impl Blockchain {
                     return Err(PushError::InvalidBlock(BlockError::InvalidValidators));
                 }
 
+                if real_pk_tree_root != body.pk_tree_root {
+                    warn!("Rejecting block - PK Tree root doesn't match real PK Tree root");
+                    return Err(PushError::InvalidBlock(BlockError::InvalidPKTreeRoot));
+                }
+
                 if !body.transactions.is_empty() {
                     warn!("Rejecting block - Macro block contains transactions");
                     return Err(PushError::InvalidBlock(BlockError::BodyHashMismatch));
@@ -404,6 +425,7 @@ impl Blockchain {
                 // its hash against the block header.
                 let real_body = MacroBody {
                     validators: real_validators,
+                    pk_tree_root: real_pk_tree_root,
                     lost_reward_set: real_lost_rewards,
                     disabled_set: real_disabled_slots,
                     transactions: vec![],

--- a/blockchain/src/history_store/history_store.rs
+++ b/blockchain/src/history_store/history_store.rs
@@ -204,7 +204,7 @@ impl HistoryStore {
         ));
 
         // Return the history root.
-        Some(tree.get_root().ok()?)
+        tree.get_root().ok()
     }
 
     /// Calculates the history tree root from a vector of extended transactions. It doesn't use the
@@ -219,7 +219,7 @@ impl HistoryStore {
         }
 
         // Return the history root.
-        Some(tree.get_root().ok()?)
+        tree.get_root().ok()
     }
 
     /// Gets an extended transaction given its hash.

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -36,7 +36,7 @@ fn it_can_create_batch_finalization_inherents() {
     };
 
     // Simple case. Expect 1x FinalizeBatch, 1x Reward to validator
-    let inherents = blockchain.finalize_previous_batch(&blockchain.state(), &macro_header);
+    let inherents = blockchain.finalize_previous_batch(blockchain.state(), &macro_header);
     assert_eq!(inherents.len(), 2);
 
     let active_validators = blockchain.get_staking_contract().active_validators;
@@ -89,7 +89,7 @@ fn it_can_create_batch_finalization_inherents() {
         .is_ok());
     txn.commit();
 
-    let inherents = blockchain.finalize_previous_batch(&blockchain.state(), &macro_header);
+    let inherents = blockchain.finalize_previous_batch(blockchain.state(), &macro_header);
     assert_eq!(inherents.len(), 3);
     let one_slot_reward = 8_74999 / policy::SLOTS as u64;
     let mut got_reward = false;

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -80,9 +80,13 @@ fn test_replay() {
 
     let validators = blockchain.current_validators().unwrap();
 
-    // Calculate the validator Merkle root (used in the nano sync).
-    let validator_merkle_root =
-        pk_tree_construct(vec![key_pair.public_key.public_key; policy::SLOTS as usize]);
+    // Calculate the validator Merkle root (used in the nano sync). This only needs to be calculated
+    // on election blocks.
+    let validator_merkle_root = if policy::is_election_block_at(1u32) {
+        pk_tree_construct(vec![key_pair.public_key.public_key; policy::SLOTS as usize])
+    } else {
+        vec![]
+    };
 
     // create a TendermintVote for the PreVote round
     let vote = TendermintVote {

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -88,6 +88,12 @@ fn test_replay() {
         vec![]
     };
 
+    let pk_tree_root = if policy::is_election_block_at(1u32) {
+        Some(validator_merkle_root.clone())
+    } else {
+        None
+    };
+
     // create a TendermintVote for the PreVote round
     let vote = TendermintVote {
         proposal_hash: Some(block_hash.clone()),
@@ -116,7 +122,7 @@ fn test_replay() {
         sig: MultiSignature::new(signature, signers),
     };
     // verify commit - this should fail
-    assert!(!justification.verify(block_hash.clone(), 1u32, &validators));
+    assert!(!justification.verify(block_hash.clone(), 1u32, &validators, pk_tree_root.clone()));
 
     // create the same thing again but for the PreCommit round
     let vote = TendermintVote {
@@ -147,5 +153,5 @@ fn test_replay() {
     };
     // verify commit - this should not fail as this time it is the correct round
     // assert exists to make sure this is in fact the deciding factor (not i.e wrong validator slots or something else)
-    assert!(justification.verify(block_hash, 1u32, &validators));
+    assert!(justification.verify(block_hash, 1u32, &validators, pk_tree_root));
 }

--- a/consensus/tests/block_queue.rs
+++ b/consensus/tests/block_queue.rs
@@ -306,8 +306,8 @@ async fn send_micro_blocks_out_of_order() {
     assert_eq!(blockchain1.read().block_number(), 0);
 
     // Obtain the buffered blocks
-    let buffered_blocks = block_queue.buffered_blocks().collect::<Vec<_>>();
-    assert_eq!(buffered_blocks.len() as u64, n_blocks - 1);
+
+    assert_eq!(block_queue.buffered_blocks().count() as u64, n_blocks - 1);
 
     // now send block1 to fill the gap
     tx.send((blocks[0].clone(), mock_id)).await.unwrap();

--- a/nano-blockchain/src/push.rs
+++ b/nano-blockchain/src/push.rs
@@ -57,7 +57,7 @@ impl NanoBlockchain {
         // Check the justification.
         Blockchain::verify_block_justification(
             self,
-            &block.header(),
+            &block,
             &block.justification(),
             &intended_slot_owner,
             None,

--- a/nano-blockchain/src/sync.rs
+++ b/nano-blockchain/src/sync.rs
@@ -156,11 +156,18 @@ impl NanoBlockchain {
             .as_ref()
             .ok_or(PushError::InvalidBlock(BlockError::NoJustification))?;
 
+        // Check if there's a block body from which to get the pk_tree_root.
+        let pk_tree_root = match block.body() {
+            Some(body) => body.unwrap_macro().pk_tree_root,
+            None => None,
+        };
+
         // Verify the justification.
         if !justification.verify(
             block.hash(),
             block.block_number(),
             &self.current_validators().unwrap(),
+            pk_tree_root,
         ) {
             return Err(PushError::InvalidBlock(BlockError::InvalidJustification));
         }

--- a/nano-primitives/src/merkle_tree.rs
+++ b/nano-primitives/src/merkle_tree.rs
@@ -53,7 +53,7 @@ pub fn merkle_tree_construct(inputs: Vec<Vec<bool>>) -> Vec<u8> {
         // Serialize all the child nodes.
         let bits: Vec<bool> = nodes
             .par_iter()
-            .map(|node| bytes_to_bits(&serialize_g1_mnt6(&node)))
+            .map(|node| bytes_to_bits(&serialize_g1_mnt6(node)))
             .flatten()
             .collect();
 

--- a/nano-primitives/src/pk_tree.rs
+++ b/nano-primitives/src/pk_tree.rs
@@ -16,9 +16,6 @@ pub const PK_TREE_BREADTH: usize = 2_usize.pow(PK_TREE_DEPTH as u32);
 /// This function is meant to calculate the public key tree "off-circuit". Generating the public key
 /// tree with this function guarantees that it is compatible with the ZK circuit.
 pub fn pk_tree_construct(public_keys: Vec<G2Projective>) -> Vec<u8> {
-    // FIXME This computation is too slow ATM. Disable it for the time being.
-    return Default::default();
-
     // Checking that the number of public keys is equal to the number of validator slots.
     assert_eq!(public_keys.len(), SLOTS as usize);
 

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -159,6 +159,14 @@ impl Block {
         }
     }
 
+    /// Returns the Blake2s hash of the block header.
+    pub fn hash_blake2s(&self) -> Blake2sHash {
+        match self {
+            Block::Macro(ref block) => block.header.hash(),
+            Block::Micro(ref block) => block.header.hash(),
+        }
+    }
+
     /// Returns a copy of the validators. Only returns Some if it is an election block.
     pub fn validators(&self) -> Option<Validators> {
         match self {

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -81,4 +81,6 @@ pub enum BlockError {
     InvalidHistoryRoot,
     #[error("Incorrect validators")]
     InvalidValidators,
+    #[error("Incorrect PK Tree root")]
+    InvalidPKTreeRoot,
 }

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -98,8 +98,14 @@ impl MacroBlock {
         self.body.as_ref()?.validators.clone()
     }
 
-    /// Calculates the PKTree root from the given validators.
-    pub fn create_pk_tree_root(validators: &Validators) -> Vec<u8> {
+    /// Calculates the PKTree root from the given validators. This only needs to be calculated
+    /// if we are in an election block, otherwise we return an empty vector.
+    pub fn create_pk_tree_root(validators: &Validators, block_number: u32) -> Vec<u8> {
+        // Check if we are in an election block.
+        if !policy::is_election_block_at(block_number) {
+            return vec![];
+        }
+
         // Get the public keys.
         let public_keys = validators.to_pks().iter().map(|pk| pk.public_key).collect();
 
@@ -168,28 +174,4 @@ pub enum IntoSlotsError {
     MissingBody,
     #[error("Not an election macro block")]
     NoElection,
-}
-
-pub fn create_pk_tree_root(slots: &Validators) -> Vec<u8> {
-    // create a
-    let public_keys = (0..policy::SLOTS)
-        // map every index
-        .map(|index| {
-            slots
-                // to the validator with index index
-                .get_validator(index as u16)
-                // then get its public key
-                .public_key
-                // uncompress it
-                .uncompress()
-                // this as well must succeed for the validator to work at all.
-                .expect("Failed to retrieve public_key")
-                // finally get the G2Projective as implicit type.
-                .public_key
-        })
-        // finally collect to get a Vec<G2Projective>
-        .collect();
-
-    // Create the tree
-    pk_tree_construct(public_keys)
 }

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -11,7 +11,7 @@ use crate::signed::{
     Message, SignedMessage, PREFIX_TENDERMINT_COMMIT, PREFIX_TENDERMINT_PREPARE,
     PREFIX_TENDERMINT_PROPOSAL,
 };
-use crate::{MacroBlock, MacroHeader, MultiSignature};
+use crate::{MacroHeader, MultiSignature};
 
 /// The proposal message sent by the Tendermint leader.
 #[derive(Clone, Debug, Serialize, Deserialize, SerializeContent, PartialEq, Eq)]

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -4,7 +4,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_primitives::policy::TWO_THIRD_SLOTS;
+use nimiq_primitives::policy;
 use nimiq_primitives::slots::Validators;
 
 use crate::signed::{
@@ -51,9 +51,10 @@ impl TendermintProof {
         block_hash: Blake2bHash,
         block_number: u32,
         validators: &Validators,
+        pk_tree_root: Option<Vec<u8>>,
     ) -> bool {
         // Check if there are enough votes.
-        if self.votes() < TWO_THIRD_SLOTS {
+        if self.votes() < policy::TWO_THIRD_SLOTS {
             return false;
         }
 
@@ -67,8 +68,14 @@ impl TendermintProof {
             }
         }
 
-        // Calculate the validator Merkle root (used in the nano sync).
-        let validator_merkle_root = MacroBlock::create_pk_tree_root(validators, block_number);
+        // If the pk_tree_root is None (i.e. in checkpoint blocks), then we serialize it as an empty
+        // vec.
+        let validator_merkle_root = match pk_tree_root {
+            Some(x) => x,
+            None => {
+                vec![]
+            }
+        };
 
         // Calculate the message that was actually signed by the validators.
         let message = TendermintVote {

--- a/primitives/block/tests/mod.rs
+++ b/primitives/block/tests/mod.rs
@@ -101,6 +101,7 @@ fn it_can_convert_macro_block_into_slots() {
         justification: None,
         body: Some(MacroBody {
             validators: Some(validator_slots.clone()),
+            pk_tree_root: None,
             lost_reward_set: BitSet::new(),
             disabled_set: BitSet::new(),
             transactions: vec![],

--- a/tendermint/src/outside_deps.rs
+++ b/tendermint/src/outside_deps.rs
@@ -17,7 +17,7 @@ pub trait TendermintOutsideDeps: Send + Unpin {
     /// using a previous state.
     fn verify_state(&self, state: &TendermintState<Self::ProposalTy, Self::ProofTy>) -> bool;
 
-    /// Checks if it our turn to propose for the given round.
+    /// Checks if it is our turn to propose for the given round.
     fn is_our_turn(&self, round: u32) -> bool;
 
     /// Produces a proposal for the given round. It is used when it is our turn to propose. The

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -87,9 +87,13 @@ pub fn sign_macro_block(
     // Calculate block hash.
     let block_hash = header.hash::<Blake2bHash>();
 
-    // Calculate the validator Merkle root (used in the nano sync).
-    let validator_merkle_root =
-        pk_tree_construct(vec![keypair.public_key.public_key; policy::SLOTS as usize]);
+    // Calculate the validator Merkle root (used in the nano sync). This only needs to be calculated
+    // on election blocks.
+    let validator_merkle_root = if policy::is_election_block_at(header.block_number) {
+        pk_tree_construct(vec![keypair.public_key.public_key; policy::SLOTS as usize])
+    } else {
+        vec![]
+    };
 
     // Create the precommit tendermint vote.
     let precommit = TendermintVote {

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -7,9 +7,7 @@ use futures::{future, StreamExt};
 use tokio::{sync::mpsc, time};
 
 use bls::SecretKey;
-use nimiq_block::{
-    MacroBlock, MultiSignature, TendermintIdentifier, TendermintStep, TendermintVote,
-};
+use nimiq_block::{MultiSignature, TendermintIdentifier, TendermintStep, TendermintVote};
 use nimiq_handel::{identity::WeightRegistry, update::LevelUpdateMessage};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{policy, slots::Validators};

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -53,9 +53,10 @@ where
         network: Arc<N>,
         secret_key: SecretKey,
     ) -> Self {
-        let validator_merkle_root = MacroBlock::create_pk_tree_root(&active_validators);
+        let validator_merkle_root =
+            MacroBlock::create_pk_tree_root(&active_validators, block_height);
 
-        // the input stream is all levelUpdateMessages concerning a TendemrintContribution and TendemrintIdentifier.
+        // the input stream is all levelUpdateMessages concerning a TendermintContribution and TendermintIdentifier.
         // We get rid of the sender, but while processing these messages they need to be dispatched to the appropriate Aggregation.
         let input = Box::pin(
             network

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -32,7 +32,6 @@ pub struct HandelTendermintAdapter<N: ValidatorNetwork> {
     current_bests: Arc<RwLock<BTreeMap<(u32, TendermintStep), TendermintContribution>>>,
     current_aggregate: Arc<RwLock<Option<CurrentAggregation>>>,
     pending_new_round: Arc<RwLock<Option<u32>>>,
-    validator_merkle_root: Vec<u8>,
     block_height: u32,
     secret_key: SecretKey,
     validator_id: u16,
@@ -53,9 +52,6 @@ where
         network: Arc<N>,
         secret_key: SecretKey,
     ) -> Self {
-        let validator_merkle_root =
-            MacroBlock::create_pk_tree_root(&active_validators, block_height);
-
         // the input stream is all levelUpdateMessages concerning a TendermintContribution and TendermintIdentifier.
         // We get rid of the sender, but while processing these messages they need to be dispatched to the appropriate Aggregation.
         let input = Box::pin(
@@ -101,7 +97,6 @@ where
             current_bests,
             current_aggregate,
             pending_new_round,
-            validator_merkle_root,
             block_height,
             secret_key,
             validator_id,
@@ -121,6 +116,7 @@ where
         round: u32,
         step: impl Into<TendermintStep>,
         proposal_hash: Option<Blake2bHash>,
+        validator_merkle_root: Vec<u8>,
     ) -> Result<AggregationResult<MultiSignature>, TendermintError> {
         let step = step.into();
         // make sure that there is no currently ongoing aggregation from a previous call to `broadcast_and_aggregate` which has not yet been awaited.
@@ -133,13 +129,13 @@ where
 
             match current_aggregate.take() {
                 Some(aggr) => {
-                    // re-set the current_agggregate and return error
+                    // re-set the current_aggregate and return error
                     *current_aggregate = Some(aggr);
                     debug!("An aggregation was started before the previous one was cleared");
                     return Err(TendermintError::AggregationError);
                 }
                 None => {
-                    // create channel foor result propagation
+                    // create channel for result propagation
                     let (sender, aggregate_receiver) =
                         mpsc::unbounded_channel::<AggregationResult<MultiSignature>>();
                     // set the current aggregate
@@ -154,7 +150,7 @@ where
             }
         };
 
-        // Assemble identifier from availablle information
+        // Assemble identifier from available information
         let id = TendermintIdentifier {
             block_number: self.block_height,
             round_number: round,
@@ -165,7 +161,7 @@ where
         let vote = TendermintVote {
             proposal_hash: proposal_hash.clone(),
             id: id.clone(),
-            validator_merkle_root: self.validator_merkle_root.clone(),
+            validator_merkle_root: validator_merkle_root.clone(),
         };
 
         // Create the signed contribution of this validator
@@ -185,7 +181,7 @@ where
             .send(AggregationEvent::Start(
                 id.clone(),
                 own_contribution,
-                self.validator_merkle_root.clone(),
+                validator_merkle_root.clone(),
                 output_sink,
             ))
             .await

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -292,7 +292,7 @@ impl<N: ValidatorNetwork + 'static> TendermintOutsideDeps for TendermintInterfac
                 // Update our blockchain state using the received proposal. If we can't update the state, we
                 // return a proposal timeout.
                 if blockchain
-                    .commit_accounts(&state, &block, 0, &mut txn)
+                    .commit_accounts(state, &block, 0, &mut txn)
                     .is_err()
                 {
                     debug!("Tendermint - await_proposal: Can't update state");
@@ -301,7 +301,7 @@ impl<N: ValidatorNetwork + 'static> TendermintOutsideDeps for TendermintInterfac
                     // Check the validity of the block against our state. If it is invalid, we return a proposal
                     // timeout. This also returns the block body that matches the block header
                     // (assuming that the block is valid).
-                    let block_state = blockchain.verify_block_state(&state, &block, Some(&txn));
+                    let block_state = blockchain.verify_block_state(state, &block, Some(&txn));
 
                     if let Ok(body) = block_state {
                         // Cache the body that we calculated.

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -322,7 +322,7 @@ impl<N: ValidatorNetwork + 'static> TendermintOutsideDeps for TendermintInterfac
             }
         };
 
-        // If the message was validated sucessfully, the network may now relay it to other peers.
+        // If the message was validated successfully, the network may now relay it to other peers.
         // Otherwise, reject or ignore the message.
         if let Some((MsgAcceptance::Accept, header, valid_round)) = acceptance {
             self.network
@@ -349,8 +349,17 @@ impl<N: ValidatorNetwork + 'static> TendermintOutsideDeps for TendermintInterfac
         step: Step,
         proposal: Option<Blake2bHash>,
     ) -> Result<AggregationResult<Self::ProofTy>, TendermintError> {
+        // If the pk_tree_root is None (i.e. in checkpoint blocks), then we serialize it as an empty
+        // vec.
+        let validator_merkle_root = match &self.cache_body.as_ref().unwrap().pk_tree_root {
+            Some(x) => x.clone(),
+            None => {
+                vec![]
+            }
+        };
+
         self.aggregation_adapter
-            .broadcast_and_aggregate(round, step, proposal)
+            .broadcast_and_aggregate(round, step, proposal, validator_merkle_root)
             .await
     }
 

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -12,7 +12,6 @@ use nimiq_build_tools::genesis::{GenesisBuilder, GenesisInfo};
 use nimiq_consensus::sync::history::HistorySync;
 use nimiq_consensus::Consensus as AbstractConsensus;
 use nimiq_database::volatile::VolatileEnvironment;
-use nimiq_hash::Hash;
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
 use nimiq_mempool::{Mempool, MempoolConfig};
 use nimiq_network_interface::network::Network as NetworkInterface;

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -14,7 +14,6 @@ use nimiq_consensus::sync::history::HistorySync;
 use nimiq_consensus::{Consensus as AbstractConsensus, ConsensusEvent};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_handel::update::{LevelUpdate, LevelUpdateMessage};
-use nimiq_hash::Hash;
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
 use nimiq_mempool::{Mempool, MempoolConfig};
 use nimiq_network_interface::network::Network;


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes #275 and fixes #326.

## What's in this pull request?
1. The pk_tree_root was added as a field to the body of the macro blocks. It is an Option like the Validators and is only set on election blocks. This way the pk_tree_root can be cached and is only calculated once, when producing or verifying a block.
2. The pk_tree_root is no longer calculated on checkpoint blocks, only on election blocks. On the macro block body it is set to None and on the Tendermint justification message it is set to an empty vec.
3. The calculation of the pk_tree_root now uses the validator set for the next epoch instead of the current validator set (which was incorrect).

P.S. Having the pk_tree_root as a field in the macro blocks does have the advantage that the nano clients won't need to calculate it when syncing, saving them quite a few seconds.