### PR TITLE
Improve performance of public key deserialization

### DIFF
--- a/keys/src/key_pair.rs
+++ b/keys/src/key_pair.rs
@@ -1,5 +1,5 @@
 use beserial::{Deserialize, Serialize};
-use ed25519_zebra::{SigningKey, VerificationKey};
+use ed25519_zebra::{SigningKey, VerificationKeyBytes};
 use utils::key_rng::SecureGenerate;
 
 use rand_core::{CryptoRng, RngCore};
@@ -23,7 +23,7 @@ impl SecureGenerate for KeyPair {
     fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let zebra_priv_key = SigningKey::new(rng);
         let priv_key = PrivateKey(zebra_priv_key);
-        let pub_key = PublicKey(VerificationKey::from(&zebra_priv_key));
+        let pub_key = PublicKey(VerificationKeyBytes::from(&zebra_priv_key));
         KeyPair {
             private: priv_key,
             public: pub_key,

--- a/primitives/account/tests/htlc_contract.rs
+++ b/primitives/account/tests/htlc_contract.rs
@@ -357,9 +357,7 @@ fn it_can_verify_regular_transfer() {
     tx.proof[72] = tx.proof[72] % 250 + 1;
     assert_eq!(
         AccountType::verify_outgoing_transaction(&tx),
-        Err(TransactionError::InvalidSerialization(
-            SerializingError::InvalidValue
-        ))
+        Err(TransactionError::InvalidProof)
     );
 
     // regular: invalid signature
@@ -412,9 +410,7 @@ fn it_can_verify_early_resolve() {
     tx.proof[4] = tx.proof[4] % 250 + 1;
     assert_eq!(
         AccountType::verify_outgoing_transaction(&tx),
-        Err(TransactionError::InvalidSerialization(
-            SerializingError::InvalidValue
-        ))
+        Err(TransactionError::InvalidProof)
     );
     tx.proof[4] = bak;
 

--- a/primitives/account/tests/vesting_contract.rs
+++ b/primitives/account/tests/vesting_contract.rs
@@ -311,9 +311,7 @@ fn it_can_verify_outgoing_transactions() {
     // Proof is not a valid point, so Deserialize will result in an error.
     assert_eq!(
         AccountType::verify_outgoing_transaction(&tx),
-        Err(TransactionError::InvalidSerialization(
-            SerializingError::InvalidValue
-        ))
+        Err(TransactionError::InvalidProof)
     );
 }
 


### PR DESCRIPTION
Improve performance of public key deserialization by avoiding
the curve25519 validity checks of the key.
This in the world of `ed25519-zebra` means to use the
`VerificationKeyBytes` struct instead of `VerificationKey`.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.