### PR TITLE
Replace `gcc` with `clang` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For more detailed information about how to connect and use the development netwo
 Besides [Rust nightly](https://www.rust-lang.org/learn/get-started#installing-rust) itself,
 the following packages are required to be able to compile the source code:
 
-- `gcc`
+- `clang`
 - `pkg-config`
 - `libssl-dev` (in Debian/Ubuntu) or `openssl-devel` (in Fedora/Red Hat)
 


### PR DESCRIPTION
Due to the database change, we now need `clang` installed. I tested that
it works without explicitly installing `gcc` on Arch Linux, Debian and
Fedora.

Without having `clang` installed, you get a message like this:
```
error: failed to run custom build command for `mdbx-sys v0.11.4-git.20210105`Caused by:
  process didn't exit successfully: `path/to/core-rs-albatross/target/debug/build/mdbx-sys-4de169d42151e6ee/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', home/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.59.2/src/lib.rs:2144:31
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/f0c4da49983aa699f715caf681e3154b445fb60b/library/std/src/panicking.rs:584:5
```