### PR TITLE
Remove clippy workaround introduced

### DIFF
--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -238,10 +238,6 @@ impl FromStr for Network {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Network, ()> {
-        // Fixme: Introduced this to workaround false positives in clippy
-        // as documented here:
-        // https://github.com/rust-lang/rust-clippy/issues/7863
-        #[allow(clippy::match_str_case_mismatch)]
         Ok(match s.to_lowercase().as_str() {
             "main" => Network::Main,
             "test" => Network::Test,


### PR DESCRIPTION
Remove clippy workaround introduced to avoid false positive checks
in the file `lib/src/config/config_file/mod.rs`. This can be
removed now since the issue that introduced it in clippy land is
already closed.
This closes #378.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.