### PR TITLE
Fix compilation of the lib crate with no features

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,7 +30,7 @@ hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 log-panics = { version = "2.0", features = ["with-backtrace"], optional = true }
-parking_lot = { version = "0.11", features = ["deadlock_detection"], optional = true }
+parking_lot = { version = "0.11", features = ["deadlock_detection"] }
 paw = "1.0"
 rand = "0.7"
 serde = "1.0"
@@ -64,12 +64,12 @@ nimiq-validator-network = { path = "../validator-network", optional = true }
 nimiq-wallet = { path = "../wallet", optional = true }
 
 [features]
-deadlock = ["parking_lot"]
+deadlock = []
 default = []
 launcher = []
 logging = ["fern", "colored"]
 metrics-server = ["nimiq-metrics-server"]
 panic = ["log-panics"]
-rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet", "parking_lot"]
+rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]
 wallet = ["nimiq-wallet"]


### PR DESCRIPTION
Fix compilation of the lib crate with no features.
Since the introduction of RwLocks around blockchain, parking_lot
is required and it can no longer be optional.
This fixes #358.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
