### PR TITLE
Include NORDAHEAD DB flag

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -204,7 +204,7 @@ fn it_can_produce_a_chain_with_txns() {
             tmp_dir,
             1024 * 1024 * 1024 * 1024,
             21,
-            LmdbFlags::NOMETASYNC | LmdbFlags::NOSYNC,
+            LmdbFlags::NOMETASYNC | LmdbFlags::NOSYNC | LmdbFlags::NORDAHEAD,
         )
         .unwrap()
     };

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -257,7 +257,7 @@ pub struct DatabaseConfig {
     max_readers: u32,
 
     /// Additional LMDB flags
-    #[builder(default = "LmdbFlags::NOMETASYNC | LmdbFlags::NOSYNC")]
+    #[builder(default = "LmdbFlags::NOMETASYNC | LmdbFlags::NOSYNC | LmdbFlags::NORDAHEAD")]
     flags: LmdbFlags::Flags,
 }
 
@@ -268,7 +268,7 @@ impl Default for DatabaseConfig {
             size: 1024 * 1024 * 1024 * 1024,
             max_dbs: 12,
             max_readers: 600,
-            flags: LmdbFlags::NOMETASYNC | LmdbFlags::NOSYNC,
+            flags: LmdbFlags::NOMETASYNC | LmdbFlags::NOSYNC | LmdbFlags::NORDAHEAD,
         }
     }
 }


### PR DESCRIPTION
This flag improves the DB performance in Linux based platforms, which solves
the high disk reads issue described in #595.