### PR TITLE
Fix panic in mempool executor

### DIFF
--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -88,7 +88,7 @@ async fn send_txn_to_mempool(
 
     let timeout = tokio::time::Duration::from_secs(1);
     tokio::time::sleep(timeout).await;
-    mempool.stop_executor();
+    mempool.stop_executor().await;
 }
 
 async fn multiple_start_stop_send(
@@ -126,7 +126,7 @@ async fn multiple_start_stop_send(
 
     let timeout = tokio::time::Duration::from_secs(2);
     tokio::time::sleep(timeout).await;
-    mempool.stop_executor();
+    mempool.stop_executor().await;
 
     // Get the transactions from the mempool
     let obtained_txns = mempool.get_transactions_for_block(usize::MAX);
@@ -151,7 +151,7 @@ async fn multiple_start_stop_send(
     tokio::time::sleep(timeout).await;
 
     // Call stop again, nothing should happen.
-    mempool.stop_executor();
+    mempool.stop_executor().await;
 
     // We should not obtain any, since the executor should not be running.
     let obtained_txns = mempool.get_transactions_for_block(usize::MAX);
@@ -189,7 +189,7 @@ async fn multiple_start_stop_send(
 
     let timeout = tokio::time::Duration::from_secs(2);
     tokio::time::sleep(timeout).await;
-    mempool.stop_executor();
+    mempool.stop_executor().await;
 
     // Get the transactions from the mempool
     let obtained_txns = mempool.get_transactions_for_block(usize::MAX);

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -665,7 +665,9 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork> Future
                 Ok(ConsensusEvent::Lost) => {
                     if let MempoolState::Active = self.mempool_state {
                         let mempool = Arc::clone(&self.mempool);
-                        mempool.stop_executor();
+                        tokio::spawn(async move {
+                            mempool.stop_executor().await;
+                        });
                         self.mempool_state = MempoolState::Inactive;
                     }
                 }


### PR DESCRIPTION
Fixes #491
Fix a panic caused by an improper use of a mutex guard: the lock was
taken via an if statement which was not protecting the code where the
executor is created, so during some concurrent use cases, there
was a race condition that caused the executor to be created twice,
which translates to subscribing multiple times to the same transaction
topic, which is not allowed.
