### PR TITLE
Fix panic caused by mempool executor

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -12,7 +12,7 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use nimiq_blockchain::{AbstractBlockchain, Blockchain};
 use nimiq_database::Environment;
-use nimiq_mempool::executor::TransactionTopic;
+use nimiq_mempool::mempool::TransactionTopic;
 use nimiq_network_interface::network::Network;
 use nimiq_transaction::Transaction;
 

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -88,7 +88,7 @@ async fn send_txn_to_mempool(
 
     let timeout = tokio::time::Duration::from_secs(1);
     tokio::time::sleep(timeout).await;
-    mempool.stop_executor().await;
+    mempool.stop_executor_without_unsuscribe().await;
 }
 
 async fn multiple_start_stop_send(
@@ -126,7 +126,7 @@ async fn multiple_start_stop_send(
 
     let timeout = tokio::time::Duration::from_secs(2);
     tokio::time::sleep(timeout).await;
-    mempool.stop_executor().await;
+    mempool.stop_executor_without_unsuscribe().await;
 
     // Get the transactions from the mempool
     let obtained_txns = mempool.get_transactions_for_block(usize::MAX);
@@ -151,7 +151,7 @@ async fn multiple_start_stop_send(
     tokio::time::sleep(timeout).await;
 
     // Call stop again, nothing should happen.
-    mempool.stop_executor().await;
+    mempool.stop_executor_without_unsuscribe().await;
 
     // We should not obtain any, since the executor should not be running.
     let obtained_txns = mempool.get_transactions_for_block(usize::MAX);
@@ -189,7 +189,7 @@ async fn multiple_start_stop_send(
 
     let timeout = tokio::time::Duration::from_secs(2);
     tokio::time::sleep(timeout).await;
-    mempool.stop_executor().await;
+    mempool.stop_executor_without_unsuscribe().await;
 
     // Get the transactions from the mempool
     let obtained_txns = mempool.get_transactions_for_block(usize::MAX);

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -662,8 +662,9 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork> Future
                 Ok(ConsensusEvent::Lost) => {
                     if let MempoolState::Active = self.mempool_state {
                         let mempool = Arc::clone(&self.mempool);
+                        let network = Arc::clone(&self.consensus.network);
                         tokio::spawn(async move {
-                            mempool.stop_executor().await;
+                            mempool.stop_executor(network).await;
                         });
                         self.mempool_state = MempoolState::Inactive;
                     }


### PR DESCRIPTION
Fixes #516
When the mempool executor was stopped, it was not being unsuscribed
from the network transaction topic, which is problematic after
it is restarted, since the network fails if we try to suscribe
and we are already suscribed.

Signed-off-by: viquezclaudio <viquezclaudio@gmail.com>
