### PR TITLE
Removes unstaking delays

### DIFF
--- a/primitives/account/src/account.rs
+++ b/primitives/account/src/account.rs
@@ -53,7 +53,7 @@ impl Account {
             Account::StakingValidatorsStaker(_) => {
                 unimplemented!()
             }
-            Account::StakingStaker(ref account) => account.active_stake + account.inactive_stake,
+            Account::StakingStaker(ref account) => account.balance,
         }
     }
 

--- a/primitives/account/src/staking_contract/receipts.rs
+++ b/primitives/account/src/staking_contract/receipts.rs
@@ -43,7 +43,7 @@ pub struct UnparkValidatorReceipt {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct DropValidatorReceipt {
+pub struct DeleteValidatorReceipt {
     pub signing_key: SchnorrPublicKey,
     pub voting_key: BlsPublicKey,
     pub reward_address: Address,
@@ -54,17 +54,6 @@ pub struct DropValidatorReceipt {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct UpdateStakerReceipt {
-    pub old_delegation: Option<Address>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct RetireStakerReceipt {
-    pub old_retire_time: u32,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct DropStakerReceipt {
+pub struct StakerReceipt {
     pub delegation: Option<Address>,
-    pub retire_time: u32,
 }

--- a/rpc-client/src/bin/client.rs
+++ b/rpc-client/src/bin/client.rs
@@ -134,42 +134,6 @@ enum TransactionCommand {
         dry: bool,
     },
 
-    /// Retires the stake from the address of a given `key_pair`.
-    Retire {
-        /// The stake will be retired from this wallet.
-        wallet: Address,
-
-        value: Coin,
-
-        #[structopt(short, long, default_value = "0")]
-        fee: Coin,
-
-        #[structopt(short, long, default_value)]
-        validity_start_height: ValidityStartHeight,
-
-        /// Don't actually send the transaction, but output the transaction as hex string.
-        #[structopt(long = "dry")]
-        dry: bool,
-    },
-
-    /// Reactivates the stake from the address of a given `key_pair`.
-    Reactivate {
-        /// The stake will be reactivated from this wallet.
-        wallet: Address,
-
-        value: Coin,
-
-        #[structopt(short, long, default_value = "0")]
-        fee: Coin,
-
-        #[structopt(short, long, default_value)]
-        validity_start_height: ValidityStartHeight,
-
-        /// Don't actually send the transaction, but output the transaction as hex string.
-        #[structopt(long = "dry")]
-        dry: bool,
-    },
-
     Unstake {
         /// The stake will be sent from this wallet.
         wallet: Address,
@@ -353,78 +317,6 @@ impl Command {
                             .send_stake_transaction(
                                 wallet,
                                 staker_address,
-                                value,
-                                fee,
-                                validity_start_height,
-                            )
-                            .await?;
-                        println!("{}", txid);
-                    }
-                }
-
-                TransactionCommand::Retire {
-                    wallet,
-                    value,
-                    fee,
-                    validity_start_height,
-                    dry,
-                } => {
-                    if dry {
-                        let tx = client
-                            .consensus
-                            .create_retire_transaction(
-                                None,
-                                None,
-                                wallet,
-                                value,
-                                fee,
-                                validity_start_height,
-                            )
-                            .await?;
-                        println!("{}", tx);
-                    } else {
-                        let txid = client
-                            .consensus
-                            .send_retire_transaction(
-                                None,
-                                None,
-                                wallet,
-                                value,
-                                fee,
-                                validity_start_height,
-                            )
-                            .await?;
-                        println!("{}", txid);
-                    }
-                }
-
-                TransactionCommand::Reactivate {
-                    wallet,
-                    value,
-                    fee,
-                    validity_start_height,
-                    dry,
-                } => {
-                    if dry {
-                        let tx = client
-                            .consensus
-                            .create_reactivate_transaction(
-                                None,
-                                None,
-                                wallet,
-                                value,
-                                fee,
-                                validity_start_height,
-                            )
-                            .await?;
-                        println!("{}", tx);
-                    } else {
-                        let txid = client
-                            .consensus
-                            .send_reactivate_transaction(
-                                None,
-                                None,
-                                wallet,
                                 value,
                                 fee,
                                 validity_start_height,

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -252,7 +252,6 @@ pub trait ConsensusInterface {
     async fn create_update_transaction(
         &mut self,
         sender_wallet: Option<Address>,
-        from_active_balance: Option<bool>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
         fee: Coin,
@@ -262,49 +261,8 @@ pub trait ConsensusInterface {
     async fn send_update_transaction(
         &mut self,
         sender_wallet: Option<Address>,
-        from_active_balance: Option<bool>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
-
-    async fn create_retire_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        from_active_balance: Option<bool>,
-        staker_wallet: Address,
-        value: Coin,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
-
-    async fn send_retire_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        from_active_balance: Option<bool>,
-        staker_wallet: Address,
-        value: Coin,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
-
-    async fn create_reactivate_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        from_active_balance: Option<bool>,
-        staker_wallet: Address,
-        value: Coin,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
-
-    async fn send_reactivate_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        from_active_balance: Option<bool>,
-        staker_wallet: Address,
-        value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Self::Error>;
@@ -375,7 +333,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Self::Error>;
 
-    async fn create_retire_validator_transaction(
+    async fn create_inactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
         validator_address: Address,
@@ -384,7 +342,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> Result<String, Self::Error>;
 
-    async fn send_retire_validator_transaction(
+    async fn send_inactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
         validator_address: Address,
@@ -429,7 +387,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Self::Error>;
 
-    async fn create_drop_validator_transaction(
+    async fn create_delete_validator_transaction(
         &mut self,
         validator_wallet: Address,
         recipient: Address,
@@ -437,7 +395,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> Result<String, Self::Error>;
 
-    async fn send_drop_validator_transaction(
+    async fn send_delete_validator_transaction(
         &mut self,
         validator_wallet: Address,
         recipient: Address,

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -641,21 +641,17 @@ impl Account {
 #[serde(rename_all = "camelCase")]
 pub struct Staker {
     pub address: Address,
-    pub active_stake: Coin,
-    pub inactive_stake: Coin,
+    pub balance: Coin,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation: Option<Address>,
-    pub retire_time: u32,
 }
 
 impl Staker {
     pub fn from_staker(staker: &nimiq_account::Staker) -> Self {
         Staker {
             address: staker.address.clone(),
-            active_stake: staker.active_stake,
-            inactive_stake: staker.inactive_stake,
+            balance: staker.balance,
             delegation: staker.delegation.clone(),
-            retire_time: staker.retire_time,
         }
     }
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -455,8 +455,8 @@ impl BlockchainInterface for BlockchainDispatcher {
 
             for address in staker_addresses {
                 let staker = StakingContract::get_staker(accounts_tree, &db_txn, &address).unwrap();
-                if !staker.active_stake.is_zero() {
-                    stakers_map.insert(address, staker.active_stake);
+                if !staker.balance.is_zero() {
+                    stakers_map.insert(address, staker.balance);
                 }
             }
 

--- a/transaction-builder/src/proof/mod.rs
+++ b/transaction-builder/src/proof/mod.rs
@@ -289,7 +289,7 @@ impl TransactionProofBuilder {
     /// let proof_builder = tx_builder.generate().unwrap();
     /// // Unwrap staking proof builder.
     /// let mut staking_proof_builder = proof_builder.unwrap_out_staking();
-    /// staking_proof_builder.drop_validator(&key_pair);
+    /// staking_proof_builder.delete_validator(&key_pair);
     ///
     /// let final_transaction = staking_proof_builder.generate();
     /// assert!(final_transaction.is_some());

--- a/transaction-builder/src/proof/staking_contract.rs
+++ b/transaction-builder/src/proof/staking_contract.rs
@@ -61,10 +61,9 @@ impl StakingDataBuilder {
 /// The `StakingProofBuilder` can be used to build proofs for transactions
 /// to move funds out of the staking contract. These are:
 ///     - Validator
-///         * Drop
+///         * Delete
 ///     - Staker
 ///         * Unstake
-///         * Deduct fees
 #[derive(Clone, Debug)]
 pub struct StakingProofBuilder {
     pub transaction: Transaction,
@@ -80,12 +79,12 @@ impl StakingProofBuilder {
         }
     }
 
-    /// This methods sets the action to drop a validator and builds the corresponding proof
+    /// This methods sets the action to delete a validator and builds the corresponding proof
     /// from a validator's `key_pair`.
-    pub fn drop_validator(&mut self, key_pair: &KeyPair) -> &mut Self {
+    pub fn delete_validator(&mut self, key_pair: &KeyPair) -> &mut Self {
         let signature = key_pair.sign(self.transaction.serialize_content().as_slice());
         let proof = SignatureProof::from(key_pair.public, signature);
-        self.proof = Some(OutgoingStakingTransactionProof::DropValidator { proof });
+        self.proof = Some(OutgoingStakingTransactionProof::DeleteValidator { proof });
         self
     }
 
@@ -95,18 +94,6 @@ impl StakingProofBuilder {
         let signature = key_pair.sign(self.transaction.serialize_content().as_slice());
         let proof = SignatureProof::from(key_pair.public, signature);
         self.proof = Some(OutgoingStakingTransactionProof::Unstake { proof });
-        self
-    }
-
-    /// This methods sets the action to deduct fees and builds the corresponding proof
-    /// from a staker's `key_pair`.
-    pub fn deduct_fees(&mut self, from_active_balance: bool, key_pair: &KeyPair) -> &mut Self {
-        let signature = key_pair.sign(self.transaction.serialize_content().as_slice());
-        let proof = SignatureProof::from(key_pair.public, signature);
-        self.proof = Some(OutgoingStakingTransactionProof::DeductFees {
-            from_active_balance,
-            proof,
-        });
         self
     }
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This removes all unstaking delays from the staking contract. Stakers can now unstake without having to retire their stake first.

## What's in this pull request?
This includes changes in the primitives/account, primitives/transaction, transaction-builder, rpc-interface, rpc-client and rpc-server crates.

- Deletes the retire, reactivate and deduct fees transactions from the staker account. They are no longer needed. 
- Modifies the unstake transaction to have immediate effect. 
- Renames the "retire" and "drop" validator transactions to "inactivate" and "delete".