### PR TITLE
Fix panic in consensus sync clustering

### DIFF
--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -47,7 +47,7 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
         cx: &mut Context<'_>,
     ) -> Poll<Option<HistorySyncReturn<TNetwork::PeerType>>> {
         // TODO We might want to not send an epoch_id request in the first place if we're at the
-        //  cluster limit.
+        // cluster limit.
         while self.epoch_clusters.len() < Self::MAX_CLUSTERS {
             let epoch_ids = match self.epoch_ids_stream.poll_next_unpin(cx) {
                 Poll::Ready(Some(epoch_ids)) => epoch_ids,


### PR DESCRIPTION
Fix panic trying to access the `epochs_ids` array out of bounds.
The access is done in `cluster_epoch_ids` and happens when the
received epoch IDs are from a peer that is behind our current
epoch ID. To fix this, the code will check for this case and
ignore the received epoch IDs since they come from a peer that
is behind our accepted state.

This fixes #490.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.