### PR TITLE
Fix devnet scripts to properly configure a spammer

### DIFF
--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -160,7 +160,11 @@ do
 done
 
 echo "Building config files..."
-python3 scripts/devnet/python/devnet_create.py $MAX_VALIDATORS $configdir
+if [ "$SPAMMER" = true ] ; then
+    python3 scripts/devnet/python/devnet_create.py $MAX_VALIDATORS -o $configdir -s
+else
+    python3 scripts/devnet/python/devnet_create.py $MAX_VALIDATORS -o $configdir
+fi
 echo "Config files generated in '$configdir'"
 echo "Initializing genesis..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG="$PWD/$configdir/dev-albatross.toml"

--- a/scripts/devnet_docker_scenario.sh
+++ b/scripts/devnet_docker_scenario.sh
@@ -43,7 +43,7 @@ tmp_dir=`mktemp -d -t docker_devnet.XXXXXXXXXX`
 
 # Create devnet configuration
 echo "Creating devnet configuration... "
-python3 scripts/devnet/python/devnet_create.py $MAX_VALIDATORS $tmp_dir
+python3 scripts/devnet/python/devnet_create.py $MAX_VALIDATORS -o $tmp_dir -s
 
 # Overwrite the docker compose and genesis
 echo "Copying the genesis and docker compose files... "


### PR DESCRIPTION
Fix devnet scripts to properly configure a spammer.
Since the spammer has a hardcoded private key, when using a spammer
the genesis must have the account that the private key belongs to.
In order for that to happen, an optional argument was added to the
python `devnet_create` script to only generate the spammer
configuration files if the spammer option is specified.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.