### PR TITLE
Include Staking checks during mempool update.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,6 +2888,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-test-utils",
  "nimiq-transaction",
+ "nimiq-transaction-builder",
  "nimiq-utils",
  "nimiq-vrf",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -50,4 +50,5 @@ nimiq-genesis-builder = { path = "../genesis-builder" }
 nimiq-network-mock = { path = "../network-mock" }
 nimiq-test-log = { path = "../test-log" }
 nimiq-test-utils = { path = "../test-utils" }
+nimiq-transaction-builder = { path = "../transaction-builder" }
 nimiq-vrf = { path = "../vrf" }

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -188,10 +188,10 @@ pub(crate) async fn verify_tx<'a>(
         let duplicate = match data.clone() {
             OutgoingStakingTransactionProof::DeleteValidator { proof } => mempool_state
                 .outgoing_validators
-                .contains(&proof.compute_signer()),
+                .contains_key(&proof.compute_signer()),
             OutgoingStakingTransactionProof::Unstake { proof } => mempool_state
                 .outgoing_stakers
-                .contains(&proof.compute_signer()),
+                .contains_key(&proof.compute_signer()),
         };
 
         if duplicate {
@@ -226,10 +226,10 @@ pub(crate) async fn verify_tx<'a>(
         let duplicate = match data.clone() {
             IncomingStakingTransactionData::CreateValidator { proof, .. } => mempool_state
                 .creating_validators
-                .contains(&proof.compute_signer()),
+                .contains_key(&proof.compute_signer()),
             IncomingStakingTransactionData::CreateStaker { proof, .. } => mempool_state
                 .creating_stakers
-                .contains(&proof.compute_signer()),
+                .contains_key(&proof.compute_signer()),
             _ => false,
         };
 


### PR DESCRIPTION
- The staking checks should be performed as well during blocks adoption, specially during adopted blocks:
  The staking state in the blockchain could have changed, causing some staking txns in the mempool
  become invalid.
- Fixes #701

