### PR TITLE
Remove unnecesary blockchain read from mempool

### DIFF
--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -427,8 +427,9 @@ impl Mempool {
         let blockchain = Arc::clone(&self.blockchain);
         let mempool_state = Arc::clone(&self.state);
         let filter = Arc::clone(&self.filter);
-
-        let verify_tx_ret = verify_tx(&transaction, blockchain, &mempool_state, filter).await;
+        let network_id = Arc::new(blockchain.read().network_id);
+        let verify_tx_ret =
+            verify_tx(&transaction, blockchain, network_id, &mempool_state, filter).await;
 
         match verify_tx_ret {
             Ok(mempool_state_lock) => {


### PR DESCRIPTION
- The network_id is basically an static parameter, so it is not necessary to get the blockchain read lock to get this value each time a transaction is verified
- Fixed a bug that was not limiting the number of concurrent transaction verification tasks
