### PR TITLE
Increase the initial DB map size

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The Nimiq Rust client comes without wallet and can currently not be used to send
 - [Nimiq Developer Reference](https://nimiq-network.github.io/developer-reference/): Details of the protocol architecture.
 
 
+## System requirements
+- 32-bit architectures are not supported.
+- File systems with sparse file support (most modern files systems support it).
+
+
 ## Install
 
 Besides [Rust nightly](https://www.rust-lang.org/learn/get-started#installing-rust) itself, the following packages are required to be able to compile this source code:

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -244,8 +244,8 @@ impl Default for FileStorageConfig {
 #[derive(Debug, Clone, Builder)]
 #[builder(setter(into))]
 pub struct DatabaseConfig {
-    /// Initial database size. Default: 50 MB
-    #[builder(default = "50 * 1024 * 1024")]
+    /// Initial database size. Default: 1 TB
+    #[builder(default = "1024 * 1024 * 1024 * 1024")]
     size: usize,
 
     /// Max number of DBs. Recommended: 12
@@ -267,7 +267,8 @@ pub struct DatabaseConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            size: 1024 * 1024 * 1024,
+            // 1 TB
+            size: 1024 * 1024 * 1024 * 1024,
             max_dbs: 12,
             max_readers: 600,
             flags: LmdbFlags::NOMETASYNC,


### PR DESCRIPTION
Increase the initial DB map size from 1G to 1T.
Also increase the percentage threshold that defines when to resize
the DB to 100% such that the DB never gets resized.
This is to address issues resizing LMDB which is not well supported
and the recommendation is to use a large initial mapping size.
This will affect 32-bit systems and systems without sparse file
system support that are also written in the system requirements
section in the `README.md` file.

This closes #419.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.