### PR TITLE
Fix panic caused by corner case in mempool

### DIFF
--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -42,6 +42,7 @@ rand = "0.8"
 
 nimiq-block = { path = "../primitives/block" }
 nimiq-blockchain = { path = "../blockchain" }
+nimiq-block-production = {path = "../block-production"}
 nimiq-bls = { path = "../bls" }
 nimiq-database = { path = "../database" }
 nimiq-genesis = { path = "../genesis" }

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -291,7 +291,11 @@ pub(crate) async fn verify_tx<'a>(
     }
 
     if sender_in_fly_balance > blockchain_sender_balance {
-        log::debug!("Dropped because sum of txs in mempool is larger than the account balance");
+        log::debug!(
+            "Dropped because sum of txs in mempool {} is larger than the account balance {}",
+            sender_in_fly_balance,
+            blockchain_sender_balance
+        );
         return Err(VerifyErr::NotEnoughFunds);
     }
 


### PR DESCRIPTION
- When adopted blocks are recieved and mempool update is called, we need to handle the case
  where the transactions in the adopted blocks caused some sender to be pruned from the
  accounts tree, because in this particular case, we need to remove all the txns that
  belong to the pruned sender from the mempool
- Some unittests were added to reproduce the issue and verify the fix
- This fixes #678

