### PR TITLE
Fix inconsistent failure for network test

### DIFF
--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1273,9 +1273,10 @@ mod tests {
                 .dial_address(addresses[(peer - 1) as usize].clone())
                 .await
                 .unwrap();
-            let timeout = tokio::time::Duration::from_secs(1);
-            tokio::time::sleep(timeout).await;
         }
+
+        let timeout = tokio::time::Duration::from_secs((n_peers * 2).try_into().unwrap());
+        tokio::time::sleep(timeout).await;
 
         // Verify that each network has all the other peers connected
         for peer in 0..n_peers {
@@ -1290,7 +1291,7 @@ mod tests {
             );
         }
 
-        // Now disconnect and reconnect a random peer from all peeers
+        // Now disconnect and reconnect a random peer from all peers
         for peer in 0..n_peers {
             let network1 = &networks[peer as usize];
             let peer_id1 = network1.local_peer_id();


### PR DESCRIPTION
Fix inconsistency failure for the `connections_stress_and_reconnect`
network test where under some loaded conditions the test could fail
due to timing.

This fixes #589.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.