### PR TITLE
Replace the tempdir dependency in favor of tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,12 +1482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,7 +2970,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "strum_macros",
- "tempdir",
+ "tempfile",
  "thiserror",
 ]
 
@@ -3032,7 +3026,7 @@ dependencies = [
  "nimiq-vrf",
  "parking_lot 0.11.2 (git+https://github.com/styppo/parking_lot.git)",
  "rand 0.8.5",
- "tempdir",
+ "tempfile",
 ]
 
 [[package]]
@@ -4707,19 +4701,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4761,21 +4742,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4827,15 +4793,6 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5541,16 +5498,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -42,7 +42,7 @@ nimiq-utils = { path = "../utils"}
 nimiq-test-utils = { path = "../test-utils" }
 nimiq-transaction-builder = { path = "../transaction-builder" }
 nimiq-keys = { path = "../keys" }
-tempdir = "0.3"
+tempfile = "3.3"
 rand = "0.8"
 [features]
 default = []

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -1,7 +1,7 @@
 use parking_lot::RwLock;
 use std::convert::TryInto;
 use std::sync::Arc;
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 use beserial::Deserialize;
 use nimiq_block::{Block, BlockError, ForkProof};
@@ -198,7 +198,7 @@ fn it_can_produce_a_chain_with_txns() {
     let env = if VOLATILE_ENV {
         VolatileEnvironment::new(10).unwrap()
     } else {
-        let tmp_dir = TempDir::new("chain_with_txns").expect("Could not create temporal directory");
+        let tmp_dir = tempdir().expect("Could not create temporal directory");
         let tmp_dir = tmp_dir.path().to_str().unwrap();
         LmdbEnvironment::new(
             tmp_dir,

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -36,7 +36,7 @@ nimiq-vrf = {path = "../../vrf"}
 
 [dev-dependencies]
 hex = "0.4"
-tempdir = "0.3"
+tempfile = "3.3"
 
 nimiq-build-tools = {path = "../../build-tools"}
 nimiq-test-utils = {path = "../../test-utils"}

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -2,7 +2,7 @@ use rand::prelude::StdRng;
 use rand::SeedableRng;
 use std::convert::TryFrom;
 use std::time::Instant;
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 use nimiq_account::{Accounts, Inherent, InherentType};
 use nimiq_account::{Receipt, Receipts};
@@ -434,8 +434,7 @@ fn accounts_performance() {
         (env, num_txns)
     } else {
         let num_txns = 10_000;
-        let tmp_dir =
-            TempDir::new("accounts_performance_test").expect("Could not create temporal directory");
+        let tmp_dir = tempdir().expect("Could not create temporal directory");
         let tmp_dir = tmp_dir.path().to_str().unwrap();
         log::debug!("Creating a non volatile environment in {}", tmp_dir);
         let env = LmdbEnvironment::new(


### PR DESCRIPTION
Replace the `tempdir` dependency in favor of `tempfile` which is
required only for testing and is defined as `dev` dependency for
the `accounts` and `block-production` crates.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.