### PR TITLE
Upgrade the atomic dependency and fix some clippy issues

### DIFF
--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -39,7 +39,7 @@ nimiq-utils = { path = "../utils", features = ["observer", "unique-ptr", "iterat
 nimiq-vrf = { path = "../vrf" }
 
 [dev-dependencies]
-atomic = "0.4"
+atomic = "0.5"
 
 nimiq-block-production = { path = "../block-production", features = ["test-utils"] }
 nimiq-nano-primitives = { path= "../nano-primitives" }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -18,7 +18,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-atomic = "0.4"
+atomic = "0.5"
 bitflags = "1.0"
 hex = "0.4"
 lazy_static = "1.2"

--- a/keys/src/key_pair.rs
+++ b/keys/src/key_pair.rs
@@ -23,7 +23,7 @@ impl SecureGenerate for KeyPair {
     fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let zebra_priv_key = SigningKey::new(rng);
         let priv_key = PrivateKey(zebra_priv_key);
-        let pub_key = PublicKey(VerificationKey::from(&zebra_priv_key).into());
+        let pub_key = PublicKey(VerificationKey::from(&zebra_priv_key));
         KeyPair {
             private: priv_key,
             public: pub_key,

--- a/keys/src/multisig.rs
+++ b/keys/src/multisig.rs
@@ -182,15 +182,18 @@ impl KeyPair {
         commitments: &[Commitment],
         data: &[u8],
     ) -> (PartialSignature, PublicKey, Commitment) {
-        if public_keys.len() != commitments.len() {
-            panic!("Number of public keys and commitments must be the same.");
-        }
-        if public_keys.is_empty() {
-            panic!("Number of public keys and commitments must be greater than 0.");
-        }
-        if !public_keys.contains(&self.public) {
-            panic!("Public keys must contain own key.")
-        }
+        assert!(
+            public_keys.len() == commitments.len(),
+            "Number of public keys and commitments must be the same."
+        );
+        assert!(
+            !public_keys.is_empty(),
+            "Number of public keys and commitments must be greater than 0."
+        );
+        assert!(
+            public_keys.contains(&self.public),
+            "Public keys must contain own key."
+        );
 
         // Sort public keys.
         // public_keys.sort();
@@ -241,7 +244,7 @@ impl KeyPair {
 }
 
 impl PublicKey {
-    fn to_edwards_point(&self) -> Option<EdwardsPoint> {
+    fn to_edwards_point(self) -> Option<EdwardsPoint> {
         let mut bits: [u8; PublicKey::SIZE] = [0u8; PublicKey::SIZE];
         bits.copy_from_slice(&self.as_bytes()[..PublicKey::SIZE]);
 

--- a/keys/src/private_key.rs
+++ b/keys/src/private_key.rs
@@ -61,8 +61,7 @@ impl From<[u8; PrivateKey::SIZE]> for PrivateKey {
 
 impl Clone for PrivateKey {
     fn clone(&self) -> Self {
-        let cloned_zebra = self.0.into();
-        PrivateKey(cloned_zebra)
+        PrivateKey(self.0.clone())
     }
 }
 

--- a/keys/src/public_key.rs
+++ b/keys/src/public_key.rs
@@ -92,7 +92,7 @@ impl Eq for PublicKey {}
 
 impl Ord for PublicKey {
     fn cmp(&self, other: &PublicKey) -> Ordering {
-        <&[u8]>::from(self.0.as_ref()).cmp(<&[u8]>::from(other.0.as_ref()))
+        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
@@ -112,7 +112,7 @@ impl<'a> From<&'a PrivateKey> for PublicKey {
 impl<'a> From<&'a [u8; PublicKey::SIZE]> for PublicKey {
     fn from(bytes: &'a [u8; PublicKey::SIZE]) -> Self {
         let vk_bytes =
-            ed25519_zebra::VerificationKey::try_from(bytes.clone()).expect("Unexpected size for");
+            ed25519_zebra::VerificationKey::try_from(*bytes).expect("Unexpected size for");
         PublicKey(vk_bytes)
     }
 }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 async-trait = "0.1"
-atomic = "0.4"
+atomic = "0.5"
 futures = "0.1"
 futures-03 = { package = "futures", version = "0.3" }
 hex = "0.4"

--- a/peer-address/Cargo.toml
+++ b/peer-address/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-atomic = "0.4"
+atomic = "0.5"
 bitflags = "1.0"
 thiserror = "1.0"
 hex = "0.4"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-atomic = { version = "0.4", optional = true }
+atomic = { version = "0.5", optional = true }
 
 clear_on_drop = { version = "0.2", optional = true }
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
- Update the `atomic` dependency version from 0.4 to 0.5.
- Fix some clippy warnings found in the nimiq-keys crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.