### PR TITLE
Ignore flaky test `connections_are_properly_closed`

### DIFF
--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -392,6 +392,7 @@ async fn both_peers_can_talk_with_each_other() {
     assert_eq!(msg2.id, 420);
 }
 
+#[ignore]
 #[test(tokio::test)]
 async fn connections_are_properly_closed() {
     let (net1, net2) = create_connected_networks().await;


### PR DESCRIPTION
This allows us to continue using the CI normally while the failing test
is being tracked at #708.