### PR TITLE
RPC: Proper account object format

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -1,13 +1,12 @@
 use async_trait::async_trait;
 
 use futures::stream::BoxStream;
-use nimiq_account::Account;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use std::collections::HashMap;
 
-use crate::types::{Block, Inherent, SlashedSlots, Slot, Staker, Transaction, Validator};
+use crate::types::{Account, Block, Inherent, SlashedSlots, Slot, Staker, Transaction, Validator};
 
 #[cfg_attr(
     feature = "proxy",
@@ -90,5 +89,5 @@ pub trait BlockchainInterface {
     #[stream]
     async fn head_subscribe(&mut self) -> Result<BoxStream<'static, Blake2bHash>, Self::Error>;
 
-    async fn get_account(&mut self, address: Address) -> Result<Option<Account>, Self::Error>;
+    async fn get_account(&mut self, address: Address) -> Result<Account, Self::Error>;
 }

--- a/rpc-interface/src/serde_helpers.rs
+++ b/rpc-interface/src/serde_helpers.rs
@@ -35,54 +35,6 @@ pub mod account_type {
     }
 }
 
-pub mod address_hex {
-    use serde::{
-        de::{Deserialize, Deserializer, Error},
-        ser::{Serialize, Serializer},
-    };
-
-    use nimiq_keys::Address;
-
-    pub fn serialize<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Serialize::serialize(&address.to_hex(), serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Address, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: &'de str = Deserialize::deserialize(deserializer)?;
-        s.parse().map_err(D::Error::custom)
-    }
-}
-
-pub mod address_friendly {
-    use serde::{
-        de::{Deserialize, Deserializer, Error},
-        ser::{Serialize, Serializer},
-    };
-
-    use nimiq_keys::Address;
-
-    pub fn serialize<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Serialize::serialize(&address.to_user_friendly_address(), serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Address, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: &'de str = Deserialize::deserialize(deserializer)?;
-        Address::from_user_friendly_address(s).map_err(D::Error::custom)
-    }
-}
-
 pub mod hex {
     // TODO: Make generic over `ToHex` and `FromHex`. Or use `serde_hex`
 

--- a/rpc-interface/src/serde_helpers.rs
+++ b/rpc-interface/src/serde_helpers.rs
@@ -12,15 +12,26 @@ pub mod account_type {
     where
         S: Serializer,
     {
-        Serialize::serialize(&u8::from(*account_type), serializer)
+        let ty = match account_type {
+            AccountType::Basic => "basic",
+            AccountType::Vesting => "vesting",
+            AccountType::HTLC => "htlc",
+            _ => unreachable!(),
+        };
+        Serialize::serialize(ty, serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<AccountType, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let n: u8 = Deserialize::deserialize(deserializer)?;
-        AccountType::try_from(n).map_err(D::Error::custom)
+        let ty: AccountType = match Deserialize::deserialize(deserializer)? {
+            "basic" => AccountType::Basic,
+            "vesting" => AccountType::Vesting,
+            "htlc" => AccountType::HTLC,
+            _ => unreachable!(),
+        };
+        AccountType::try_from(ty).map_err(D::Error::custom)
     }
 }
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes an item in #229.
#### This can replace #350.

## What's in this pull request?

This PR adds proper formatting for account objects returned from RPC.

Instead of before:
```js
const result =  {
    Basic: {
        balance: 1000
    }
}
```

it now returns properly formatted objects without nesting:
```js
const result = {
    address: "NQ...",
    balance: 1000,
    type: "basic"
}
```

These objects are much easier to work with.

**Additionally**, an empty basic account is now returned when the account does not exist in the account store, instead of an error like before.
