### PR TITLE
libp2p: Use WindowUpdateMode::OnRead for yamux

### DIFF
--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -188,10 +188,13 @@ impl Network {
             .into_authentic(keypair)
             .unwrap();
 
+        let mut yamux = yamux::YamuxConfig::default();
+        yamux.set_window_update_mode(yamux::WindowUpdateMode::on_read());
+
         Ok(transport
             .upgrade(core::upgrade::Version::V1)
             .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-            .multiplex(yamux::YamuxConfig::default())
+            .multiplex(yamux)
             .timeout(std::time::Duration::from_secs(20))
             .boxed())
     }


### PR DESCRIPTION
Use yamux `WindowUpdateMode::OnRead` for yamux configuration to
enable full yamux flow control and preventing streams to reset
due to reaching the buffer limit.
The default `WindowUpdateMode::OnReceive` that was in place may have
been overwhelming the receiver if for some reason there was some
slowness attending the buffer.
This avoids issues of peer connections being closed with messages
such as: `buffer of stream grows beyond limit`.
This fixes #556.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.