### PR TITLE
Use `-C instrument-coverage` for coverage

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,6 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-output-type: lcov
-output-path: ./lcov.info
-prefix-dir: /home/user/build/

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -48,22 +48,31 @@ jobs:
         profile: minimal
         toolchain: nightly
         override: true
-    - uses: actions-rs/cargo@v1
+        components: llvm-tools-preview
+    - name: Install cargo-llvm-cov
+      uses: actions-rs/cargo@v1
       with:
-        command: test
+        command: install
+        args: cargo-llvm-cov
+    - name: Remove possible stale artifacts
+      uses: actions-rs/cargo@v1
+      with:
+        command: llvm-cov
+        args: clean --workspace
+    - name: Run test with coverage instrumentation
+      uses: actions-rs/cargo@v1
+      with:
+        command: llvm-cov
         args: --all-features
-      # Add flags for gcov
-      env:
-        CARGO_INCREMENTAL: '0'
-        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-    - id: coverage
-      name: Generate coverage  report
-      uses: actions-rs/grcov@v0.1
+    - name: Generate coverage report
+      uses: actions-rs/cargo@v1
+      with:
+        command: llvm-cov
+        args: --no-run --lcov --output-path coverage.lcov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
-        files: ${{ steps.coverage.outputs.report }}
+        files: coverage.lcov
         fail_ci_if_error: false
         flags: unittests
         name: Nimiq code coverage


### PR DESCRIPTION
Use the recent added `-C instrument-coverage` to generate coverage
data. To use it, the `build+test` workflow relies in the
`cargo-llvm-cov` cargo extension to easily use LLVM source-based
code coverage.
This improves also the code coverage reporting.
This closes #300.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.