### PR TITLE
Typos, only call the test log initialization routine once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,6 +3269,7 @@ name = "nimiq-test-log"
 version = "0.1.0"
 dependencies = [
  "nimiq-test-log-proc-macro",
+ "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "tracing-subscriber 0.3.9",
 ]
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -193,7 +193,7 @@ impl<N: Network> Consensus<N> {
     }
 
     /// Calculates and sets established state, returns a ConsensusEvent if the state changed.
-    /// Once consensus is established, we can only loose it if we loose all our peers.
+    /// Once consensus is established, we can only lose it if we lose all our peers.
     /// To reach consensus established state, we need at least `minPeers` peers and
     /// one of the following conditions must be true:
     /// - we accepted at least `MIN_BLOCKS_ESTABLISHED` block announcements

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -150,7 +150,7 @@ struct TaskState {
     dht_puts: HashMap<QueryId, oneshot::Sender<Result<(), NetworkError>>>,
     dht_gets: HashMap<QueryId, oneshot::Sender<Result<Option<Vec<u8>>, NetworkError>>>,
     gossip_topics: HashMap<TopicHash, (mpsc::Sender<(GossipsubMessage, MessageId, PeerId)>, bool)>,
-    is_bootstraped: bool,
+    is_bootstrapped: bool,
     requests: HashMap<
         RequestId,
         oneshot::Sender<(ResponseMessage<Bytes>, RequestId, PeerId, MessageType)>,
@@ -387,12 +387,12 @@ impl Network {
                         .add_peer_address(peer_id, listen_addr.clone());
 
                     // Bootstrap Kademlia if we're performing our first connection
-                    if !state.is_bootstraped {
+                    if !state.is_bootstrapped {
                         log::debug!("Bootstrapping DHT");
                         if swarm.behaviour_mut().dht.bootstrap().is_err() {
                             log::error!("Bootstrapping DHT error: No known peers");
                         }
-                        state.is_bootstraped = true;
+                        state.is_bootstrapped = true;
                     }
                 }
             }
@@ -605,12 +605,12 @@ impl Network {
                                     swarm.behaviour_mut().add_peer_address(peer_id, listen_addr);
 
                                     // Bootstrap Kademlia if we're adding our first address
-                                    if !state.is_bootstraped {
+                                    if !state.is_bootstrapped {
                                         log::debug!("Bootstrapping DHT");
                                         if swarm.behaviour_mut().dht.bootstrap().is_err() {
                                             log::error!("Bootstrapping DHT error: No known peers");
                                         }
-                                        state.is_bootstraped = true;
+                                        state.is_bootstrapped = true;
                                     }
                                 }
                             }

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 nimiq-test-log-proc-macro = { path = "proc-macro" }
+parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/test-log/src/lib.rs
+++ b/test-log/src/lib.rs
@@ -1,9 +1,15 @@
+use parking_lot::Once;
+
 pub use nimiq_test_log_proc_macro::test;
+
+static INITIALIZE: Once = Once::new();
 
 #[doc(hidden)]
 pub fn initialize() {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_test_writer()
-        .try_init();
+    INITIALIZE.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .init();
+    });
 }

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -31,7 +31,7 @@ impl TestNetwork for MockNetwork {
     ) -> Arc<MockNetwork> {
         let hub = hub
             .as_mut()
-            .expect("Can't build a Mock Network without a MuckHub");
+            .expect("Can't build a Mock Network without a MockHub");
         Arc::new(hub.new_network_with_address(peer_id))
     }
 

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -130,7 +130,7 @@ where
                     return Err(TendermintError::AggregationError);
                 }
                 None => {
-                    // create channel foor result propagation
+                    // create channel for result propagation
                     let (sender, aggregate_receiver) =
                         mpsc::unbounded_channel::<AggregationResult<Blake2sHash, MultiSignature>>();
                     // set the current aggregate


### PR DESCRIPTION
This way, the log setup only has to happen once, all other calls to the
initialization function will simply wait for the lucky one to complete.