### PR TITLE
Script to generate docker devnet scenarios

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 *
 !/target/debug/nimiq-client
 !/target/release/nimiq-client
+!/target/debug/nimiq-spammer
+!/target/release/nimiq-spammer
 !/scripts/docker_*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ VOLUME /home/nimiq/.nimiq
 COPY ./scripts/docker_*.sh /home/nimiq/
 
 ARG BUILD=debug
-COPY ./target/${BUILD}/nimiq-client /usr/local/bin/nimiq-client
+ARG APP=client
+COPY ./target/${BUILD}/nimiq-${APP} /usr/local/bin/nimiq-client
 
 EXPOSE 8443/tcp 8648/tcp
 

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -192,7 +192,7 @@ do
     if [ $restarts_count -lt $max_restarts ] ; then
 
         # Select a random validator to restart
-        index=$((0 + $RANDOM % 3))
+        index=$(($RANDOM % 4))
 
         echo "  Killing validator: $(($index + 1 ))"
 

--- a/scripts/devnet_docker_scenario.sh
+++ b/scripts/devnet_docker_scenario.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+MAX_VALIDATORS=4
+
+usage()
+{
+cat << EOF
+usage: $0 [-v|--validators COUNT] [-h|--help]
+
+This script launches a scenario with N validators + spammer + seed node, each one running in its own docker container
+This script should be executed from the root of your nimiq repository
+
+OPTIONS:
+   -h|--help       Show this message
+   -v|--validators The number of validators, as a minimun 4 validators are created
+EOF
+}
+
+while [ ! $# -eq 0 ]; do
+    case "$1" in
+        -v | --validators)
+            if [ "$2" ]; then
+                MAX_VALIDATORS=$2
+                shift
+            else
+                echo '--validators requires a value'
+                exit 1
+            fi
+            ;;
+        -h | --help)
+            usage
+            exit
+            ;;
+        *)
+            usage
+            exit
+            ;;
+    esac
+    shift
+done
+
+# Create devnet configuration
+echo "Creating devnet configuration... "
+python3 scripts/devnet_create.py $MAX_VALIDATORS
+
+# Overwrite the docker compose and genesis
+echo "Copying the genesis and docker compose files... "
+cp -v /tmp/nimiq-devnet/dev-albatross.toml genesis/src/genesis/dev-albatross.toml
+cp -v /tmp/nimiq-devnet/docker-compose.yml docker-compose.yml
+
+#Compile the code
+echo "Compiling the code"
+cargo build --release
+
+echo "Create docker images... "
+docker buildx build . --pull -t core --progress=plain --build-arg BUILD=release
+docker buildx build . --pull -t spammer --progress=plain --build-arg APP=spammer --build-arg BUILD=release
+
+NETWORK_NAME=nimiq.local docker-compose -f docker-compose.yml up

--- a/scripts/docker_config.sh
+++ b/scripts/docker_config.sh
@@ -72,6 +72,7 @@ if [[ "$ROTATING_LOG_ENABLED" == "true" ]]; then
     optional file_count ROTATING_LOG_FILE_COUNT number
 fi
 
+if [[ ! -z "${VALIDATOR_ADDRESS+x}" ]]; then
 echo '[validator]'
 required validator_address VALIDATOR_ADDRESS string
 optional validator_key_file VALIDATOR_KEY_FILE string
@@ -80,6 +81,7 @@ optional fee_key_file FEE_KEY_FILE string
 optional fee_key FEE_KEY string
 optional warm_key_file WARM_KEY_FILE string
 optional warm_key WARM_KEY string
+fi
 
 if [[ "$RPC_ENABLED" == "true" ]]; then
     echo '[rpc-server]'


### PR DESCRIPTION
-Modified the devnet create script to also generate a docker compose
file with all the necessary information to create a multiple validators,
spammer and seed scenario. The number of validators is parameterized.

-Included a simple script to automatically generate and start running a
docker compose based scenario with multiple validators, seed node and
spammer.

-Small changes to Dockerfile in order to create docker images with
transaction spammer
