### PR TITLE
tracingify `blockchain::push`

### DIFF
--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -356,7 +356,7 @@ do
 
     # First collect the last block number from each validator
     for log in $logsdir/*.log; do
-        bn=$({ grep "Accepted block #" $log || test $? = 1; } | tail -1 | awk -F# '{print $2}' | cut --delimiter=. --fields 1)
+        bn=$({ grep "Accepted block" $log || test $? = 1; } | tail -1 | awk -F# '{print $2}' | cut --delimiter=. --fields 1)
         if [ -z "$bn" ]; then
             bns+=(0)
         else


### PR DESCRIPTION
Changes log messages a little, not sure if it affects readability too
much.

Old:
```
2022-03-11T17:25:45.637897Z DEBUG push                 | Accepted block #9.0:MI:df4a6595d1 with 0 transactions (extend)
2022-03-11T17:25:45.660765Z DEBUG push                 | Accepted block #10.0:MI:be38f68765 with 0 transactions (extend)
2022-03-11T17:25:45.687445Z DEBUG push                 | Accepted block #11.0:MI:2600b77a25 with 0 transactions (extend)

```

New:
```
2022-03-11T23:46:59.815181Z DEBUG push                 | Accepted block block=#9.0:MI:d846e5a8b4 num_transactions=0 kind="extend"
2022-03-11T23:46:59.863129Z DEBUG push                 | Accepted block block=#10.0:MI:1ea7fa1e4e num_transactions=0 kind="extend"
2022-03-11T23:46:59.899362Z DEBUG push                 | Accepted block block=#11.0:MI:a97db2b9df num_transactions=0 kind="extend"
```

Also, these haven't been tested for ingestion into Grafana yet, so maybe
we should hold off merging them.