### PR TITLE
Allow devnet scripts to clean specific crates

### DIFF
--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -217,7 +217,7 @@ echo "Config files generated in '$configdir'"
 echo "Initializing genesis..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG="$PWD/$configdir/dev-albatross.toml"
 echo "Compiling the code using genesis from '$NIMIQ_OVERRIDE_DEVNET_CONFIG' ..."
-$cargo_clean
+$cargo_clean -p nimiq-genesis
 $cargo_build
 echo "Done."
 

--- a/scripts/devnet_docker_scenario.sh
+++ b/scripts/devnet_docker_scenario.sh
@@ -51,7 +51,7 @@ echo "Copying the genesis and docker compose files... "
 #Compile the code
 echo "Compiling the code using '$tmp_dir/dev-albatross.toml' ..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG=$tmp_dir/dev-albatross.toml
-cargo clean --release
+cargo clean -p nimiq-genesis --release
 cargo build --release
 
 echo "Create docker images... "


### PR DESCRIPTION
Now that the issue in nightly `rustc` reported
[here](https://github.com/rust-lang/rust/issues/92163) is fixed,
allow the devnet scripts to only clean the `nimiq-genesis` crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.