### PR TITLE
Use correct validator set for pk_tree_root calculation

### DIFF
--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -129,7 +129,6 @@ impl TemporaryBlockProducer {
                 step: TendermintStep::PreCommit,
                 round_number: 0,
             },
-            validator_merkle_root,
         };
 
         // sign the hash

--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -13,7 +13,7 @@ use nimiq_bls::{AggregateSignature, KeyPair as BlsKeyPair, SecretKey as BlsSecre
 use nimiq_collections::BitSet;
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
-use nimiq_hash::Blake2bHash;
+use nimiq_hash::Blake2sHash;
 use nimiq_keys::{KeyPair as SchnorrKeyPair, PrivateKey as SchnorrPrivateKey};
 use nimiq_primitives::policy;
 use nimiq_utils::time::OffsetTime;
@@ -115,7 +115,7 @@ impl TemporaryBlockProducer {
     pub fn finalize_macro_block(
         proposal: TendermintProposal,
         body: MacroBody,
-        block_hash: Blake2bHash,
+        block_hash: Blake2sHash,
     ) -> MacroBlock {
         let keypair = BlsKeyPair::from(
             BlsSecretKey::deserialize_from_vec(&hex::decode(VOTING_KEY).unwrap()).unwrap(),

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -90,8 +90,7 @@ impl Blockchain {
         // Check the justification.
         if let Err(e) = Blockchain::verify_block_justification(
             &*this,
-            &block.header(),
-            &block.justification(),
+            &block,
             &slot_owner.signing_key,
             Some(&read_txn),
             !trusted,

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -2,8 +2,8 @@ use std::cmp::Ordering;
 
 use beserial::Serialize;
 use nimiq_block::{
-    Block, BlockBody, BlockError, BlockHeader, BlockJustification, BlockType, ForkProof, MacroBody,
-    TendermintProof, ViewChange,
+    Block, BlockBody, BlockError, BlockHeader, BlockType, ForkProof, MacroBody, TendermintProof,
+    ViewChange,
 };
 use nimiq_database::Transaction as DBtx;
 use nimiq_hash::{Blake2bHash, Hash};

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -138,6 +138,17 @@ impl fmt::Debug for Signature {
     }
 }
 
+impl From<G1Projective> for Signature {
+    fn from(signature: G1Projective) -> Self {
+        let compressed = CompressedSignature::from(signature);
+
+        Signature {
+            signature,
+            compressed,
+        }
+    }
+}
+
 #[cfg(feature = "serde-derive")]
 mod serde_derive {
     // TODO: Replace this with a generic serialization using `ToHex` and `FromHex`.

--- a/nano-blockchain/src/push.rs
+++ b/nano-blockchain/src/push.rs
@@ -59,14 +59,7 @@ impl NanoBlockchain {
         }
 
         // Check the justification.
-        Blockchain::verify_block_justification(
-            self,
-            &block.header(),
-            &block.justification(),
-            &slot_owner.signing_key,
-            None,
-            true,
-        )?;
+        Blockchain::verify_block_justification(self, &block, &slot_owner.signing_key, None, true)?;
 
         // Create the chaininfo for the new block.
         let chain_info = match ChainInfo::from_block(block, &prev_info) {

--- a/nano-blockchain/src/sync.rs
+++ b/nano-blockchain/src/sync.rs
@@ -1,4 +1,4 @@
-use nimiq_block::{Block, BlockError};
+use nimiq_block::{Block, BlockError, TendermintProof};
 use nimiq_blockchain::{AbstractBlockchain, ChainInfo, PushError, PushResult};
 use nimiq_nano_zkp::{NanoProof, NanoZKP};
 use nimiq_primitives::policy;
@@ -149,17 +149,9 @@ impl NanoBlockchain {
             }
         }
 
-        // Checks if the justification exists.
-        let justification = block
-            .unwrap_macro_ref()
-            .justification
-            .as_ref()
-            .ok_or(PushError::InvalidBlock(BlockError::NoJustification))?;
-
         // Verify the justification.
-        if !justification.verify(
-            block.hash(),
-            block.block_number(),
+        if !TendermintProof::verify(
+            block.unwrap_macro_ref(),
             &self.current_validators().unwrap(),
         ) {
             return Err(PushError::InvalidBlock(BlockError::InvalidJustification));

--- a/nano-primitives/Cargo.toml
+++ b/nano-primitives/Cargo.toml
@@ -14,6 +14,7 @@ rayon = "^1.5"
 
 ark-crypto-primitives = "0.3"
 ark-ec = "0.3"
+ark-ff = "0.3"
 ark-groth16 = "0.3"
 ark-mnt4-753 = "0.3"
 ark-mnt6-753 = "0.3"
@@ -21,3 +22,12 @@ ark-mnt6-753 = "0.3"
 nimiq-bls = { path = "../bls", version = "0.1" }
 nimiq-hash = { path = "../hash", version = "0.1" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }
+
+[dev-dependencies]
+rand = "0.8"
+
+nimiq-block = { path = "../primitives/block", version = "0.1" }
+nimiq-collections = { path = "../collections", version = "0.1" }
+nimiq-keys = { path = "../keys", version = "0.1" }
+nimiq-utils = { path = "../utils", version = "0.1" }
+nimiq-primitives = { path = "../primitives", features = ["slots"] }

--- a/nano-zkp/src/circuits/mnt4/macro_block.rs
+++ b/nano-zkp/src/circuits/mnt4/macro_block.rs
@@ -209,12 +209,7 @@ impl ConstraintSynthesizer<MNT4Fr> for MacroBlockCircuit {
 
         // Verifying that the block is valid.
         block_var
-            .verify(
-                cs,
-                &final_pk_tree_root_var,
-                &agg_pk_var,
-                &pedersen_generators_var,
-            )?
+            .verify(cs, &final_pk_tree_root_var, &agg_pk_var)?
             .enforce_equal(&Boolean::constant(true))?;
 
         Ok(())

--- a/nano-zkp/src/utils.rs
+++ b/nano-zkp/src/utils.rs
@@ -226,7 +226,7 @@ pub fn create_test_blocks(
 
     for i in 0..SLOTS as usize {
         if signer_bitmap[i] {
-            block.sign(initial_sks[i], i, final_pk_tree_root.clone());
+            block.sign(&initial_sks[i], i, &final_pk_tree_root);
         }
     }
 

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -15,7 +15,7 @@ use crate::signed::{Message, PREFIX_TENDERMINT_PROPOSAL};
 use crate::tendermint::TendermintProof;
 
 /// The struct representing a Macro block (can be either checkpoint or election).
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MacroBlock {
     /// The header, contains some basic information and commitments to the body and the state.
     pub header: MacroHeader,
@@ -27,7 +27,7 @@ pub struct MacroBlock {
 }
 
 /// The struct representing the header of a Macro block (can be either checkpoint or election).
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MacroHeader {
     /// The version number of the block. Changing this always results in a hard fork.
     pub version: u16,

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -84,6 +84,11 @@ impl MacroBlock {
         self.header.hash()
     }
 
+    /// TODO
+    pub fn nano_zkp_hash(&self) -> Blake2bHash {
+        self.header.hash()
+    }
+
     /// Returns whether or not this macro block is an election block.
     pub fn is_election_block(&self) -> bool {
         policy::is_election_block_at(self.header.block_number)
@@ -156,28 +161,4 @@ pub enum IntoSlotsError {
     MissingBody,
     #[error("Not an election macro block")]
     NoElection,
-}
-
-pub fn create_pk_tree_root(slots: &Validators) -> Vec<u8> {
-    // create a
-    let public_keys = (0..policy::SLOTS)
-        // map every index
-        .map(|index| {
-            slots
-                // to the validator with index index
-                .get_validator(index as u16)
-                // then get its public key
-                .voting_key
-                // uncompress it
-                .uncompress()
-                // this as well must succeed for the validator to work at all.
-                .expect("Failed to retrieve public_key")
-                // finally get the G2Projective as implicit type.
-                .public_key
-        })
-        // finally collect to get a Vec<G2Projective>
-        .collect();
-
-    // Create the tree
-    pk_tree_construct(public_keys)
 }

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
-use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
+use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_primitives::policy::TWO_THIRD_SLOTS;
 use nimiq_primitives::slots::Validators;
@@ -140,7 +140,7 @@ pub struct TendermintIdentifier {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TendermintVote {
     /// Hash of the proposed macro block
-    pub proposal_hash: Option<Blake2bHash>,
+    pub proposal_hash: Option<Blake2sHash>,
     /// Identifier to this votes aggregation
     pub id: TendermintIdentifier,
 }

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -5,7 +5,6 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_nano_primitives::pk_tree_construct;
 use nimiq_primitives::policy::TWO_THIRD_SLOTS;
 use nimiq_primitives::slots::Validators;
 

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -66,7 +66,7 @@ impl TendermintProof {
             return false;
         }
 
-        // Calculate the `nano_zkp_hash`. This a special hash that is calculated using the validators
+        // Calculate the `nano_zkp_hash`. This a special hash that is calculated using the `validators`
         // field of the block body. It is necessary for the ZKP proofs used in the nano sync.
         let block_hash = block.nano_zkp_hash();
 

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -22,6 +22,8 @@ pub use utils::*;
 // code. It results in code that is cleaner and easier to understand.
 pub trait ProposalTrait = Clone + Debug + PartialEq + Unpin + Send + Sync + 'static;
 
+pub trait ProposalHashTrait = Clone + Debug + PartialEq + Ord + Unpin + Send + 'static;
+
 pub trait ProofTrait = Clone + Debug + Unpin + Send + 'static;
 
 pub trait ResultTrait = Clone + Debug + Unpin + Send + 'static;

--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -3,7 +3,6 @@
 #[macro_use]
 extern crate log;
 
-use nimiq_hash::Hash;
 use std::fmt::Debug;
 
 pub(crate) mod network;
@@ -21,6 +20,8 @@ pub use utils::*;
 
 // These are trait aliases. We use them instead of repeating these trait bounds all throughout the
 // code. It results in code that is cleaner and easier to understand.
-pub trait ProposalTrait = Clone + Debug + PartialEq + Hash + Unpin + Send + Sync + 'static;
+pub trait ProposalTrait = Clone + Debug + PartialEq + Unpin + Send + Sync + 'static;
+
 pub trait ProofTrait = Clone + Debug + Unpin + Send + 'static;
+
 pub trait ResultTrait = Clone + Debug + Unpin + Send + 'static;

--- a/tendermint/src/network.rs
+++ b/tendermint/src/network.rs
@@ -4,17 +4,22 @@ use crate::utils::{
     aggregation_to_vote, has_2f1_votes, Checkpoint, ProposalResult, Step, VoteDecision, VoteResult,
 };
 use crate::TendermintError;
-use crate::{ProofTrait, ProposalTrait, ResultTrait};
+use crate::{ProofTrait, ProposalHashTrait, ProposalTrait, ResultTrait};
 
 /// This section implements methods to interface with TendermintOutsideDeps. All of them get or
 /// broadcast some information from/to the network, processes it and then updates Tendermint's state.
 impl<
         ProposalTy: ProposalTrait,
+        ProposalHashTy: ProposalHashTrait,
         ProofTy: ProofTrait,
         ResultTy: ResultTrait,
-        DepsTy: TendermintOutsideDeps<ProposalTy = ProposalTy, ResultTy = ResultTy, ProofTy = ProofTy>
-            + 'static,
-    > Tendermint<ProposalTy, ProofTy, ResultTy, DepsTy>
+        DepsTy: TendermintOutsideDeps<
+                ProposalTy = ProposalTy,
+                ProposalHashTy = ProposalHashTy,
+                ResultTy = ResultTy,
+                ProofTy = ProofTy,
+            > + 'static,
+    > Tendermint<ProposalTy, ProposalHashTy, ProofTy, ResultTy, DepsTy>
 {
     /// Wait for a proposal for a given round from that round's proposer. The proposal that we
     /// is guaranteed to be valid.

--- a/tendermint/src/outside_deps.rs
+++ b/tendermint/src/outside_deps.rs
@@ -75,5 +75,9 @@ pub trait TendermintOutsideDeps: Send + Unpin {
         step: Step,
     ) -> Result<AggregationResult<Self::ProofTy>, TendermintError>;
 
+    // Calculates the hash of a given proposal. We have it into a separate function so that
+    // we can support arbitrary hashing schemes.
+    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2bHash;
+
     fn get_background_task(&mut self) -> BoxFuture<'static, ()>;
 }

--- a/tendermint/src/outside_deps.rs
+++ b/tendermint/src/outside_deps.rs
@@ -3,7 +3,7 @@ use crate::utils::{AggregationResult, ProposalResult, Step, TendermintError};
 use crate::{ProofTrait, ProposalTrait, ResultTrait};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
-use nimiq_hash::Blake2bHash;
+use nimiq_hash::Blake2sHash;
 
 /// The (async) trait that we need for all of Tendermint's low-level functions. The functions are
 /// mostly about producing proposals and networking.
@@ -62,7 +62,7 @@ pub trait TendermintOutsideDeps: Send + Unpin {
         &mut self,
         round: u32,
         step: Step,
-        proposal: Option<Blake2bHash>,
+        proposal: Option<Blake2sHash>,
     ) -> Result<AggregationResult<Self::ProofTy>, TendermintError>;
 
     /// Returns the current aggregation for a given round and step. The returned aggregation might
@@ -77,7 +77,7 @@ pub trait TendermintOutsideDeps: Send + Unpin {
 
     // Calculates the hash of a given proposal. We have it into a separate function so that
     // we can support arbitrary hashing schemes.
-    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2bHash;
+    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2sHash;
 
     fn get_background_task(&mut self) -> BoxFuture<'static, ()>;
 }

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -2,7 +2,7 @@ use crate::outside_deps::TendermintOutsideDeps;
 use crate::tendermint::Tendermint;
 use crate::utils::{Checkpoint, Step, VoteDecision};
 use crate::TendermintError;
-use crate::{ProofTrait, ProposalTrait, ResultTrait};
+use crate::{ProofTrait, ProposalHashTrait, ProposalTrait, ResultTrait};
 
 /// This section has methods that implement the Tendermint protocol as described in the original
 /// paper (https://arxiv.org/abs/1807.04938v3).
@@ -21,11 +21,16 @@ use crate::{ProofTrait, ProposalTrait, ResultTrait};
 /// passing form into the state machine form that we use.
 impl<
         ProposalTy: ProposalTrait,
+        ProposalHashTy: ProposalHashTrait,
         ProofTy: ProofTrait,
         ResultTy: ResultTrait,
-        DepsTy: TendermintOutsideDeps<ProposalTy = ProposalTy, ResultTy = ResultTy, ProofTy = ProofTy>
-            + 'static,
-    > Tendermint<ProposalTy, ProofTy, ResultTy, DepsTy>
+        DepsTy: TendermintOutsideDeps<
+                ProposalTy = ProposalTy,
+                ProposalHashTy = ProposalHashTy,
+                ResultTy = ResultTy,
+                ProofTy = ProofTy,
+            > + 'static,
+    > Tendermint<ProposalTy, ProposalHashTy, ProofTy, ResultTy, DepsTy>
 {
     /// Lines 11-21 of Tendermint consensus algorithm (Algorithm 1)
     pub(crate) async fn start_round(&mut self) -> Result<(), TendermintError> {

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -1,16 +1,21 @@
 use crate::outside_deps::TendermintOutsideDeps;
 use crate::state::TendermintState;
-use crate::{ProofTrait, ProposalTrait, ResultTrait};
+use crate::{ProofTrait, ProposalHashTrait, ProposalTrait, ResultTrait};
 
 /// This is the struct that implements the Tendermint state machine. Its only fields are deps
 /// (dependencies, any type that implements the trait TendermintOutsideDeps, needed for a variety of
 /// low-level tasks) and state (stores the current state of Tendermint).
 pub struct Tendermint<
     ProposalTy: ProposalTrait,
+    ProposalHashTy: ProposalHashTrait,
     ProofTy: ProofTrait,
     ResultTy: ResultTrait,
-    DepsTy: TendermintOutsideDeps<ProposalTy = ProposalTy, ResultTy = ResultTy, ProofTy = ProofTy>
-        + 'static,
+    DepsTy: TendermintOutsideDeps<
+            ProposalTy = ProposalTy,
+            ProposalHashTy = ProposalHashTy,
+            ResultTy = ResultTy,
+            ProofTy = ProofTy,
+        > + 'static,
 > {
     pub deps: DepsTy,
     pub state: TendermintState<ProposalTy, ProofTy>,

--- a/tendermint/src/utils.rs
+++ b/tendermint/src/utils.rs
@@ -1,7 +1,6 @@
 use crate::state::TendermintState;
-use crate::{ProofTrait, ProposalTrait, ResultTrait};
+use crate::{ProofTrait, ProposalHashTrait, ProposalTrait, ResultTrait};
 use nimiq_block::TendermintStep;
-use nimiq_hash::Blake2sHash;
 use nimiq_primitives::policy::TWO_THIRD_SLOTS;
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -76,12 +75,12 @@ pub enum VoteResult<ProofTy: ProofTrait> {
 /// Represents the results we can get from calling `broadcast_and_aggregate` from
 /// TendermintOutsideDeps.
 #[derive(Clone, Debug)]
-pub enum AggregationResult<ProofTy: ProofTrait> {
+pub enum AggregationResult<ProposalHashTy: ProposalHashTrait, ProofTy: ProofTrait> {
     // If the aggregation was able to complete (get 2f+1 votes), we receive a BTreeMap of the
     // different vote messages (Some(hash) is a vote for a proposal with that hash, None is a vote
     // for Nil) along with the corresponding proofs (the aggregation of the votes signatures) and
     // a integer representing how many votes were received for that particular message.
-    Aggregation(BTreeMap<Option<Blake2sHash>, (ProofTy, usize)>),
+    Aggregation(BTreeMap<Option<ProposalHashTy>, (ProofTy, usize)>),
     // Means that we have received f+1 messages for a round greater than our current one. The field
     // states for which round we received those messages.
     NewRound(u32),
@@ -124,26 +123,26 @@ pub enum StreamResult<ProposalTy: ProposalTrait, ProofTy: ProofTrait, ResultTy: 
 /// An utility function that converts an AggregationResult into a VoteResult. The AggregationResult
 /// just returns the raw vote messages it got (albeit in an aggregated form), so we need provide the
 /// semantics to translate that into the VoteResult that the Tendermint protocol expects.
-pub(crate) fn aggregation_to_vote<ProofTy: ProofTrait>(
+pub(crate) fn aggregation_to_vote<ProposalHashTy: ProposalHashTrait, ProofTy: ProofTrait>(
     // This is the hash of the current proposal (None means we don't have a current proposal).
-    proposal: Option<Blake2sHash>,
-    aggregation: AggregationResult<ProofTy>,
+    proposal_hash: Option<ProposalHashTy>,
+    aggregation: AggregationResult<ProposalHashTy, ProofTy>,
 ) -> VoteResult<ProofTy> {
     match aggregation {
         // If we got an aggregation we need to handle it.
         AggregationResult::Aggregation(agg) => {
-            if proposal.is_some()
-                && agg.get(&proposal).map_or(0, |x| x.1) >= TWO_THIRD_SLOTS as usize
+            if proposal_hash.is_some()
+                && agg.get(&proposal_hash).map_or(0, |x| x.1) >= TWO_THIRD_SLOTS as usize
             {
                 log::debug!(
                     "Aggregate: {:#?}\nCurrent proposal {:?} has {} votes",
                     &agg,
-                    &proposal,
-                    agg.get(&proposal).map_or(0, |x| x.1),
+                    &proposal_hash,
+                    agg.get(&proposal_hash).map_or(0, |x| x.1),
                 );
                 // If we received 2f+1 votes for the current (assuming that it isn't None), then we
                 // must return Block.
-                VoteResult::Block(agg.get(&proposal).cloned().unwrap().0)
+                VoteResult::Block(agg.get(&proposal_hash).cloned().unwrap().0)
             } else if agg.get(&None).map_or(0, |x| x.1) >= TWO_THIRD_SLOTS as usize {
                 log::debug!(
                     "Aggregate: {:#?}\nNil has {} votes",
@@ -170,9 +169,9 @@ pub(crate) fn aggregation_to_vote<ProofTy: ProofTrait>(
 
 /// An utility function that checks if a given AggregationResult has 2f+1 votes for a given
 /// proposal.
-pub(crate) fn has_2f1_votes<ProofTy: ProofTrait>(
-    proposal: Blake2sHash,
-    aggregation: AggregationResult<ProofTy>,
+pub(crate) fn has_2f1_votes<ProposalHashTy: ProposalHashTrait, ProofTy: ProofTrait>(
+    proposal: ProposalHashTy,
+    aggregation: AggregationResult<ProposalHashTy, ProofTy>,
 ) -> bool {
     let agg = match aggregation {
         AggregationResult::Aggregation(v) => v,

--- a/tendermint/src/utils.rs
+++ b/tendermint/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::state::TendermintState;
 use crate::{ProofTrait, ProposalTrait, ResultTrait};
 use nimiq_block::TendermintStep;
-use nimiq_hash::Blake2bHash;
+use nimiq_hash::Blake2sHash;
 use nimiq_primitives::policy::TWO_THIRD_SLOTS;
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -81,7 +81,7 @@ pub enum AggregationResult<ProofTy: ProofTrait> {
     // different vote messages (Some(hash) is a vote for a proposal with that hash, None is a vote
     // for Nil) along with the corresponding proofs (the aggregation of the votes signatures) and
     // a integer representing how many votes were received for that particular message.
-    Aggregation(BTreeMap<Option<Blake2bHash>, (ProofTy, usize)>),
+    Aggregation(BTreeMap<Option<Blake2sHash>, (ProofTy, usize)>),
     // Means that we have received f+1 messages for a round greater than our current one. The field
     // states for which round we received those messages.
     NewRound(u32),
@@ -126,7 +126,7 @@ pub enum StreamResult<ProposalTy: ProposalTrait, ProofTy: ProofTrait, ResultTy: 
 /// semantics to translate that into the VoteResult that the Tendermint protocol expects.
 pub(crate) fn aggregation_to_vote<ProofTy: ProofTrait>(
     // This is the hash of the current proposal (None means we don't have a current proposal).
-    proposal: Option<Blake2bHash>,
+    proposal: Option<Blake2sHash>,
     aggregation: AggregationResult<ProofTy>,
 ) -> VoteResult<ProofTy> {
     match aggregation {
@@ -171,7 +171,7 @@ pub(crate) fn aggregation_to_vote<ProofTy: ProofTrait>(
 /// An utility function that checks if a given AggregationResult has 2f+1 votes for a given
 /// proposal.
 pub(crate) fn has_2f1_votes<ProofTy: ProofTrait>(
-    proposal: Blake2bHash,
+    proposal: Blake2sHash,
     aggregation: AggregationResult<ProofTy>,
 ) -> bool {
     let agg = match aggregation {

--- a/tendermint/tests/mod.rs
+++ b/tendermint/tests/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use beserial::Serialize;
 use futures::{FutureExt, StreamExt};
-use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
+use nimiq_hash::{Blake2sHash, Hash, SerializeContent};
 use nimiq_primitives::policy::{SLOTS, TWO_THIRD_SLOTS};
 use nimiq_tendermint::*;
 use std::collections::BTreeMap;
@@ -127,7 +127,7 @@ impl TendermintOutsideDeps for TestValidator {
         &mut self,
         round: u32,
         step: Step,
-        _proposal: Option<Blake2bHash>,
+        _proposal: Option<Blake2sHash>,
     ) -> Result<AggregationResult<Self::ProofTy>, TendermintError> {
         // Calculate the hashes for the proposals 'A' and 'B'.
         let a_hash = TestProposal('A', 0).hash();
@@ -211,7 +211,7 @@ impl TendermintOutsideDeps for TestValidator {
         }
     }
 
-    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2bHash {
+    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2sHash {
         proposal.hash()
     }
 

--- a/tendermint/tests/mod.rs
+++ b/tendermint/tests/mod.rs
@@ -211,6 +211,10 @@ impl TendermintOutsideDeps for TestValidator {
         }
     }
 
+    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2bHash {
+        proposal.hash()
+    }
+
     fn get_background_task(&mut self) -> futures::future::BoxFuture<'static, ()> {
         futures::future::pending().boxed()
     }

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -104,7 +104,6 @@ pub fn sign_macro_block(
             round_number: 0,
             step: TendermintStep::PreCommit,
         },
-        validator_merkle_root,
     };
 
     // Create signed precommit.

--- a/validator/src/aggregation/tendermint/aggregations.rs
+++ b/validator/src/aggregation/tendermint/aggregations.rs
@@ -80,7 +80,6 @@ impl<N: ValidatorNetwork> TendermintAggregations<N> {
         &mut self,
         id: TendermintIdentifier,
         own_contribution: TendermintContribution,
-        validator_merkle_root: Vec<u8>,
         output_sink: Box<
             (dyn Sink<
                 (
@@ -104,7 +103,6 @@ impl<N: ValidatorNetwork> TendermintAggregations<N> {
                 self.validator_id as usize,
                 1, // To be removed
                 id.clone(),
-                validator_merkle_root,
             );
 
             let (sender, receiver) =
@@ -181,17 +179,9 @@ impl<N: ValidatorNetwork + 'static> Stream for TendermintAggregations<N> {
     ) -> Poll<Option<Self::Item>> {
         while let Poll::Ready(Some(event)) = self.event_receiver.poll_recv(cx) {
             match event {
-                AggregationEvent::Start(
-                    id,
-                    own_contribution,
-                    validator_merkle_root,
-                    output_sink,
-                ) => self.broadcast_and_aggregate(
-                    id,
-                    own_contribution,
-                    validator_merkle_root,
-                    output_sink,
-                ),
+                AggregationEvent::Start(id, own_contribution, output_sink) => {
+                    self.broadcast_and_aggregate(id, own_contribution, output_sink)
+                }
                 AggregationEvent::Cancel(round, step) => self.cancel_aggregation(round, step),
             }
         }

--- a/validator/src/aggregation/tendermint/contribution.rs
+++ b/validator/src/aggregation/tendermint/contribution.rs
@@ -1,17 +1,17 @@
 use std::collections::BTreeMap;
 
 use beserial::{Deserialize, Serialize};
+use hash::Blake2sHash;
 use nimiq_block::{MultiSignature, TendermintVote};
 use nimiq_bls::{AggregateSignature, SecretKey};
 use nimiq_collections::bitset::BitSet;
-use nimiq_hash::Blake2bHash;
 
 use nimiq_handel::contribution::{AggregatableContribution, ContributionError};
 
 #[derive(Serialize, Deserialize, std::fmt::Debug, Clone)]
 pub struct TendermintContribution {
     #[beserial(len_type(u16))]
-    pub contributions: BTreeMap<Option<Blake2bHash>, MultiSignature>,
+    pub contributions: BTreeMap<Option<Blake2sHash>, MultiSignature>,
 }
 
 impl TendermintContribution {

--- a/validator/src/aggregation/tendermint/protocol.rs
+++ b/validator/src/aggregation/tendermint/protocol.rs
@@ -29,7 +29,6 @@ impl TendermintAggregationProtocol {
         node_id: usize,
         threshold: usize,
         id: TendermintIdentifier,
-        validator_merkle_root: Vec<u8>,
     ) -> Self {
         let partitioner = Arc::new(BinomialPartitioner::new(node_id, validators.len()));
 
@@ -45,11 +44,7 @@ impl TendermintAggregationProtocol {
             threshold,
         ));
 
-        let verifier = Arc::new(TendermintVerifier::new(
-            validators.clone(),
-            id,
-            validator_merkle_root,
-        ));
+        let verifier = Arc::new(TendermintVerifier::new(validators.clone(), id));
 
         Self {
             verifier,

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -7,9 +7,7 @@ use futures::{future, StreamExt};
 use tokio::{sync::mpsc, time};
 
 use bls::SecretKey;
-use nimiq_block::{
-    MacroBlock, MultiSignature, TendermintIdentifier, TendermintStep, TendermintVote,
-};
+use nimiq_block::{MultiSignature, TendermintIdentifier, TendermintStep, TendermintVote};
 use nimiq_handel::{identity::WeightRegistry, update::LevelUpdateMessage};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{policy, slots::Validators};

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -27,12 +27,12 @@ use super::{
     utils::{AggregationEvent, CurrentAggregation},
 };
 
-/// Adaption for tendermint not using the handel stream directly. Ideally all of what this Adapter does would be done callerside just using the stream
+/// Adaption for tendermint not using the handel stream directly. Ideally all of what this Adapter
+/// does would be done callerside just using the stream
 pub struct HandelTendermintAdapter<N: ValidatorNetwork> {
     current_bests: Arc<RwLock<BTreeMap<(u32, TendermintStep), TendermintContribution>>>,
     current_aggregate: Arc<RwLock<Option<CurrentAggregation>>>,
     pending_new_round: Arc<RwLock<Option<u32>>>,
-    validator_merkle_root: Vec<u8>,
     block_height: u32,
     secret_key: SecretKey,
     validator_id: u16,
@@ -53,8 +53,6 @@ where
         network: Arc<N>,
         secret_key: SecretKey,
     ) -> Self {
-        let validator_merkle_root = MacroBlock::create_pk_tree_root(&active_validators);
-
         // the input stream is all levelUpdateMessages concerning a TendermintContribution and TendermintIdentifier.
         // We get rid of the sender, but while processing these messages they need to be dispatched to the appropriate Aggregation.
         let input = Box::pin(
@@ -100,7 +98,6 @@ where
             current_bests,
             current_aggregate,
             pending_new_round,
-            validator_merkle_root,
             block_height,
             secret_key,
             validator_id,
@@ -114,7 +111,8 @@ where
     /// starts an aggregation for given `round` and `step`.
     /// * `round` is the number indicating in which round Tendermint is
     /// * `step` is either `TendermintStep::PreVote` or `Tendermint::PreCommit`.
-    /// * `proposal` is the hash of the proposed macro block header this node wants to vote for or `None`, if this node wishes to not vote for any block.
+    /// * `proposal` is the hash of the proposed macro block header this node wants to vote for or
+    ///     `None`, if this node wishes to not vote for any block.
     pub async fn broadcast_and_aggregate(
         &mut self,
         round: u32,
@@ -183,7 +181,6 @@ where
             .send(AggregationEvent::Start(
                 id.clone(),
                 own_contribution,
-                self.validator_merkle_root.clone(),
                 output_sink,
             ))
             .await

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -117,7 +117,7 @@ where
         round: u32,
         step: impl Into<TendermintStep>,
         proposal_hash: Option<Blake2sHash>,
-    ) -> Result<AggregationResult<MultiSignature>, TendermintError> {
+    ) -> Result<AggregationResult<Blake2sHash, MultiSignature>, TendermintError> {
         let step = step.into();
         // make sure that there is no currently ongoing aggregation from a previous call to `broadcast_and_aggregate` which has not yet been awaited.
         // if there is none make sure to set this one with the same lock to prevent a race condition
@@ -137,7 +137,7 @@ where
                 None => {
                     // create channel foor result propagation
                     let (sender, aggregate_receiver) =
-                        mpsc::unbounded_channel::<AggregationResult<MultiSignature>>();
+                        mpsc::unbounded_channel::<AggregationResult<Blake2sHash, MultiSignature>>();
                     // set the current aggregate
                     *current_aggregate = Some(CurrentAggregation {
                         sender: sender.clone(),
@@ -347,7 +347,7 @@ where
         &self,
         round: u32,
         step: impl Into<TendermintStep>,
-    ) -> Result<AggregationResult<MultiSignature>, TendermintError> {
+    ) -> Result<AggregationResult<Blake2sHash, MultiSignature>, TendermintError> {
         if let Some(current_best) = self
             .current_bests
             .read()

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -55,7 +55,7 @@ where
     ) -> Self {
         let validator_merkle_root = MacroBlock::create_pk_tree_root(&active_validators);
 
-        // the input stream is all levelUpdateMessages concerning a TendemrintContribution and TendemrintIdentifier.
+        // the input stream is all levelUpdateMessages concerning a TendermintContribution and TendermintIdentifier.
         // We get rid of the sender, but while processing these messages they need to be dispatched to the appropriate Aggregation.
         let input = Box::pin(
             network
@@ -153,7 +153,7 @@ where
             }
         };
 
-        // Assemble identifier from availablle information
+        // Assemble identifier from available information
         let id = TendermintIdentifier {
             block_number: self.block_height,
             round_number: round,
@@ -164,7 +164,6 @@ where
         let vote = TendermintVote {
             proposal_hash: proposal_hash.clone(),
             id: id.clone(),
-            validator_merkle_root: self.validator_merkle_root.clone(),
         };
 
         // Create the signed contribution of this validator

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -7,9 +7,10 @@ use futures::{future, StreamExt};
 use tokio::{sync::mpsc, time};
 
 use bls::SecretKey;
+use hash::Blake2sHash;
 use nimiq_block::{MultiSignature, TendermintIdentifier, TendermintStep, TendermintVote};
 use nimiq_handel::{identity::WeightRegistry, update::LevelUpdateMessage};
-use nimiq_hash::Blake2bHash;
+
 use nimiq_primitives::{policy, slots::Validators};
 use nimiq_tendermint::{AggregationResult, TendermintError};
 use nimiq_validator_network::ValidatorNetwork;
@@ -115,7 +116,7 @@ where
         &mut self,
         round: u32,
         step: impl Into<TendermintStep>,
-        proposal_hash: Option<Blake2bHash>,
+        proposal_hash: Option<Blake2sHash>,
     ) -> Result<AggregationResult<MultiSignature>, TendermintError> {
         let step = step.into();
         // make sure that there is no currently ongoing aggregation from a previous call to `broadcast_and_aggregate` which has not yet been awaited.

--- a/validator/src/aggregation/tendermint/utils.rs
+++ b/validator/src/aggregation/tendermint/utils.rs
@@ -49,7 +49,6 @@ pub enum AggregationEvent<N: ValidatorNetwork> {
     Start(
         TendermintIdentifier,
         TendermintContribution,
-        Vec<u8>,
         Box<NetworkSink<LevelUpdateMessage<TendermintContribution, TendermintIdentifier>, N>>,
     ),
     Cancel(u32, TendermintStep),
@@ -58,7 +57,7 @@ pub enum AggregationEvent<N: ValidatorNetwork> {
 impl<N: ValidatorNetwork> std::fmt::Debug for AggregationEvent<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AggregationEvent::Start(i, _, _, _) => f.debug_struct("Start").field("id", i).finish(),
+            AggregationEvent::Start(i, _, _) => f.debug_struct("Start").field("id", i).finish(),
             AggregationEvent::Cancel(r, s) => f.debug_struct("Start").field("id", &(r, s)).finish(),
         }
     }

--- a/validator/src/aggregation/tendermint/utils.rs
+++ b/validator/src/aggregation/tendermint/utils.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use handel::update::LevelUpdateMessage;
+use hash::Blake2sHash;
 use nimiq_validator_network::ValidatorNetwork;
 use tokio::sync::mpsc;
 
@@ -16,7 +17,7 @@ use super::contribution::TendermintContribution;
 /// Struct intended to track the currently awaited round and step of Aggregation.
 pub(super) struct CurrentAggregation {
     /// Channel which results are send to
-    pub(super) sender: mpsc::UnboundedSender<AggregationResult<MultiSignature>>,
+    pub(super) sender: mpsc::UnboundedSender<AggregationResult<Blake2sHash, MultiSignature>>,
     /// The round of the current aggregation
     pub(super) round: u32,
     /// The Step of the current aggregation

--- a/validator/src/aggregation/tendermint/verifier.rs
+++ b/validator/src/aggregation/tendermint/verifier.rs
@@ -15,19 +15,13 @@ use super::contribution::TendermintContribution;
 pub(crate) struct TendermintVerifier<I: IdentityRegistry> {
     identity_registry: Arc<I>,
     id: TendermintIdentifier,
-    validator_merkle_root: Vec<u8>,
 }
 
 impl<I: IdentityRegistry> TendermintVerifier<I> {
-    pub(crate) fn new(
-        identity_registry: Arc<I>,
-        id: TendermintIdentifier,
-        validator_merkle_root: Vec<u8>,
-    ) -> Self {
+    pub(crate) fn new(identity_registry: Arc<I>, id: TendermintIdentifier) -> Self {
         Self {
             identity_registry,
             id,
-            validator_merkle_root,
         }
     }
 }

--- a/validator/src/aggregation/tendermint/verifier.rs
+++ b/validator/src/aggregation/tendermint/verifier.rs
@@ -61,7 +61,6 @@ impl<I: IdentityRegistry + Sync + Send + 'static> Verifier for TendermintVerifie
             let vote = TendermintVote {
                 id: self.id.clone(),
                 proposal_hash: hash.clone(),
-                validator_merkle_root: self.validator_merkle_root.clone(),
             };
 
             results.push(task::spawn_blocking(move || {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -82,7 +82,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
     /// This function is meant to verify the validity of a TendermintState. However, this function
     /// is only used when Tendermint is starting from a saved state. There is no reasonable
     /// situation where anyone would need to edit the saved TendermintState, so there's no situation
-    /// where the TendermintState feed into this function would be invalid (unless it gets corrupted
+    /// where the TendermintState fed into this function would be invalid (unless it gets corrupted
     /// in memory, but then we have bigger problems).
     /// So, we leave this function simply returning true and not doing any checks. Mostly likely we
     /// will get rid of it in the future.
@@ -392,7 +392,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
             .await
     }
 
-    /// Returns the vote aggregation for a given proposal and round. It simply calls the aggregation
+    /// Returns the vote aggregation for a given round and step. It simply calls the aggregation
     /// adapter, which does all the work.
     async fn get_aggregation(
         &mut self,

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -402,6 +402,11 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
         self.aggregation_adapter.get_aggregate(round, step)
     }
 
+    // TODO
+    fn hash_proposal(&self, proposal: Self::ProposalTy) -> Blake2bHash {
+        proposal.hash()
+    }
+
     fn get_background_task(&mut self) -> BoxFuture<'static, ()> {
         self.aggregation_adapter.create_background_task().boxed()
     }

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -73,6 +73,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
     for TendermintInterface<TValidatorNetwork>
 {
     type ProposalTy = MacroHeader;
+    type ProposalHashTy = Blake2sHash;
     type ProofTy = MultiSignature;
     type ResultTy = MacroBlock;
 
@@ -400,10 +401,10 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
         &mut self,
         round: u32,
         step: Step,
-        proposal: Option<Blake2sHash>,
-    ) -> Result<AggregationResult<Self::ProofTy>, TendermintError> {
+        proposal_hash: Option<Self::ProposalHashTy>,
+    ) -> Result<AggregationResult<Self::ProposalHashTy, Self::ProofTy>, TendermintError> {
         self.aggregation_adapter
-            .broadcast_and_aggregate(round, step, proposal)
+            .broadcast_and_aggregate(round, step, proposal_hash)
             .await
     }
 
@@ -413,12 +414,12 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
         &mut self,
         round: u32,
         step: Step,
-    ) -> Result<AggregationResult<Self::ProofTy>, TendermintError> {
+    ) -> Result<AggregationResult<Self::ProposalHashTy, Self::ProofTy>, TendermintError> {
         self.aggregation_adapter.get_aggregate(round, step)
     }
 
     /// Simply fetches the cached proposal hash.
-    fn hash_proposal(&self, _proposal: Self::ProposalTy) -> Blake2sHash {
+    fn hash_proposal(&self, _proposal: Self::ProposalTy) -> Self::ProposalHashTy {
         self.cache_hash
             .clone()
             .expect("Tried to fetch a non-existing proposal hash. This shouldn't happen!")


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes #326.

## What's in this pull request?
This PR changes the way the pk_tree_root is incorporated into the macro block hash that the validators sign. First, we created a new method `nano_zkp_hash` that calculates the block hash like so:

> nano_zkp_hash = Blake2s( Blake2b(header) || pk_tree_root )

Only election blocks have the `validators` field, which contain the validators for the next epoch, so for checkpoint blocks the `pk_tree_root` doesn't exist. Then, for checkpoint blocks the method simply returns:

> nano_zkp_hash = Blake2s( Blake2b(header) )

Then we entirely removed the `pk_tree_root`/`validator_merkle_root` fields from the `validator` crate and the `TendermintVote` struct. This way the whole Tendermint/Handel codebase has no notion of the `pk_tree_root`.
Finally, we modified the `nano-primitives` and `nano-zkp` crates to match the new hash function for the macro blocks.