### PR TITLE
Don't rebuild nimiq-genesis for each devnet script run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,5 @@ opt-level = 3
 [profile.test.package.beserial]
 opt-level = 3
 
-# Optimize the release profile for speed.
 [profile.release]
-lto = "fat"
-codegen-units = 1
+lto = "thin"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -29,6 +29,8 @@ beserial_derive = { path = "../beserial/beserial_derive" }
 nimiq-account = { path = "../primitives/account" }
 nimiq-block = { path = "../primitives/block" }
 nimiq-bls = { path = "../bls" }
+nimiq-build-tools = { path = "../build-tools" }
+nimiq-database = { path = "../database" }
 nimiq-hash = { path = "../hash" }
 nimiq-hash_derive = { path = "../hash/hash_derive" }
 nimiq-keys = { path = "../keys" }

--- a/genesis/build.rs
+++ b/genesis/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use nimiq_build_tools::genesis::GenesisBuilder;
 use nimiq_database::volatile::VolatileEnvironment;
@@ -19,22 +19,13 @@ fn write_genesis_rs(directory: &Path, name: &str, genesis_hash: &Blake2bHash) {
     fs::write(directory.join("genesis.rs"), genesis_rs.as_bytes()).unwrap();
 }
 
-fn generate_albatross(
-    name: &str,
-    out_dir: &Path,
-    src_dir: &Path,
-    config_override: Option<PathBuf>,
-) {
+fn generate_albatross(name: &str, out_dir: &Path, src_dir: &Path) {
     log::info!("Generating Albatross genesis config: {}", name);
 
     let directory = out_dir.join(name);
     fs::create_dir_all(&directory).unwrap();
 
-    let genesis_config = if let Some(config_override) = config_override {
-        config_override
-    } else {
-        src_dir.join(format!("{}.toml", name))
-    };
+    let genesis_config = src_dir.join(format!("{}.toml", name));
     log::info!("genesis source file: {}", genesis_config.display());
 
     let mut builder = GenesisBuilder::new();
@@ -49,9 +40,6 @@ fn main() {
 
     let out_dir = Path::new(&env::var("OUT_DIR").unwrap()).join("genesis");
     let src_dir = Path::new("src").join("genesis");
-    let devnet_override = env::var("NIMIQ_OVERRIDE_DEVNET_CONFIG")
-        .ok()
-        .map(PathBuf::from);
 
     log::info!("Taking genesis config files from: {}", src_dir.display());
     log::info!("Writing genesis data to: {}", out_dir.display());
@@ -59,13 +47,7 @@ fn main() {
         "DevNet override {:?}",
         env::var("NIMIQ_OVERRIDE_DEVNET_CONFIG")
     );
-    if let Some(devnet_override) = &devnet_override {
-        log::info!(
-            "Using override for Albatross DevNet config: {}",
-            devnet_override.display()
-        );
-    }
 
-    generate_albatross("dev-albatross", &out_dir, &src_dir, devnet_override);
-    generate_albatross("unit-albatross", &out_dir, &src_dir, None);
+    generate_albatross("dev-albatross", &out_dir, &src_dir);
+    generate_albatross("unit-albatross", &out_dir, &src_dir);
 }

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -20,7 +20,6 @@ RELEASE=false
 MAX_VALIDATORS=4
 cargo="cargo run"
 cargo_build="cargo build"
-cargo_clean="cargo clean"
 tpb=150
 vkill=1
 down_time=10
@@ -202,12 +201,11 @@ mkdir -p $logsdir
 mkdir -p $configdir
 
 # Erase all previous state (if any) and start fresh
-rm -rf temp-state
+rm -rf temp-state/*
 
 if [ "$RELEASE" = true ] ; then
     cargo+=" --release"
     cargo_build+=" --release"
-    cargo_clean+=" --release"
 fi
 
 if [ "$METRICS" = true ] ; then
@@ -237,10 +235,9 @@ else
     python3 scripts/devnet/python/devnet_create.py $MAX_VALIDATORS -o $configdir
 fi
 echo "Config files generated in '$configdir'"
-echo "Initializing genesis..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG="$PWD/$configdir/dev-albatross.toml"
-echo "Compiling the code using genesis from '$NIMIQ_OVERRIDE_DEVNET_CONFIG' ..."
-$cargo_clean -p nimiq-genesis
+echo "Overriding genesis with '$NIMIQ_OVERRIDE_DEVNET_CONFIG' ..."
+echo "Compiling ..."
 $cargo_build
 echo "Done."
 

--- a/scripts/devnet_docker_scenario.sh
+++ b/scripts/devnet_docker_scenario.sh
@@ -51,7 +51,6 @@ echo "Copying the genesis and docker compose files... "
 #Compile the code
 echo "Compiling the code using '$tmp_dir/dev-albatross.toml' ..."
 export NIMIQ_OVERRIDE_DEVNET_CONFIG=$tmp_dir/dev-albatross.toml
-cargo clean -p nimiq-genesis --release
 cargo build --release
 
 echo "Create docker images... "


### PR DESCRIPTION
Achieve this by reading the genesis block at runtime if
`NIMIQ_OVERRIDE_DEVNET_CONFIG` is set.

This unfortunately introduces a runtime dependency of `genesis` to
`nimiq-build-tools`. This could be fixed by either moving
`GenesisBuilder` out of `nimiq-build-tools` or making this
`NIMIQ_OVERRIDE_DEVNET_CONFIG` feature optional by introducing a cargo
feature for it.

Also move to thin LTO instead of fat LTO for release mode.

This improves compilation times for nimiq-client and nimiq-spammer by
40% on my machine, going down from over 5 minutes to 3 minutes.

Runtime performance differences in TPS when running the devnet script
seem to be within the variance of normal runs.

https://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html