### PR TITLE
Slot owner selection without replacement

### DIFF
--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -271,7 +271,7 @@ impl Blockchain {
         );
 
         // Get RNG from last block's seed and build lookup table based on number of eligible slots.
-        let mut rng = macro_header.seed.rng(VrfUseCase::RewardDistribution, 0);
+        let mut rng = macro_header.seed.rng(VrfUseCase::RewardDistribution);
         let lookup = AliasMethod::new(num_eligible_slots_for_accepted_inherent);
 
         // Randomly give remainder to one accepting slot. We don't bother to distribute it over all

--- a/primitives/account/src/staking_contract/mod.rs
+++ b/primitives/account/src/staking_contract/mod.rs
@@ -287,7 +287,7 @@ impl StakingContract {
             validator_stakes.push(u64::from(*coin));
         }
 
-        let mut rng = seed.rng(VrfUseCase::ValidatorSelection, 0);
+        let mut rng = seed.rng(VrfUseCase::ValidatorSelection);
 
         let lookup = AliasMethod::new(validator_stakes);
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes #353.

## What's in this pull request?
1. It simplifies the VRF RNG by removing the round number. It is not necessary.
2. Fixes the slot owner selection algorithm so that slots are sampled without replacement.