### PR TITLE
RPC: Add method getBalance

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -91,4 +91,6 @@ pub trait BlockchainInterface {
     async fn head_subscribe(&mut self) -> Result<BoxStream<'static, Blake2bHash>, Self::Error>;
 
     async fn get_account(&mut self, address: Address) -> Result<Option<Account>, Self::Error>;
+
+    async fn get_balance(&mut self, address: Address) -> Result<Coin, Self::Error>;
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -360,4 +360,12 @@ impl BlockchainInterface for BlockchainDispatcher {
             _ => Ok(account),
         }
     }
+
+    async fn get_balance(&mut self, address: Address) -> Result<Coin, Error> {
+        let account = self.get_account(address.clone()).await?;
+        match account {
+            Some(account) => Ok(account.balance()),
+            None => Err(Error::AccountNotFound(address)),
+        }
+    }
 }


### PR DESCRIPTION
## What's in this pull request?

This PR adds a new method to the RPC interface and server: `getBalance` which returns the balance of an account. Important to note is that this currently only covers accounts, not staking contract actors like stakers and validators. I also don't know if it is is preferred to have those actors in this method, although the account protocol seems to leave room for that [as seen here](https://github.com/nimiq/core-rs-albatross/blob/albatross/primitives/account/src/account.rs#L46). I tested this in the docker setup, and for normal accounts works fine. 
