### PR TITLE
Fix genesis env variable for docker environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 !/target/debug/nimiq-spammer
 !/target/release/nimiq-spammer
 !/scripts/docker_*.sh
+!/genesis/src/genesis/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ VOLUME /home/nimiq/.nimiq
 
 # Copy necessary files from host environment
 COPY ./scripts/docker_*.sh /home/nimiq/
+COPY ./genesis/src/genesis/dev-albatross-4-validators.toml /home/nimiq/
 
 ARG BUILD=debug
 ARG APP=client

--- a/build_alpine.Dockerfile
+++ b/build_alpine.Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir -p /home/nimiq/.nimiq
 VOLUME /home/nimiq/.nimiq
 
 COPY ./scripts/docker_*.sh /home/nimiq/
+COPY ./genesis/src/genesis/dev-albatross-4-validators.toml /home/nimiq/
 
 # Pull necessary files from builder image
 COPY --chown=root:root --from=builder /build/nimiq-client /usr/local/bin/nimiq-client

--- a/build_ubuntu.Dockerfile
+++ b/build_ubuntu.Dockerfile
@@ -47,6 +47,7 @@ RUN mkdir -p /home/nimiq/.nimiq
 VOLUME /home/nimiq/.nimiq
 
 COPY ./scripts/docker_*.sh /home/nimiq/
+COPY ./genesis/src/genesis/dev-albatross-4-validators.toml /home/nimiq/
 
 # Pull necessary files from builder image
 COPY --chown=root:root --from=builder /build/nimiq-client /usr/local/bin/nimiq-client

--- a/scripts/devnet_docker_scenario.sh
+++ b/scripts/devnet_docker_scenario.sh
@@ -50,7 +50,7 @@ echo "Copying the genesis and docker compose files... "
 
 #Compile the code
 echo "Compiling the code using '$tmp_dir/dev-albatross.toml' ..."
-export NIMIQ_OVERRIDE_DEVNET_CONFIG=$tmp_dir/dev-albatross.toml
+cp -v $tmp_dir/dev-albatross.toml genesis/src/genesis/dev-albatross-4-validators.toml
 cargo build --release
 
 echo "Create docker images... "

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -11,5 +11,5 @@ fi
 if [[ ! -e "/home/nimiq/.nimiq/client.toml" || $OVERRIDE_CONFIG_FILE -eq 1 ]]; then
     ./docker_config.sh > /home/nimiq/.nimiq/client.toml
 fi
-
+export NIMIQ_OVERRIDE_DEVNET_CONFIG=/home/nimiq/dev-albatross-4-validators.toml
 /usr/local/bin/nimiq-client $@


### PR DESCRIPTION
The NIMIQ_OVERRIDE_DEVNET_CONFIG flag needs to be set during runtime for the different
docker based scenarios

This is part of issue #643 