### PR TITLE
Fix network issues

### DIFF
--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use std::num::NonZeroU8;
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
@@ -213,7 +212,6 @@ impl Network {
         // TODO add proper config
         SwarmBuilder::new(transport, behaviour, local_peer_id)
             .connection_limits(limits)
-            .dial_concurrency_factor(NonZeroU8::new(10).unwrap())
             .executor(Box::new(|fut| {
                 tokio::spawn(fut);
             }))

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -595,7 +595,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         tokio::spawn(async move {
             debug!("Sending unpark transaction");
             if cn.send_transaction(unpark_transaction).await.is_err() {
-                error!("Failed to send unpark transatction");
+                error!("Failed to send unpark transaction");
             }
         });
         self.unpark_sent = true;


### PR DESCRIPTION
- Reduce the number of concurrent dial addresses to 1 in the network,
  which is also the default hence the code won't set any value to it.
  This was detected as the cause of several dials being launch when
  issuing a peer dial and provoking error messages since only one of
  the dial actions succeed while the other fails with messages
  reporting incoming connection errors. 
  This fixes #446.
    
- Fix incoming dial failure handling for connection pool behavour.
  Since the recent update of libp2p, [this
  change](https://github.com/libp2p/rust-libp2p/pull/2191) introduces
  state to dial request that can be transmitted in
  `inject_dial_failure`. So there are a couple of cases where the
  function is called but we can ignore the error since the connection
  is still to be completed or is already connected.
  This fixes #447.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
