### PR TITLE
RPC: Add method isAccountUnlocked

### DIFF
--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -47,6 +47,8 @@ pub trait WalletInterface {
         duration: Option<u64>,
     ) -> Result<(), Self::Error>;
 
+    async fn is_account_unlocked(&mut self, address: Address) -> Result<bool, Self::Error>;
+
     async fn sign(
         &mut self,
         message: String,

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -111,6 +111,13 @@ impl WalletInterface for WalletDispatcher {
         Ok(())
     }
 
+    async fn is_account_unlocked(&mut self, address: Address) -> Result<bool, Error> {
+        let unlocked_wallets = self.unlocked_wallets.read();
+        let is_unlocked = unlocked_wallets.get(&address).is_some();
+
+        Ok(is_unlocked)
+    }
+
     async fn sign(
         &mut self,
         message: String,


### PR DESCRIPTION
## What's in this pull request?
This change adds a new RPC method that can be used to check if an account for the given address is unlocked to send transactions. This method can be used mainly for monitoring purposes to make sure an account is properly unlocked or locked, depending on the use case without having to brute force a lock or unlock which can be costly operations. Especially when a `duration` is implemented later for unlocking the account, this method is simple but rather useful to have. At least in my opinion. 

### Tests
* Builds without errors
* Tested in the docker dev setup, and tried it out seems to work as intended



