### PR TITLE
Properly implement gossipsub peer scoring

### DIFF
--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -314,14 +314,7 @@ impl ConnectionPoolBehaviour {
             let peer_score = contacts.get(peer_id).map(|e| e.get_score());
             if let Some(score) = peer_score {
                 if score < 0.0 {
-                    self.actions
-                        .push_back(NetworkBehaviourAction::NotifyHandler {
-                            peer_id: *peer_id,
-                            handler: NotifyHandler::Any,
-                            event: HandlerInEvent::Close {
-                                reason: CloseReason::Other,
-                            },
-                        });
+                    log::info!("Peer {:?} has a negative score: {}", peer_id, score);
                 }
             }
         }

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -39,6 +39,12 @@ pub enum NetworkError {
 
     #[error("Already unsubscribed to topic: {topic_name}")]
     AlreadyUnsubscribed { topic_name: &'static str },
+
+    #[error("Couldn't set topic score parameters")]
+    TopicScoreParams {
+        topic_name: &'static str,
+        error: &'static str,
+    },
 }
 
 impl From<libp2p::kad::store::Error> for NetworkError {

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -22,7 +22,7 @@ use libp2p::{
     dns,
     gossipsub::{
         error::PublishError, GossipsubEvent, GossipsubMessage, IdentTopic, MessageAcceptance,
-        MessageId, TopicHash,
+        MessageId, TopicHash, TopicScoreParams,
     },
     identify::IdentifyEvent,
     identity::Keypair,
@@ -690,7 +690,19 @@ impl Network {
 
                         state.gossip_topics.insert(topic.hash(), (tx, validate));
 
-                        output.send(Ok(rx)).ok();
+                        match swarm
+                            .behaviour_mut()
+                            .gossipsub
+                            .set_topic_params(topic, TopicScoreParams::default())
+                        {
+                            Ok(_) => output.send(Ok(rx)).ok(),
+                            Err(e) => output
+                                .send(Err(NetworkError::TopicScoreParams {
+                                    topic_name,
+                                    error: e,
+                                }))
+                                .ok(),
+                        };
                     }
 
                     // Apparently we're already subscribed.


### PR DESCRIPTION
Properly implement gossipsub peer scoring by setting topic score
parameters after subscribing to a topic.
This allows the gossipsub scoring mechanism to properly account
the weights and penalties per topic as described in the gossipsub
v1.1 extension.
Also, avoid disconnecting a peer when it reaches a negative score
since this has these 2 downsides:
1. Interferes with the already present scoring mechanism in
   gossipsub.
2. Closing a connection to a peer doesn't prevent the peer to
   connect again as soon as the peer can.

Before this change it was seen that all peer scores were zero or a
negative value and that provoked:
1. A non functional peer scoring affecting internal gossipsub
   algorithms.
2. Peer disconnections since the code was closing connections to
   peers with negative scores.

This fixes #562.