### PR TITLE
network: Implement topic unsubscribe API for the network

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -60,7 +60,7 @@ impl<N: Network> ConsensusProxy<N> {
         }
 
         self.network
-            .publish(&TransactionTopic::default(), tx)
+            .publish::<TransactionTopic>(tx)
             .await
             .map(|_| ReturnCode::Accepted)
     }
@@ -149,7 +149,7 @@ impl<N: Network> Consensus<N> {
         .await;
 
         let tx_stream = network
-            .subscribe::<TransactionTopic>(&TransactionTopic::default())
+            .subscribe::<TransactionTopic>()
             .await
             .unwrap()
             .boxed();

--- a/consensus/src/sync/block_queue.rs
+++ b/consensus/src/sync/block_queue.rs
@@ -483,11 +483,7 @@ impl<N: Network, TReq: RequestComponent<N::PeerType>> BlockQueue<N, TReq> {
         network: Arc<N>,
         request_component: TReq,
     ) -> Self {
-        let block_stream = network
-            .subscribe::<BlockTopic>(&BlockTopic::default())
-            .await
-            .unwrap()
-            .boxed();
+        let block_stream = network.subscribe::<BlockTopic>().await.unwrap().boxed();
 
         Self::with_block_stream(config, blockchain, network, request_component, block_stream)
     }

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -97,7 +97,6 @@ pub trait Network: Send + Sync + 'static {
 
     async fn subscribe<'a, T>(
         &self,
-        topic: &T,
     ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync;
@@ -106,7 +105,7 @@ pub trait Network: Send + Sync + 'static {
     where
         T: Topic + Sync;
 
-    async fn publish<T: Topic>(&self, topic: &T, item: T::Item) -> Result<(), Self::Error>
+    async fn publish<T>(&self, item: T::Item) -> Result<(), Self::Error>
     where
         T: Topic + Sync;
 

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -102,6 +102,10 @@ pub trait Network: Send + Sync + 'static {
     where
         T: Topic + Sync;
 
+    async fn unsubscribe<'a, T>(&self) -> Result<(), Self::Error>
+    where
+        T: Topic + Sync;
+
     async fn publish<T: Topic>(&self, topic: &T, item: T::Item) -> Result<(), Self::Error>
     where
         T: Topic + Sync;

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -36,6 +36,9 @@ pub enum NetworkError {
 
     #[error("Already subscribed to topic: {topic_name}")]
     AlreadySubscribed { topic_name: &'static str },
+
+    #[error("Already unsubscribed to topic: {topic_name}")]
+    AlreadyUnsubscribed { topic_name: &'static str },
 }
 
 impl From<libp2p::kad::store::Error> for NetworkError {

--- a/network-mock/src/lib.rs
+++ b/network-mock/src/lib.rs
@@ -191,10 +191,10 @@ pub mod tests {
 
         let test_message = TestRecord { x: 42 };
 
-        let mut messages = net1.subscribe(&TestTopic).await.unwrap();
-        consume_stream(net2.subscribe(&TestTopic).await.unwrap());
+        let mut messages = net1.subscribe::<TestTopic>().await.unwrap();
+        consume_stream(net2.subscribe::<TestTopic>().await.unwrap());
 
-        net2.publish(&TestTopic, test_message.clone())
+        net2.publish::<TestTopic>(test_message.clone())
             .await
             .unwrap();
 

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -186,7 +186,6 @@ impl Network for MockNetwork {
 
     async fn subscribe<'a, T>(
         &self,
-        topic: &T,
     ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync,
@@ -243,8 +242,6 @@ impl Network for MockNetwork {
                 (topic, id)
             })
             .boxed())
-
-        //   Ok(stream.boxed())
     }
 
     async fn unsubscribe<'a, T>(&self) -> Result<(), Self::Error>
@@ -272,7 +269,7 @@ impl Network for MockNetwork {
         }
     }
 
-    async fn publish<T: Topic>(&self, topic: &T, item: T::Item) -> Result<(), Self::Error>
+    async fn publish<T: Topic>(&self, item: T::Item) -> Result<(), Self::Error>
     where
         T: Topic + Sync,
     {

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use futures::stream::{BoxStream, StreamExt};
 use parking_lot::Mutex;
 use thiserror::Error;
+use tokio::sync::broadcast::Sender;
 use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 
 use beserial::{Deserialize, Serialize};
@@ -16,7 +17,7 @@ use nimiq_network_interface::{network::Network, peer_map::ObservablePeerMap};
 
 use crate::{hub::MockHubInner, peer::MockPeer, MockAddress, MockPeerId};
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error, PartialEq)]
 pub enum MockNetworkError {
     #[error("Serialization error: {0}")]
     Serialization(#[from] beserial::SerializingError),
@@ -26,6 +27,12 @@ pub enum MockNetworkError {
 
     #[error("Network is not connected")]
     NotConnected,
+
+    #[error("Peer is already subscribed to topic: {0}")]
+    AlreadySubscribed(&'static str),
+
+    #[error("Peer is already unsubscribed to topic: {0}")]
+    AlreadyUnsubscribed(&'static str),
 }
 
 #[derive(Clone, Debug)]
@@ -187,30 +194,46 @@ impl Network for MockNetwork {
         let mut hub = self.hub.lock();
         let is_connected = Arc::clone(&self.is_connected);
 
-        let stream = BroadcastStream::new(hub.get_topic(<T as Topic>::NAME).subscribe())
-            .filter_map(move |r| {
-                let is_connected = Arc::clone(&is_connected);
+        let topic_name = T::NAME;
 
-                async move {
-                    if is_connected.load(Ordering::SeqCst) {
-                        match r {
-                            Ok((data, peer_id)) => match T::Item::deserialize_from_vec(&data) {
-                                Ok(item) => return Some((item, peer_id)),
-                                Err(e) => {
-                                    log::warn!("Dropped item because deserialization failed: {}", e)
-                                }
-                            },
-                            Err(BroadcastStreamRecvError::Lagged(_)) => {
-                                log::warn!("Mock gossipsub channel is lagging")
+        log::debug!(
+            "Peer {} subscribing to topic '{}'",
+            self.address,
+            topic_name
+        );
+
+        // Add this peer to the topic list
+        let sender: &Sender<(Arc<Vec<u8>>, MockPeerId)>;
+
+        if let Some(topic) = hub.subscribe(topic_name, self.address) {
+            sender = &topic.sender;
+        } else {
+            return Err(MockNetworkError::AlreadySubscribed(topic_name));
+        }
+
+        let stream = BroadcastStream::new(sender.subscribe()).filter_map(move |r| {
+            let is_connected = Arc::clone(&is_connected);
+
+            async move {
+                if is_connected.load(Ordering::SeqCst) {
+                    match r {
+                        Ok((data, peer_id)) => match T::Item::deserialize_from_vec(&data) {
+                            Ok(item) => return Some((item, peer_id)),
+                            Err(e) => {
+                                log::warn!("Dropped item because deserialization failed: {}", e)
                             }
+                        },
+                        Err(BroadcastStreamRecvError::Lagged(_)) => {
+                            log::warn!("Mock gossipsub channel is lagging")
                         }
-                    } else {
-                        log::debug!("Network not connected: Dropping gossipsub message.");
                     }
-
-                    None
+                } else {
+                    log::debug!("Network not connected: Dropping gossipsub message.");
                 }
-            });
+
+                None
+            }
+        });
 
         Ok(stream
             .map(|(topic, peer_id)| {
@@ -224,27 +247,58 @@ impl Network for MockNetwork {
         //   Ok(stream.boxed())
     }
 
+    async fn unsubscribe<'a, T>(&self) -> Result<(), Self::Error>
+    where
+        T: Topic + Sync,
+    {
+        let mut hub = self.hub.lock();
+
+        let topic_name = T::NAME;
+
+        log::debug!(
+            "Peer {} unsubscribing from topic '{}'",
+            self.address,
+            topic_name
+        );
+
+        if self.is_connected.load(Ordering::SeqCst) {
+            if hub.unsubscribe(topic_name, &self.address) {
+                Ok(())
+            } else {
+                Err(MockNetworkError::AlreadyUnsubscribed(topic_name))
+            }
+        } else {
+            Err(MockNetworkError::NotConnected)
+        }
+    }
+
     async fn publish<T: Topic>(&self, topic: &T, item: T::Item) -> Result<(), Self::Error>
     where
         T: Topic + Sync,
     {
         let mut hub = self.hub.lock();
 
-        let topic = T::NAME;
+        let topic_name = T::NAME;
         let data = item.serialize_to_vec();
 
         log::debug!(
             "Peer {} publishing on topic '{}': {:?}",
             self.address,
-            topic,
+            topic_name,
             item
         );
 
         if self.is_connected.load(Ordering::SeqCst) {
-            hub.get_topic(topic)
-                .send((Arc::new(data), self.address.into()))
-                .unwrap();
-            Ok(())
+            if let Some(topic) = hub.get_topic(topic_name) {
+                topic
+                    .sender
+                    .send((Arc::new(data), self.address.into()))
+                    .unwrap();
+                Ok(())
+            } else {
+                log::debug!("No peer is subscribed to topic: '{}'", topic_name);
+                Ok(())
+            }
         } else {
             Err(MockNetworkError::NotConnected)
         }

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -496,6 +496,13 @@ impl NetworkInterface for Network {
         unimplemented!()
     }
 
+    async fn unsubscribe<'a, T>(&self) -> Result<(), Self::Error>
+    where
+        T: Topic + Sync,
+    {
+        unimplemented!()
+    }
+
     async fn publish<T>(&self, _topic: &T, _item: <T as Topic>::Item) -> Result<(), Self::Error>
     where
         T: Topic + Sync,

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -488,7 +488,6 @@ impl NetworkInterface for Network {
 
     async fn subscribe<'a, T>(
         &self,
-        _topic: &T,
     ) -> Result<BoxStream<'a, (T::Item, Self::PubsubId)>, Self::Error>
     where
         T: Topic + Sync,
@@ -503,7 +502,7 @@ impl NetworkInterface for Network {
         unimplemented!()
     }
 
-    async fn publish<T>(&self, _topic: &T, _item: <T as Topic>::Item) -> Result<(), Self::Error>
+    async fn publish<T>(&self, _item: <T as Topic>::Item) -> Result<(), Self::Error>
     where
         T: Topic + Sync,
     {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -181,7 +181,7 @@ impl<N: ValidatorNetwork + 'static> TendermintOutsideDeps for TendermintInterfac
         );
 
         // Broadcast the signed proposal to the network.
-        if let Err(err) = self.network.publish(&ProposalTopic, signed_proposal).await {
+        if let Err(err) = self.network.publish::<ProposalTopic>(signed_proposal).await {
             error!("Publishing proposal failed: {:?}", err);
         }
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -153,7 +153,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
 
         tokio::spawn(async move {
             network1
-                .subscribe(&ProposalTopic)
+                .subscribe::<ProposalTopic>()
                 .await
                 .expect("Failed to subscribe to proposal topic")
                 .for_each(|proposal| async { proposal_sender.send(proposal) })
@@ -373,7 +373,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                         tokio::spawn(async move {
                             trace!("publishing macro block: {:?}", &block_copy);
                             network
-                                .publish(&BlockTopic, Block::Macro(block_copy))
+                                .publish::<BlockTopic>(Block::Macro(block_copy))
                                 .await
                                 .map_err(|e| trace!("Failed to publish block: {:?}", e))
                                 .ok();
@@ -428,7 +428,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                         tokio::spawn(async move {
                             trace!("publishing micro block: {:?}", &block_copy);
                             if nw
-                                .publish(&BlockTopic, Block::Micro(block_copy))
+                                .publish::<BlockTopic>(Block::Micro(block_copy))
                                 .await
                                 .is_err()
                             {


### PR DESCRIPTION
The network is missing a topic unsubscribe API to complement the subscribe API.

This commit implements that API for the mock network and the libp2p network via Gossipsub.

This closes #332.
