### PR TITLE
Update some outdated dependencies

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.11"
-pin-project = "0.4.8"
+pin-project = "1.0"
 rand = "0.8"
 thiserror = "1.0"
 tokio = { version = "1.9", features = ["full"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,10 +20,10 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 chrono = "0.4"
-colored = { version = "1.7", optional = true }
+colored = { version = "2.0", optional = true }
 derive_builder = "0.9"
-directories = "2.0"
-fern = { version = "0.5", features = ["colored"], optional = true }
+directories = "4.0"
+fern = { version = "0.6", features = ["colored"], optional = true }
 file-rotate = { version = "0.4" }
 hex = "0.4"
 # human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
@@ -36,7 +36,7 @@ rand = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 structopt = { version = "0.3", features = ["paw"] }
-strum_macros = "0.20"
+strum_macros = "0.22"
 toml = "0.5"
 url = "1.7"
 thiserror = "1.0"

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -238,6 +238,10 @@ impl FromStr for Network {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Network, ()> {
+        // Fixme: Introduced this to workaround false positives in clippy
+        // as documented here:
+        // https://github.com/rust-lang/rust-clippy/issues/7863
+        #[allow(clippy::match_str_case_mismatch)]
         Ok(match s.to_lowercase().as_str() {
             "main" => Network::Main,
             "test" => Network::Test,

--- a/nano-zkp/Cargo.toml
+++ b/nano-zkp/Cargo.toml
@@ -21,7 +21,7 @@ ark-groth16 = "0.3"
 ark-mnt4-753 = "0.3"
 ark-mnt6-753 = "0.3"
 ark-relations = "0.3"
-ark-r1cs-std = "0.3"
+ark-r1cs-std = "0.3.1"
 ark-serialize = "0.3"
 ark-std = "0.3"
 

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -32,4 +32,4 @@ nimiq-network-interface = { path = "../network-interface" }
 nimiq-utils = { path = "../utils", features = ["crc"] }
 
 [dev-dependencies]
-env_logger = "0.8"
+env_logger = "0.9"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,7 +28,7 @@ num-traits = { version = "0.2", optional = true }
 parking_lot = { version = "0.11", optional = true }
 regex = { version = "1.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-strum_macros = "0.20"
+strum_macros = "0.22"
 
 beserial = { path = "../beserial" }
 beserial_derive = { path = "../beserial/beserial_derive" }

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 parking_lot = "0.11"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
-strum_macros = "0.20"
+strum_macros = "0.22"
 thiserror = "1.0"
 
 beserial = { path = "../../beserial" }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.0"
 hex = "0.4"
 log = "0.4"
 serde = { version = "1.0", optional = true }
-strum_macros = "0.20"
+strum_macros = "0.22"
 thiserror = "1.0"
 
 beserial = { path = "../../beserial" }


### PR DESCRIPTION
Update outdated dependencies:
- `colored` from 1.7 to 2.0.
- `pin-project` from 0.4.8 to 1.0.
- `strum_macros` from 0.20 to 0.22.
- `env_logger` from 0.8 to 0.9.
- `ark-r1cs-std` from 0.3 to 0.3.1: This dependency has a possible
  security vulnerability up to version 0.3.0.
- `fern` from 0.5 to 0.6.
- `directories` from 2.0 to 4.0.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.