### PR TITLE
Remove interior mutability primitives from Blockchain, use outer RwLock

### DIFF
--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 log = "0.4"
 hex = "0.4"
+parking_lot = "0.11"
 
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account" }
@@ -36,6 +37,8 @@ nimiq-primitives = { path = "../primitives" }
 nimiq-vrf = { path = "../vrf" }
 
 [dev-dependencies]
+simple_logger = "1.0"
+
 nimiq-transaction = { path = "../primitives/transaction" }
 nimiq-test-utils = { path = "../test-utils" }
 

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 thiserror = "1.0"
 hex = "0.4"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 
 beserial = { path = "../beserial" }

--- a/blockchain/src/abstract_blockchain.rs
+++ b/blockchain/src/abstract_blockchain.rs
@@ -222,23 +222,23 @@ impl AbstractBlockchain for Blockchain {
     }
 
     fn head(&self) -> Block {
-        self.state.read().main_chain.head.clone()
+        self.state.main_chain.head.clone()
     }
 
     fn macro_head(&self) -> MacroBlock {
-        self.state.read().macro_info.head.unwrap_macro_ref().clone()
+        self.state.macro_info.head.unwrap_macro_ref().clone()
     }
 
     fn election_head(&self) -> MacroBlock {
-        self.state.read().election_head.clone()
+        self.state.election_head.clone()
     }
 
     fn current_validators(&self) -> Option<Validators> {
-        self.state.read().current_slots.clone()
+        self.state.current_slots.clone()
     }
 
     fn previous_validators(&self) -> Option<Validators> {
-        self.state.read().previous_slots.clone()
+        self.state.previous_slots.clone()
     }
 
     fn contains(&self, hash: &Blake2bHash, include_forks: bool) -> bool {

--- a/blockchain/src/blockchain/slots.rs
+++ b/blockchain/src/blockchain/slots.rs
@@ -9,14 +9,12 @@ use nimiq_account::StakingContract;
 impl Blockchain {
     /// Gets the validators for a given epoch.
     pub fn get_validators_for_epoch(&self, epoch: u32) -> Option<Validators> {
-        let state = self.state.read();
-
-        let current_epoch = policy::epoch_at(state.main_chain.head.block_number());
+        let current_epoch = policy::epoch_at(self.state.main_chain.head.block_number());
 
         let slots = if epoch == current_epoch {
-            state.current_slots.as_ref()?.clone()
+            self.state.current_slots.as_ref()?.clone()
         } else if epoch == current_epoch - 1 {
-            state.previous_slots.as_ref()?.clone()
+            self.state.previous_slots.as_ref()?.clone()
         } else {
             let macro_block = self
                 .chain_store

--- a/blockchain/tests/mod.rs
+++ b/blockchain/tests/mod.rs
@@ -170,8 +170,8 @@ fn create_fork_proof() {
 
     producer1
         .blockchain
-        .fork_notifier
         .write()
+        .fork_notifier
         .register(move |e: &ForkEvent| match e {
             ForkEvent::Detected(_) => *event1_rc2.write().unwrap() = true,
         });

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.3.4"
 thiserror = "1.0"
 hex = "0.4"
 log = "0.4"
-parking_lot = { version = "0.9", optional = true }
+parking_lot = { version = "0.11", optional = true }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 async-trait = "0.1"
 futures = "0.3"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 pin-project = "0.4.8"
 rand = "0.7"
 thiserror = "1.0"

--- a/consensus/src/consensus/request_response.rs
+++ b/consensus/src/consensus/request_response.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
+use parking_lot::RwLock;
 
 use crate::messages::handlers::Handle;
 use crate::messages::{
@@ -13,7 +14,7 @@ use blockchain::Blockchain;
 use network_interface::prelude::{Network, Peer};
 
 impl<N: Network> Consensus<N> {
-    pub(super) fn init_network_requests(network: &Arc<N>, blockchain: &Arc<Blockchain>) {
+    pub(super) fn init_network_requests(network: &Arc<N>, blockchain: &Arc<RwLock<Blockchain>>) {
         let blockchain_outer = blockchain;
         let blockchain = Arc::clone(blockchain_outer);
         let mut stream = network.receive_from_all::<RequestBlockHashes>();

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = "1.0"
 fs2 = "0.4"
 lmdb-zero = "0.4"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 tempfile = "3"
 

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3"
 futures-cpupool = "0.1"
 lazy_static = "1.3"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 thiserror = "1.0"
 tokio = { version = "1.9", features = ["rt", "time"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,7 +30,7 @@ hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 log-panics = { version = "2.0", features = ["with-backtrace"], optional = true }
-parking_lot = { version = "0.9", features = ["deadlock_detection"], optional = true }
+parking_lot = { version = "0.11", features = ["deadlock_detection"], optional = true }
 paw = "1.0"
 rand = "0.7"
 serde = "1.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account" }

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use parking_lot::RwLock;
+
 use beserial::{Deserialize, Serialize};
 use nimiq_account::{Inherent, InherentType};
 use nimiq_blockchain::Blockchain;
@@ -19,7 +21,9 @@ const BASIC_TRANSACTION: &str = "000222666efadc937148a6d61589ce6d4aeecca97fda4c3
 fn push_same_tx_twice() {
     let env = VolatileEnvironment::new(10).unwrap();
 
-    let blockchain = Arc::new(Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap(),
+    ));
 
     let mempool = Mempool::new(blockchain.clone(), MempoolConfig::default());
 
@@ -40,7 +44,8 @@ fn push_same_tx_twice() {
     let mut txn = WriteTransaction::new(&env);
 
     blockchain
-        .state()
+        .read()
+        .state
         .accounts
         .commit(&mut txn, &[], &[reward], 0, 0)
         .unwrap();
@@ -69,7 +74,9 @@ fn push_same_tx_twice() {
 fn push_tx_with_wrong_signature() {
     let env = VolatileEnvironment::new(10).unwrap();
 
-    let blockchain = Arc::new(Blockchain::new(env, NetworkId::UnitAlbatross).unwrap());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(env, NetworkId::UnitAlbatross).unwrap(),
+    ));
 
     let mempool = Mempool::new(blockchain, MempoolConfig::default());
 
@@ -87,7 +94,9 @@ fn push_tx_with_wrong_signature() {
 fn push_tx_with_insufficient_balance() {
     let env = VolatileEnvironment::new(10).unwrap();
 
-    let blockchain = Arc::new(Blockchain::new(env, NetworkId::UnitAlbatross).unwrap());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(env, NetworkId::UnitAlbatross).unwrap(),
+    ));
 
     let mempool = Mempool::new(blockchain, MempoolConfig::default());
 
@@ -102,7 +111,9 @@ fn push_tx_with_insufficient_balance() {
 fn push_and_get_valid_tx() {
     let env = VolatileEnvironment::new(10).unwrap();
 
-    let blockchain = Arc::new(Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap(),
+    ));
 
     let mempool = Mempool::new(blockchain.clone(), MempoolConfig::default());
 
@@ -123,7 +134,8 @@ fn push_and_get_valid_tx() {
     let mut txn = WriteTransaction::new(&env);
 
     blockchain
-        .state()
+        .read()
+        .state
         .accounts
         .commit(&mut txn, &[], &[reward], 1, 1)
         .unwrap();
@@ -162,7 +174,9 @@ fn push_and_get_valid_tx() {
 fn push_and_get_two_tx_same_user() {
     let env = VolatileEnvironment::new(10).unwrap();
 
-    let blockchain = Arc::new(Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap(),
+    ));
 
     let mempool = Mempool::new(blockchain.clone(), MempoolConfig::default());
 
@@ -183,7 +197,8 @@ fn push_and_get_two_tx_same_user() {
     let mut txn = WriteTransaction::new(&env);
 
     blockchain
-        .state()
+        .read()
+        .state
         .accounts
         .commit(&mut txn, &[], &[reward], 1, 1)
         .unwrap();
@@ -241,7 +256,9 @@ fn push_and_get_two_tx_same_user() {
 fn reject_free_tx_beyond_limit() {
     let env = VolatileEnvironment::new(10).unwrap();
 
-    let blockchain = Arc::new(Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(env.clone(), NetworkId::UnitAlbatross).unwrap(),
+    ));
 
     let mempool = Mempool::new(blockchain.clone(), MempoolConfig::default());
 
@@ -262,7 +279,8 @@ fn reject_free_tx_beyond_limit() {
     let mut txn = WriteTransaction::new(&env);
 
     blockchain
-        .state()
+        .read()
+        .state
         .accounts
         .commit(&mut txn, &[], &[reward], 1, 1)
         .unwrap();

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -22,7 +22,7 @@ bitvec = "0.17"
 byteorder = "1.2"
 hex = "0.4"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 thiserror = "1.0"
 

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -27,7 +27,7 @@ hex = "0.4"
 ip_network = "0.3"
 libp2p = { version = "0.39", features = ["dns-tokio"] }
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 pin-project = "1.0"
 pin-project-lite = "0.2.0"
 rand = "0.7.3"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -24,7 +24,7 @@ futures-03 = { package = "futures", version = "0.3" }
 hex = "0.4"
 log = "0.4"
 native-tls = "0.2"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 reqwest = "0.9"
 thiserror = "1.0"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = { version = "1.2", optional = true }
 log = "0.4"
 num-bigint = { version = "0.4.2", optional = true }
 num-traits = { version = "0.2", optional = true }
-parking_lot = { version = "0.9", optional = true }
+parking_lot = { version = "0.11", optional = true }
 regex = { version = "1.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.20"

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 hex = { version = "0.4" }
 lazy_static = "1.3"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.20"

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 use futures::stream::{BoxStream, StreamExt};
+use parking_lot::RwLock;
 
 use nimiq_account::{Account, StakingContract};
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent};
@@ -18,11 +18,11 @@ use crate::error::Error;
 use nimiq_rpc_interface::types::Validator;
 
 pub struct BlockchainDispatcher {
-    blockchain: Arc<Blockchain>,
+    blockchain: Arc<RwLock<Blockchain>>,
 }
 
 impl BlockchainDispatcher {
-    pub fn new(blockchain: Arc<Blockchain>) -> Self {
+    pub fn new(blockchain: Arc<RwLock<Blockchain>>) -> Self {
         Self { blockchain }
     }
 }
@@ -33,15 +33,15 @@ impl BlockchainInterface for BlockchainDispatcher {
     type Error = Error;
 
     async fn get_block_number(&mut self) -> Result<u32, Error> {
-        Ok(self.blockchain.block_number())
+        Ok(self.blockchain.read().block_number())
     }
 
     async fn get_epoch_number(&mut self) -> Result<u32, Error> {
-        Ok(policy::epoch_at(self.blockchain.block_number()))
+        Ok(policy::epoch_at(self.blockchain.read().block_number()))
     }
 
     async fn get_batch_number(&mut self) -> Result<u32, Error> {
-        Ok(policy::batch_at(self.blockchain.block_number()))
+        Ok(policy::batch_at(self.blockchain.read().block_number()))
     }
 
     async fn get_block_by_hash(
@@ -49,9 +49,10 @@ impl BlockchainInterface for BlockchainDispatcher {
         hash: Blake2bHash,
         include_transactions: bool,
     ) -> Result<Block, Error> {
-        self.blockchain
+        let blockchain = self.blockchain.read();
+        blockchain
             .get_block(&hash, true, None)
-            .map(|block| Block::from_block(&self.blockchain, block, include_transactions))
+            .map(|block| Block::from_block(blockchain.deref(), block, include_transactions))
             .ok_or_else(|| Error::BlockNotFound(hash.into()))
     }
 
@@ -60,23 +61,24 @@ impl BlockchainInterface for BlockchainDispatcher {
         block_number: u32,
         include_transactions: bool,
     ) -> Result<Block, Error> {
-        let block = self
-            .blockchain
+        let blockchain = self.blockchain.read();
+        let block = blockchain
             .get_block_at(block_number, true, None)
             .ok_or_else(|| Error::BlockNotFound(block_number.into()))?;
 
         Ok(Block::from_block(
-            &self.blockchain,
+            blockchain.deref(),
             block,
             include_transactions,
         ))
     }
 
     async fn get_latest_block(&mut self, include_transactions: bool) -> Result<Block, Error> {
-        let block = self.blockchain.head();
+        let blockchain = self.blockchain.read();
+        let block = blockchain.head();
 
         Ok(Block::from_block(
-            &self.blockchain,
+            blockchain.deref(),
             block,
             include_transactions,
         ))
@@ -94,10 +96,12 @@ impl BlockchainInterface for BlockchainDispatcher {
             return Err(Error::UnexpectedMacroBlock(block_number.into()));
         }
 
+        let blockchain = self.blockchain.read();
+
         let view_number = if let Some(view_number) = view_number_opt {
             view_number
         } else {
-            self.blockchain
+            blockchain
                 .chain_store
                 .get_block_at(block_number, false, None)
                 .ok_or_else(|| Error::BlockNotFound(block_number.into()))?
@@ -105,16 +109,18 @@ impl BlockchainInterface for BlockchainDispatcher {
         };
 
         Ok(Slot::from_producer(
-            &self.blockchain,
+            blockchain.deref(),
             block_number,
             view_number,
         ))
     }
 
     async fn get_slashed_slots(&mut self) -> Result<SlashedSlots, Error> {
+        let blockchain = self.blockchain.read();
+
         // FIXME: Race condition
-        let block_number = self.blockchain.block_number();
-        let staking_contract = self.blockchain.get_staking_contract();
+        let block_number = blockchain.block_number();
+        let staking_contract = blockchain.get_staking_contract();
 
         let current_slashed_set =
             staking_contract.current_lost_rewards() & staking_contract.current_disabled_slots();
@@ -135,12 +141,10 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     async fn get_transaction_by_hash(&mut self, hash: Blake2bHash) -> Result<Transaction, Error> {
         // TODO: Check mempool for the transaction, too
+        let blockchain = self.blockchain.read();
 
         // Get all the extended transactions that correspond to this hash.
-        let mut extended_tx_vec = self
-            .blockchain
-            .history_store
-            .get_ext_tx_by_hash(&hash, None);
+        let mut extended_tx_vec = blockchain.history_store.get_ext_tx_by_hash(&hash, None);
 
         // If we get more than 1 extended transaction, we panic. This shouldn't happen.
         assert!(extended_tx_vec.len() < 2);
@@ -158,7 +162,7 @@ impl BlockchainInterface for BlockchainDispatcher {
             transaction.clone(),
             extended_tx.block_number,
             extended_tx.block_time,
-            self.blockchain.block_number(),
+            blockchain.block_number(),
         ))
     }
 
@@ -166,9 +170,9 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         block_number: u32,
     ) -> Result<Vec<Transaction>, Error> {
+        let blockchain = self.blockchain.read();
         // Get all the extended transactions that correspond to this block.
-        let extended_tx_vec = self
-            .blockchain
+        let extended_tx_vec = blockchain
             .history_store
             .get_block_transactions(block_number, None);
 
@@ -180,7 +184,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                     ext_tx.unwrap_basic().clone(),
                     ext_tx.block_number,
                     ext_tx.block_time,
-                    self.blockchain.block_number(),
+                    blockchain.block_number(),
                 ));
             }
         }
@@ -189,11 +193,12 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_batch_inherents(&mut self, batch_number: u32) -> Result<Vec<Inherent>, Error> {
+        let blockchain = self.blockchain.read();
+
         let macro_block_number = policy::macro_block_of(batch_number);
 
         // Check the batch's macro block to see if the batch includes slashes
-        let macro_block = self
-            .blockchain
+        let macro_block = blockchain
             .get_block_at(macro_block_number, true, None) // The lost_reward_set is in the MacroBody
             .ok_or_else(|| Error::BlockNotFound(macro_block_number.into()))?;
 
@@ -207,10 +212,7 @@ impl BlockchainInterface for BlockchainDispatcher {
             let last_micro_block = macro_block_number - 1;
 
             for i in first_micro_block..last_micro_block {
-                let micro_ext_tx_vec = self
-                    .blockchain
-                    .history_store
-                    .get_block_transactions(i, None);
+                let micro_ext_tx_vec = blockchain.history_store.get_block_transactions(i, None);
 
                 for ext_tx in micro_ext_tx_vec {
                     if ext_tx.is_inherent() {
@@ -222,8 +224,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
         // Append inherents of the macro block (we do this after the micro blocks so the inherents are in order)
         inherent_tx_vec.append(
-            &mut self
-                .blockchain
+            &mut blockchain
                 .history_store
                 .get_block_transactions(macro_block_number, None)
                 .into_iter()
@@ -253,11 +254,11 @@ impl BlockchainInterface for BlockchainDispatcher {
         address: Address,
         max: Option<u16>,
     ) -> Result<Vec<Blake2bHash>, Error> {
-        Ok(self.blockchain.history_store.get_tx_hashes_by_address(
-            &address,
-            max.unwrap_or(500),
-            None,
-        ))
+        Ok(self
+            .blockchain
+            .read()
+            .history_store
+            .get_tx_hashes_by_address(&address, max.unwrap_or(500), None))
     }
 
     async fn get_transactions_by_address(
@@ -279,7 +280,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn list_stakes(&mut self) -> Result<HashMap<Address, Coin>, Error> {
-        let staking_contract = self.blockchain.get_staking_contract();
+        let staking_contract = self.blockchain.read().get_staking_contract();
 
         let mut active_validators = HashMap::new();
 
@@ -295,8 +296,9 @@ impl BlockchainInterface for BlockchainDispatcher {
         address: Address,
         include_stakers: Option<bool>,
     ) -> Result<Validator, Error> {
-        let accounts_tree = &self.blockchain.state().accounts.tree;
-        let db_txn = self.blockchain.read_transaction();
+        let blockchain = self.blockchain.read();
+        let accounts_tree = &blockchain.state().accounts.tree;
+        let db_txn = blockchain.read_transaction();
         let validator = StakingContract::get_validator(accounts_tree, &db_txn, &address);
 
         if validator.is_none() {
@@ -325,8 +327,9 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_staker(&mut self, address: Address) -> Result<Staker, Error> {
-        let accounts_tree = &self.blockchain.state().accounts.tree;
-        let db_txn = self.blockchain.read_transaction();
+        let blockchain = self.blockchain.read();
+        let accounts_tree = &blockchain.state().accounts.tree;
+        let db_txn = blockchain.read_transaction();
         let staker = StakingContract::get_staker(accounts_tree, &db_txn, &address);
 
         match staker {
@@ -337,7 +340,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     #[stream]
     async fn head_subscribe(&mut self) -> Result<BoxStream<'static, Blake2bHash>, Error> {
-        let stream = self.blockchain.notifier.write().as_stream();
+        let stream = self.blockchain.write().notifier.as_stream();
         Ok(stream
             .map(|event| match event {
                 BlockchainEvent::Extended(hash) => hash,
@@ -351,7 +354,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_account(&mut self, address: Address) -> Result<Option<Account>, Error> {
-        let account = self.blockchain.get_account(&address);
+        let account = self.blockchain.read().get_account(&address);
         match account {
             Some(Account::Staking(_)) => Err(Error::GetAccountUnsupportedStakingContract),
             _ => Ok(account),

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -58,11 +58,11 @@ impl ConsensusDispatcher {
     }
 
     fn network_id(&self) -> NetworkId {
-        self.consensus.blockchain.network_id
+        self.consensus.blockchain.read().network_id
     }
 
     fn validity_start_height(&self, validity_start_height: ValidityStartHeight) -> u32 {
-        validity_start_height.block_number(self.consensus.blockchain.block_number())
+        validity_start_height.block_number(self.consensus.blockchain.read().block_number())
     }
 }
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 
 [dependencies]
 hex = "0.4"
+parking_lot = "0.11"
 
 beserial = { path = "../beserial" }
 nimiq-block = { path = "../primitives/block" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -24,7 +24,7 @@ futures = { version = "0.1", optional = true }
 hex = { version = "0.4", optional = true }
 libp2p = { version = "0.39", optional = true }
 log = { version = "0.4", optional = true }
-parking_lot = { version = "0.9", optional = true }
+parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.7", optional = true }
 rand_core = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.3"
 linked-hash-map = "0.5.4"
 lmdb-zero = "0.4"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 rand = "0.7"
 tokio = { version = "1.9", features = ["rt", "time"] }
 tokio-stream ={ version = "0.1", features = ["sync"] }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -11,7 +11,7 @@ use parking_lot::RwLock;
 use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream};
 
 use block::{Block, BlockType, SignedTendermintProposal, ViewChange, ViewChangeProof};
-use blockchain::{AbstractBlockchain, BlockchainEvent, ForkEvent, PushResult};
+use blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent, ForkEvent, PushResult};
 use bls::CompressedPublicKey;
 use consensus::{sync::block_queue::BlockTopic, Consensus, ConsensusEvent, ConsensusProxy};
 use database::{Database, Environment, ReadTransaction, WriteTransaction};
@@ -103,17 +103,20 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         wallet_key: Option<keys::KeyPair>,
     ) -> Self {
         let consensus_event_rx = consensus.subscribe_events();
-        let blockchain_event_rx = consensus.blockchain.notifier.write().as_stream();
-        let fork_event_rx = consensus.blockchain.fork_notifier.write().as_stream();
+
+        let mut blockchain = consensus.blockchain.write();
+        let blockchain_event_rx = blockchain.notifier.as_stream();
+        let fork_event_rx = blockchain.fork_notifier.as_stream();
+
+        let micro_state = ProduceMicroBlockState {
+            view_number: blockchain.view_number(),
+            view_change_proof: None,
+            view_change: None,
+        };
+        drop(blockchain);
 
         let blockchain_state = BlockchainState {
             fork_proofs: ForkProofPool::new(),
-        };
-
-        let micro_state = ProduceMicroBlockState {
-            view_number: consensus.blockchain.view_number(),
-            view_change_proof: None,
-            view_change: None,
         };
 
         let env = consensus.env.clone();
@@ -176,7 +179,12 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         self.macro_producer = None;
         self.micro_producer = None;
 
-        let validators = self.consensus.blockchain.current_validators().unwrap();
+        let validators = self
+            .consensus
+            .blockchain
+            .read()
+            .current_validators()
+            .unwrap();
 
         // TODO: This code block gets this validators position in the validators struct by searching it
         //  with its public key. This is an insane way of doing this. Just start saving the validator
@@ -220,16 +228,16 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             return;
         }
 
-        let _lock = self.consensus.blockchain.lock();
+        let blockchain = self.consensus.blockchain.read();
 
         self.macro_producer = None;
         self.micro_producer = None;
 
-        match self.consensus.blockchain.get_next_block_type(None) {
+        match blockchain.get_next_block_type(None) {
             BlockType::Macro => {
                 let block_producer = BlockProducer::new(
-                    self.consensus.blockchain.clone(),
-                    self.consensus.mempool.clone(),
+                    Arc::clone(&self.consensus.blockchain),
+                    Arc::clone(&self.consensus.mempool),
                     self.signing_key.clone(),
                 );
 
@@ -241,7 +249,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                     .macro_state
                     .take()
                     .map(|state| {
-                        if state.height == self.consensus.blockchain.block_number() + 1 {
+                        if state.height == blockchain.block_number() + 1 {
                             Some(state)
                         } else {
                             None
@@ -252,8 +260,8 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                 let proposal_stream = self.proposal_receiver.clone().boxed();
 
                 self.macro_producer = Some(ProduceMacroBlock::new(
-                    self.consensus.blockchain.clone(),
-                    self.network.clone(),
+                    Arc::clone(&self.consensus.blockchain),
+                    Arc::clone(&self.network),
                     block_producer,
                     self.signing_key.clone(),
                     self.validator_id(),
@@ -263,7 +271,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             }
             BlockType::Micro => {
                 self.micro_state = ProduceMicroBlockState {
-                    view_number: self.consensus.blockchain.head().next_view_number(),
+                    view_number: blockchain.head().next_view_number(),
                     view_change_proof: None,
                     view_change: None,
                 };
@@ -308,6 +316,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         let block = self
             .consensus
             .blockchain
+            .read()
             .get_block(hash, true, None)
             .expect("Head block not found");
         self.blockchain_state.fork_proofs.apply_block(&block);
@@ -340,12 +349,14 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                 TendermintReturn::Result(block) => {
                     // If the event is a result meaning the next macro block was produced we push it onto our local chain
                     let block_copy = block.clone();
-                    let result = self
-                        .consensus
-                        .blockchain
-                        .push(Block::Macro(block))
-                        .map_err(|e| error!("Failed to push macro block onto the chain: {:?}", e))
-                        .ok();
+
+                    let result = Blockchain::push(
+                        self.consensus.blockchain.upgradable_read(),
+                        Block::Macro(block),
+                    )
+                    .map_err(|e| error!("Failed to push macro block onto the chain: {:?}", e))
+                    .ok();
+
                     if result == Some(PushResult::Extended)
                         || result == Some(PushResult::Rebranched)
                     {
@@ -377,7 +388,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                 TendermintReturn::StateUpdate(update) => {
                     let mut write_transaction = WriteTransaction::new(&self.env);
                     let persistable_state = PersistedMacroState::<TValidatorNetwork> {
-                        height: self.consensus.blockchain.block_number() + 1,
+                        height: self.consensus.blockchain.read().block_number() + 1,
                         step: update.step.into(),
                         round: update.round,
                         locked_round: update.locked_round,
@@ -406,12 +417,13 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             match event {
                 ProduceMicroBlockEvent::MicroBlock(block) => {
                     let block_copy = block.clone();
-                    let result = self
-                        .consensus
-                        .blockchain
-                        .push(Block::Micro(block))
-                        .map_err(|e| error!("Failed to push our block onto the chain: {:?}", e))
-                        .ok();
+                    let result = Blockchain::push(
+                        self.consensus.blockchain.upgradable_read(),
+                        Block::Micro(block),
+                    )
+                    .map_err(|e| error!("Failed to push our block onto the chain: {:?}", e))
+                    .ok();
+
                     if result == Some(PushResult::Extended)
                         || result == Some(PushResult::Rebranched)
                     {


### PR DESCRIPTION
## Pull request checklist
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

This PR resolves #320.

## What's in this pull request?

The `Blockchain` struct itself no longer uses any `RwLock` internally. The locking now happens on the outside as `Arc<Blockchain>` is changed to `Arc<RwLock<Blockchain>>` everywhere.

The only operations requiring write are subscribing a listener to the observable as well as `Blockchain::push` and `Blockchain::push_history_sync`. 
Both the `push*` functions do work on an `RwLockUpgradableReadGuard` such that the time spend with a held `RwLockWriteGuard` is minimised, while giving the option of having held the lock prior to the `push*` calls.  
The subscribing of listeners does happen mostly on startup and should not be too bad, however there are plans to remove the Observable here as we did throughout the project.

Neither the obsolete `nimiq-network` nor the currently unused and `metrics-server` were updated.

Important to note is that the `nimiq-nano-blockchain` is untouched by this as well, as I am unsure of whether or not it is actually needed.