### PR TITLE
Refactor mempool tests and add testcase for mempool update (rebranch cases)

### DIFF
--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -50,3 +50,4 @@ nimiq-build-tools = { path = "../build-tools" }
 nimiq-database = { path = "../database" }
 nimiq-genesis = { path = "../genesis" }
 nimiq-network-mock = { path = "../network-mock" }
+nimiq-vrf = { path = "../vrf" }

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -182,12 +182,12 @@ impl Mempool {
 
         // Now iterate over the transactions in the adopted blocks:
         //  if transaction was known:
-        //      remove it from the mempool
+        //    remove it from the mempool
         //  else
-        //      if we know the sender
-        //          update the sender state (some transactions could become invalid )
-        //      else
-        //          we don't care, since it won't affect our senders balance
+        //    if we know the sender
+        //      update the sender state (some transactions could become invalid )
+        //    else
+        //      we don't care, since it won't affect our senders balance
         //
         for (_, block) in adopted_blocks {
             if let Some(transactions) = block.transactions() {
@@ -247,7 +247,6 @@ impl Mempool {
         // what we need to know is if we need to add back the transaction into the mempool
         // This is similar to an operation where we try to add a transaction,
         // the only difference is that we don't need to re-check signature
-        //
         for (_, block) in reverted_blocks {
             let block_height = blockchain.block_number() + 1;
 
@@ -257,7 +256,6 @@ impl Mempool {
 
                     // Check if we already know this transaction. If yes, skip ahead.
                     if mempool_state.contains(&tx_hash) {
-                        mempool_state.remove(&tx_hash);
                         continue;
                     }
 
@@ -289,7 +287,7 @@ impl Mempool {
                     let in_fly_balance = tx.total_value().unwrap() + sender_total;
 
                     if in_fly_balance <= sender_balance {
-                        log::debug!(" Accepting new transaction from reverted blocks ");
+                        log::debug!("Accepting new transaction from reverted blocks");
                         mempool_state.put(tx);
                     } else {
                         log::debug!(

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -290,7 +290,7 @@ impl Mempool {
 
                     if in_fly_balance <= sender_balance {
                         log::debug!(" Accepting new transaction from reverted blocks ");
-                        mempool_state.put(&tx);
+                        mempool_state.put(tx);
                     } else {
                         log::debug!(
                             "The Tx from reverted blocks was dropped because of not enough funds"


### PR DESCRIPTION
- Fix issue in mempool logic for reverted blocks  
  If a transaction in the reverted block was already in the mempool,
  the code was removing it as well from the mempool when it should
  just ignore it and continue with the next transaction.
- Add testcase for mempool update function that is called on
  blockchain re-branch cases.
- Fix clippy warning regarding a needless borrow in the mempool
  implementation.
- Refactor mempool test to use utility functions to generate
  transactions and accounts to avoid replicated code.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.