### PR TITLE
network: Don't stall the network if there are many incoming Gossipsub message

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -29,13 +29,9 @@ pub struct TransactionTopic;
 impl Topic for TransactionTopic {
     type Item = Transaction;
 
-    fn topic(&self) -> String {
-        "transactions".to_owned()
-    }
-
-    fn validate(&self) -> bool {
-        true
-    }
+    const BUFFER_SIZE: usize = 1024;
+    const NAME: &'static str = "transactions";
+    const VALIDATE: bool = true;
 }
 
 pub struct ConsensusProxy<N: Network> {

--- a/consensus/src/sync/block_queue.rs
+++ b/consensus/src/sync/block_queue.rs
@@ -33,13 +33,9 @@ pub struct BlockTopic;
 impl Topic for BlockTopic {
     type Item = Block;
 
-    fn topic(&self) -> String {
-        "blocks".to_owned()
-    }
-
-    fn validate(&self) -> bool {
-        true
-    }
+    const BUFFER_SIZE: usize = 16;
+    const NAME: &'static str = "blocks";
+    const VALIDATE: bool = true;
 }
 
 pub type BlockStream<N> = BoxStream<'static, (Block, <N as Network>::PubsubId)>;

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -22,8 +22,9 @@ pub enum NetworkEvent<P> {
 pub trait Topic {
     type Item: Serialize + Deserialize + Send + Sync + std::fmt::Debug + 'static;
 
-    fn topic(&self) -> String;
-    fn validate(&self) -> bool;
+    const BUFFER_SIZE: usize;
+    const NAME: &'static str;
+    const VALIDATE: bool;
 }
 
 impl<P: Peer> std::fmt::Debug for NetworkEvent<P> {

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -94,11 +94,10 @@ pub trait Network: Send + Sync + 'static {
         ReceiveFromAll::new(self).boxed()
     }
 
-    // TODO: Use `BoxStream`
-    async fn subscribe<T>(
+    async fn subscribe<'a, T>(
         &self,
         topic: &T,
-    ) -> Result<Pin<Box<dyn Stream<Item = (T::Item, Self::PubsubId)> + Send>>, Self::Error>
+    ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync;
 

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -35,7 +35,7 @@ pub enum NetworkError {
     GossipsubSubscription(libp2p::gossipsub::error::SubscriptionError),
 
     #[error("Already subscribed to topic: {topic_name}")]
-    AlreadySubscribed { topic_name: String },
+    AlreadySubscribed { topic_name: &'static str },
 }
 
 impl From<libp2p::kad::store::Error> for NetworkError {

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::{Buf, Bytes};
@@ -9,7 +9,7 @@ use futures::{
     channel::{mpsc, oneshot},
     future::FutureExt,
     sink::SinkExt,
-    stream::{BoxStream, Stream, StreamExt},
+    stream::{BoxStream, StreamExt},
 };
 use ip_network::IpNetwork;
 #[cfg(feature = "memory-transport")]
@@ -149,7 +149,6 @@ impl Network {
     ///
     /// # Arguments
     ///
-    ///  - `listen_addresses`: The multi-addresses on which to listen for inbound connections.
     ///  - `clock`: The clock that is used to establish the network time. The discovery behaviour will determine the
     ///             offset by exchanging their wall-time with other peers.
     ///  - `config`: The network configuration, containing key pair, and other behaviour-specific configuration.
@@ -738,10 +737,10 @@ impl NetworkInterface for Network {
             .boxed()
     }
 
-    async fn subscribe<T>(
+    async fn subscribe<'a, T>(
         &self,
         topic: &T,
-    ) -> Result<Pin<Box<dyn Stream<Item = (T::Item, Self::PubsubId)> + Send>>, Self::Error>
+    ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync,
     {

--- a/network-mock/src/hub.rs
+++ b/network-mock/src/hub.rs
@@ -29,7 +29,7 @@ pub(crate) struct MockHubInner {
     /// Senders for gossipsub topics
     ///
     /// The data is Arc'd, such that cloning is cheap, and we need only a borrow when we deserialize.
-    pub gossipsub_topics: HashMap<String, broadcast::Sender<(Arc<Vec<u8>>, MockPeerId)>>,
+    pub gossipsub_topics: HashMap<&'static str, broadcast::Sender<(Arc<Vec<u8>>, MockPeerId)>>,
 
     /// DHT
     pub dht: HashMap<Vec<u8>, Vec<u8>>,
@@ -39,7 +39,10 @@ pub(crate) struct MockHubInner {
 }
 
 impl MockHubInner {
-    pub fn get_topic(&mut self, topic: String) -> &broadcast::Sender<(Arc<Vec<u8>>, MockPeerId)> {
+    pub fn get_topic(
+        &mut self,
+        topic: &'static str,
+    ) -> &broadcast::Sender<(Arc<Vec<u8>>, MockPeerId)> {
         self.gossipsub_topics
             .entry(topic)
             .or_insert_with(|| broadcast::channel(16).0)

--- a/network-mock/src/lib.rs
+++ b/network-mock/src/lib.rs
@@ -171,13 +171,9 @@ pub mod tests {
     impl Topic for TestTopic {
         type Item = TestRecord;
 
-        fn topic(&self) -> String {
-            "hello_world".to_owned()
-        }
-
-        fn validate(&self) -> bool {
-            false
-        }
+        const BUFFER_SIZE: usize = 8;
+        const NAME: &'static str = "hello_world";
+        const VALIDATE: bool = false;
     }
 
     fn consume_stream<T: std::fmt::Debug>(

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -1,13 +1,10 @@
-use std::{
-    pin::Pin,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
 };
 
 use async_trait::async_trait;
-use futures::stream::{Stream, StreamExt};
+use futures::stream::{BoxStream, StreamExt};
 use parking_lot::Mutex;
 use thiserror::Error;
 use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
@@ -180,10 +177,10 @@ impl Network for MockNetwork {
         self.get_peer_updates().1
     }
 
-    async fn subscribe<T>(
+    async fn subscribe<'a, T>(
         &self,
         topic: &T,
-    ) -> Result<Pin<Box<dyn Stream<Item = (T::Item, Self::PubsubId)> + Send>>, Self::Error>
+    ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync,
     {

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -187,8 +187,8 @@ impl Network for MockNetwork {
         let mut hub = self.hub.lock();
         let is_connected = Arc::clone(&self.is_connected);
 
-        let stream =
-            BroadcastStream::new(hub.get_topic(topic.topic()).subscribe()).filter_map(move |r| {
+        let stream = BroadcastStream::new(hub.get_topic(<T as Topic>::NAME).subscribe())
+            .filter_map(move |r| {
                 let is_connected = Arc::clone(&is_connected);
 
                 async move {
@@ -230,7 +230,7 @@ impl Network for MockNetwork {
     {
         let mut hub = self.hub.lock();
 
-        let topic = topic.topic();
+        let topic = T::NAME;
         let data = item.serialize_to_vec();
 
         log::debug!(

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp,
-    pin::Pin,
     sync::{Arc, Weak},
     time::Duration,
 };
@@ -8,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use atomic::Atomic;
 use atomic::Ordering;
-use futures_03::Stream;
+use futures_03::stream::BoxStream;
 use parking_lot::RwLock;
 use parking_lot::RwLockReadGuard;
 use rand::rngs::OsRng;
@@ -487,10 +486,10 @@ impl NetworkInterface for Network {
         unimplemented!()
     }
 
-    async fn subscribe<T>(
+    async fn subscribe<'a, T>(
         &self,
         _topic: &T,
-    ) -> Result<Pin<Box<dyn Stream<Item = (T::Item, Self::PubsubId)> + Send>>, Self::Error>
+    ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync,
     {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -33,13 +33,9 @@ pub struct ProposalTopic;
 impl Topic for ProposalTopic {
     type Item = SignedTendermintProposal;
 
-    fn topic(&self) -> String {
-        "tendermint-proposal".to_owned()
-    }
-
-    fn validate(&self) -> bool {
-        true
-    }
+    const BUFFER_SIZE: usize = 8;
+    const NAME: &'static str = "tendermint-proposal";
+    const VALIDATE: bool = true;
 }
 
 enum ValidatorStakingState {


### PR DESCRIPTION
When a Gossipsub message is received, it is relayed with an async send to the appropriate subscriber bounded channel. If the buffer of that channel fills, the network will stall until the queue is cleared.

Define the buffer size of the channels when creating a Gossipsub topic and syncronically relay the messages to avoid that blocking behaviour.

This fixes #269 