### PR TITLE
Remove the chrono dependency in favor of time

### DIFF
--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/devnet/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
 ctrlc = "3.1"
 hex = "0.4"
 lazy_static = "1.3"
@@ -27,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 shellfn = "0.1"
 structopt = { version = "0.3", features = ["paw"] }
 thiserror = "1.0"
+time = { version = "0.3", features = ["parsing"] }
 toml = "0.5"
 
 beserial = { path = "../beserial" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,7 +19,6 @@ maintenance = { status = "experimental" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
 colored = { version = "2.0", optional = true }
 derive_builder = "0.9"
 directories = "4.0"
@@ -39,6 +38,7 @@ structopt = { version = "0.3", features = ["paw"] }
 strum_macros = "0.22"
 toml = "0.5"
 url = "2.2"
+time = { version = "0.3", features = ["formatting"] }
 thiserror = "1.0"
 
 beserial = { path = "../beserial" }

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -1,12 +1,12 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use chrono::Local;
 use colored::Colorize;
 use fern::colors::{Color, ColoredLevelConfig};
 use fern::{log_file, Dispatch};
 use file_rotate::{FileRotate, RotationMode};
 use lazy_static::lazy_static;
 use log::{Level, LevelFilter};
+use time::OffsetDateTime;
 
 use crate::{
     config::{command_line::CommandLine, config_file::LogSettings},
@@ -134,11 +134,15 @@ fn pretty_logging_with_timestamps(
         let target_text = record.target().split("::").last().unwrap();
         let max_width = max_module_width(target_text);
         let target = format!("{: <width$}", target_text, width = max_width);
+        let ts_format = time::format_description::parse(
+            "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]",
+        )
+        .unwrap();
 
         if formatted {
             out.finish(format_args!(
                 " {timestamp} {level: <5} {target} | {message}",
-                timestamp = Local::now().format("%Y-%m-%d %T.%3f"),
+                timestamp = OffsetDateTime::now_utc().format(&ts_format).unwrap(),
                 target = target.bold(),
                 level = colors_level.color(record.level()),
                 message = message,
@@ -146,7 +150,7 @@ fn pretty_logging_with_timestamps(
         } else {
             out.finish(format_args!(
                 " {timestamp} {level: <5} {target} | {message}",
-                timestamp = Local::now().format("%Y-%m-%d %T.%3f"),
+                timestamp = OffsetDateTime::now_utc().format(&ts_format).unwrap(),
                 target = target,
                 level = record.level(),
                 message = message,


### PR DESCRIPTION
Remove the chrono dependency in favor of time since the first has
been flagged as insecure. This is due to the fact that chrono has
a stale dependency in time that has CVE-2020-26235.
The chrono issue is documented
[here](https://github.com/chronotope/chrono/issues/602).

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.