### PR TITLE
Add accounts tree performance test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,12 +2851,14 @@ dependencies = [
  "lazy_static",
  "log",
  "nimiq-bls",
+ "nimiq-build-tools",
  "nimiq-collections",
  "nimiq-database",
  "nimiq-hash",
  "nimiq-keys",
  "nimiq-macros",
  "nimiq-primitives",
+ "nimiq-test-utils",
  "nimiq-transaction",
  "nimiq-trie",
  "nimiq-utils",
@@ -2859,6 +2867,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "strum_macros",
+ "tempdir",
  "thiserror",
 ]
 
@@ -3088,6 +3097,7 @@ dependencies = [
  "nimiq-block",
  "nimiq-bls",
  "nimiq-build-tools",
+ "nimiq-database",
  "nimiq-hash",
  "nimiq-hash_derive",
  "nimiq-keys",
@@ -3321,6 +3331,7 @@ dependencies = [
  "nimiq-network-interface",
  "nimiq-network-mock",
  "nimiq-primitives",
+ "nimiq-test-utils",
  "nimiq-transaction",
  "nimiq-utils",
  "nimiq-vrf",
@@ -3697,6 +3708,7 @@ dependencies = [
  "nimiq-network-libp2p",
  "nimiq-network-mock",
  "nimiq-primitives",
+ "nimiq-transaction",
  "nimiq-utils",
  "nimiq-validator",
  "nimiq-validator-network",
@@ -4529,6 +4541,19 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4571,6 +4596,21 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4631,6 +4671,15 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5289,6 +5338,16 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "tempfile"

--- a/build-tools/src/genesis/main.rs
+++ b/build-tools/src/genesis/main.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::process::exit;
 
 use nimiq_build_tools::genesis::{GenesisBuilder, GenesisInfo};
+use nimiq_database::volatile::VolatileEnvironment;
 
 fn usage(args: Vec<String>) -> ! {
     eprintln!(
@@ -14,6 +15,7 @@ fn usage(args: Vec<String>) -> ! {
 fn main() {
     pretty_env_logger::init();
 
+    let env = VolatileEnvironment::new(10).expect("Could not open a volatile database");
     let args = env::args().collect::<Vec<String>>();
 
     if let Some(file) = args.get(1) {
@@ -24,7 +26,7 @@ fn main() {
         } = GenesisBuilder::new()
             .with_config_file(file)
             .unwrap()
-            .generate()
+            .generate(env)
             .unwrap();
 
         println!("Genesis Block: {}", hash);

--- a/consensus/tests/request_component.rs
+++ b/consensus/tests/request_component.rs
@@ -4,6 +4,7 @@ use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::AbstractBlockchain;
 use nimiq_bls::KeyPair as BLSKeyPair;
 use nimiq_build_tools::genesis::GenesisBuilder;
+use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_test_utils::blockchain::{produce_macro_blocks, signing_key, voting_key};
@@ -16,6 +17,7 @@ async fn test_request_component() {
     //simple_logger::init_by_env();
 
     let mut hub = Some(MockHub::default());
+    let env = VolatileEnvironment::new(10).expect("Could not open a volatile database");
 
     // Generate genesis block.
     let key = KeyPair::generate(&mut seeded_rng(0));
@@ -29,7 +31,7 @@ async fn test_request_component() {
             vtn_key.public_key,
             Address::default(),
         )
-        .generate()
+        .generate(env)
         .unwrap();
 
     let mut node1 = Node::<MockNetwork>::new(1, genesis.clone(), &mut hub).await;

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -44,5 +44,6 @@ log = "0.4"
 pretty_env_logger = "0.4"
 
 nimiq-build-tools = { path = "../build-tools" }
+nimiq-database = { path = "../database" }
 nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }

--- a/genesis/build.rs
+++ b/genesis/build.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use nimiq_build_tools::genesis::GenesisBuilder;
+use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_hash::Blake2bHash;
 
 fn write_genesis_rs(directory: &Path, name: &str, genesis_hash: &Blake2bHash) {
@@ -37,8 +38,9 @@ fn generate_albatross(
     log::info!("genesis source file: {}", genesis_config.display());
 
     let mut builder = GenesisBuilder::new();
+    let env = VolatileEnvironment::new(10).expect("Could not open a volatile database");
     builder.with_config_file(genesis_config).unwrap();
-    let genesis_hash = builder.write_to_files(&directory).unwrap();
+    let genesis_hash = builder.write_to_files(env, &directory).unwrap();
     write_genesis_rs(&directory, name, &genesis_hash);
 }
 

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -49,4 +49,5 @@ nimiq-build-tools = { path = "../build-tools" }
 nimiq-database = { path = "../database" }
 nimiq-genesis = { path = "../genesis" }
 nimiq-network-mock = { path = "../network-mock" }
+nimiq-test-utils = { path = "../test-utils" }
 nimiq-vrf = { path = "../vrf" }

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -1,41 +1,45 @@
 [package]
-name = "nimiq-account"
-version = "0.1.0"
 authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
-description = "Account primitives to be used in Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
 categories = ["cryptography::cryptocurrencies"]
+description = "Account primitives to be used in Nimiq's Albatross implementation"
+edition = "2021"
+homepage = "https://nimiq.com"
 keywords = ["nimiq", "cryptocurrency", "blockchain"]
+license = "Apache-2.0"
+name = "nimiq-account"
+repository = "https://github.com/nimiq/core-rs-albatross"
+version = "0.1.0"
 
 [dependencies]
-hex = { version = "0.4" }
+hex = {version = "0.4"}
 lazy_static = "1.3"
 log = "0.4"
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = {git = "https://github.com/styppo/parking_lot.git"}
 rand = "0.8"
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = {version = "1.0", features = ["derive"], optional = true}
 strum_macros = "0.23"
 thiserror = "1.0"
 
-beserial = { path = "../../beserial" }
-beserial_derive = { path = "../../beserial/beserial_derive" }
-nimiq-bls = { path = "../../bls" }
-nimiq-collections = { path = "../../collections", features = ["bitset"] }
-nimiq-database = { path = "../../database" }
-nimiq-hash = { path = "../../hash" }
-nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
-nimiq-primitives = { path = "..", features = ["coin", "policy", "serde-derive", "slots"] }
-nimiq-transaction = { path = "../transaction", features = ["serde-derive"] }
-nimiq-trie = { path = "../trie" }
-nimiq-utils = { path = "../../utils", features = ["hash-rng"] }
-nimiq-vrf = { path = "../../vrf" }
-nimiq-macros = { path = "../../macros" }
+beserial = {path = "../../beserial"}
+beserial_derive = {path = "../../beserial/beserial_derive"}
+nimiq-bls = {path = "../../bls"}
+nimiq-collections = {path = "../../collections", features = ["bitset"]}
+nimiq-database = {path = "../../database"}
+nimiq-hash = {path = "../../hash"}
+nimiq-keys = {path = "../../keys", features = ["serde-derive"]}
+nimiq-macros = {path = "../../macros"}
+nimiq-primitives = {path = "..", features = ["coin", "policy", "serde-derive", "slots"]}
+nimiq-transaction = {path = "../transaction", features = ["serde-derive"]}
+nimiq-trie = {path = "../trie"}
+nimiq-utils = {path = "../../utils", features = ["hash-rng"]}
+nimiq-vrf = {path = "../../vrf"}
 
 [dev-dependencies]
 hex = "0.4"
+tempdir = "0.3"
+
+nimiq-build-tools = {path = "../../build-tools"}
+nimiq-test-utils = {path = "../../test-utils"}
 
 [features]
 serde-derive = ["serde"]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -37,6 +37,7 @@ nimiq-network-interface = { path = "../network-interface" }
 nimiq-network-libp2p = { path = "../network-libp2p" }
 nimiq-network-mock = { path = "../network-mock" }
 nimiq-primitives = { path = "../primitives" }
+nimiq-transaction = { path = "../primitives/transaction" }
 nimiq-validator = { path = "../validator" }
 nimiq-validator-network = { path = "../validator-network" }
 nimiq-utils = { path = "../utils" }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -2,4 +2,5 @@ pub mod blockchain;
 pub mod consensus;
 pub mod node;
 pub mod test_network;
+pub mod test_transaction;
 pub mod validator;

--- a/test-utils/src/test_transaction.rs
+++ b/test-utils/src/test_transaction.rs
@@ -1,0 +1,82 @@
+use beserial::Serialize;
+use nimiq_build_tools::genesis::GenesisBuilder;
+use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
+use nimiq_primitives::coin::Coin;
+use nimiq_primitives::networks::NetworkId;
+use nimiq_transaction::{SignatureProof, Transaction};
+
+#[derive(Clone)]
+pub struct TestAccount {
+    pub keypair: SchnorrKeyPair,
+    pub address: Address,
+}
+
+#[derive(Clone)]
+pub struct TestTransaction {
+    pub fee: u64,
+    pub value: u64,
+    pub sender: TestAccount,
+    pub recipient: TestAccount,
+}
+
+pub fn generate_accounts(
+    balances: Vec<u64>,
+    genesis_builder: &mut GenesisBuilder,
+    add_to_genesis: bool,
+) -> Vec<TestAccount> {
+    let mut mempool_accounts = vec![];
+
+    for balance in balances {
+        // Generate the txns_sender and txns_rec vectors to later generate transactions
+        let keypair = SchnorrKeyPair::generate_default_csprng();
+        let address = Address::from(&keypair.public);
+        let mempool_account = TestAccount {
+            keypair,
+            address: address.clone(),
+        };
+        mempool_accounts.push(mempool_account);
+
+        if add_to_genesis {
+            // Add accounts to the genesis builder
+            genesis_builder.with_basic_account(address, Coin::from_u64_unchecked(balance));
+        }
+    }
+    mempool_accounts
+}
+
+pub fn generate_transactions(
+    mempool_transactions: Vec<TestTransaction>,
+    signature: bool,
+) -> (Vec<Transaction>, usize) {
+    let mut txns_len = 0;
+    let mut txns: Vec<Transaction> = vec![];
+
+    log::debug!("Generating transactions and accounts");
+
+    for mempool_transaction in mempool_transactions {
+        // Generate transactions
+        let mut txn = Transaction::new_basic(
+            mempool_transaction.sender.address.clone(),
+            mempool_transaction.recipient.address.clone(),
+            Coin::from_u64_unchecked(mempool_transaction.value),
+            Coin::from_u64_unchecked(mempool_transaction.fee),
+            1,
+            NetworkId::UnitAlbatross,
+        );
+
+        if signature {
+            let signature_proof = SignatureProof::from(
+                mempool_transaction.sender.keypair.public,
+                mempool_transaction
+                    .sender
+                    .keypair
+                    .sign(&txn.serialize_content()),
+            );
+
+            txn.proof = signature_proof.serialize_to_vec();
+        }
+        txns.push(txn.clone());
+        txns_len += txn.serialized_size();
+    }
+    (txns, txns_len)
+}

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -13,6 +13,7 @@ use nimiq_blockchain::AbstractBlockchain;
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_build_tools::genesis::{GenesisBuilder, GenesisInfo};
 use nimiq_consensus::{Consensus as AbstractConsensus, ConsensusEvent};
+use nimiq_database::Environment;
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
 use nimiq_mempool::config::MempoolConfig;
 use nimiq_network_interface::{network::Network as NetworkInterface, peer::Peer as PeerInterface};
@@ -57,6 +58,7 @@ where
 }
 
 pub async fn build_validators<N: TestNetwork + NetworkInterface>(
+    env: Environment,
     num_validators: usize,
     hub: &mut Option<MockHub>,
 ) -> Vec<AbstractValidator<N, ValidatorNetworkImpl<N>>>
@@ -89,7 +91,7 @@ where
             Address::default(),
         );
     }
-    let genesis = genesis_builder.generate().unwrap();
+    let genesis = genesis_builder.generate(env).unwrap();
 
     // Instantiate validators.
     let mut validators = vec![];

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use futures::{future, StreamExt};
 use log::LevelFilter::{Debug, Info};
 use nimiq_blockchain::AbstractBlockchain;
+use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_network_libp2p::Network;
 use nimiq_test_utils::validator::build_validators;
 
@@ -20,7 +21,9 @@ async fn four_validators_can_create_an_epoch() {
         .init()
         .ok();
 
-    let validators = build_validators::<Network>(4, &mut None).await;
+    let env = VolatileEnvironment::new(10).expect("Could not open a volatile database");
+
+    let validators = build_validators::<Network>(env, 4, &mut None).await;
 
     let blockchain = Arc::clone(&validators.first().unwrap().consensus.blockchain);
 


### PR DESCRIPTION
Add accounts tree performance test and refactored the Mempool
test utilities to generates transactions and accounts. Now these
utilities are under the `test-utils` crate and can be used by any
test.
Also change the genesis build tools `generate` function to receive the
DB transaction instead of assuming an volatile environment.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
