### PR TITLE
Forget about peer in sync clustering

### DIFF
--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -367,7 +367,7 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
                             agent.peer.id(),
                             cluster.id
                         );
-                        agent.peer.close(CloseReason::Other);
+                        //agent.peer.close(CloseReason::Other);
                     }
                 }
             }


### PR DESCRIPTION
Temporal WA to forget about peer if the cluster count reaches 0 after
cluster failed
This is intended to solve a problem when validators stop producing blocks 
