### PR TITLE
Remove unwraps from bls/src/compression.rs, return Err instead

### DIFF
--- a/bls/src/compression.rs
+++ b/bls/src/compression.rs
@@ -178,13 +178,16 @@ impl BeSerialize for MNT6Fq {
 impl BeDeserialize for MNT6Fq {
     fn deserialize<R: ReadBytesExt>(reader: &mut R) -> Result<Self, Error> {
         let value: BigInteger768 = CustomLengthDeSerialize::deserialize(reader, 95)?;
-        Ok(MNT6Fq::from_repr(value).unwrap())
+        MNT6Fq::from_repr(value).ok_or_else(|| Error::from(std::io::ErrorKind::InvalidData))
     }
 
     fn deserialize_with_flags<R: ReadBytesExt>(reader: &mut R) -> Result<(Self, Flags), Error> {
         let (value, flags): (BigInteger768, _) =
             CustomLengthDeSerialize::deserialize_with_flags(reader, 95)?;
-        Ok((MNT6Fq::from_repr(value).unwrap(), flags))
+        Ok((
+            MNT6Fq::from_repr(value).ok_or_else(|| Error::from(std::io::ErrorKind::InvalidData))?,
+            flags,
+        ))
     }
 }
 
@@ -241,13 +244,16 @@ impl BeSerialize for MNT4Fq {
 impl BeDeserialize for MNT4Fq {
     fn deserialize<R: ReadBytesExt>(reader: &mut R) -> Result<Self, Error> {
         let value: BigInteger768 = CustomLengthDeSerialize::deserialize(reader, 95)?;
-        Ok(MNT4Fq::from_repr(value).unwrap())
+        MNT4Fq::from_repr(value).ok_or_else(|| Error::from(std::io::ErrorKind::InvalidData))
     }
 
     fn deserialize_with_flags<R: ReadBytesExt>(reader: &mut R) -> Result<(Self, Flags), Error> {
         let (value, flags): (BigInteger768, _) =
             CustomLengthDeSerialize::deserialize_with_flags(reader, 95)?;
-        Ok((MNT4Fq::from_repr(value).unwrap(), flags))
+        Ok((
+            MNT4Fq::from_repr(value).ok_or_else(|| Error::from(std::io::ErrorKind::InvalidData))?,
+            flags,
+        ))
     }
 }
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes #416 .

## What's in this pull request?

Previous to this PR some of the bls deserialisations can panic when invalid data is deserialised. With this PR they return Err instead of panicking. 

However it was not checked, that the caller side is handling the Err case appropriately, but since the return signature was of type Result before the change that would be expected. 
