### PR TITLE
Correctly detect panics in the devnet script

### DIFF
--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -51,7 +51,7 @@ function check_failures() {
     while [ $secs -le $sleep_time ]
     do
         # Search for panics/crashes
-        if grep -wrin " panic " $logsdir/*.log
+        if grep -rin " panic " $logsdir/*.log
         then
             echo "   !!!   PANIC   !!!"
             echo "PANIC" >> temp-state/RESULT.TXT


### PR DESCRIPTION
Fix `grep` expression to correctly detect panics in the devnet
script and thus in the CI.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.