### PR TITLE
Use nightly-2022-03-13 for CI jobs

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
         components: rustfmt
     - uses: actions-rs/cargo@v1
@@ -46,7 +46,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
         components: llvm-tools-preview
     - name: Install cargo-llvm-cov
@@ -93,7 +93,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
         components: clippy
     - uses: actions-rs/clippy-check@v1
@@ -123,7 +123,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/build_crate_features.yml
+++ b/.github/workflows/build_crate_features.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - name: Set up python
       uses: actions/setup-python@v3

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:
@@ -112,7 +112,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:
@@ -195,7 +195,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:
@@ -278,7 +278,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:
@@ -361,7 +361,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - name: Configure micro block per epoch
       run: |
@@ -447,7 +447,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/release_mode_scenarios.yml
+++ b/.github/workflows/release_mode_scenarios.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/testnet_scenarios.yml
+++ b/.github/workflows/testnet_scenarios.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2022-03-13
         override: true
     - uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Temporaly uses a static nightly version due to a recent rustc change that broke
the compilation of some crates.
This commit can be reverted in the future to continue using the latest nightly version

