### PR TITLE
Add workaround to avoid cleaning specific crates in devnet scripts

### DIFF
--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -2,7 +2,7 @@ name: Devnet Scenarios
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
     default: "default"
 

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -171,7 +171,7 @@ echo "Config files generated in '$configdir'"
 echo "Initializing genesis..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG="$PWD/$configdir/dev-albatross.toml"
 echo "Compiling the code using genesis from '$NIMIQ_OVERRIDE_DEVNET_CONFIG' ..."
-$cargo_clean -p nimiq-genesis
+$cargo_clean
 $cargo_build
 echo "Done."
 

--- a/scripts/devnet_docker_scenario.sh
+++ b/scripts/devnet_docker_scenario.sh
@@ -51,7 +51,7 @@ echo "Copying the genesis and docker compose files... "
 #Compile the code
 echo "Compiling the code using '$tmp_dir/dev-albatross.toml' ..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG=$tmp_dir/dev-albatross.toml
-cargo clean -p nimiq-genesis --release
+cargo clean --release
 cargo build --release
 
 echo "Create docker images... "


### PR DESCRIPTION
- Change the devnet actions CI frequency to run each 2 hours instead
  of each hour.
  This is because the script would take more time to run due to a WA
  for a recent `rustc` issue where we need to clean the whole project
  to compile a new genesis.
- Avoid cleaning specific crates since latest `rustc` nightly
  presents issues with the disk cache when doing a clean of a
  specific crate as reported
  [here](https://github.com/rust-lang/rust/issues/92163).
  This affects only the devnet scripts and would make the CI to
  take longer to run these scripts.

