### PR TITLE
Rename `{BATCH,EPOCH}_LENGTH` to `BLOCK_PER_{BATCH,EPOCH}`

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1432,7 +1432,7 @@ mod tests {
         let history_store = HistoryStore::new(env.clone());
         let mut txn = WriteTransaction::new(&env);
 
-        for i in 0..=(16 * policy::BATCH_LENGTH) {
+        for i in 0..=(16 * policy::BLOCKS_PER_BATCH) {
             if policy::is_macro_block_at(i) {
                 let ext_txs = vec![
                     create_inherent(i, 1),
@@ -1458,7 +1458,7 @@ mod tests {
         for i in (1..=16).rev() {
             history_store.remove_partial_history(
                 &mut txn,
-                policy::epoch_at(i * policy::BATCH_LENGTH),
+                policy::epoch_at(i * policy::BLOCKS_PER_BATCH),
                 4,
             );
 

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -84,7 +84,7 @@ fn it_can_create_batch_finalization_inherents() {
             &mut txn,
             &[],
             &[slash_inherent],
-            policy::BATCH_LENGTH + 1,
+            policy::BLOCKS_PER_BATCH + 1,
             0,
         )
         .is_ok());

--- a/blockchain/tests/mod.rs
+++ b/blockchain/tests/mod.rs
@@ -150,13 +150,13 @@ fn micro_block_works_after_macro_block() {
     let temp_producer = TemporaryBlockProducer::new();
 
     // apply an entire batch including macro block on view_number/round_number zero
-    for _ in 0..policy::BATCH_LENGTH {
+    for _ in 0..policy::BLOCKS_PER_BATCH {
         let _ = temp_producer.next_block(0, vec![]);
     }
     // make sure we are at the beginning of the batch and all block were applied
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BATCH_LENGTH
+        policy::BLOCKS_PER_BATCH
     );
     assert_eq!(temp_producer.blockchain.read().view_number(), 0);
 
@@ -171,24 +171,24 @@ fn micro_block_works_after_macro_block() {
     // make sure this was an extend
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BATCH_LENGTH + 1
+        policy::BLOCKS_PER_BATCH + 1
     );
     // and rebranch it to block view number 1
     temp_producer.push(rebranch).unwrap();
     // make sure this was a rebranch
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BATCH_LENGTH + 1
+        policy::BLOCKS_PER_BATCH + 1
     );
 
     // apply the rest of the batch including macro block on view_number/round_number one
-    for _ in 0..policy::BATCH_LENGTH - 1 {
+    for _ in 0..policy::BLOCKS_PER_BATCH - 1 {
         let _ = temp_producer.next_block(2, vec![]);
     }
     // make sure we are at the beginning of the batch
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BATCH_LENGTH * 2
+        policy::BLOCKS_PER_BATCH * 2
     );
     assert_eq!(temp_producer.blockchain.read().view_number(), 2);
 
@@ -206,7 +206,7 @@ fn micro_block_works_after_macro_block() {
 
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BATCH_LENGTH * 2 + 1
+        policy::BLOCKS_PER_BATCH * 2 + 1
     );
     assert_eq!(temp_producer.blockchain.read().view_number(), 2);
 }
@@ -283,7 +283,7 @@ fn it_cant_rebranch_across_epochs() {
     temp_producer2.push(ancestor).unwrap();
 
     // progress the chain across an epoch boundary.
-    for _ in 0..policy::EPOCH_LENGTH {
+    for _ in 0..policy::BLOCKS_PER_EPOCH {
         temp_producer1.next_block(0, vec![]);
     }
 
@@ -327,7 +327,7 @@ fn it_can_rebranch_to_inferior_macro_block() {
 
     // [0] - [0] - ... - [0] - [macro 0]
     //    \- [1] - ... - [1]
-    for _ in 0..policy::BATCH_LENGTH - 1 {
+    for _ in 0..policy::BLOCKS_PER_BATCH - 1 {
         let inferior = producer1.next_block(0, vec![]);
         producer2.next_block(1, vec![]);
         assert_eq!(producer2.push(inferior), Ok(PushResult::Ignored));

--- a/consensus/src/sync/block_queue.rs
+++ b/consensus/src/sync/block_queue.rs
@@ -61,8 +61,8 @@ pub struct BlockQueueConfig {
 impl Default for BlockQueueConfig {
     fn default() -> Self {
         Self {
-            buffer_max: 4 * policy::BATCH_LENGTH as usize,
-            window_max: 2 * policy::BATCH_LENGTH,
+            buffer_max: 4 * policy::BLOCKS_PER_BATCH as usize,
+            window_max: 2 * policy::BLOCKS_PER_BATCH,
         }
     }
 }

--- a/nano-blockchain/src/push.rs
+++ b/nano-blockchain/src/push.rs
@@ -226,7 +226,7 @@ impl NanoBlockchain {
 
         // Check if we have this block's successor.
         let prev_block = chain_store_r
-            .get_election(epoch + policy::EPOCH_LENGTH)
+            .get_election(epoch + policy::BLOCKS_PER_EPOCH)
             .ok_or(PushError::InvalidSuccessor)?;
 
         // Verify that the block is indeed the predecessor.

--- a/nano-zkp/examples/verify.rs
+++ b/nano-zkp/examples/verify.rs
@@ -7,7 +7,7 @@ use ark_serialize::CanonicalDeserialize;
 
 use nimiq_nano_zkp::utils::create_test_blocks;
 use nimiq_nano_zkp::NanoZKP;
-use nimiq_primitives::policy::EPOCH_LENGTH;
+use nimiq_primitives::policy::BLOCKS_PER_EPOCH;
 
 /// Verifies a proof for a chain of election blocks. The random parameters generation uses always
 /// the same seed, so it will always generate the same data (validators, signatures, etc).
@@ -47,7 +47,7 @@ fn main() {
         0,
         initial_header_hash,
         initial_pks,
-        EPOCH_LENGTH * number_epochs as u32,
+        BLOCKS_PER_EPOCH * number_epochs as u32,
         final_header_hash,
         final_pks,
         proof,

--- a/nano-zkp/src/circuits/mnt4/macro_block.rs
+++ b/nano-zkp/src/circuits/mnt4/macro_block.rs
@@ -12,7 +12,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 
 use nimiq_bls::pedersen::pedersen_generators;
 use nimiq_nano_primitives::MacroBlock;
-use nimiq_primitives::policy::EPOCH_LENGTH;
+use nimiq_primitives::policy::BLOCKS_PER_EPOCH;
 
 use crate::gadgets::mnt4::{
     MacroBlockGadget, PedersenHashGadget, SerializeGadget, StateCommitmentGadget,
@@ -78,7 +78,7 @@ impl ConstraintSynthesizer<MNT4Fr> for MacroBlockCircuit {
     /// This function generates the constraints for the circuit.
     fn generate_constraints(self, cs: ConstraintSystemRef<MNT4Fr>) -> Result<(), SynthesisError> {
         // Allocate all the constants.
-        let epoch_length_var = UInt32::<MNT4Fr>::new_constant(cs.clone(), EPOCH_LENGTH)?;
+        let epoch_length_var = UInt32::<MNT4Fr>::new_constant(cs.clone(), BLOCKS_PER_EPOCH)?;
 
         let pedersen_generators_var =
             Vec::<G1Var>::new_constant(cs.clone(), pedersen_generators(5))?;
@@ -105,7 +105,10 @@ impl ConstraintSynthesizer<MNT4Fr> for MacroBlockCircuit {
         let block_var = MacroBlockGadget::new_witness(cs.clone(), || Ok(&self.block))?;
 
         let initial_block_number_var =
-            UInt32::new_witness(cs.clone(), || Ok(self.block.block_number - EPOCH_LENGTH))?;
+            UInt32::new_witness(
+                cs.clone(),
+                || Ok(self.block.block_number - BLOCKS_PER_EPOCH),
+            )?;
 
         // Allocate all the inputs.
         let initial_state_commitment_var =

--- a/nano-zkp/src/nano_zkp/prove.rs
+++ b/nano-zkp/src/nano_zkp/prove.rs
@@ -18,7 +18,7 @@ use nimiq_nano_primitives::{merkle_tree_prove, serialize_g1_mnt6, serialize_g2_m
 use nimiq_nano_primitives::{
     pk_tree_construct, state_commitment, vk_commitment, MacroBlock, PK_TREE_BREADTH, PK_TREE_DEPTH,
 };
-use nimiq_primitives::policy::{EPOCH_LENGTH, SLOTS};
+use nimiq_primitives::policy::{BLOCKS_PER_EPOCH, SLOTS};
 
 use crate::circuits::mnt4::{
     MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT4, PKTreeNodeCircuit as NodeMNT4,
@@ -671,7 +671,7 @@ impl NanoZKP {
 
         // Calculate the inputs.
         let mut initial_state_commitment = pack_inputs(bytes_to_bits(&state_commitment(
-            block.block_number - EPOCH_LENGTH,
+            block.block_number - BLOCKS_PER_EPOCH,
             initial_header_hash,
             initial_pks.to_vec(),
         )));
@@ -749,7 +749,7 @@ impl NanoZKP {
 
         // Calculate the inputs.
         let mut initial_state_commitment = pack_inputs(bytes_to_bits(&state_commitment(
-            block.block_number - EPOCH_LENGTH,
+            block.block_number - BLOCKS_PER_EPOCH,
             initial_header_hash,
             initial_pks.to_vec(),
         )));
@@ -828,7 +828,7 @@ impl NanoZKP {
 
         // Get the intermediate state commitment.
         let intermediate_state_commitment = state_commitment(
-            block.block_number - EPOCH_LENGTH,
+            block.block_number - BLOCKS_PER_EPOCH,
             initial_header_hash,
             initial_pks.to_vec(),
         );
@@ -936,7 +936,7 @@ impl NanoZKP {
         // Calculate the inputs.
         let initial_state_comm_bytes = match genesis_data {
             None => state_commitment(
-                block.block_number - EPOCH_LENGTH,
+                block.block_number - BLOCKS_PER_EPOCH,
                 initial_header_hash,
                 initial_pks.to_vec(),
             ),

--- a/nano-zkp/src/utils.rs
+++ b/nano-zkp/src/utils.rs
@@ -13,7 +13,7 @@ use rand::rngs::SmallRng;
 use rand::{RngCore, SeedableRng};
 
 use nimiq_nano_primitives::{pk_tree_construct, state_commitment, MacroBlock};
-use nimiq_primitives::policy::{EPOCH_LENGTH, SLOTS, TWO_F_PLUS_ONE};
+use nimiq_primitives::policy::{BLOCKS_PER_EPOCH, SLOTS, TWO_F_PLUS_ONE};
 
 /// Takes a vector of booleans and converts it into a vector of field elements, which is the way we
 /// represent inputs to circuits (natively).
@@ -222,7 +222,7 @@ pub fn create_test_blocks(
 
     // Create the macro block.
     let mut block =
-        MacroBlock::without_signatures(EPOCH_LENGTH * (index as u32 + 1), 0, final_header_hash);
+        MacroBlock::without_signatures(BLOCKS_PER_EPOCH * (index as u32 + 1), 0, final_header_hash);
 
     for i in 0..SLOTS as usize {
         if signer_bitmap[i] {

--- a/primitives/account/src/staking_contract/mod.rs
+++ b/primitives/account/src/staking_contract/mod.rs
@@ -343,7 +343,8 @@ impl StakingContract {
                         return false;
                     }
                     Some(time) => {
-                        if block_height <= policy::election_block_after(time) + policy::BATCH_LENGTH
+                        if block_height
+                            <= policy::election_block_after(time) + policy::BLOCKS_PER_BATCH
                         {
                             warn!(
                     "Cannot pay fees for transaction because validator hasn't been inactive for long enough."

--- a/primitives/account/src/staking_contract/validator.rs
+++ b/primitives/account/src/staking_contract/validator.rs
@@ -673,7 +673,7 @@ impl StakingContract {
                 return Err(AccountError::InvalidForSender);
             }
             Some(time) => {
-                if block_height <= policy::election_block_after(time) + policy::BATCH_LENGTH {
+                if block_height <= policy::election_block_after(time) + policy::BLOCKS_PER_BATCH {
                     return Err(AccountError::InvalidForSender);
                 }
             }

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -16,7 +16,7 @@ use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_primitives::policy;
 use nimiq_primitives::policy::{
-    BATCH_LENGTH, EPOCH_LENGTH, STAKING_CONTRACT_ADDRESS, VALIDATOR_DEPOSIT,
+    BLOCKS_PER_BATCH, BLOCKS_PER_EPOCH, STAKING_CONTRACT_ADDRESS, VALIDATOR_DEPOSIT,
 };
 use nimiq_primitives::slots::SlashedSlot;
 use nimiq_transaction::account::staking_contract::{
@@ -946,7 +946,7 @@ fn delete_validator_works() {
             &accounts_tree,
             &mut db_txn,
             &tx,
-            next_election_block + BATCH_LENGTH + 1,
+            next_election_block + BLOCKS_PER_BATCH + 1,
             0
         ),
         Ok(Some(receipt.clone()))
@@ -1753,7 +1753,7 @@ fn slash_inherents_work() {
             &accounts_tree,
             &mut db_txn,
             &inherent,
-            1 + BATCH_LENGTH,
+            1 + BLOCKS_PER_BATCH,
             0
         ),
         Ok(Some(receipt.clone()))
@@ -1782,7 +1782,7 @@ fn slash_inherents_work() {
         &accounts_tree,
         &mut db_txn,
         &inherent,
-        1 + BATCH_LENGTH,
+        1 + BLOCKS_PER_BATCH,
         Some(&receipt),
         &validator_address,
         slot.slot,
@@ -1801,7 +1801,7 @@ fn slash_inherents_work() {
             &accounts_tree,
             &mut db_txn,
             &inherent,
-            1 + EPOCH_LENGTH,
+            1 + BLOCKS_PER_EPOCH,
             0
         ),
         Ok(Some(receipt.clone()))
@@ -1829,7 +1829,7 @@ fn slash_inherents_work() {
         &accounts_tree,
         &mut db_txn,
         &inherent,
-        1 + EPOCH_LENGTH,
+        1 + BLOCKS_PER_EPOCH,
         Some(&receipt),
         &validator_address,
         slot.slot,

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -49,13 +49,13 @@ pub const TWO_F_PLUS_ONE: u16 = (2 * SLOTS + 3 - 1) / 3;
 pub const F_PLUS_ONE: u16 = (SLOTS + 3 - 1) / 3;
 
 /// Length of a batch including the macro block
-pub const BATCH_LENGTH: u32 = 32; // TODO Set
+pub const BLOCKS_PER_BATCH: u32 = 32; // TODO Set
 
 /// How many batches constitute an epoch
 pub const BATCHES_PER_EPOCH: u16 = 4; // TODO Set
 
 /// Length of epoch including election macro block
-pub const EPOCH_LENGTH: u32 = BATCH_LENGTH * BATCHES_PER_EPOCH as u32;
+pub const BLOCKS_PER_EPOCH: u32 = BLOCKS_PER_BATCH * BATCHES_PER_EPOCH as u32;
 
 /// The maximum drift, in milliseconds, that is allowed between any block's timestamp and the node's
 /// system time. We only care about drifting to the future.
@@ -90,33 +90,33 @@ pub const SUPPLY_DECAY: f64 = 4.692821935e-13;
 /// Returns the epoch number at a given block number (height).
 #[inline]
 pub fn epoch_at(block_number: u32) -> u32 {
-    (block_number + EPOCH_LENGTH - 1) / EPOCH_LENGTH
+    (block_number + BLOCKS_PER_EPOCH - 1) / BLOCKS_PER_EPOCH
 }
 
 /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
 /// to the the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
 #[inline]
 pub fn epoch_index_at(block_number: u32) -> u32 {
-    (block_number + EPOCH_LENGTH - 1) % EPOCH_LENGTH
+    (block_number + BLOCKS_PER_EPOCH - 1) % BLOCKS_PER_EPOCH
 }
 
 /// Returns the batch number at a given `block_number` (height)
 #[inline]
 pub fn batch_at(block_number: u32) -> u32 {
-    (block_number + BATCH_LENGTH - 1) / BATCH_LENGTH
+    (block_number + BLOCKS_PER_BATCH - 1) / BLOCKS_PER_BATCH
 }
 
 /// Returns the batch index at a given block number. The batch index is the number of a block relative
 /// to the the batch it is in. For example, the first block of any batch always has an batch index of 0.
 #[inline]
 pub fn batch_index_at(block_number: u32) -> u32 {
-    (block_number + BATCH_LENGTH - 1) % BATCH_LENGTH
+    (block_number + BLOCKS_PER_BATCH - 1) % BLOCKS_PER_BATCH
 }
 
 /// Returns the number (height) of the next election macro block after a given block number (height).
 #[inline]
 pub fn election_block_after(block_number: u32) -> u32 {
-    (block_number / EPOCH_LENGTH + 1) * EPOCH_LENGTH
+    (block_number / BLOCKS_PER_EPOCH + 1) * BLOCKS_PER_EPOCH
 }
 
 /// Returns the number (height) of the preceding election macro block before a given block number (height).
@@ -126,26 +126,26 @@ pub fn election_block_before(block_number: u32) -> u32 {
     if block_number == 0 {
         panic!("Called macro_block_before with block_number 0");
     }
-    (block_number - 1) / EPOCH_LENGTH * EPOCH_LENGTH
+    (block_number - 1) / BLOCKS_PER_EPOCH * BLOCKS_PER_EPOCH
 }
 
 /// Returns the number (height) of the last election macro block at a given block number (height).
 /// If the given block number is an election macro block, then it returns that block number.
 #[inline]
 pub fn last_election_block(block_number: u32) -> u32 {
-    block_number / EPOCH_LENGTH * EPOCH_LENGTH
+    block_number / BLOCKS_PER_EPOCH * BLOCKS_PER_EPOCH
 }
 
 /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
 #[inline]
 pub fn is_election_block_at(block_number: u32) -> bool {
-    epoch_index_at(block_number) == EPOCH_LENGTH - 1
+    epoch_index_at(block_number) == BLOCKS_PER_EPOCH - 1
 }
 
 /// Returns the number (height) of the next macro block after a given block number (height).
 #[inline]
 pub fn macro_block_after(block_number: u32) -> u32 {
-    (block_number / BATCH_LENGTH + 1) * BATCH_LENGTH
+    (block_number / BLOCKS_PER_BATCH + 1) * BLOCKS_PER_BATCH
 }
 
 /// Returns the number (height) of the preceding macro block before a given block number (height).
@@ -155,26 +155,26 @@ pub fn macro_block_before(block_number: u32) -> u32 {
     if block_number == 0 {
         panic!("Called macro_block_before with block_number 0");
     }
-    (block_number - 1) / BATCH_LENGTH * BATCH_LENGTH
+    (block_number - 1) / BLOCKS_PER_BATCH * BLOCKS_PER_BATCH
 }
 
 /// Returns the number (height) of the last macro block at a given block number (height).
 /// If the given block number is a macro block, then it returns that block number.
 #[inline]
 pub fn last_macro_block(block_number: u32) -> u32 {
-    block_number / BATCH_LENGTH * BATCH_LENGTH
+    block_number / BLOCKS_PER_BATCH * BLOCKS_PER_BATCH
 }
 
 /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
 #[inline]
 pub fn is_macro_block_at(block_number: u32) -> bool {
-    batch_index_at(block_number) == BATCH_LENGTH - 1
+    batch_index_at(block_number) == BLOCKS_PER_BATCH - 1
 }
 
 /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
 #[inline]
 pub fn is_micro_block_at(block_number: u32) -> bool {
-    batch_index_at(block_number) != BATCH_LENGTH - 1
+    batch_index_at(block_number) != BLOCKS_PER_BATCH - 1
 }
 
 /// Returns the block number of the first block of the given epoch (which is always a micro block).
@@ -182,7 +182,7 @@ pub fn first_block_of(epoch: u32) -> u32 {
     if epoch == 0 {
         panic!("Called first_block_of for epoch 0");
     }
-    (epoch - 1) * EPOCH_LENGTH + 1
+    (epoch - 1) * BLOCKS_PER_EPOCH + 1
 }
 
 ///  Returns the block number of the first block of the given batch (which is always a micro block).
@@ -190,25 +190,25 @@ pub fn first_block_of_batch(batch: u32) -> u32 {
     if batch == 0 {
         panic!("Called first_block_of_batch for batch 0");
     }
-    (batch - 1) * BATCH_LENGTH + 1
+    (batch - 1) * BLOCKS_PER_BATCH + 1
 }
 
 /// Returns the block number of the election macro block of the given epoch (which is always the last block).
 pub fn election_block_of(epoch: u32) -> u32 {
-    epoch * EPOCH_LENGTH
+    epoch * BLOCKS_PER_EPOCH
 }
 
 /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
 /// is always the last block).
 pub fn macro_block_of(batch: u32) -> u32 {
-    batch * BATCH_LENGTH
+    batch * BLOCKS_PER_BATCH
 }
 
 /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
 /// of the epoch.
 #[inline]
 pub fn first_batch_of_epoch(block_number: u32) -> bool {
-    epoch_index_at(block_number) < BATCH_LENGTH
+    epoch_index_at(block_number) < BLOCKS_PER_BATCH
 }
 
 /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -131,7 +131,7 @@ pub fn fill_micro_blocks(producer: &BlockProducer, blockchain: &Arc<RwLock<Block
 
     assert!(policy::is_macro_block_at(init_height));
 
-    let macro_block_number = init_height + policy::BATCH_LENGTH;
+    let macro_block_number = init_height + policy::BLOCKS_PER_BATCH;
 
     for i in (init_height + 1)..macro_block_number {
         let blockchain = blockchain.upgradable_read();
@@ -165,7 +165,7 @@ pub fn fill_micro_blocks_with_txns(
     let key_pair = KeyPair::from(PrivateKey::from_str(UNIT_KEY).unwrap());
     assert!(policy::is_macro_block_at(init_height));
 
-    let macro_block_number = init_height + policy::BATCH_LENGTH;
+    let macro_block_number = init_height + policy::BLOCKS_PER_BATCH;
 
     for i in (init_height + 1)..macro_block_number {
         log::debug!(" Current Height: {}", i);

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -241,7 +241,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             let staking_state = self.get_staking_state(&*blockchain);
             if staking_state == ValidatorStakingState::Parked
                 && blockchain.block_number()
-                    >= parking_state.park_tx_validity_window_start + policy::EPOCH_LENGTH
+                    >= parking_state.park_tx_validity_window_start + policy::BLOCKS_PER_EPOCH
                 && !blockchain.tx_in_validity_window(
                     &parking_state.park_tx_hash,
                     parking_state.park_tx_validity_window_start,


### PR DESCRIPTION
Helpful commands:
```
sed -i 's/BATCH_LENGTH/BLOCKS_PER_BATCH/g' **/*.rs
sed -i 's/EPOCH_LENGTH/BLOCKS_PER_EPOCH/g' **/*.rs
```

A naive grep suggested that they're almost never used in a `usize`
context, so I kept them as `u32`.

```
$ rg 'BLOCKS_PER_(BATCH|EPOCH)' | wc -l
78
$ rg 'BLOCKS_PER_(BATCH|EPOCH)' | grep usize | wc -l
1
```

Fixes #674.