### PR TITLE
Fix building of the primitives subcrates with different features

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -27,7 +27,7 @@ num-bigint = { version = "0.2", optional = true }
 num-traits = { version = "0.2", optional = true }
 parking_lot = { version = "0.9", optional = true }
 regex = { version = "1.3", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.20"
 
 beserial = { path = "../beserial" }

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.3"
 log = "0.4"
 parking_lot = "0.9"
 rand = "0.7"
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.20"
 thiserror = "1.0"
 
@@ -26,9 +26,9 @@ nimiq-bls = { path = "../../bls" }
 nimiq-collections = { path = "../../collections", features = ["bitset"] }
 nimiq-database = { path = "../../database" }
 nimiq-hash = { path = "../../hash" }
-nimiq-keys = { path = "../../keys" }
-nimiq-primitives = { path = "..", features = ["coin", "policy", "slots"] }
-nimiq-transaction = { path = "../transaction" }
+nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
+nimiq-primitives = { path = "..", features = ["coin", "policy", "serde-derive", "slots"] }
+nimiq-transaction = { path = "../transaction", features = ["serde-derive"] }
 nimiq-trie = { path = "../trie" }
 nimiq-utils = { path = "../../utils", features = ["hash-rng"] }
 nimiq-vrf = { path = "../../vrf" }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -21,11 +21,11 @@ thiserror = "1.0"
 
 beserial = { path = "../../beserial" }
 beserial_derive = { path = "../../beserial/beserial_derive" }
-nimiq-bls = { path = "../../bls", features = ["beserial"] }
-nimiq-hash = { path = "../../hash" }
-nimiq-keys = { path = "../../keys" }
+nimiq-bls = { path = "../../bls", features = ["serde-derive"] }
+nimiq-hash = { path = "../../hash", features = ["serde-derive"] }
+nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
 nimiq-macros = { path = "../../macros" }
-nimiq-primitives = { path = "..", features = ["policy", "networks", "account", "coin"] }
+nimiq-primitives = { path = "..", features = ["account", "coin", "networks", "policy", "serde-derive"] }
 nimiq-utils = { path = "../../utils", features = ["merkle"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Fix the building of the primitives subcrates `nimiq-account` and
`nimiq-transaction` with the `serde-derive` feature and without
features.

This closes #311.
This closes #312.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.