### PR TITLE
Change to upstream `tracing-gelf` again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,8 +5852,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gelf"
-version = "0.6.0"
-source = "git+https://github.com/hrxi/tracing-gelf.git?branch=nimiq#6640b2d3932037590d14d382de2ccf0c6041b161"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d094204165dcfc9cffe7b2c22d98e4a7bc86f1e8a052c83c7c5442ee325bf4"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,7 +39,7 @@ toml = "0.5"
 url = "2.2"
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["rt"], optional = true }
-tracing-gelf = { git = "https://github.com/hrxi/tracing-gelf.git", branch = "nimiq", optional = true }
+tracing-gelf = { version = "0.6.1", optional = true }
 tracing-log = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 


### PR DESCRIPTION
Now that they released 0.6.1 with the error message fixes
(https://github.com/hlb8122/tracing-gelf/pull/16).