### PR TITLE
Surface errors in transaction-builder

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -297,7 +297,8 @@ fn it_can_revert_unpark_transactions() {
         Coin::ZERO,
         1,
         NetworkId::UnitAlbatross,
-    );
+    )
+    .unwrap();
 
     transactions.push(tx);
 
@@ -395,7 +396,8 @@ fn it_can_revert_create_stacker_transaction() {
         100.try_into().unwrap(),
         1,
         NetworkId::UnitAlbatross,
-    );
+    )
+    .unwrap();
 
     transactions.push(tx);
 

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -109,7 +109,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -147,7 +147,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -197,7 +197,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -247,7 +247,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -301,7 +301,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -364,7 +364,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -420,7 +420,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -477,7 +477,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -527,7 +527,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(hex::encode(&sig.serialize_to_vec()))
     }
@@ -551,7 +551,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -597,7 +597,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -647,7 +647,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -692,7 +692,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -760,7 +760,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -862,7 +862,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -921,7 +921,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -969,7 +969,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -1017,7 +1017,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }
@@ -1059,7 +1059,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        );
+        )?;
 
         Ok(transaction_to_hex_string(&transaction))
     }

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -403,7 +403,8 @@ fn generate_transactions(
             Coin::from_u64_unchecked(200),
             start_height,
             network_id,
-        );
+        )
+        .unwrap();
         txs.push(tx);
     }
 

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -51,7 +51,8 @@ pub fn generate_transactions(
             Coin::from_u64_unchecked(2),
             start_height,
             network_id,
-        );
+        )
+        .unwrap();
         txs.push(tx);
     }
 

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -153,7 +153,7 @@ impl TransactionBuilder {
     ///     NetworkId::Main
     /// );
     ///
-    /// let proof_builder = builder.generate().unwrap();
+    /// let proof_builder = builder.generate()?;
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(transaction.sender, sender);
     /// ```
@@ -227,7 +227,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
-    /// let proof_builder = builder.generate().unwrap();
+    /// let proof_builder = builder.generate()?;
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(transaction.fee, Coin::from_u64_unchecked(1337));
     /// ```
@@ -292,7 +292,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
-    /// let proof_builder = builder.generate().unwrap();
+    /// let proof_builder = builder.generate()?;
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(transaction.sender_type, AccountType::HTLC);
     ///
@@ -336,7 +336,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
-    /// let proof_builder = builder.generate().unwrap();
+    /// let proof_builder = builder.generate()?;
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(
     ///     transaction.recipient,
@@ -413,7 +413,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
-    /// let proof_builder = builder.generate().unwrap();
+    /// let proof_builder = builder.generate()?;
     /// let transaction = proof_builder.preliminary_transaction();
     /// ```
     ///
@@ -503,7 +503,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let sender = Address::from(key_pair);
         let mut builder = Self::new();
         builder
@@ -514,11 +514,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Basic(mut builder) => {
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -550,7 +550,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let sender = Address::from(key_pair);
 
         let mut builder = Self::new();
@@ -562,11 +562,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Basic(mut builder) => {
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -604,7 +604,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_vesting_builder(owner);
         recipient.with_steps(value, start_time, time_step, num_steps);
 
@@ -617,11 +617,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Basic(mut builder) => {
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -652,7 +652,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut builder = Self::new();
         builder
             .with_sender(contract_address)
@@ -663,11 +663,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Basic(mut builder) => {
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -710,7 +710,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_htlc_builder();
         recipient
             .with_sender(htlc_sender)
@@ -727,11 +727,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Basic(mut builder) => {
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -777,7 +777,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut builder = Self::new();
         builder
             .with_sender(contract_address)
@@ -788,12 +788,12 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Htlc(mut builder) => {
                 let sig = builder.signature_with_key_pair(key_pair);
                 builder.regular_transfer(hash_algorithm, pre_image, hash_count, hash_root, sig);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -826,7 +826,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut builder = Self::new();
         builder
             .with_sender(contract_address)
@@ -837,12 +837,12 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Htlc(mut builder) => {
                 let sig = builder.signature_with_key_pair(key_pair);
                 builder.timeout_resolve(sig);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -878,7 +878,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut builder = Self::new();
         builder
             .with_sender(contract_address)
@@ -889,11 +889,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::Htlc(mut builder) => {
                 builder.early_resolve(htlc_sender_signature, htlc_recipient_signature);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -927,7 +927,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> SignatureProof {
+    ) -> Result<SignatureProof, TransactionBuilderError> {
         let mut builder = Self::new();
         builder
             .with_sender(contract_address)
@@ -938,9 +938,9 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
-            TransactionProofBuilder::Htlc(builder) => builder.signature_with_key_pair(key_pair),
+            TransactionProofBuilder::Htlc(builder) => Ok(builder.signature_with_key_pair(key_pair)),
             _ => unreachable!(),
         }
     }
@@ -972,7 +972,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.create_staker(delegation);
 
@@ -985,13 +985,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(staker_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1022,7 +1022,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.stake(staker_address);
 
@@ -1035,13 +1035,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(&KeyPair::default());
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1078,7 +1078,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.update_staker(new_delegation);
 
@@ -1101,7 +1101,7 @@ impl TransactionBuilder {
             }
         }
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(staker_key_pair);
@@ -1109,12 +1109,12 @@ impl TransactionBuilder {
                     None => {
                         let mut builder = builder.generate().unwrap().unwrap_out_staking();
                         builder.unstake(staker_key_pair);
-                        builder.generate().unwrap()
+                        Ok(builder.generate().unwrap())
                     }
                     Some(key) => {
                         let mut builder = builder.generate().unwrap().unwrap_basic();
                         builder.sign_with_key_pair(key);
-                        builder.generate().unwrap()
+                        Ok(builder.generate().unwrap())
                     }
                 }
             }
@@ -1146,7 +1146,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let recipient = Recipient::new_basic(recipient);
 
         let mut builder = Self::new();
@@ -1159,11 +1159,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::OutStaking(mut builder) => {
                 builder.unstake(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1199,7 +1199,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.create_validator(signing_key, voting_key_pair, reward_address, signal_data);
 
@@ -1212,13 +1212,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(cold_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1258,7 +1258,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.update_validator(
             new_signing_key,
@@ -1276,13 +1276,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(cold_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1316,7 +1316,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.inactivate_validator(validator_address);
 
@@ -1329,13 +1329,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(signing_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1369,7 +1369,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.reactivate_validator(validator_address);
 
@@ -1382,13 +1382,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(signing_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1422,7 +1422,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
         recipient.unpark_validator(validator_address);
 
@@ -1435,13 +1435,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(signing_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }
@@ -1469,7 +1469,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Transaction {
+    ) -> Result<Transaction, TransactionBuilderError> {
         let recipient = Recipient::new_basic(recipient);
 
         let mut builder = Self::new();
@@ -1482,11 +1482,11 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate().unwrap();
+        let proof_builder = builder.generate()?;
         match proof_builder {
             TransactionProofBuilder::OutStaking(mut builder) => {
                 builder.delete_validator(cold_key_pair);
-                builder.generate().unwrap()
+                Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),
         }

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -153,7 +153,7 @@ impl TransactionBuilder {
     ///     NetworkId::Main
     /// );
     ///
-    /// let proof_builder = builder.generate()?;
+    /// let proof_builder = builder.generate().unwrap();
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(transaction.sender, sender);
     /// ```
@@ -227,7 +227,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
-    /// let proof_builder = builder.generate()?;
+    /// let proof_builder = builder.generate().unwrap();
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(transaction.fee, Coin::from_u64_unchecked(1337));
     /// ```
@@ -292,7 +292,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
-    /// let proof_builder = builder.generate()?;
+    /// let proof_builder = builder.generate().unwrap();
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(transaction.sender_type, AccountType::HTLC);
     ///
@@ -336,7 +336,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
-    /// let proof_builder = builder.generate()?;
+    /// let proof_builder = builder.generate().unwrap();
     /// let transaction = proof_builder.preliminary_transaction();
     /// assert_eq!(
     ///     transaction.recipient,
@@ -413,7 +413,7 @@ impl TransactionBuilder {
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
-    /// let proof_builder = builder.generate()?;
+    /// let proof_builder = builder.generate().unwrap();
     /// let transaction = proof_builder.preliminary_transaction();
     /// ```
     ///

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -11,7 +11,7 @@ use nimiq_transaction::account::staking_contract::{
     IncomingStakingTransactionData, OutgoingStakingTransactionProof,
 };
 use nimiq_transaction::{SignatureProof, Transaction};
-use nimiq_transaction_builder::TransactionBuilder;
+use nimiq_transaction_builder::{TransactionBuilder, TransactionBuilderError};
 
 const ADDRESS: &str = "9cd82948650d902d95d52ea2ec91eae6deb0c9fe";
 const PRIVATE_KEY: &str = "b410a7a583cbc13ef4f1cbddace30928bcb4f9c13722414bc4a2faaba3f4e187";
@@ -42,7 +42,8 @@ fn it_can_create_staker_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -62,7 +63,8 @@ fn it_can_create_staker_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -83,7 +85,8 @@ fn it_can_create_staker_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -103,7 +106,8 @@ fn it_can_create_staker_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -117,9 +121,33 @@ fn it_can_create_staker_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
+}
+
+#[test]
+fn it_can_fail_creating_staker_transactions() {
+    let key_pair = ed25519_key_pair();
+    let address = Address::from_any_str(ADDRESS).unwrap();
+
+    // Invalid stake
+    let err3 = TransactionBuilder::new_stake(
+        &key_pair,
+        address,
+        0.try_into().unwrap(), // InvalidValue
+        100.try_into().unwrap(),
+        1,
+        NetworkId::Dummy,
+    )
+    .err();
+
+    match err3 {
+        Some(TransactionBuilderError::InvalidValue) => {}
+        Some(_) => panic!("Wrong error returned"),
+        None => panic!("No error returned"),
+    }
 }
 
 #[test]
@@ -152,7 +180,8 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -180,7 +209,8 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -201,7 +231,8 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -222,7 +253,8 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -243,7 +275,8 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 
@@ -256,7 +289,8 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tx, tx2);
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -590,7 +590,8 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             Coin::ZERO,
             validity_start_height,
             blockchain.network_id(),
-        );
+        )
+        .unwrap(); // TODO: Handle transaction creation error
         let tx_hash = unpark_transaction.hash();
 
         let cn = self.consensus.clone();


### PR DESCRIPTION
#### This fixes #667.

## What's in this pull request?

Errors generating a `proof_builder` in `transaction-builder` were not handled, which lead to panics when invalid input is provided, such as e.g. an invalid tx value.
