### PR TITLE
Fix locking issues for the mempool

### DIFF
--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -358,9 +358,10 @@ async fn mempool_get_txn_ordered() {
     // Check transactions are sorted
     let mut prev_txn = txns.first().expect("Is vector empty?").clone();
     for txn in txns {
-        if prev_txn.fee < txn.fee {
-            assert!(false, "Transactions in mempool are not ordered by fee");
-        }
+        assert!(
+            prev_txn.fee >= txn.fee,
+            "Transactions in mempool are not ordered by fee"
+        );
         prev_txn = txn.clone();
     }
 }
@@ -544,14 +545,15 @@ async fn multiple_transactions_multiple_senders() {
     // Check transactions are sorted
     let mut prev_txn = txns.first().expect("Is vector empty?").clone();
     for txn in txns {
-        if prev_txn.fee < txn.fee {
-            assert!(false, "Transactions in mempool are not ordered by fee");
-        }
+        assert!(
+            prev_txn.fee >= txn.fee,
+            "Transactions in mempool are not ordered by fee"
+        );
         prev_txn = txn.clone();
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn mempool_tps() {
     if ENABLE_LOG {
         simple_logger::SimpleLogger::new()
@@ -651,9 +653,10 @@ async fn mempool_tps() {
     // Check transactions are sorted
     let mut prev_txn = txns.first().expect("Is vector empty?").clone();
     for txn in txns {
-        if prev_txn.fee < txn.fee {
-            assert!(false, "Transactions in mempool are not ordered by fee");
-        }
+        assert!(
+            prev_txn.fee >= txn.fee,
+            "Transactions in mempool are not ordered by fee"
+        );
         prev_txn = txn.clone();
     }
 }


### PR DESCRIPTION
This PR contains two commits.
The first commit originally tried to increase the mempool performance by:
- Having the `mempool_state` and `blockchain` locks less time taken.
- Spawning the transaction verification task.

By implementing this optimization and in conversations with @nibhar we realized there were
locking issues with the current implementation and a second commit was added.
This commit fixes possible issue with the `mempool_state` locking. Before this change the
read lock of the `mempool_state` was dropped before taking a write lock to it to push a
transaction. This may lead to issues were a transaction could change the `mempool_state` in
between.
This change re-adds the upgradable RW lock of the `mempool_state` which is now returned by
the `verify_tx` function such that the caller can upgrade the lock and push a transaction.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
