### PR TITLE
Add tokio-console support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc347c19eb5b940f396ac155822caee6662f850d97306890ac3773ed76c90c5a"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565a7dfea2d10dd0e5c57cc394d5d441b1910960d8c9211ed14135e0e6ec3a20"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "parking_lot 0.11.2",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.9",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1490,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1636,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite 0.2.8",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2716,6 +2785,7 @@ dependencies = [
  "ansi_term",
  "beserial",
  "clap",
+ "console-subscriber",
  "derive_builder",
  "directories",
  "file-rotate",
@@ -4720,6 +4790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite 0.2.8",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,6 +4881,75 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project 1.0.10",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project 1.0.10",
+ "pin-project-lite 0.2.8",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.0",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
@@ -4901,6 +5050,7 @@ dependencies = [
  "ansi_term",
  "lazy_static",
  "matchers",
+ "parking_lot 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex",
  "sharded-slab",
  "smallvec",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,6 +21,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 ansi_term = "0.12"
 clap = { version = "3.0", features = ["derive"] }
+console-subscriber = { version = "0.1", features = ["parking_lot"], optional = true }
 derive_builder = "0.11"
 directories = "4.0"
 file-rotate = { version = "0.6" }
@@ -37,7 +38,7 @@ strum_macros = "0.24"
 toml = "0.5"
 url = "2.2"
 thiserror = "1.0"
-tokio = { version = "1.16", features = ["rt"], optional = true }
+tokio = { version = "1.16", features = ["rt", "tracing"], optional = true }
 tracing-gelf = { version = "0.6.1", optional = true }
 tracing-log = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
@@ -67,7 +68,7 @@ nimiq-wallet = { path = "../wallet", optional = true }
 deadlock = []
 default = []
 launcher = []
-logging = ["serde_json", "tokio", "tracing-gelf", "tracing-log", "tracing-subscriber"]
+logging = ["console-subscriber", "serde_json", "tokio", "tracing-gelf", "tracing-log", "tracing-subscriber"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -196,6 +196,10 @@ level = "debug"
 # Default: none
 #file = "nimiq-client.log"
 
+# Tokio console
+# Default: None
+#tokio_console_bind_address = "127.0.0.1:6669"
+
 # Specify a rotating log file containing a trace log
 # [log.rotating_trace_log]
 

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -366,6 +366,8 @@ pub struct LogSettings {
     pub graylog: Option<GraylogConfig>,
     #[serde(default = "LogSettings::default_rotating_trace_log")]
     pub rotating_trace_log: Option<RotatingLogFileConfig>,
+    #[serde(default)]
+    pub tokio_console_bind_address: Option<String>,
 }
 
 impl LogSettings {
@@ -388,6 +390,7 @@ impl Default for LogSettings {
             file: None,
             graylog: None,
             rotating_trace_log: Self::default_rotating_trace_log(),
+            tokio_console_bind_address: None,
         }
     }
 }


### PR DESCRIPTION
As this is an unstable feature of `tokio`, you need to pass
`RUSTFLAGS="--cfg tokio_unstable"` to cargo while compiling.

Example:
```
RUSTFLAGS='--cfg tokio_unstable' cargo run --bin=nimiq-client -- -c client.toml
```

Unfortunately, any changes to `RUSTFLAGS` cause a complete rebuild
including all dependencies.

In order to also enable the support at runtime, you either need to set
the `TOKIO_CONSOLE_BIND` or the `log.tokio_console_bind_address` config
variable.

```
TOKIO_CONSOLE_BIND=127.0.0.1:6669 RUSTFLAGS='--cfg tokio_unstable' cargo run --bin=nimiq-client -- -c client.toml
```

or in `client.toml`:

```
[log]
tokio_console_bind_address = "127.0.0.1:6669"
```

tokio-console can be installed with `cargo install tokio-console`.