### PR TITLE
Increase Gossipsub max transmission size

### DIFF
--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -30,7 +30,7 @@ impl Config {
         let gossipsub = GossipsubConfigBuilder::default()
             .mesh_n_low(3)
             .validate_messages()
-            .max_transmit_size(131_072)
+            .max_transmit_size(200_000)
             .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
             .build()
             .expect("Invalid Gossipsub config");


### PR DESCRIPTION
Increased the Gossipsub max transmission size to avoid
"Message exceeded the maximum transmission size and was not sent."
This needs further investigation to understand why we were hitting the
previous 131K limit.  
