### PR TITLE
Re-implement KeyNibbles using arrays instead of vectors

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -185,7 +185,7 @@ impl<'env> WriteTransaction<'env> {
     }
 
     /// Puts a key/value pair into the database by copying it into a reserved space in the database.
-    /// This works best for values that need to be serialised into the reserved space.
+    /// This works best for values that need to be serialized into the reserved space.
     /// This method will panic when called on a database with duplicate keys!
     pub fn put_reserve<K, V>(&mut self, db: &Database, key: &K, value: &V)
     where
@@ -206,7 +206,7 @@ impl<'env> WriteTransaction<'env> {
     }
 
     /// Puts a key/value pair into the database by passing a reference to a byte slice.
-    /// This is more efficient than `put_reserve` if no serialisation is needed,
+    /// This is more efficient than `put_reserve` if no serialization is needed,
     /// and the existing value can be immediately written into the database.
     /// This also works with duplicate key databases.
     pub fn put<K, V>(&mut self, db: &Database, key: &K, value: &V)


### PR DESCRIPTION
- Re-implement KeyNibbles using arrays
  - Re-implement KeyNibbles using arrays instead of vectors.
    This is to improve the performance of KeyNibbles since the profiler
    showed that with vectors there is plenty of CPU cycles spent
    in vector heap allocation and handling.

- Fix some typos in the database crate

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
