### PR TITLE
Make reward inherents more discoverable

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -116,8 +116,13 @@ impl BlockProducer {
             .expect("Failed to compute accounts hash during block production");
 
         // Calculate the extended transactions from the transactions and the inherents.
-        let ext_txs =
-            ExtendedTransaction::from(block_number, timestamp, transactions.clone(), inherents);
+        let ext_txs = ExtendedTransaction::from(
+            blockchain.network_id,
+            block_number,
+            timestamp,
+            transactions.clone(),
+            inherents,
+        );
 
         // Store the extended transactions into the history tree and calculate the history root.
         let mut txn = blockchain.write_transaction();
@@ -231,7 +236,13 @@ impl BlockProducer {
             .expect("Failed to compute accounts hash during block production.");
 
         // Calculate the extended transactions from the transactions and the inherents.
-        let ext_txs = ExtendedTransaction::from(block_number, timestamp, vec![], inherents);
+        let ext_txs = ExtendedTransaction::from(
+            blockchain.network_id,
+            block_number,
+            timestamp,
+            vec![],
+            inherents,
+        );
 
         // Store the extended transactions into the history tree and calculate the history root.
         let mut txn = blockchain.write_transaction();

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -46,6 +46,7 @@ impl Blockchain {
 
                 // Store the transactions and the inherents into the History tree.
                 let ext_txs = ExtendedTransaction::from(
+                    self.network_id,
                     macro_block.header.block_number,
                     macro_block.header.timestamp,
                     vec![],
@@ -94,6 +95,7 @@ impl Blockchain {
 
                 // Store the transactions and the inherents into the History tree.
                 let ext_txs = ExtendedTransaction::from(
+                    self.network_id,
                     micro_block.header.block_number,
                     micro_block.header.timestamp,
                     body.transactions.clone(),

--- a/blockchain/src/history_store/history_store.rs
+++ b/blockchain/src/history_store/history_store.rs
@@ -347,7 +347,7 @@ impl HistoryStore {
         tree.num_leaves()
     }
 
-    /// Returns a vector containing all transaction (no inherents) hashes corresponding to the given
+    /// Returns a vector containing all transaction (and reward inherents) hashes corresponding to the given
     /// address. It fetches the transactions from most recent to least recent up to the maximum
     /// number given.
     pub fn get_tx_hashes_by_address(
@@ -1246,17 +1246,17 @@ mod tests {
         assert_eq!(query_2[0], ext_txs[6].tx_hash());
         assert_eq!(query_2[1], ext_txs[5].tx_hash());
 
-        let query_2 = history_store.get_tx_hashes_by_address(
+        let query_3 = history_store.get_tx_hashes_by_address(
             &Address::from_user_friendly_address("NQ04 B79B R4FF 4NGU A9H0 2PT9 9ART 5A88 J73T")
                 .unwrap(),
             99,
             Some(&txn),
         );
 
-        assert_eq!(query_2.len(), 3);
-        assert_eq!(query_2[0], ext_txs[7].tx_hash());
-        assert_eq!(query_2[1], ext_txs[4].tx_hash());
-        assert_eq!(query_2[2], ext_txs[2].tx_hash());
+        assert_eq!(query_3.len(), 3);
+        assert_eq!(query_3[0], ext_txs[7].tx_hash());
+        assert_eq!(query_3[1], ext_txs[4].tx_hash());
+        assert_eq!(query_3[2], ext_txs[2].tx_hash());
     }
 
     #[test]
@@ -1342,6 +1342,7 @@ mod tests {
 
     fn create_inherent(block: u32, value: u64) -> ExtendedTransaction {
         ExtendedTransaction {
+            network_id: NetworkId::UnitAlbatross,
             block_number: block,
             block_time: 0,
             data: ExtTxData::Inherent(Inherent {
@@ -1358,6 +1359,7 @@ mod tests {
 
     fn create_transaction(block: u32, value: u64) -> ExtendedTransaction {
         ExtendedTransaction {
+            network_id: NetworkId::UnitAlbatross,
             block_number: block,
             block_time: 0,
             data: ExtTxData::Basic(BlockchainTransaction::new_basic(

--- a/blockchain/src/history_store/history_tree_chunk.rs
+++ b/blockchain/src/history_store/history_tree_chunk.rs
@@ -1,12 +1,11 @@
 use std::fmt::{self, Debug, Formatter};
 
-use nimiq_mmr::mmr::proof::{Proof, RangeProof};
-
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
     SerializingError, WriteBytesExt,
 };
 use nimiq_hash::Blake2bHash;
+use nimiq_mmr::mmr::proof::{Proof, RangeProof};
 
 use crate::history_store::ExtendedTransaction;
 

--- a/blockchain/src/history_store/history_tree_proof.rs
+++ b/blockchain/src/history_store/history_tree_proof.rs
@@ -1,10 +1,9 @@
-use nimiq_mmr::mmr::proof::Proof;
-
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
     SerializingError, WriteBytesExt,
 };
 use nimiq_hash::Blake2bHash;
+use nimiq_mmr::mmr::proof::Proof;
 
 use crate::history_store::ExtendedTransaction;
 

--- a/blockchain/src/history_store/mmr_store.rs
+++ b/blockchain/src/history_store/mmr_store.rs
@@ -1,11 +1,10 @@
 use std::cmp;
 use std::convert::TryInto;
 
-use nimiq_mmr::store::Store;
-
 use nimiq_database::cursor::ReadCursor;
 use nimiq_database::{Database, Transaction, WriteTransaction};
 use nimiq_hash::Blake2bHash;
+use nimiq_mmr::store::Store;
 
 #[derive(Debug)]
 enum Tx<'a, 'env> {

--- a/blockchain/src/history_store/ordered_hash.rs
+++ b/blockchain/src/history_store/ordered_hash.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io;
 
 use nimiq_database::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_hash::{Blake2bHash, HashOutput};
-use std::convert::TryInto;
 
 /// A wrapper for an u32 and a Blake2bHash. We use it to for two different functions:
 /// 1) store the hash and index of leaf nodes

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -3,6 +3,10 @@ use std::cmp;
 /// This is the address for the staking contract in user-friendly format.
 pub const STAKING_CONTRACT_ADDRESS: &str = "NQ38 STAK 1NG0 0000 0000 C0NT RACT 0000 0000";
 
+/// This is the address for the coinbase in user-friendly format. Note that this is not a real
+/// account, it is just the address we use to denote that some coins originated from a coinbase event.
+pub const COINBASE_ADDRESS: &str = "NQ81 C01N BASE 0000 0000 0000 0000 0000 0000";
+
 /// Number of blocks a transaction is valid with Albatross consensus.
 pub const TRANSACTION_VALIDITY_WINDOW: u32 = 7200;
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes #337

## What's in this pull request?
1. Added a method to ExtendedTransaction to convert to Transaction. It will also convert reward inherents into dummy reward transactions.
2. Changed the tx_hash method of ExtendedTransaction. When you call it with a reward inherent, it will return the hash of the corresponding eward transaction.
3. Reward inherents now get added to the address_db in the HistoryStore. This means that when fetching transactions hashes for a given address, you will also get the hashes of any reward inherents that the given address received.