### PR TITLE
AccountsHashMismatch fix and IOOB fix

### DIFF
--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -55,6 +55,12 @@ impl TemporaryBlockProducer {
     }
 
     pub fn next_block(&self, view_number: u32, extra_data: Vec<u8>) -> Block {
+        let block = self.next_block_no_push(view_number, extra_data);
+        assert_eq!(self.push(block.clone()), Ok(PushResult::Extended));
+        block
+    }
+
+    pub fn next_block_no_push(&self, view_number: u32, extra_data: Vec<u8>) -> Block {
         let blockchain = self.blockchain.read();
 
         let height = blockchain.block_number() + 1;
@@ -63,7 +69,7 @@ impl TemporaryBlockProducer {
             let macro_block_proposal = self.producer.next_macro_block_proposal(
                 &blockchain,
                 blockchain.time.now() + height as u64 * 1000,
-                0u32,
+                view_number,
                 extra_data,
             );
 
@@ -108,7 +114,6 @@ impl TemporaryBlockProducer {
         // drop the lock before pushing the block as that will acquire write eventually
         drop(blockchain);
 
-        assert_eq!(self.push(block.clone()), Ok(PushResult::Extended));
         block
     }
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -233,7 +233,7 @@ impl Blockchain {
         if let Err(e) = this.check_and_commit(
             &this.state,
             &chain_info.head,
-            prev_info.head.view_number(),
+            prev_info.head.next_view_number(),
             &mut txn,
         ) {
             txn.abort();

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -371,7 +371,7 @@ impl Blockchain {
                         &this.state.accounts,
                         &mut write_txn,
                         micro_block,
-                        prev_info.head.view_number(),
+                        prev_info.head.next_view_number(),
                     )?;
 
                     assert_eq!(


### PR DESCRIPTION
Prior to this PR any Micro block directly succeeding a MacroBlock with a non-zero round number cannot get view changed. Every Validator who attempts it will be unable to push its own block due to an `AccountsHashMismatch`, because the `view_number` calculation was faulty. The other Validators then view change and the next producer awaits the same fate, ultimately halting the network.

The view number calculation is fixed in this PR and a test is added to avoid regression. Related is #423 as the fix re-introduces the IOOB, which is also fixed again in this PR. The test does also test against regression of #423. 