### PR TITLE
Disable deadlock detection/reporting in ci script

### DIFF
--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -53,6 +53,13 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(${{ steps.reason.outputs.FAIL_REASON }}, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in FourValidatorsReconnectTest'
+          footer: '<{run_url}|View Run>'
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1
@@ -109,6 +116,13 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(${{ steps.reason.outputs.FAIL_REASON }}, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in MultipleValidatorsDownTest'
+          footer: '<{run_url}|View Run>'
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1
@@ -165,6 +179,13 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(steps.reason.outputs.FAIL_REASON, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in FourValidatorsReconnectRMdatabaseTest'
+          footer: '<{run_url}|View Run>'
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1
@@ -221,6 +242,13 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(${{ steps.reason.outputs.FAIL_REASON }}, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in FourValidatorsReconnectSpammer'
+          footer: '<{run_url}|View Run>'
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1
@@ -280,6 +308,15 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(${{ steps.reason.outputs.FAIL_REASON }}, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in MacroProductionTest'
+          footer: '<{run_url}|View Run>'
+      env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1
@@ -336,6 +373,15 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(${{ steps.reason.outputs.FAIL_REASON }}, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in ViewChangeTest'
+          footer: '<{run_url}|View Run>'
+      env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1

--- a/.github/workflows/release_mode_scenarios.yml
+++ b/.github/workflows/release_mode_scenarios.yml
@@ -53,6 +53,13 @@ jobs:
             echo "::set-output name=FAIL_REASON::other"
           fi
       id: reason
+    - name: Report potential deadlocks to slack
+      if: always() && contains(${{ steps.reason.outputs.FAIL_REASON }}, 'DEADLOCK')
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+          status: ${{ job.status }}
+          notification_title: 'Potential deadlock detected in FourValidatorsReconnectTest'
+          footer: '<{run_url}|View Run>'
     - name: Report Status to Slack
       if: always() && github.ref == 'refs/heads/albatross'
       uses: ravsamhq/notify-slack-action@v1

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -49,15 +49,6 @@ function check_failures() {
     secs=0
     while [ $secs -le $sleep_time ]
     do
-        # Search for deadlocks
-        if grep -wrin "deadlock" $logsdir/*.log
-        then
-            echo "   !!!   DEADLOCK   !!!"
-            echo "DEADLOCK" >> temp-state/RESULT.TXT
-            fail=true
-            break
-        fi
-
         # Search for panics/crashes
         if grep -wrin " panic " $logsdir/*.log
         then
@@ -65,6 +56,20 @@ function check_failures() {
             echo "PANIC" >> temp-state/RESULT.TXT
             fail=true
             break
+        fi
+        # Search for deadlocks
+        if grep -wrin "deadlock" $logsdir/*.log
+        then
+            # Only report deadlock once
+            if [ -f "temp-state/RESULT.TXT" ] && [ $(grep "DEADLOCK" temp-state/RESULT.TXT) ]
+            then
+                :
+            else
+                echo "   !!!   POTENTIAL DEADLOCK DETECTED  !!!"
+                echo "DEADLOCK" >> temp-state/RESULT.TXT
+                #  Do not mark the test as failed if a potential deadlock is detected
+                #    fail=true
+            fi
         fi
 
         sleep 1


### PR DESCRIPTION
Temporally disable the deadlock detection in the devnet script, so that if a deadlock
is reported, the process is not killed and it continues running
