### PR TITLE
Remove signature verification for gossipsub messages

### DIFF
--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -138,11 +138,8 @@ impl NimiqBehaviour {
 
         let kademlia = Kademlia::with_config(peer_id, store, config.kademlia);
 
-        let mut gossipsub = Gossipsub::new(
-            MessageAuthenticity::Signed(config.keypair),
-            config.gossipsub,
-        )
-        .expect("Wrong configuration");
+        let mut gossipsub = Gossipsub::new(MessageAuthenticity::Author(peer_id), config.gossipsub)
+            .expect("Wrong configuration");
 
         let identify_config = IdentifyConfig::new("/albatross/2.0".to_string(), public_key);
         let identify = Identify::new(identify_config);

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -36,6 +36,7 @@ impl Config {
             .mesh_n_low(3)
             .validate_messages()
             .max_transmit_size(131_072)
+            .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
             .build()
             .expect("Invalid Gossipsub config");
 

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1014,6 +1014,7 @@ mod tests {
         peer_contact.set_current_time();
 
         let gossipsub = GossipsubConfigBuilder::default()
+            .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
             .build()
             .expect("Invalid Gossipsub config");
 


### PR DESCRIPTION
Remove signature verification for libp2p gossipsib messages.
This also required to change the privacy settings of gossipsub
messages to only contain the peer ID instead of the sender public
key.
This change also improves the performance of the network as found
after profiling the code and seeing that a lot of CPU was being
spent in signature verifications for gossipsub messages.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
