### PR TITLE
Improve performance of the BLS signature serialization

### DIFF
--- a/bls/src/types/aggregate_signature.rs
+++ b/bls/src/types/aggregate_signature.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use ark_ff::Zero;
 use ark_mnt6_753::G1Projective;
 
-use crate::Signature;
+use crate::{CompressedSignature, Signature};
 
 /// An aggregate signature. Mathematically, it is equivalent to a regular signature. However, we created a new type for it in order to help differentiate between the two use cases.
 #[derive(Clone, Copy)]
@@ -17,8 +17,10 @@ pub struct AggregateSignature(pub Signature);
 impl AggregateSignature {
     /// Creates a new "empty" aggregate signature. It is simply the identity element of the elliptic curve, also known as the point at infinity.
     pub fn new() -> Self {
+        let signature = G1Projective::zero();
         AggregateSignature(Signature {
-            signature: G1Projective::zero(),
+            signature,
+            compressed: CompressedSignature::from(signature),
         })
     }
 
@@ -28,17 +30,22 @@ impl AggregateSignature {
         for x in sigs {
             agg_sig += &x.signature;
         }
-        AggregateSignature(Signature { signature: agg_sig })
+        AggregateSignature(Signature {
+            signature: agg_sig,
+            compressed: CompressedSignature::from(agg_sig),
+        })
     }
 
     /// Adds a single regular signature to an aggregated signature.
     pub fn aggregate(&mut self, sig: &Signature) {
         self.0.signature += &sig.signature;
+        self.0.compressed = CompressedSignature::from(self.0.signature);
     }
 
     /// Merges two aggregated signatures.
     pub fn merge_into(&mut self, other: &Self) {
         self.0.signature += &other.0.signature;
+        self.0.compressed = CompressedSignature::from(self.0.signature);
     }
 }
 

--- a/bls/src/types/secret_key.rs
+++ b/bls/src/types/secret_key.rs
@@ -10,7 +10,7 @@ use nimiq_hash::Hash;
 use nimiq_utils::key_rng::SecureGenerate;
 use nimiq_utils::key_rng::{CryptoRng, RngCore};
 
-use crate::{SigHash, Signature};
+use crate::{CompressedSignature, SigHash, Signature};
 
 #[derive(Clone, Copy)]
 pub struct SecretKey {
@@ -36,7 +36,10 @@ impl SecretKey {
     pub fn sign_g1(&self, hash_curve: G1Projective) -> Signature {
         let mut sig = hash_curve;
         sig *= self.secret_key;
-        Signature { signature: sig }
+        Signature {
+            signature: sig,
+            compressed: CompressedSignature::from(sig),
+        }
     }
 }
 


### PR DESCRIPTION
Improve performance of the BLS signature serialization by caching
the compressed version of the signature which according to the
profiler it is an expensive operation.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
