### PR TITLE
Avoid setting DB defaults in 2 places

### DIFF
--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -38,7 +38,6 @@ pub struct ConfigFile {
     //pub reverse_proxy: Option<ReverseProxySettings>,
     #[serde(default)]
     pub log: LogSettings,
-    #[serde(default)]
     pub database: DatabaseSettings,
     pub mempool: Option<MempoolSettings>,
     #[serde(default)]
@@ -381,24 +380,13 @@ impl Default for LogSettings {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DatabaseSettings {
     pub path: Option<String>,
     pub size: Option<usize>,
     pub max_dbs: Option<u32>,
     pub max_readers: Option<u32>,
-}
-
-impl Default for DatabaseSettings {
-    fn default() -> Self {
-        DatabaseSettings {
-            path: None,
-            size: Some(1024 * 1024 * 50),
-            max_dbs: Some(12),
-            max_readers: Some(600),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Avoid setting Database setting default values in 2 different places.
Use only the settings defined in the `lib/src/config.rs` and do not
let the `config_file` module to set them if no entries in the
config file are found.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.