### PR TITLE
Change mempool tx verif to spawn blocking

### DIFF
--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -428,7 +428,7 @@ impl Mempool {
         let mempool_state = Arc::clone(&self.state);
         let filter = Arc::clone(&self.filter);
 
-        let verify_tx_ret = verify_tx(&transaction, blockchain, &mempool_state, filter).await;
+        let verify_tx_ret = verify_tx(&transaction, blockchain, &mempool_state, filter);
 
         match verify_tx_ret {
             Ok(mempool_state_lock) => {


### PR DESCRIPTION
The current spawn method used in the mempool-executor transaction verification can be problematic:
the tx verif code does not have await points, which prevents other tasks from running, this causes
several issues, as this code tries to obtain blockchain read and mempool write locks, which eventually
can starve other operations trying to obtain these locks (blockchain extend is one example of such operation)
