### PR TITLE
Fix transaction building for dropping validators

### DIFF
--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -1653,7 +1653,7 @@ impl TransactionBuilder {
         let proof_builder = builder.generate().unwrap();
         match proof_builder {
             TransactionProofBuilder::OutStaking(mut builder) => {
-                builder.unstake(cold_key_pair);
+                builder.drop_validator(cold_key_pair);
                 builder.generate().unwrap()
             }
             _ => unreachable!(),


### PR DESCRIPTION
Fix issue building a transaction to drop a validator due to
incorrectly being built for unstaking.
This fixes #462.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.