### PR TITLE
Reduce number of validators in release mode CI test

### DIFF
--- a/.github/workflows/release_mode_scenarios.yml
+++ b/.github/workflows/release_mode_scenarios.yml
@@ -36,7 +36,7 @@ jobs:
         command: build
     - name: Executes the test
       run: |
-          bash scripts/devnet/devnet.sh --validators 10 -R -s 800 -k 0
+          bash scripts/devnet/devnet.sh --validators 5 -R -s 500 -k 0
     - name: Archive test results
       if: always()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Reduced the number of validators in release mode in our CI tests
and reduced the number of transactions per block in the spammer
to 500

