### PR TITLE
Fix some clippy warnings

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -280,7 +280,7 @@ impl Blockchain {
         this.state.main_chain = chain_info;
         this.state.head_hash = block_hash.clone();
 
-        // Downgrade the lock again as the nofity listeners might want to acquire read access themselves.
+        // Downgrade the lock again as the notify listeners might want to acquire read access themselves.
         let this = RwLockWriteGuard::downgrade_to_upgradable(this);
 
         if is_election_block {

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -174,23 +174,21 @@ impl Handle<ResponseBlocks> for RequestMissingBlocks {
         // if no start_block can be found, assume the last macro block before target_block
         let start_block = if let Some(block) = start_block {
             block
+        } else if let Some(block) = blockchain.get_block_at(
+            policy::macro_block_before(target_block.block_number()),
+            false,
+            None,
+        ) {
+            block
         } else {
-            if let Some(block) = blockchain.get_block_at(
-                policy::macro_block_before(target_block.block_number()),
-                false,
-                None,
-            ) {
-                block
-            } else {
-                debug!(
-                    "ResponseBlocks [{}] - unknown locators and preceding macro block",
-                    self.request_identifier
-                );
-                return ResponseBlocks {
-                    blocks: None,
-                    request_identifier: self.get_request_identifier(),
-                };
-            }
+            debug!(
+                "ResponseBlocks [{}] - unknown locators and preceding macro block",
+                self.request_identifier
+            );
+            return ResponseBlocks {
+                blocks: None,
+                request_identifier: self.get_request_identifier(),
+            };
         };
 
         // Check that the distance is sensible.

--- a/consensus/src/sync/block_queue.rs
+++ b/consensus/src/sync/block_queue.rs
@@ -116,7 +116,7 @@ impl<N: Network> Inner<N> {
 
         // Ideally we would acquire upgradable read here. And provide it to push_block. RwLockUpgradableRead however is not
         // Send and cannot be moved into the future that is created.
-        // Howoever the push_block does not push the block but creates a future which pushes the block.
+        // However the push_block does not push the block but creates a future which pushes the block.
         // Hence every future would only be created when an RwLockUpgradableReadGuard can be acquired, requiring
         // to wait for the previous future to have been polled and concluded.
         // Therefore the read here needs to suffice even though the condition (block_height <= head_height) might

--- a/lib/src/config/command_line.rs
+++ b/lib/src/config/command_line.rs
@@ -76,16 +76,18 @@ impl CommandLine {
     pub fn from_args() -> Self {
         <Self as StructOpt>::from_args()
     }
+}
 
+impl FromIterator<String> for CommandLine {
     /// Load command line from command line arguments (std::env::args)
-    pub fn from_iter<I: IntoIterator<Item = String>>(args: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = String>>(args: I) -> Self {
         <Self as StructOpt>::from_iter(args)
     }
 }
 
 #[derive(Debug, Error)]
 pub enum LogTagParseError {
-    #[error("Log tag is missing seperator: {0}")]
+    #[error("Log tag is missing separator: {0}")]
     MissingColon(String),
     #[error("Invalid log level: {0}")]
     InvalidLogLevel(#[from] ParseLevelError),

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -54,19 +54,14 @@ impl ConfigFile {
     ///
     const EXAMPLE_CONFIG: &'static str = include_str!("client.example.toml");
 
-    /// Parse config file from string
-    pub fn from_str<S: AsRef<str>>(config: S) -> Result<ConfigFile, Error> {
-        Ok(toml::from_str(config.as_ref())?)
-    }
-
     /// Parse config file from file
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<ConfigFile, Error> {
-        Self::from_str(read_to_string(path)?)
+        Self::from_str(&read_to_string(path)?)
     }
 
     /// Find config file.
     ///
-    /// If the config file location was overwritte by the optional command line argument, it will
+    /// If the config file location was overwritten by the optional command line argument, it will
     /// try this and possibly fail.
     ///
     /// Otherwise it will look into the default location, which is ~/.nimiq
@@ -110,6 +105,15 @@ impl ConfigFile {
 
         // Load config.
         Self::from_file(&path)
+    }
+}
+
+impl FromStr for ConfigFile {
+    type Err = Error;
+
+    /// Parse config file from string
+    fn from_str(s: &str) -> Result<ConfigFile, Self::Err> {
+        Ok(toml::from_str(s)?)
     }
 }
 

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -51,9 +51,11 @@ impl SpammerCommandLine {
     pub fn from_args() -> Self {
         <Self as StructOpt>::from_args()
     }
+}
 
+impl FromIterator<String> for SpammerCommandLine {
     /// Load command line from command line arguments (std::env::args)
-    pub fn from_iter<I: IntoIterator<Item = String>>(args: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = String>>(args: I) -> Self {
         <Self as StructOpt>::from_iter(args)
     }
 }

--- a/utils/src/merkle/partial.rs
+++ b/utils/src/merkle/partial.rs
@@ -8,13 +8,13 @@ use crate::math::CeilingDiv;
 
 /// A PartialMerkleProofBuilder can construct sequentially verifiable merkle proofs for a large list of data.
 /// The data can then be split into chunks and each chunk has its own (small) proof.
-/// Each proof can be verified by taking the previous proof's result into account (to minimise the amount of work required).
+/// Each proof can be verified by taking the previous proof's result into account (to minimize the amount of work required).
 /// This way, the large list of data can be transmitted in smaller chunks and one can incrementally verify
 /// the correctness of these chunks.
 pub struct PartialMerkleProofBuilder {}
 
 impl PartialMerkleProofBuilder {
-    pub fn new<H: HashOutput>(
+    pub fn get_proofs<H: HashOutput>(
         hashes: &[H],
         chunk_size: usize,
     ) -> Result<Vec<PartialMerkleProof<H>>, PartialMerkleProofError> {
@@ -35,7 +35,7 @@ impl PartialMerkleProofBuilder {
             .iter()
             .map(|v| H::Builder::default().chain(v).finish())
             .collect();
-        PartialMerkleProofBuilder::new::<H>(&hashes, chunk_size)
+        PartialMerkleProofBuilder::get_proofs::<H>(&hashes, chunk_size)
     }
 
     fn compute<H: HashOutput>(

--- a/utils/src/mutable_once.rs
+++ b/utils/src/mutable_once.rs
@@ -15,7 +15,10 @@ impl<T> MutableOnce<T> {
     }
 
     /// This mutates the content of the cell
-    /// and should only be called once, before any other reference can exist.
+    ///
+    /// # Safety
+    ///
+    /// This function should only be called once, before any other reference can exist.
     /// This condition is not checked, thus this call is unsafe.
     pub unsafe fn replace(&self, value: T) {
         let _ = mem::replace(&mut *self.inner.get(), value);


### PR DESCRIPTION
- Fix some minor typos in comments.
- Fix some more clippy warnings in `utils`, `lib`, `spammer` and
  `consensus` crates.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.