### PR TITLE
Add option for a graylog backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,8 +3494,10 @@ dependencies = [
  "structopt",
  "strum_macros",
  "thiserror",
+ "tokio",
  "toml",
  "tracing",
+ "tracing-gelf",
  "tracing-log",
  "tracing-subscriber 0.3.9",
  "url",
@@ -5922,6 +5924,35 @@ checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.10",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-gelf"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef407d785989f789a53a00c9a6196735ef6e407ae2bb20e0282b3b9dc271f66"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "hostname",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.6.9",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,6 +38,8 @@ strum_macros = "0.24"
 toml = "0.5"
 url = "2.2"
 thiserror = "1.0"
+tokio = { version = "1.16", features = ["rt"], optional = true }
+tracing-gelf = { version = "0.6", optional = true }
 tracing-log = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
@@ -66,7 +68,7 @@ nimiq-wallet = { path = "../wallet", optional = true }
 deadlock = []
 default = []
 launcher = []
-logging = ["tracing-log", "tracing-subscriber"]
+logging = ["tokio", "tracing-gelf", "tracing-log", "tracing-subscriber"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -353,6 +353,8 @@ pub struct LogSettings {
     pub statistics: u64,
     #[serde(default)]
     pub file: Option<String>,
+    #[serde(default)]
+    pub graylog_address: Option<String>,
     #[serde(default = "LogSettings::default_rotating_trace_log")]
     pub rotating_trace_log: Option<RotatingLogFileConfig>,
 }
@@ -375,6 +377,7 @@ impl Default for LogSettings {
             tags: HashMap::new(),
             statistics: Self::default_statistics_interval(),
             file: None,
+            graylog_address: None,
             rotating_trace_log: Self::default_rotating_trace_log(),
         }
     }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     #[error("Logger error: {0}")]
     Logging(#[from] tracing_subscriber::filter::FromEnvError),
 
+    #[error("Gelf logger error: {0}")]
+    LoggingGelf(#[from] tracing_gelf::BuilderError),
+
     #[error("Failed to parse multiaddr: {0}")]
     Multiaddr(#[from] nimiq_network_libp2p::libp2p::core::multiaddr::Error),
 


### PR DESCRIPTION
Add the config option `graylog_address` to specify where the logs get
sent. The graylog backend is intended to be used for centralizing our
logging for the devnet.