### PR TITLE
Reduce the Gossipsub hearbeat interval

### DIFF
--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use libp2p::{
     gossipsub::{GossipsubConfig, GossipsubConfigBuilder},
     identity::Keypair,
@@ -32,6 +34,7 @@ impl Config {
             .validate_messages()
             .max_transmit_size(200_000)
             .validation_mode(libp2p::gossipsub::ValidationMode::Permissive)
+            .heartbeat_interval(Duration::from_millis(700))
             .build()
             .expect("Invalid Gossipsub config");
 


### PR DESCRIPTION
Reduces the Gossipbub heartbeat interval from 1 sec(default) to
700ms, in order to decrease the probability of
"Message exceeded the maximum transmission size and was not sent"
errors, by reducing the amount of messages that are buffered

