### PR TITLE
Add network fixes

### DIFF
--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,5 +1,4 @@
 use std::time::Duration;
-
 use libp2p::{
     gossipsub::{GossipsubConfig, GossipsubConfigBuilder},
     identity::Keypair,

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,10 +1,10 @@
-use std::time::Duration;
 use libp2p::{
     gossipsub::{GossipsubConfig, GossipsubConfigBuilder},
     identity::Keypair,
     kad::{KademliaBucketInserts, KademliaConfig},
     Multiaddr,
 };
+use std::time::Duration;
 
 use nimiq_hash::Blake2bHash;
 
@@ -39,6 +39,9 @@ impl Config {
 
         let mut kademlia = KademliaConfig::default();
         kademlia.set_kbucket_inserts(KademliaBucketInserts::OnConnected);
+        kademlia.set_record_ttl(Some(Duration::from_secs(5 * 60)));
+        kademlia.set_publication_interval(Some(Duration::from_secs(60)));
+        kademlia.set_replication_interval(Some(Duration::from_secs(20)));
 
         Self {
             keypair,

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -543,7 +543,7 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
 
     fn inject_connection_closed(
         &mut self,
-        _peer_id: &PeerId,
+        peer_id: &PeerId,
         _conn: &ConnectionId,
         endpoint: &ConnectedPoint,
         _handler: <Self::ProtocolsHandler as IntoProtocolsHandler>::Handler,
@@ -573,6 +573,15 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
         };
 
         self.addresses.mark_closed(address.clone());
+        // Notify handler about the connection is going to be shut down
+        self.actions
+            .push_back(NetworkBehaviourAction::NotifyHandler {
+                peer_id: *peer_id,
+                handler: NotifyHandler::Any,
+                event: HandlerInEvent::Close {
+                    reason: CloseReason::RemoteClosed,
+                },
+            });
     }
 
     fn inject_event(

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -14,8 +14,8 @@ use libp2p::swarm::DialPeerCondition;
 use libp2p::{
     core::{connection::ConnectionId, multiaddr::Protocol, ConnectedPoint},
     swarm::{
-        DialError, IntoProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler,
-        PollParameters, ProtocolsHandler,
+        CloseConnection, DialError, IntoProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction,
+        NotifyHandler, PollParameters, ProtocolsHandler,
     },
     Multiaddr, PeerId,
 };
@@ -597,6 +597,13 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
                     .push_back(NetworkBehaviourAction::GenerateEvent(
                         ConnectionPoolEvent::PeerJoined { peer },
                     ));
+            }
+            HandlerOutEvent::PeerLeft { peer_id, .. } => {
+                self.actions
+                    .push_back(NetworkBehaviourAction::CloseConnection {
+                        peer_id,
+                        connection: CloseConnection::All,
+                    });
             }
         }
     }


### PR DESCRIPTION
Decrease the DHT record TTL and related settings:
- Reduce record TTL from 36 h to 6 min.
- Reduce the publication interval from 24h to 1 min.
- Reduce the replication interval from 60 min to 20s.
    
Remove the peer from the network observable peer map and let the
peer's dispatcher that the connections is going to be closed.
This fixes issues related to stale dispatchers and peers when a
peer closes and then rejoins.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
