### PR TITLE
Properly handle a peer leaving in HistorySync

### DIFF
--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -90,6 +90,18 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
     pub fn agents(&self) -> impl Iterator<Item = &Arc<ConsensusAgent<TNetwork::PeerType>>> {
         self.agents.values().map(|(agent, _)| agent)
     }
+
+    pub fn remove_agent(&mut self, peer_id: <<TNetwork as Network>::PeerType as Peer>::Id) {
+        for cluster in self.epoch_clusters.iter_mut() {
+            cluster.remove_peer(&peer_id);
+        }
+        for cluster in self.checkpoint_clusters.iter_mut() {
+            cluster.remove_peer(&peer_id);
+        }
+        if let Some(cluster) = self.active_cluster.as_mut() {
+            cluster.remove_peer(&peer_id);
+        }
+    }
 }
 
 impl<TNetwork: Network> HistorySyncStream<TNetwork::PeerType> for HistorySync<TNetwork> {

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -358,7 +358,7 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
                             cluster.id
                         )
                     });
-                    pair.1 += 1;
+                    pair.1 = pair.1.saturating_add(1);
                 }
             }
         }
@@ -450,7 +450,7 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
                             cluster.id
                         )
                     });
-                    pair.1 -= 1;
+                    pair.1 = pair.1.saturating_sub(1);
                     pair.1
                 };
 

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -27,7 +27,7 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
                     // Delete the ConsensusAgent from the agents map, removing the only "persistent"
                     // strong reference to it. There might not be an entry for every peer (e.g. if
                     // it didn't send any epoch ids).
-                    // FIXME This doesn't work if we're currently requesting epoch_ids from this peer
+                    self.remove_agent(peer.id());
                     self.agents.remove(&peer);
                 }
                 Ok(NetworkEvent::PeerJoined(peer)) => {

--- a/consensus/src/sync/request_component.rs
+++ b/consensus/src/sync/request_component.rs
@@ -75,11 +75,15 @@ impl<TPeer: Peer + 'static> BlockRequestComponent<TPeer> {
                 Self::NUM_PENDING_BLOCKS,
                 |(target_block_hash, locators), peer| {
                     async move {
-                        let res = peer
-                            .request_missing_blocks(target_block_hash, locators)
-                            .await;
-                        if let Ok(Some(missing_blocks)) = res {
-                            Some(missing_blocks)
+                        if let Some(peer) = Weak::upgrade(&peer) {
+                            let res = peer
+                                .request_missing_blocks(target_block_hash, locators)
+                                .await;
+                            if let Ok(Some(missing_blocks)) = res {
+                                Some(missing_blocks)
+                            } else {
+                                None
+                            }
                         } else {
                             None
                         }

--- a/consensus/src/sync/request_component.rs
+++ b/consensus/src/sync/request_component.rs
@@ -154,7 +154,8 @@ impl<TPeer: Peer + 'static> Stream for BlockRequestComponent<TPeer> {
             match result {
                 Some(HistorySyncReturn::Good(peer)) => {
                     debug!("Adding peer {:?} into follow mode", peer.peer.id());
-                    self.sync_queue.add_peer(Arc::downgrade(&peer));
+                    self.sync_queue
+                        .add_peer(peer.peer.id(), Arc::downgrade(&peer));
                     self.agents.insert(Arc::clone(&peer.peer), peer);
                 }
                 Some(HistorySyncReturn::Outdated(peer)) => {

--- a/network-interface/src/peer/mod.rs
+++ b/network-interface/src/peer/mod.rs
@@ -35,7 +35,7 @@ pub trait RequestResponse {
 #[async_trait]
 // TODO: Use Peer::Error for returned error for send, etc.
 pub trait Peer: Send + Sync + Hash + Eq {
-    type Id: Debug + Send + Sync + Hash + Eq + Unpin;
+    type Id: Clone + Debug + Send + Sync + Hash + Eq + Unpin;
     type Error: std::error::Error;
 
     fn id(&self) -> Self::Id;


### PR DESCRIPTION
- Change `sync_queue` interface to avoid the need of returning strong
  references and make the consumer handle when to upgrade an agent
  reference.
  This allows strong references of consensus agents to be held less
  time and only get upgraded when it is absolutely required.
  Also makes consistent the interface of `sync_queue` handling and
  returning only weak reference counters. 
- Add several changes to properly clean consensus agents from
  `HistorySync`.
  This includes these changes to `sync_queue`:
  - Keep track of the peer ID of each consensus agent to properly
    identify it.
  - Change `has_peer` function to properly detect when a peer has
    been added to the `SyncQueue`. Before, the detection was broken
    since it was using pointer comparison which only works for
    same instance detection.
  - Add a function to remove peers from the `SyncQueue` such that
    when required a proper peer cleaning can be made.  
  
  This also includes an extra function to `HistorySync` to remove
  peers from the different set of clusters present. This function is
  also called upon the detection of the `PeerLeft` event such that
  no stale peers are found in clusters while a peer was already been
  removed from the list of `HistorySync` agents as it was happening
  in #498.

This fixes #498.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.