### PR TITLE
RPC: Add method isAccountImported

### DIFF
--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -31,6 +31,8 @@ pub trait WalletInterface {
         passphrase: Option<String>,
     ) -> Result<Address, Self::Error>;
 
+    async fn is_account_imported(&mut self, address: Address) -> Result<bool, Self::Error>;
+
     async fn list_accounts(&mut self) -> Result<Vec<Address>, Self::Error>;
 
     async fn lock_account(&mut self, address: Address) -> Result<(), Self::Error>;

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -60,6 +60,12 @@ impl WalletInterface for WalletDispatcher {
         Ok(address)
     }
 
+    async fn is_account_imported(&mut self, address: Address) -> Result<bool, Error> {
+        let is_imported = self.wallet_store.get(&address, None).is_some();
+
+        Ok(is_imported)
+    }
+
     async fn list_accounts(&mut self) -> Result<Vec<Address>, Error> {
         Ok(self.wallet_store.list(None))
     }


### PR DESCRIPTION
## What's in this pull request?
This PR adds a new RPC method to the RPC interface / server "isAccountImported" which returns whether an account with the given address is loaded into the wallet store. This is a follow up to PR #327 