### PR TITLE
Use different Type IDs for LevelUpdate messages

### DIFF
--- a/handel/src/contribution.rs
+++ b/handel/src/contribution.rs
@@ -17,6 +17,12 @@ pub trait AggregatableContribution:
     + beserial::Deserialize
     + Unpin
 {
+    /// Type ID to use when registering a receiver for the network
+    ///
+    /// This value must be unique not only within this trait but within all
+    /// implementations of the `Message` trait.
+    const TYPE_ID: u64;
+
     /// A BitSet signaling which contributors have contributed in this Contribution
     fn contributors(&self) -> BitSet;
 

--- a/handel/src/update.rs
+++ b/handel/src/update.rs
@@ -38,7 +38,7 @@ impl<C: AggregatableContribution> LevelUpdate<C> {
         }
     }
 
-    /// Add a tag to the Update, resulting in a LeveelUpdateMessage which can be send over wire.
+    /// Add a tag to the Update, resulting in a LevelUpdateMessage which can be send over wire.
     /// * `tag` The message this aggregation runs over
     pub fn with_tag<T: Clone + Debug + Serialize + Deserialize + Send + Unpin>(
         self,
@@ -76,5 +76,9 @@ impl<
         T: Clone + Debug + Serialize + Deserialize + Send + Sync + Unpin + 'static,
     > Message for LevelUpdateMessage<C, T>
 {
-    const TYPE_ID: u64 = 121;
+    // The Type ID to use will come from the AggregatableContribution implementation
+    // since having a fixed value here would imply that there could be different
+    // types using the same type ID which would confuse the network at decoding
+    // messages upon receiving them.
+    const TYPE_ID: u64 = C::TYPE_ID;
 }

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -39,6 +39,8 @@ pub struct Contribution {
 }
 
 impl AggregatableContribution for Contribution {
+    const TYPE_ID: u64 = 44;
+
     fn contributors(&self) -> BitSet {
         self.contributors.clone()
     }

--- a/primitives/block/src/multisig.rs
+++ b/primitives/block/src/multisig.rs
@@ -65,6 +65,8 @@ impl MultiSignature {
 }
 
 impl AggregatableContribution for MultiSignature {
+    const TYPE_ID: u64 = 128;
+
     fn contributors(&self) -> BitSet {
         self.signers.clone()
     }

--- a/validator/src/aggregation/tendermint/contribution.rs
+++ b/validator/src/aggregation/tendermint/contribution.rs
@@ -42,6 +42,8 @@ impl TendermintContribution {
 }
 
 impl AggregatableContribution for TendermintContribution {
+    const TYPE_ID: u64 = 124;
+
     /// Combines two TendermintContributions Every different proposal is represented as its own multisignature.
     /// When combining non existing keys must be inserted while the mutlisignatures of existing keys are combined.
     fn combine(&mut self, other_contribution: &Self) -> Result<(), ContributionError> {

--- a/validator/src/aggregation/view_change.rs
+++ b/validator/src/aggregation/view_change.rs
@@ -110,6 +110,8 @@ pub struct SignedViewChangeMessage {
 }
 
 impl AggregatableContribution for SignedViewChangeMessage {
+    const TYPE_ID: u64 = 123;
+
     fn contributors(&self) -> BitSet {
         self.view_change.contributors()
     }


### PR DESCRIPTION
Use different Type IDs for `LevelUpdate` messages to allow the
network to properly decode an incoming message using the proper
type.
Since `LevelUpdateMessage` is a `struct` with generic elements,
it can't have a fixed Type ID since this is the mechanism the
network has to differentiate between types and then later do
a proper deserialization. As seen in #433, this may lead to
circumstances where the network fails to deserialize these type
of messages with the BLS signature deserialization being the most
notorious error.
This change changes the `LevelUpdateMessage` to not have a fixed
Type ID and use instead the one provided by the element implementing
the `AggregatableContribution` trait. This way the different
`LevelUpdateMessage` would have their own Type ID and then the
network would be able to properly decode them.

This fixes #433.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.