### PR TITLE
Record the block height a Tendermint instance is started with

### DIFF
--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -6,7 +6,7 @@ use nimiq_hash::Blake2bHash;
 use nimiq_primitives::networks::NetworkId;
 
 /// An enum used when a fork is detected.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ForkEvent {
     Detected(ForkProof),
 }

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -45,7 +45,7 @@ pub struct MacroHeader {
     /// The seed of the block. This is the BLS signature of the seed of the immediately preceding
     /// block (either micro or macro) using the validator key of the block proposer.
     pub seed: VrfSeed,
-    /// The extra data of the block. It is simply 32 raw bytes.
+    /// The extra data of the block. It is simply up to 32 raw bytes.
     ///
     /// It encodes the initial supply in the genesis block, as a big-endian `u64`.
     ///

--- a/tendermint/src/outside_deps.rs
+++ b/tendermint/src/outside_deps.rs
@@ -13,7 +13,7 @@ pub trait TendermintOutsideDeps: Send + Unpin {
     type ProofTy: ProofTrait;
     type ResultTy: ResultTrait;
 
-    /// The round tendermint is supposed to start with.
+    /// The round Tendermint is supposed to start with.
     fn initial_round(&self) -> u32;
 
     /// Verify that a given Tendermint state is valid. This is necessary when we are initializing

--- a/tendermint/src/outside_deps.rs
+++ b/tendermint/src/outside_deps.rs
@@ -13,6 +13,9 @@ pub trait TendermintOutsideDeps: Send + Unpin {
     type ProofTy: ProofTrait;
     type ResultTy: ResultTrait;
 
+    /// The block height this Tendermint instance is supposed to be used for.
+    fn block_height(&self) -> u32;
+
     /// The round Tendermint is supposed to start with.
     fn initial_round(&self) -> u32;
 

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -44,13 +44,13 @@ impl<
         let valid_round = self.state.valid_round;
 
         if self.deps.is_our_turn(round) {
-            let proposal = if self.state.valid_value.is_some() {
+            let proposal = if let Some(valid_value) = &self.state.valid_value {
                 debug!(
                     "Our turn at round {}, broadcasting former valid proposal of round {}",
                     round,
                     self.state.valid_round.unwrap()
                 );
-                self.state.valid_value.clone().unwrap()
+                valid_value.clone()
             } else {
                 debug!("Our turn at round {}, broadcasting fresh proposal", round);
                 self.deps.get_value(round)?

--- a/tendermint/src/state.rs
+++ b/tendermint/src/state.rs
@@ -8,6 +8,7 @@ use crate::{
 /// variables that we need for our implementation (those are prefixed with "current").
 #[derive(Clone, Debug)]
 pub struct TendermintState<ProposalTy: ProposalTrait, ProofTy: ProofTrait> {
+    pub height: u32,
     pub round: u32,
     pub step: Step,
     pub locked_value: Option<ProposalTy>,
@@ -21,8 +22,9 @@ pub struct TendermintState<ProposalTy: ProposalTrait, ProofTy: ProofTrait> {
 }
 
 impl<ProposalTy: ProposalTrait, ProofTy: ProofTrait> TendermintState<ProposalTy, ProofTy> {
-    pub fn new(initial_round: u32) -> Self {
+    pub fn new(height: u32, initial_round: u32) -> Self {
         Self {
+            height,
             round: initial_round,
             step: Step::Propose,
             locked_value: None,

--- a/tendermint/src/stream.rs
+++ b/tendermint/src/stream.rs
@@ -117,7 +117,7 @@ where
             }
         }
 
-        // get the background_stream fromthe outside deps.
+        // get the background_stream from the outside deps.
         let background_task = deps
             .get_background_task()
             .into_stream()

--- a/tendermint/src/stream.rs
+++ b/tendermint/src/stream.rs
@@ -45,7 +45,7 @@ where
     let mut tendermint = if let Some(state) = state_opt {
         Tendermint { deps, state }
     } else {
-        Tendermint { state: TendermintState::new(deps.initial_round()), deps }
+        Tendermint { state: TendermintState::new(deps.block_height(), deps.initial_round()), deps }
     };
 
     // This is the main loop of the function. It progresses the Tendermint state machine.

--- a/tendermint/src/stream.rs
+++ b/tendermint/src/stream.rs
@@ -111,6 +111,11 @@ where
         // An optional input for the TendermintState.
         state_opt: Option<TendermintState<ProposalTy, ProofTy>>,
     ) -> Result<Self, DepsTy> {
+        debug!(
+            "Initializing tendermint with{} prior state",
+            if state_opt.is_some() { "" } else { "out" }
+        );
+
         if let Some(state) = &state_opt {
             if !deps.verify_state(state) {
                 return Err(deps);

--- a/tendermint/tests/mod.rs
+++ b/tendermint/tests/mod.rs
@@ -70,6 +70,10 @@ impl TendermintOutsideDeps for TestValidator {
     // is just the empty type, our result is just the TestProposal.
     type ResultTy = TestProposal;
 
+    fn block_height(&self) -> u32 {
+        0
+    }
+
     fn initial_round(&self) -> u32 {
         0
     }

--- a/validator/src/aggregation/tendermint/aggregations.rs
+++ b/validator/src/aggregation/tendermint/aggregations.rs
@@ -164,7 +164,7 @@ impl<N: ValidatorNetwork> TendermintAggregations<N> {
 
     pub fn cancel_aggregation(&self, round: u32, step: TendermintStep) {
         if let Some(descriptor) = self.aggregation_descriptors.get(&(round, step)) {
-            trace!("canceling aggregation for {}-{:?}", &round, &step);
+            trace!("cancelling aggregation for {}-{:?}", &round, &step);
             descriptor.is_running.store(false, Ordering::Relaxed);
         }
     }

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -126,7 +126,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
             vec![],
         );
 
-        // Cache the block body and hash for future use.
+        // Cache the block body for future use.
         self.cache_body = block.body;
 
         // Return the block header as the proposal.

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -82,6 +82,10 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
     type ProofTy = MultiSignature;
     type ResultTy = MacroBlock;
 
+    fn block_height(&self) -> u32 {
+        self.block_height
+    }
+
     fn initial_round(&self) -> u32 {
         // Macro blocks follow the same rules as micro blocks when it comes to view_number/round.
         // Thus the round is offset by the predecessors view.

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -127,7 +127,8 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
         );
 
         // Cache the block body for future use.
-        self.cache_body = block.body;
+        // Always `Some(…)` because the above function always sets it to `Some(…)`.
+        self.cache_body = Some(block.body.expect("produced blocks always have a body"));
 
         // Return the block header as the proposal.
         Ok(block.header)
@@ -334,7 +335,9 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
                     match block_state {
                         Ok(body) => {
                             // Cache the body that we calculated.
-                            self.cache_body = body;
+                            self.cache_body = Some(body.expect(
+                                "verify_block_state returns a body for blocks without one",
+                            ));
                             (MsgAcceptance::Accept, valid_round, Some(header))
                         }
                         Err(err) => {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -250,7 +250,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             {
                 // If we are parked and no transaction has been seen in the expected validity window
                 // after an epoch, reset our parking state
-                log::debug!("Reseting state to re-send un-park transactions since we are parked and validity window doesn't contain the transaction sent");
+                log::debug!("Resetting state to re-send un-park transactions since we are parked and validity window doesn't contain the transaction sent");
                 self.parking_state = None;
             }
         }
@@ -434,7 +434,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         while let Poll::Ready(Some(event)) = macro_producer.poll_next_unpin(cx) {
             match event {
                 TendermintReturn::Error(err) => {
-                    log::error!("Tendermint Returned an Error: {:?}", err);
+                    log::error!("Tendermint returned an error: {:?}", err);
                 }
                 TendermintReturn::Result(block) => {
                     // If the event is a result meaning the next macro block was produced we push it onto our local chain


### PR DESCRIPTION
Previously, when Tendermint state was persisted, it was annotated with
the block height at the time of persistence instead of the block height
the Tendermint instance was started for.

Fixes https://github.com/nimiq/core-rs-albatross/issues/645.