### PR TITLE
Add option for a graylog backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,8 +3494,10 @@ dependencies = [
  "structopt",
  "strum_macros",
  "thiserror",
+ "tokio",
  "toml",
  "tracing",
+ "tracing-gelf",
  "tracing-log",
  "tracing-subscriber 0.3.9",
  "url",
@@ -5922,6 +5924,35 @@ checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.10",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-gelf"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef407d785989f789a53a00c9a6196735ef6e407ae2bb20e0282b3b9dc271f66"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "hostname",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.6.9",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
+ "serde_json",
  "structopt",
  "strum_macros",
  "thiserror",
@@ -5268,6 +5269,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,6 +33,7 @@ paw = "1.0"
 rand = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 structopt = { version = "0.3", features = ["paw"] }
 strum_macros = "0.24"
 toml = "0.5"
@@ -68,7 +69,7 @@ nimiq-wallet = { path = "../wallet", optional = true }
 deadlock = []
 default = []
 launcher = []
-logging = ["tokio", "tracing-gelf", "tracing-log", "tracing-subscriber"]
+logging = ["serde_json", "tokio", "tracing-gelf", "tracing-log", "tracing-subscriber"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,6 +38,8 @@ strum_macros = "0.24"
 toml = "0.5"
 url = "2.2"
 thiserror = "1.0"
+tokio = { version = "1.16", features = ["rt"], optional = true }
+tracing-gelf = { version = "0.6", optional = true }
 tracing-log = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
@@ -66,7 +68,7 @@ nimiq-wallet = { path = "../wallet", optional = true }
 deadlock = []
 default = []
 launcher = []
-logging = ["tracing-log", "tracing-subscriber"]
+logging = ["tokio", "tracing-gelf", "tracing-log", "tracing-subscriber"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -211,6 +211,22 @@ level = "debug"
 # Default: 3
 # file_count = 2
 
+# Graylog target
+# [log.graylog]
+
+# Graylog server address
+# address = "localhost:9000"
+
+# Extra fields to add to every log record
+# [log.graylog_extra_fields]
+# host = "mine"
+# run = 1
+# production = false
+
+# Alternate way of writing the above, under the [log] section
+# extra_fields = { host = "mine", run = 1, production = false }
+
+
 ##############################################################################
 ##
 ## Configure mempool

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -204,8 +204,8 @@ level = "debug"
 # path = none
 
 # Size of each log file
-# Default: 50000000 (50mB)
-# size = 50000000
+# Default: 50_000_000 (50 MB)
+# size = 50_000_000
 
 # Count of additional log files. The total log files count will be file_count + 2.
 # Default: 3

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -340,7 +340,7 @@ impl Default for RotatingLogFileConfig {
     fn default() -> Self {
         Self {
             path: paths::home().join("logs"),
-            size: 50000000, // 50mB
+            size: 50_000_000, // 50 MB
             file_count: 3,
         }
     }

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -319,6 +319,14 @@ impl From<ReverseProxySettings> for ReverseProxyConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct GraylogConfig {
+    pub address: String,
+    #[serde(default)]
+    pub extra_fields: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RotatingLogFileConfig {
     #[serde(default)]
     pub path: PathBuf,
@@ -354,7 +362,7 @@ pub struct LogSettings {
     #[serde(default)]
     pub file: Option<String>,
     #[serde(default)]
-    pub graylog_address: Option<String>,
+    pub graylog: Option<GraylogConfig>,
     #[serde(default = "LogSettings::default_rotating_trace_log")]
     pub rotating_trace_log: Option<RotatingLogFileConfig>,
 }
@@ -377,7 +385,7 @@ impl Default for LogSettings {
             tags: HashMap::new(),
             statistics: Self::default_statistics_interval(),
             file: None,
-            graylog_address: None,
+            graylog: None,
             rotating_trace_log: Self::default_rotating_trace_log(),
         }
     }

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -353,6 +353,8 @@ pub struct LogSettings {
     pub statistics: u64,
     #[serde(default)]
     pub file: Option<String>,
+    #[serde(default)]
+    pub graylog_address: Option<String>,
     #[serde(default = "LogSettings::default_rotating_trace_log")]
     pub rotating_trace_log: Option<RotatingLogFileConfig>,
 }
@@ -375,6 +377,7 @@ impl Default for LogSettings {
             tags: HashMap::new(),
             statistics: Self::default_statistics_interval(),
             file: None,
+            graylog_address: None,
             rotating_trace_log: Self::default_rotating_trace_log(),
         }
     }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     #[error("Logger error: {0}")]
     Logging(#[from] tracing_subscriber::filter::FromEnvError),
 
+    #[error("Gelf logger error: {0}")]
+    LoggingGelf(#[from] tracing_gelf::BuilderError),
+
     #[error("Failed to parse multiaddr: {0}")]
     Multiaddr(#[from] nimiq_network_libp2p::libp2p::core::multiaddr::Error),
 

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -349,8 +349,12 @@ pub fn initialize_logging(
         None
     };
 
-    let gelf_layer = if let Some(graylog_address) = settings.graylog_address {
-        let (layer, bg_task) = tracing_gelf::Logger::builder().connect_tcp(graylog_address)?;
+    let gelf_layer = if let Some(graylog) = &settings.graylog {
+        let mut builder = tracing_gelf::Logger::builder();
+        for (name, value) in &graylog.extra_fields {
+            builder = builder.additional_field(name.clone(), value.clone());
+        }
+        let (layer, bg_task) = builder.connect_tcp(graylog.address.clone())?;
         let layer = layer.with_filter(
             Targets::new()
                 .with_default(DEFAULT_LEVEL)


### PR DESCRIPTION
Add the config option `graylog_address` to specify where the logs get
sent. The graylog backend is intended to be used for centralizing our
logging for the devnet.