### PR TITLE
Call validate_message for transactions after processing

### DIFF
--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -94,6 +94,7 @@ impl Mempool {
     pub async fn start_executor_with_txn_stream<N: Network>(
         &self,
         txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
+        network: Arc<N>,
     ) {
         if self.executor_handle.lock().unwrap().is_some() {
             // If we already have an executor running, don't do anything
@@ -104,6 +105,7 @@ impl Mempool {
             Arc::clone(&self.blockchain),
             Arc::clone(&self.state),
             Arc::clone(&self.filter),
+            network,
             txn_stream,
         );
 

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -47,10 +47,11 @@ async fn send_txn_to_mempool(
     let mempool = Mempool::new(Arc::clone(&blockchain), MempoolConfig::default());
     let mut hub = MockHub::new();
     let mock_id = MockId::new(hub.new_address().into());
+    let mock_network = Arc::new(hub.new_network());
 
     // Subscribe mempool with the mpsc stream created
     mempool
-        .start_executor_with_txn_stream::<MockNetwork>(Box::pin(txn_stream_rx))
+        .start_executor_with_txn_stream::<MockNetwork>(Box::pin(txn_stream_rx), mock_network)
         .await;
 
     // Send the transactions


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

This PR adds the network to `MempoolExecutor` such that it can be used to signal acceptance or rejection of transaction messages received on the GossipSub Topic back to the network. 
That results in transactions messages being actively propagated throughout the network (if they do end up being accepted).