### PR TITLE
Refactor `nimiq-database` a bit

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,7 +1,5 @@
 use thiserror::Error;
 
-use nimiq_database::volatile::VolatileDatabaseError;
-
 // #[cfg(feature = "validator")]
 // use validator::error::Error as ValidatorError;
 #[derive(Error, Debug)]
@@ -9,8 +7,8 @@ pub enum Error {
     #[error("Configuration error: {0}")]
     Config(String), // TODO
 
-    #[error("LMDB error: {0}")]
-    Lmdb(#[from] nimiq_database::mdbx::LmdbError),
+    #[error("MDBX error: {0}")]
+    Lmdb(#[from] nimiq_database::Error),
 
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
@@ -56,14 +54,5 @@ impl Error {
     ///
     pub fn config_error<S: AsRef<str>>(msg: S) -> Self {
         Self::Config(msg.as_ref().to_string())
-    }
-}
-
-impl From<VolatileDatabaseError> for Error {
-    fn from(e: VolatileDatabaseError) -> Self {
-        match e {
-            VolatileDatabaseError::IoError(e) => e.into(),
-            VolatileDatabaseError::LmdbError(e) => e.into(),
-        }
     }
 }


### PR DESCRIPTION
I wanted to remove the temporary files that the database tests spawn in
my source directory, then I got sidetracked by seeing a couple of
`unwrap`s, properly returned them as errors and also allowed opening
databases from `Path`s, removing one error condition in
`VolatileEnvironment::new`.