### PR TITLE
Verify records that are stored into the DHT

### DIFF
--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -51,6 +51,7 @@ wasm-timer = "0.2"
 
 beserial = { path = "../beserial", features = ["libp2p"] }
 beserial_derive = { path = "../beserial/beserial_derive" }
+nimiq-bls = { path = "../bls" }
 nimiq-macros = { path = "../macros" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-hash = { path = "../hash" }
@@ -60,6 +61,7 @@ nimiq-utils = { path = "../utils", features = [
     "libp2p",
     "time",
 ] }
+nimiq-validator-network = { path = "../validator-network" }
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,7 +1,7 @@
 use libp2p::{
     gossipsub::{GossipsubConfig, GossipsubConfigBuilder},
     identity::Keypair,
-    kad::{KademliaBucketInserts, KademliaConfig},
+    kad::{KademliaBucketInserts, KademliaConfig, KademliaStoreInserts},
     Multiaddr,
 };
 use std::time::Duration;
@@ -42,6 +42,7 @@ impl Config {
         kademlia.set_record_ttl(Some(Duration::from_secs(5 * 60)));
         kademlia.set_publication_interval(Some(Duration::from_secs(60)));
         kademlia.set_replication_interval(Some(Duration::from_secs(20)));
+        kademlia.set_record_filtering(KademliaStoreInserts::FilterBoth);
 
         Self {
             keypair,

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -3,6 +3,7 @@ extern crate beserial_derive;
 
 pub mod error;
 pub mod network_impl;
+pub mod validator_record;
 
 use std::{pin::Pin, sync::Arc, time::Duration};
 

--- a/validator-network/src/validator_record.rs
+++ b/validator-network/src/validator_record.rs
@@ -1,0 +1,60 @@
+use beserial::{Deserialize, Serialize};
+use nimiq_bls::{PublicKey, SecretKey, Signature};
+use nimiq_utils::tagged_signing::TaggedSignable;
+
+//struct ValidatorPeerId<TPeerId: Serialize>(TPeerId);
+
+// TODO: Use a tagged signature for validator records
+impl<TPeerId> TaggedSignable for ValidatorRecord<TPeerId>
+where
+    TPeerId: Serialize + Deserialize,
+{
+    const TAG: u8 = 0x03;
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidatorRecord<TPeerId>
+where
+    TPeerId: Serialize + Deserialize,
+{
+    pub peer_id: TPeerId,
+    //public_key: PublicKey,
+    // TODO: other info?
+}
+
+impl<TPeerId> ValidatorRecord<TPeerId>
+where
+    TPeerId: Serialize + Deserialize,
+{
+    pub fn new(peer_id: TPeerId) -> Self {
+        Self { peer_id }
+    }
+
+    pub fn sign(self, secret_key: &SecretKey) -> SignedValidatorRecord<TPeerId> {
+        let data = self.serialize_to_vec();
+        let signature = secret_key.sign(&data);
+
+        SignedValidatorRecord {
+            record: self,
+            signature,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SignedValidatorRecord<TPeerId>
+where
+    TPeerId: Serialize + Deserialize,
+{
+    pub record: ValidatorRecord<TPeerId>,
+    pub signature: Signature,
+}
+
+impl<TPeerId> SignedValidatorRecord<TPeerId>
+where
+    TPeerId: Serialize + Deserialize,
+{
+    pub fn verify(&self, public_key: &PublicKey) -> bool {
+        public_key.verify(&self.record.serialize_to_vec(), &self.signature)
+    }
+}


### PR DESCRIPTION
Add a filter function to verify the records in the DHT.
This filter function will try to decode the value to obtain the
signature to then perform the signature verification. Only if
the signature is verified, the DHT record is stored.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
