### PR TITLE
Update some more outdated dependencies

### DIFF
--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -330,7 +330,7 @@ impl fmt::Display for BitSet {
                 let consecutive_last = last_value.map(|lv| lv + 1 == value).unwrap_or(false);
                 let consecutive_next = value + 1 == *next_value;
                 if !(consecutive_last && consecutive_next) {
-                    write!(f, "{}", value.to_string())?;
+                    write!(f, "{}", value)?;
                     if consecutive_next {
                         write!(f, "-")?;
                     } else {
@@ -338,7 +338,7 @@ impl fmt::Display for BitSet {
                     }
                 }
             } else {
-                write!(f, "{}", value.to_string())?;
+                write!(f, "{}", value)?;
             }
             last_value = Some(value);
         }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,7 +35,7 @@ rand = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 structopt = { version = "0.3", features = ["paw"] }
-strum_macros = "0.22"
+strum_macros = "0.23"
 toml = "0.5"
 url = "2.2"
 time = { version = "0.3", features = ["formatting"] }

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "1.0"
 derive_more = "0.99"
 futures = "0.3"
 hex = "0.4"
-ip_network = "0.3"
+ip_network = "0.4"
 libp2p = { version = "0.40", default-features = false, features = [
     "gossipsub",
     "kad",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -27,7 +27,7 @@ num-traits = {version = "0.2", optional = true}
 parking_lot = {git = "https://github.com/styppo/parking_lot.git", optional = true}
 regex = {version = "1.3", optional = true}
 serde = {version = "1.0", features = ["derive"], optional = true}
-strum_macros = "0.22"
+strum_macros = "0.23"
 thiserror = {version = "1.0.20", optional = true}
 
 beserial = {path = "../beserial"}

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
-strum_macros = "0.22"
+strum_macros = "0.23"
 thiserror = "1.0"
 
 beserial = { path = "../../beserial" }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4"
 log = "0.4"
 num-traits = "0.2"
 serde = { version = "1.0", optional = true }
-strum_macros = "0.22"
+strum_macros = "0.23"
 thiserror = "1.0"
 
 beserial = { path = "../../beserial" }


### PR DESCRIPTION
- Update some outdated dependencies:
  - strum_macros from version 0.22 to version 0.23.
  - ip_network from version 0.3 to version 0.4.

- Remove some clippy warnings from the collections crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
