### PR TITLE
Change `log` to `tracing` transparently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,6 @@ dependencies = [
  "beserial_derive",
  "hex",
  "lazy_static",
- "log",
  "nimiq-bls",
  "nimiq-build-tools",
  "nimiq-collections",
@@ -3006,6 +3005,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3016,7 +3016,6 @@ dependencies = [
  "beserial_derive",
  "bitflags 1.3.2",
  "hex",
- "log",
  "nimiq-bls",
  "nimiq-collections",
  "nimiq-database",
@@ -3034,6 +3033,7 @@ dependencies = [
  "num-traits",
  "serde",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3042,7 +3042,6 @@ version = "0.1.0"
 dependencies = [
  "beserial",
  "hex",
- "log",
  "nimiq-account",
  "nimiq-block",
  "nimiq-blockchain",
@@ -3061,6 +3060,7 @@ dependencies = [
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "rand 0.8.5",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -3071,7 +3071,6 @@ dependencies = [
  "beserial",
  "beserial_derive",
  "hex",
- "log",
  "nimiq-account",
  "nimiq-block",
  "nimiq-block-production",
@@ -3092,6 +3091,7 @@ dependencies = [
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "rand 0.8.5",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3108,13 +3108,13 @@ dependencies = [
  "blake2-rfc",
  "byteorder",
  "hex",
- "log",
  "nimiq-hash",
  "nimiq-utils",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "rand 0.8.5",
  "serde",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3126,7 +3126,6 @@ dependencies = [
  "ctrlc",
  "hex",
  "lazy_static",
- "log",
  "nimiq-account",
  "nimiq-block",
  "nimiq-bls",
@@ -3147,6 +3146,7 @@ dependencies = [
  "thiserror",
  "time 0.3.7",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -3154,9 +3154,9 @@ name = "nimiq-client"
 version = "0.1.0"
 dependencies = [
  "futures",
- "log",
  "nimiq-lib",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3166,10 +3166,10 @@ dependencies = [
  "beserial",
  "hex",
  "itertools 0.10.3",
- "log",
  "num-traits",
  "rand 0.8.5",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -3182,7 +3182,6 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
- "log",
  "nimiq-block",
  "nimiq-block-production",
  "nimiq-blockchain",
@@ -3208,6 +3207,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3216,9 +3216,9 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "lmdb-zero",
- "log",
  "rand 0.8.5",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -3231,7 +3231,6 @@ dependencies = [
  "bitflags 1.3.2",
  "hex",
  "lazy_static",
- "log",
  "nimiq-account",
  "nimiq-block",
  "nimiq-bls",
@@ -3247,6 +3246,7 @@ dependencies = [
  "nimiq-trie",
  "nimiq-utils",
  "pretty_env_logger",
+ "tracing",
  "url",
 ]
 
@@ -3259,7 +3259,6 @@ dependencies = [
  "beserial_derive",
  "futures",
  "lazy_static",
- "log",
  "nimiq-bls",
  "nimiq-collections",
  "nimiq-hash",
@@ -3272,6 +3271,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3440,6 +3440,7 @@ dependencies = [
  "thiserror",
  "time 0.3.7",
  "toml",
+ "tracing",
  "url",
 ]
 
@@ -3479,6 +3480,7 @@ dependencies = [
  "simple_logger",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3569,12 +3571,12 @@ dependencies = [
  "beserial",
  "derive_more",
  "futures",
- "log",
  "nimiq-utils",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3591,7 +3593,6 @@ dependencies = [
  "hex",
  "ip_network",
  "libp2p",
- "log",
  "nimiq-bls",
  "nimiq-hash",
  "nimiq-macros",
@@ -3622,13 +3623,13 @@ dependencies = [
  "beserial_derive",
  "derive_more",
  "futures",
- "log",
  "nimiq-network-interface",
  "nimiq-utils",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3642,7 +3643,6 @@ dependencies = [
  "hex",
  "human-panic",
  "lazy_static",
- "log",
  "nimiq-bls",
  "nimiq-build-tools",
  "nimiq-hash",
@@ -3653,6 +3653,7 @@ dependencies = [
  "nimiq-utils",
  "simple_logger",
  "thiserror",
+ "tracing",
  "url",
 ]
 
@@ -3666,7 +3667,6 @@ dependencies = [
  "hex",
  "itertools 0.10.3",
  "lazy_static",
- "log",
  "nimiq-bls",
  "nimiq-keys",
  "nimiq-utils",
@@ -3677,6 +3677,7 @@ dependencies = [
  "serde",
  "strum_macros",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3735,7 +3736,6 @@ dependencies = [
  "beserial",
  "futures",
  "hex",
- "log",
  "nimiq-account",
  "nimiq-block",
  "nimiq-blockchain",
@@ -3767,6 +3767,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3775,7 +3776,6 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "lazy_static",
- "log",
  "nimiq-block",
  "nimiq-blockchain",
  "nimiq-keys",
@@ -3788,6 +3788,7 @@ dependencies = [
  "rand 0.8.5",
  "structopt",
  "tokio",
+ "tracing",
  "warp 0.3.2",
 ]
 
@@ -3799,7 +3800,6 @@ dependencies = [
  "beserial_derive",
  "bitflags 1.3.2",
  "hex",
- "log",
  "nimiq-bls",
  "nimiq-hash",
  "nimiq-keys",
@@ -3807,6 +3807,7 @@ dependencies = [
  "nimiq-primitives",
  "nimiq-transaction",
  "nimiq-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -3817,12 +3818,12 @@ dependencies = [
  "async-trait",
  "beserial",
  "futures",
- "log",
  "nimiq-block",
  "nimiq-hash",
  "nimiq-primitives",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3833,7 +3834,6 @@ dependencies = [
  "beserial",
  "futures",
  "hex",
- "log",
  "nimiq-block",
  "nimiq-block-production",
  "nimiq-blockchain",
@@ -3861,6 +3861,7 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3871,7 +3872,6 @@ dependencies = [
  "beserial",
  "clap 3.1.5",
  "hex",
- "log",
  "nimiq-bls",
  "nimiq-hash",
  "nimiq-keys",
@@ -3880,6 +3880,7 @@ dependencies = [
  "nimiq-utils",
  "rand 0.8.5",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3890,7 +3891,6 @@ dependencies = [
  "beserial_derive",
  "bitflags 1.3.2",
  "hex",
- "log",
  "nimiq-bls",
  "nimiq-hash",
  "nimiq-keys",
@@ -3901,6 +3901,7 @@ dependencies = [
  "serde",
  "strum_macros",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3929,11 +3930,11 @@ dependencies = [
  "beserial",
  "beserial_derive",
  "hex",
- "log",
  "nimiq-database",
  "nimiq-hash",
  "nimiq-keys",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3948,7 +3949,6 @@ dependencies = [
  "futures-lite",
  "hex",
  "libp2p",
- "log",
  "nimiq-collections",
  "nimiq-database",
  "nimiq-hash",
@@ -3960,6 +3960,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -4005,6 +4006,7 @@ dependencies = [
  "simple_logger",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -4015,12 +4017,12 @@ dependencies = [
  "beserial",
  "beserial_derive",
  "futures",
- "log",
  "nimiq-bls",
  "nimiq-network-interface",
  "nimiq-utils",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4031,7 +4033,6 @@ dependencies = [
  "byteorder",
  "curve25519-dalek 3.2.1",
  "hex",
- "log",
  "nimiq-hash",
  "nimiq-keys",
  "nimiq-macros",
@@ -4040,6 +4041,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha2 0.9.9",
+ "tracing",
 ]
 
 [[package]]

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 hex = "0.4"
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 thiserror = "1.0"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = "0.8"
 

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -13,7 +13,7 @@ blake2-rfc = "0.2"
 byteorder = "1.3.4"
 thiserror = "1.0"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git", optional = true }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 ctrlc = "3.1"
 hex = "0.4"
 lazy_static = "1.3"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 paw = "1.0"
 pretty_env_logger = "0.4"
 rand = "0.8"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 futures = "0.3"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 tokio = { version = "1.16", features = ["rt-multi-thread", "time", "tracing"] }
 
 [dependencies.nimiq]

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 itertools = { version = "0.10", optional = true }
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 
 beserial = { path = "../beserial", optional = true }
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 async-trait = "0.1"
 futures = "0.3"
 lazy_static = "1.4.0"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 pin-project = "1.0"
 rand = "0.8"

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -19,6 +19,6 @@ maintenance = { status = "experimental" }
 [dependencies]
 bitflags = "1.0"
 lmdb-zero = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 rand = "0.8"
 tempfile = "3"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -42,7 +42,7 @@ nimiq-trie = { path = "../primitives/trie" }
 nimiq-utils = { path = "../utils", features = ["observer", "crc", "time"] }
 
 [build-dependencies]
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 pretty_env_logger = "0.4"
 
 nimiq-build-tools = { path = "../build-tools" }

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 async-trait = "0.1"
 futures = "0.3"
 lazy_static = "1.3"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = "0.8"
 thiserror = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "experimental" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actual_log = { package = "log", version = "0.4" }
 colored = { version = "2.0", optional = true }
 derive_builder = "0.10"
 directories = "4.0"
@@ -27,7 +28,7 @@ file-rotate = { version = "0.6" }
 hex = "0.4"
 # human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
 lazy_static = "1.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 log-panics = { version = "2.0", features = ["with-backtrace"], optional = true }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git", features = ["deadlock_detection"] }
 paw = "1.0"

--- a/lib/src/config/command_line.rs
+++ b/lib/src/config/command_line.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use log::{LevelFilter, ParseLevelError};
+use actual_log::{LevelFilter, ParseLevelError};
 use structopt::StructOpt;
 use thiserror::Error;
 

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -3,7 +3,7 @@ use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use log::LevelFilter;
+use actual_log::LevelFilter;
 use serde_derive::Deserialize;
 use thiserror::Error;
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
     RpcServer(#[from] nimiq_rpc_server::Error),
 
     #[error("Logger error: {0}")]
-    Logging(#[from] log::SetLoggerError),
+    Logging(#[from] actual_log::SetLoggerError),
 
     #[error("Failed to parse multiaddr: {0}")]
     Multiaddr(#[from] nimiq_network_libp2p::libp2p::core::multiaddr::Error),

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -1,11 +1,12 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use actual_log::LevelFilter;
 use colored::Colorize;
 use fern::colors::{Color, ColoredLevelConfig};
 use fern::{log_file, Dispatch};
 use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
 use lazy_static::lazy_static;
-use log::{Level, LevelFilter};
+use log::Level;
 use time::OffsetDateTime;
 
 use crate::{
@@ -193,8 +194,8 @@ impl NimiqDispatch for Dispatch {
 
 macro_rules! force_log {
     ($lvl:expr, $($arg:tt)+) => ({
-        if log::log_enabled!($lvl) {
-            log::log!($lvl, $($arg)+);
+        if log::enabled!($lvl) {
+            log::event!($lvl, $($arg)+);
         } else {
             eprintln!($($arg)+);
         }
@@ -202,16 +203,14 @@ macro_rules! force_log {
 }
 
 pub fn log_error_cause_chain<E: std::error::Error>(e: &E) {
-    let level = Level::Error;
-
-    force_log!(level, "{}", e);
+    force_log!(Level::ERROR, "{}", e);
 
     if let Some(mut e) = e.source() {
-        force_log!(level, "  caused by");
-        force_log!(level, "    {}", e);
+        force_log!(Level::ERROR, "  caused by");
+        force_log!(Level::ERROR, "    {}", e);
 
         while let Some(source) = e.source() {
-            force_log!(level, "    {}", source);
+            force_log!(Level::ERROR, "    {}", source);
 
             e = source;
         }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 futures = "0.3"
 futures-lite = "1.12.0"
@@ -38,6 +38,7 @@ nimiq-transaction = { path = "../primitives/transaction" }
 nimiq-utils = { path = "../utils", features = ["observer", "mutable-once"] }
 
 [dev-dependencies]
+actual_log = { package = "log", version = "0.4" }
 hex = "0.4"
 rand = "0.8"
 simple_logger = "2.1"

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
+use actual_log::LevelFilter::Debug;
 use futures::{channel::mpsc, sink::SinkExt};
-use log::LevelFilter::Debug;
 use parking_lot::RwLock;
 use rand::prelude::StdRng;
 use rand::SeedableRng;

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.16", features = [
 ] }
 tokio-stream = { version = "0.1", features = ["default", "sync"] }
 
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 
 beserial = { path = "../beserial" }
 nimiq-utils = { path = "../utils", features = ["crc"] }

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -34,7 +34,7 @@ libp2p = { version = "0.43", default-features = false, features = [
     "dns-tokio",
     "tcp-tokio",
 ] }
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 pin-project = "1.0"
 pin-project-lite = "0.2.0"
@@ -44,7 +44,6 @@ thiserror = "1.0"
 tokio = { version = "1.16", features = ["macros", "rt", "tracing"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec"] }
-tracing = "0.1"
 tracing-attributes = "0.1"
 wasm-timer = "0.2"
 

--- a/network-libp2p/src/dispatch/codecs/typed.rs
+++ b/network-libp2p/src/dispatch/codecs/typed.rs
@@ -154,7 +154,7 @@ impl Decoder for MessageCodec {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<(MessageType, BytesMut)>, Error> {
-        let span = tracing::trace_span!("decode");
+        let span = log::trace_span!("decode");
         let _enter = span.enter();
         loop {
             match &self.state {

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 async-trait = "0.1"
 derive_more = "0.99"
 futures = "0.3"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 thiserror = "1.0"
 tokio = { version = "1.16", features = [

--- a/peer-address/Cargo.toml
+++ b/peer-address/Cargo.toml
@@ -36,7 +36,7 @@ nimiq-utils = { path = "../utils", features = ["observer", "crc", "time"] }
 
 [build-dependencies]
 human-panic = { version = "1.0" }
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 simple_logger = "2.1"
 
 nimiq-build-tools = { path = "../build-tools" }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -21,7 +21,7 @@ bitvec = "1.0"
 hex = {version = "0.4", optional = true}
 itertools = {version = "0.10", optional = true}
 lazy_static = {version = "1.2", optional = true}
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 num-bigint = {version = "0.4.2", optional = true}
 num-traits = {version = "0.2", optional = true}
 parking_lot = {git = "https://github.com/styppo/parking_lot.git", optional = true}

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [dependencies]
 hex = {version = "0.4"}
 lazy_static = "1.3"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = {git = "https://github.com/styppo/parking_lot.git"}
 rand = "0.8"
 serde = {version = "1.0", features = ["derive"], optional = true}

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "experimental" }
 bitflags = "1.0"
 thiserror = "1.0"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 num-bigint = "0.4.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/primitives/subscription/Cargo.toml
+++ b/primitives/subscription/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "nimiq/core-rs", branch = "master" }
 [dependencies]
 bitflags = "1.0"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 
 beserial = { path = "../../beserial" }
 beserial_derive = { path = "../../beserial/beserial_derive" }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "nimiq/core-rs", branch = "master" }
 [dependencies]
 bitflags = "1.0"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 num-traits = "0.2"
 serde = { version = "1.0", optional = true }
 strum_macros = "0.24"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 
 [dependencies]
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 thiserror = "1.0"
 
 beserial = { path = "../../beserial" }

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 async-trait = "0.1"
 futures = "0.3"
 hex = "0.4.2"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 futures = "0.3"
 lazy_static = { version = "1.4", optional = true }
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 prometheus = { version = "0.13", features = ["process"], optional = true }
 rand = "0.8.5"
 tokio = { version = "1.16", features = ["rt-multi-thread", "time", "tracing"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 async-stream = "0.3.0"
 async-trait = "0.1"
 futures = "0.3"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 thiserror = "1.0"
 
 nimiq-block = { path = "../primitives/block" }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 async-trait = "0.1"
 futures = "0.3"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 rand = "0.8"
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 tokio = { version = "1.16", features = ["rt", "time", "tracing"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/signtx/main.rs"
 anyhow = "1.0"
 clap = { version = "3.1", features = ["cargo"] }
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 rand = "0.8"
 thiserror = "1.0"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -24,7 +24,7 @@ futures = { version = "0.3" }
 futures-lite = { version = "1.12.0" }
 hex = { version = "0.4", optional = true }
 libp2p = { version = "0.43", optional = true }
-log = { version = "0.4", optional = true }
+log = { package = "tracing", version = "0.1", optional = true }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = { version = "0.8", optional = true }
 rand_core = { version = "0.6", optional = true }

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -22,7 +22,7 @@ beserial = { path = "../beserial", features = ["libp2p"] }
 beserial_derive = { path = "../beserial/beserial_derive" }
 futures = "0.3"
 thiserror = "1.0"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 tokio = "1.16"
 
 nimiq-network-interface = { path = "../network-interface" }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 lazy_static = "1.3"
 linked-hash-map = "0.5.4"
 lmdb-zero = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = "0.8"
 tokio = { version = "1.16", features = ["rt", "time", "tracing"] }
@@ -55,6 +55,7 @@ nimiq-validator-network = { path = "../validator-network" }
 nimiq-vrf = { path = "../vrf" }
 
 [dev-dependencies]
+actual_log = { package = "log", version = "0.4" }
 hex = "0.4"
 simple_logger = "2.1.0"
 tokio = { version = "1.16", features = ["rt", "test-util", "time", "tracing"] }

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
+use actual_log::LevelFilter::{Debug, Info};
 use futures::{future, StreamExt};
-use log::LevelFilter::{Debug, Info};
 use nimiq_blockchain::AbstractBlockchain;
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_network_libp2p::Network;

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 byteorder = "1.3"
 curve25519-dalek = "3"
 hex = "0.4"
-log = "0.4"
+log = { package = "tracing", version = "0.1" }
 num-traits = "0.2"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
This allows us to do very little changes. The only ones necessary were
in `network-libp2p` and `lib`.

In `network-libp2p`, both `tracing` and `log` were used before, since
there were more lines with `log`, I decided to use the name `log` there
as well.

In `lib` there was some setting up the logging output which still needs
some of the old `log` crate unless we change the output crate from
`fern` to something else. I renamed `log` to `actual_log` for this
crate.