### PR TITLE
Handle staking transactions correctly

### DIFF
--- a/beserial/beserial_derive/tests/enums.rs
+++ b/beserial/beserial_derive/tests/enums.rs
@@ -167,7 +167,7 @@ fn it_can_handle_enums_with_data() {
         v: vec![1, 2, 3],
     });
     assert_eq!(
-        TestWithData::deserialize_from_vec(&mut &v[..]),
+        TestWithData::deserialize_from_vec(&v[..]),
         Err(SerializingError::LimitExceeded)
     );
 }

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -78,7 +78,7 @@ impl Blockchain {
     }
 
     pub fn get_account(&self, address: &Address) -> Option<Account> {
-        // TODO: Find a better place for this differentiation, it should be in a more general location
+        // TODO: Find a better place for this differentiation, it should be in a more general location.
         let key = if *address == policy::STAKING_CONTRACT_ADDRESS {
             StakingContract::get_key_staking_contract()
         } else {

--- a/blockchain/tests/mod.rs
+++ b/blockchain/tests/mod.rs
@@ -80,7 +80,7 @@ fn it_can_push_consecutive_view_changes() {
         let blockchain = blockchain.read();
         producer.next_micro_block(
             &blockchain,
-            blockchain.time.now() + 1 as u64 * 1000,
+            blockchain.time.now() + 1_u64 * 1000,
             0,
             None,
             vec![],
@@ -89,10 +89,7 @@ fn it_can_push_consecutive_view_changes() {
         )
     };
     assert_eq!(
-        Blockchain::push(
-            blockchain.upgradable_read(),
-            Block::Micro(micro_block.clone())
-        ),
+        Blockchain::push(blockchain.upgradable_read(), Block::Micro(micro_block)),
         Ok(PushResult::Extended)
     );
     assert_eq!(blockchain.read().block_number(), 1);
@@ -104,7 +101,7 @@ fn it_can_push_consecutive_view_changes() {
         let view_change_proof = sign_view_change(blockchain.head().seed().clone(), 2, 5);
         producer.next_micro_block(
             &blockchain,
-            blockchain.time.now() + 2 as u64 * 1000,
+            blockchain.time.now() + 2_u64 * 1000,
             5,
             Some(view_change_proof),
             vec![],
@@ -130,7 +127,7 @@ fn it_can_push_consecutive_view_changes() {
         let view_change_proof = sign_view_change(Block::Micro(micro_block).seed().clone(), 3, 6);
         producer.next_micro_block(
             &blockchain,
-            blockchain.time.now() + 3 as u64 * 1000,
+            blockchain.time.now() + 3_u64 * 1000,
             6,
             Some(view_change_proof),
             vec![],

--- a/bls/src/types/compressed_public_key.rs
+++ b/bls/src/types/compressed_public_key.rs
@@ -122,3 +122,11 @@ mod serde_derive {
         }
     }
 }
+
+impl Default for CompressedPublicKey {
+    fn default() -> Self {
+        CompressedPublicKey {
+            public_key: [0u8; CompressedPublicKey::SIZE],
+        }
+    }
+}

--- a/consensus/tests/request_component.rs
+++ b/consensus/tests/request_component.rs
@@ -25,8 +25,8 @@ async fn test_request_component() {
     let genesis = GenesisBuilder::default()
         .with_genesis_validator(
             Address::from(&key),
-            sgn_key.public.clone(),
-            vtn_key.public_key.clone(),
+            sgn_key.public,
+            vtn_key.public_key,
             Address::default(),
         )
         .generate()

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -192,7 +192,7 @@ impl<
             let best = store
                 .best(level.id)
                 .unwrap_or_else(|| panic!("Expected a best signature for level {}", level.id));
-            self.num_contributors(&best)
+            self.num_contributors(best)
         };
 
         trace!(

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -75,7 +75,7 @@ impl identity::IdentityRegistry for Registry {
     fn signers_identity(&self, signers: &BitSet) -> Identity {
         if signers.len() == 1 {
             Identity::Single(signers.iter().next().unwrap())
-        } else if signers.len() > 0 {
+        } else if !signers.is_empty() {
             Identity::Multiple(signers.iter().collect())
         } else {
             Identity::None

--- a/mempool/src/filter.rs
+++ b/mempool/src/filter.rs
@@ -64,7 +64,7 @@ impl MempoolFilter {
          )
     }
 
-    /// Checks wether a transaction is accepted according to the Mempool filter rules for the recipient balance
+    /// Checks whether a transaction is accepted according to the Mempool filter rules for the recipient balance
     pub fn accepts_recipient_balance(
         &self,
         tx: &Transaction,
@@ -82,7 +82,7 @@ impl MempoolFilter {
             )
     }
 
-    /// Checks wether a transaction is accepted according to the Mempool filter rules for the sender balance
+    /// Checks whether a transaction is accepted according to the Mempool filter rules for the sender balance
     pub fn accepts_sender_balance(
         &self,
         _tx: &Transaction,

--- a/primitives/account/src/staking_contract/receipts.rs
+++ b/primitives/account/src/staking_contract/receipts.rs
@@ -17,6 +17,7 @@ pub struct SlashReceipt {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct UpdateValidatorReceipt {
+    pub no_op: bool,
     pub old_signing_key: SchnorrPublicKey,
     pub old_voting_key: BlsPublicKey,
     pub old_reward_address: Address,
@@ -24,17 +25,20 @@ pub struct UpdateValidatorReceipt {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct RetireValidatorReceipt {
+pub struct InactivateValidatorReceipt {
+    pub no_op: bool,
     pub parked_set: bool,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ReactivateValidatorReceipt {
+    pub no_op: bool,
     pub retire_time: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct UnparkValidatorReceipt {
+    pub no_op: bool,
     pub parked_set: bool,
     #[beserial(len_type(u16))]
     pub current_disabled_slots: Option<BTreeSet<u16>>,
@@ -55,5 +59,6 @@ pub struct DeleteValidatorReceipt {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct StakerReceipt {
+    pub no_op: bool,
     pub delegation: Option<Address>,
 }

--- a/primitives/account/src/staking_contract/staker.rs
+++ b/primitives/account/src/staking_contract/staker.rs
@@ -29,7 +29,6 @@ pub struct Staker {
 
 impl StakingContract {
     /// Creates a new staker. This function is public to fill the genesis staking contract.
-    /// If a staker already exists at this address, we simply stake the value at the existing staker.
     pub fn create_staker(
         accounts_tree: &AccountsTrie,
         db_txn: &mut WriteTransaction,
@@ -39,9 +38,9 @@ impl StakingContract {
     ) -> Result<(), AccountError> {
         // See if the staker already exists.
         if StakingContract::get_staker(accounts_tree, db_txn, staker_address).is_some() {
-            error!("There's already a staker at the address where we are trying to create a new staker. Plan B: Stake the transaction value on the the existing staker!");
-
-            return StakingContract::stake(accounts_tree, db_txn, staker_address, value);
+            return Err(AccountError::AlreadyExistentAddress {
+                address: staker_address.clone(),
+            });
         }
 
         // Get the staking contract and update it.

--- a/primitives/account/src/staking_contract/staker.rs
+++ b/primitives/account/src/staking_contract/staker.rs
@@ -685,7 +685,7 @@ impl StakingContract {
 
             Ok(Some(StakerReceipt {
                 no_op: false,
-                delegation: staker.delegation.clone(),
+                delegation: staker.delegation,
             }))
         } else {
             accounts_tree.put(

--- a/primitives/account/src/staking_contract/traits.rs
+++ b/primitives/account/src/staking_contract/traits.rs
@@ -286,7 +286,12 @@ impl AccountTransactionInteraction for StakingContract {
                 // Get the staker address from the proof.
                 let staker_address = proof.compute_signer();
 
-                StakingContract::revert_create_staker(accounts_tree, db_txn, &staker_address)?;
+                StakingContract::revert_create_staker(
+                    accounts_tree,
+                    db_txn,
+                    &staker_address,
+                    transaction.value,
+                )?;
             }
             IncomingStakingTransactionData::Stake { staker_address } => {
                 StakingContract::revert_stake(

--- a/primitives/account/src/staking_contract/validator.rs
+++ b/primitives/account/src/staking_contract/validator.rs
@@ -71,7 +71,7 @@ pub struct Validator {
 
 impl StakingContract {
     /// Creates a new validator. The initial stake is always equal to the validator deposit
-    /// and can only be retrieved by dropping the validator.
+    /// and can only be retrieved by deleting the validator.
     /// This function is public to fill the genesis staking contract.
     pub fn create_validator(
         accounts_tree: &AccountsTrie,

--- a/primitives/account/src/staking_contract/validator.rs
+++ b/primitives/account/src/staking_contract/validator.rs
@@ -599,7 +599,7 @@ impl StakingContract {
         match validator.inactivity_flag {
             None => {
                 error!(
-                    "Tried to drop a validator which was still active! Validator address {}",
+                    "Tried to delete a validator which was still active! Validator address {}",
                     validator_address
                 );
                 return Err(AccountError::InvalidForSender);

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -192,7 +192,7 @@ fn create_validator_works() {
     // Works in the valid case.
     let tx = make_signed_incoming_transaction(
         IncomingStakingTransactionData::CreateValidator {
-            signing_key: signing_key.clone(),
+            signing_key,
             voting_key: voting_key.clone(),
             proof_of_knowledge: voting_keypair
                 .sign(&voting_key.serialize_to_vec())
@@ -308,7 +308,7 @@ fn update_validator_works() {
 
     let receipt = UpdateValidatorReceipt {
         no_op: false,
-        old_signing_key: old_signing_key.clone(),
+        old_signing_key,
         old_voting_key: old_voting_key.clone(),
         old_reward_address: old_reward_address.clone(),
         old_signal_data: None,
@@ -397,7 +397,7 @@ fn update_validator_works() {
 
     assert_eq!(
         StakingContract::commit_incoming_transaction(&accounts_tree, &mut db_txn, &tx, 2, 0),
-        Ok(Some(no_op_receipt.clone()))
+        Ok(Some(no_op_receipt))
     );
 }
 
@@ -553,7 +553,7 @@ fn inactivate_validator_works() {
 
     let tx = make_signed_incoming_transaction(
         IncomingStakingTransactionData::InactivateValidator {
-            validator_address: fake_address.clone(),
+            validator_address: fake_address,
             proof: SignatureProof::default(),
         },
         0,
@@ -562,7 +562,7 @@ fn inactivate_validator_works() {
 
     assert_eq!(
         StakingContract::commit_incoming_transaction(&accounts_tree, &mut db_txn, &tx, 2, 0),
-        Ok(Some(no_op_receipt.clone()))
+        Ok(Some(no_op_receipt))
     );
 }
 
@@ -716,7 +716,7 @@ fn reactivate_validator_works() {
 
     let tx = make_signed_incoming_transaction(
         IncomingStakingTransactionData::ReactivateValidator {
-            validator_address: fake_address.clone(),
+            validator_address: fake_address,
             proof: SignatureProof::default(),
         },
         0,
@@ -725,7 +725,7 @@ fn reactivate_validator_works() {
 
     assert_eq!(
         StakingContract::commit_incoming_transaction(&accounts_tree, &mut db_txn, &tx, 2, 0),
-        Ok(Some(no_op_receipt.clone()))
+        Ok(Some(no_op_receipt))
     );
 }
 
@@ -866,7 +866,7 @@ fn unpark_validator_works() {
 
     let tx = make_signed_incoming_transaction(
         IncomingStakingTransactionData::UnparkValidator {
-            validator_address: fake_address.clone(),
+            validator_address: fake_address,
             proof: SignatureProof::default(),
         },
         0,
@@ -875,7 +875,7 @@ fn unpark_validator_works() {
 
     assert_eq!(
         StakingContract::commit_incoming_transaction(&accounts_tree, &mut db_txn, &tx, 2, 0),
-        Ok(Some(no_op_receipt.clone()))
+        Ok(Some(no_op_receipt))
     );
 }
 
@@ -932,7 +932,7 @@ fn delete_validator_works() {
     let staker_address = Address::from_any_str(STAKER_ADDRESS).unwrap();
 
     let receipt = DeleteValidatorReceipt {
-        signing_key: signing_key.clone(),
+        signing_key,
         voting_key: voting_key.clone(),
         reward_address: reward_address.clone(),
         signal_data: None,
@@ -1447,7 +1447,7 @@ fn update_staker_works() {
 
     assert_eq!(
         StakingContract::commit_incoming_transaction(&accounts_tree, &mut db_txn, &tx, 2, 0),
-        Ok(Some(no_op_receipt.clone()))
+        Ok(Some(no_op_receipt))
     );
 }
 

--- a/primitives/block/tests/mod.rs
+++ b/primitives/block/tests/mod.rs
@@ -76,7 +76,7 @@ fn it_can_convert_macro_block_into_slots() {
         let address = Address::from(validator_address);
 
         for _ in 0..num_slots {
-            builder.push(address.clone(), voting_key.clone(), signing_key.clone());
+            builder.push(address.clone(), voting_key.clone(), signing_key);
         }
     }
 

--- a/primitives/transaction/tests/staking_contract.rs
+++ b/primitives/transaction/tests/staking_contract.rs
@@ -71,7 +71,7 @@ fn create_validator() {
     // Test serialization and deserialization.
     let mut tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::CreateValidator {
-            signing_key: signing_key.clone(),
+            signing_key,
             voting_key: voting_key.clone(),
             proof_of_knowledge: voting_keypair
                 .sign(&voting_key.serialize_to_vec())
@@ -120,7 +120,7 @@ fn create_validator() {
 
     let tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::CreateValidator {
-            signing_key: signing_key.clone(),
+            signing_key,
             voting_key: voting_key.clone(),
             proof_of_knowledge: invalid_pok.compress(),
             reward_address: Address::from([3u8; 20]),
@@ -177,7 +177,7 @@ fn update_validator() {
     // Test serialization and deserialization.
     let mut tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::UpdateValidator {
-            new_signing_key: Some(signing_key.clone()),
+            new_signing_key: Some(signing_key),
             new_voting_key: Some(voting_key.clone()),
             new_proof_of_knowledge: Some(
                 voting_keypair
@@ -241,7 +241,7 @@ fn update_validator() {
 
     let tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::UpdateValidator {
-            new_signing_key: Some(signing_key.clone()),
+            new_signing_key: Some(signing_key),
             new_voting_key: Some(voting_key.clone()),
             new_proof_of_knowledge: Some(invalid_pok.compress()),
             new_reward_address: Some(Address::from([3u8; 20])),

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -43,7 +43,6 @@ nimiq-mempool = { path = "../mempool" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-primitives = { path = "../primitives" }
 nimiq-tendermint = { path = "../tendermint" }
-nimiq-transaction = { path = "../primitives/transaction" }
 nimiq-transaction-builder = { path = "../transaction-builder" }
 nimiq-utils = { path = "../utils", features = [
     "observer",

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(btree_drain_filter, drain_filter, map_first_last)]
+#![feature(btree_drain_filter, map_first_last)]
 #![allow(dead_code)]
 
 #[macro_use]

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -237,7 +237,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
                 .get_band_from_slot(slot_number);
 
             // Get the validator key.
-            let voting_key = slot.voting_key.uncompress_unchecked().clone();
+            let voting_key = *slot.voting_key.uncompress_unchecked();
             let signing_key = slot.signing_key;
 
             // Calculate the timeout duration.
@@ -288,7 +288,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
             // In case the proposal has a valid round, the original proposer signed the VRF Seed,
             // so the original slot owners key must be retrieved for header verification.
             // View numbers in macro blocks denote the original proposers round.
-            let vrf_key = if let Some(_) = valid_round {
+            let vrf_key = if valid_round.is_some() {
                 let (valid_round_slot, _) = blockchain
                     .get_slot_owner_at(expected_height, header.view_number, None)
                     .expect("Couldn't find slot owner!");


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?
After the mempool refactor, staking transactions were no longer being fully checked in the mempool. This was absolutely necessary to improve performance, however it caused several panics because of staking transactions that were invalid. We introduced a temporary fix where all transactions would be checked before a block was produced. Evidently this is sub-optimal but it did the job. This PR makes a proper fix to this problem and reverts the previous temporary fix.

We now handle staking transactions in two different ways:

1. **They fail gracefully.** Instead of panicking, they fail without consequences. The `update_validator`, `inactivate_validator`, `reactivate_validator`, `unpark_validator` and `update_staker` transactions simply become no-ops. They have no effect on the state if they fail. The `stake` transaction can only fail if there's no `Staker` account at the target address, in this case we create a new `Staker` account at the target address (with no delegation and balance equal to the value of the `stake` transaction).
2. **They are filtered in the mempool.** The mempool does a quick check to see if the transaction can succeed and filters it accordingly. The `delete_validator` and `unstake` transactions are checked because they are outgoing transactions. We need to verify that they have enough _available_ funds to pay the transaction value. The `create_validator` and `create_staker` transactions need to be checked because we cannot create validators/stakers that already exist. Additionally, because of concurrency issues, each `Validator`/`Staker` account can only have one of these types of transactions in the mempool at the same time. For example, if you send two `unstake` transactions from the same `Staker` to the mempool, the second one to arrive will be filtered (even if you had enough funds to pay for both). Since the block times are quite short in Albatross and these are rare transactions, this is unlikely to pose a problem.