### PR TITLE
Add a sensible default log level for test logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,6 @@ dependencies = [
 name = "nimiq-lib"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "beserial",
  "clap",
  "console-subscriber",
@@ -2845,6 +2844,7 @@ dependencies = [
  "nimiq-jsonrpc-core",
  "nimiq-jsonrpc-server",
  "nimiq-keys",
+ "nimiq-log",
  "nimiq-mempool",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
@@ -2866,10 +2866,19 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-log",
  "tracing-loki",
  "tracing-subscriber 0.3.9",
  "url",
+]
+
+[[package]]
+name = "nimiq-log"
+version = "0.1.0"
+dependencies = [
+ "ansi_term",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -3269,8 +3278,10 @@ dependencies = [
 name = "nimiq-test-log"
 version = "0.1.0"
 dependencies = [
+ "nimiq-log",
  "nimiq-test-log-proc-macro",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
+ "tracing",
  "tracing-subscriber 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "key-derivation",
   "keys",
   "lib",
+  "log",
   "macros",
   "mempool",
   "mnemonic",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,7 +19,6 @@ maintenance = { status = "experimental" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ansi_term = "0.12"
 clap = { version = "3.0", features = ["derive"] }
 console-subscriber = { version = "0.1", features = ["parking_lot"], optional = true }
 derive_builder = "0.11"
@@ -39,7 +38,6 @@ toml = "0.5"
 url = { version = "2.2", features = ["serde"] }
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["rt", "tracing"], optional = true }
-tracing-log = { version = "0.1", optional = true }
 tracing-loki = { version = "0.1.0", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 
@@ -53,6 +51,7 @@ nimiq-genesis = { path = "../genesis" }
 nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git" }
 nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git" }
 nimiq-keys = { path = "../keys" }
+nimiq-log = { path = "../log", optional = true }
 nimiq-mempool = { path = "../mempool" }
 nimiq-network-libp2p = { path = "../network-libp2p" }
 nimiq-network-interface = { path = "../network-interface" }
@@ -71,7 +70,7 @@ nimiq-test-log = { path = "../test-log" }
 deadlock = []
 default = []
 launcher = []
-logging = ["console-subscriber", "serde_json", "tokio", "tracing-log", "tracing-loki", "tracing-subscriber"]
+logging = ["console-subscriber", "nimiq-log", "serde_json", "tokio", "tracing-loki", "tracing-subscriber"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -32,9 +32,11 @@ pub enum Error {
     #[error("RPC server error: {0}")]
     RpcServer(#[from] nimiq_rpc_server::Error),
 
+    #[cfg(feature = "logging")]
     #[error("Logger error: {0}")]
     Logging(#[from] tracing_subscriber::filter::FromEnvError),
 
+    #[cfg(feature = "logging")]
     #[error("Loki logger error: {0}")]
     LoggingLoki(#[from] tracing_loki::Error),
 

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -1,18 +1,13 @@
 use std::env;
-use std::fmt;
 use std::fs::{self, File};
 use std::io;
 use std::sync::Arc;
 
-use ansi_term::{Color, Style};
 use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
-use log::{level_filters::LevelFilter, Event, Level, Subscriber};
+use log::{level_filters::LevelFilter, Level, Subscriber};
 use parking_lot::Mutex;
-use tracing_log::NormalizeEvent;
 use tracing_subscriber::filter::Targets;
-use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::fmt::time::{FormatTime, SystemTime};
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
+use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -22,76 +17,9 @@ use crate::{
     config::{command_line::CommandLine, config_file::LogSettings},
     error::Error,
 };
-
-static NIMIQ_MODULES: &[&str] = &[
-    "beserial",
-    "beserial_derive",
-    "nimiq_account",
-    "nimiq_address",
-    "nimiq_block",
-    "nimiq_block_production",
-    "nimiq_blockchain",
-    "nimiq_bls",
-    "nimiq_bls",
-    "nimiq_client",
-    "nimiq_collections",
-    "nimiq_consensus",
-    "nimiq_database",
-    "nimiq_devnet",
-    "nimiq_genesis",
-    "nimiq_genesis_builder",
-    "nimiq_handel",
-    "nimiq_hash",
-    "nimiq_hash_derive",
-    "nimiq_key_derivation",
-    "nimiq_keys",
-    "nimiq_lib",
-    "nimiq_macros",
-    "nimiq_mempool",
-    "nimiq_mmr",
-    "nimiq_mnemonic",
-    "nimiq_nano_blockchain",
-    "nimiq_nano_primitives",
-    "nimiq_nano_zkp",
-    "nimiq_network_interface",
-    "nimiq_network_libp2p",
-    "nimiq_network_mock",
-    "nimiq_peer_address",
-    "nimiq_primitives",
-    "nimiq_rpc",
-    "nimiq_rpc_client",
-    "nimiq_rpc_interface",
-    "nimiq_rpc_server",
-    "nimiq_signtx",
-    "nimiq_spammer",
-    "nimiq_subscription",
-    "nimiq_tendermint",
-    "nimiq_test_utils",
-    "nimiq_tools",
-    "nimiq_transaction",
-    "nimiq_transaction_builder",
-    "nimiq_trie",
-    "nimiq_utils",
-    "nimiq_validator",
-    "nimiq_validator_network",
-    "nimiq_vrf",
-    "nimiq_wallet",
-];
+use nimiq_log::{Formatting, MaybeSystemTime, TargetsExt};
 
 pub const DEFAULT_LEVEL: LevelFilter = LevelFilter::INFO;
-
-trait TargetsExt {
-    fn with_nimiq_targets(self, level: LevelFilter) -> Self;
-}
-
-impl TargetsExt for Targets {
-    fn with_nimiq_targets(mut self, level: LevelFilter) -> Targets {
-        for &module in NIMIQ_MODULES.iter() {
-            self = self.with_target(module, level);
-        }
-        self
-    }
-}
 
 macro_rules! force_log {
     ($lvl:expr, $($arg:tt)+) => ({
@@ -170,6 +98,8 @@ pub fn initialize_logging(
         .with_nimiq_targets(settings.level.unwrap_or(DEFAULT_LEVEL));
     // Set logging level for specific selected modules
     filter = filter.with_targets(settings.tags);
+    // Set logging level from the environment
+    filter = filter.with_env();
 
     let file = match &settings.file {
         Some(filename) => Some(Arc::new(File::open(filename)?)),
@@ -183,134 +113,8 @@ pub fn initialize_logging(
         })
     };
 
-    struct MaybeSystemTime(bool);
-
-    impl FormatTime for MaybeSystemTime {
-        fn format_time(&self, w: &mut Writer) -> fmt::Result {
-            if self.0 {
-                SystemTime.format_time(w)
-            } else {
-                ().format_time(w)
-            }
-        }
-    }
-
     #[derive(Clone)]
     struct Rotating(Arc<Mutex<FileRotate<AppendCount>>>);
-
-    struct Formatting<T: FormatTime>(T);
-
-    impl<S, N, T: FormatTime> FormatEvent<S, N> for Formatting<T>
-    where
-        S: Subscriber + for<'a> LookupSpan<'a>,
-        N: for<'a> FormatFields<'a> + 'static,
-    {
-        fn format_event(
-            &self,
-            ctx: &FmtContext<'_, S, N>,
-            mut writer: Writer<'_>,
-            event: &Event<'_>,
-        ) -> fmt::Result {
-            let (bold, dim) = if writer.has_ansi_escapes() {
-                (Style::default().bold(), Style::default().dimmed())
-            } else {
-                (Style::default(), Style::default())
-            };
-            write!(&mut writer, "{}", dim.prefix())?;
-            self.0.format_time(&mut writer)?;
-            write!(&mut writer, "{}", dim.suffix())?;
-
-            // Format values from the event's metadata:
-            let normalized_metadata = event.normalized_metadata();
-            let metadata = normalized_metadata
-                .as_ref()
-                .unwrap_or_else(|| event.metadata());
-
-            let color = if writer.has_ansi_escapes() {
-                Style::from(match *metadata.level() {
-                    Level::TRACE => Color::Purple,
-                    Level::DEBUG => Color::Blue,
-                    Level::INFO => Color::Green,
-                    Level::WARN => Color::Yellow,
-                    Level::ERROR => Color::Red,
-                })
-            } else {
-                Style::default()
-            };
-
-            let mut target = metadata.target();
-            // Drop everything except the module name.
-            if let Some(pos) = target.rfind("::") {
-                target = &target[pos + 2..];
-            }
-            // Pretend `target` is ASCII-only
-            const MAX_MODULE_WIDTH: usize = 20;
-            let truncate = target.len() > MAX_MODULE_WIDTH;
-            if truncate {
-                for i in (0..MAX_MODULE_WIDTH).rev() {
-                    if target.is_char_boundary(i) {
-                        target = &target[..i];
-                        break;
-                    }
-                }
-            }
-            let indicator = if truncate {
-                "…"
-            } else if target.len() < MAX_MODULE_WIDTH {
-                " "
-            } else {
-                ""
-            };
-
-            write!(
-                &mut writer,
-                " {}{:5}{} {}{:width$}{}{} | ",
-                color.prefix(),
-                metadata.level(),
-                color.suffix(),
-                dim.prefix(),
-                target,
-                indicator,
-                dim.suffix(),
-                width = MAX_MODULE_WIDTH - 1,
-            )?;
-
-            // Write fields on the event
-            ctx.field_format().format_fields(writer.by_ref(), event)?;
-
-            // Format all the spans in the event's span context.
-            if let Some(scope) = ctx.event_scope() {
-                for span in scope.from_root() {
-                    write!(
-                        writer,
-                        ", {}{}{{{}",
-                        bold.prefix(),
-                        span.name(),
-                        bold.suffix()
-                    )?;
-
-                    // `FormattedFields` is a formatted representation of the span's
-                    // fields, which is stored in its extensions by the `fmt` layer's
-                    // `new_span` method. The fields will have been formatted
-                    // by the same field formatter that's provided to the event
-                    // formatter in the `FmtContext`.
-                    let ext = span.extensions();
-                    let fields = &ext
-                        .get::<FormattedFields<N>>()
-                        .expect("will never be `None`");
-
-                    // Skip formatting the fields if the span had no fields.
-                    if !fields.is_empty() {
-                        write!(writer, "{}{}}}{}", fields, bold.prefix(), bold.suffix())?;
-                    }
-                }
-            }
-
-            writeln!(writer)?;
-
-            Ok(())
-        }
-    }
 
     impl io::Write for Rotating {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "nimiq-log"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ansi_term = "0.12"
+log = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.3"

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -1,0 +1,237 @@
+use ansi_term::{Color, Style};
+use log::{level_filters::LevelFilter, Event, Level, Subscriber};
+use std::{env, fmt};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time::{FormatTime, SystemTime};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
+use tracing_subscriber::registry::LookupSpan;
+
+pub static NIMIQ_MODULES: &[&str] = &[
+    "beserial",
+    "beserial_derive",
+    "nimiq_account",
+    "nimiq_address",
+    "nimiq_block",
+    "nimiq_block_production",
+    "nimiq_blockchain",
+    "nimiq_bls",
+    "nimiq_bls",
+    "nimiq_client",
+    "nimiq_collections",
+    "nimiq_consensus",
+    "nimiq_database",
+    "nimiq_devnet",
+    "nimiq_genesis",
+    "nimiq_genesis_builder",
+    "nimiq_handel",
+    "nimiq_hash",
+    "nimiq_hash_derive",
+    "nimiq_key_derivation",
+    "nimiq_keys",
+    "nimiq_lib",
+    "nimiq_log",
+    "nimiq_macros",
+    "nimiq_mempool",
+    "nimiq_mmr",
+    "nimiq_mnemonic",
+    "nimiq_nano_blockchain",
+    "nimiq_nano_primitives",
+    "nimiq_nano_zkp",
+    "nimiq_network_interface",
+    "nimiq_network_libp2p",
+    "nimiq_network_mock",
+    "nimiq_peer_address",
+    "nimiq_primitives",
+    "nimiq_rpc",
+    "nimiq_rpc_client",
+    "nimiq_rpc_interface",
+    "nimiq_rpc_server",
+    "nimiq_signtx",
+    "nimiq_spammer",
+    "nimiq_subscription",
+    "nimiq_tendermint",
+    "nimiq_test_utils",
+    "nimiq_tools",
+    "nimiq_transaction",
+    "nimiq_transaction_builder",
+    "nimiq_trie",
+    "nimiq_utils",
+    "nimiq_validator",
+    "nimiq_validator_network",
+    "nimiq_vrf",
+    "nimiq_wallet",
+];
+
+pub const ENV: &str = "RUST_LOG";
+
+pub trait TargetsExt {
+    fn with_nimiq_targets(self, level: LevelFilter) -> Self;
+    fn with_env(self) -> Self;
+}
+
+impl TargetsExt for Targets {
+    fn with_nimiq_targets(mut self, level: LevelFilter) -> Targets {
+        for &module in NIMIQ_MODULES.iter() {
+            self = self.with_target(module, level);
+        }
+        self
+    }
+    fn with_env(mut self) -> Targets {
+        let directives = match env::var(ENV) {
+            Ok(v) => v,
+            Err(env::VarError::NotPresent) => return self,
+            Err(env::VarError::NotUnicode(_)) => panic!("env var {} contains non-UTF-8 value", ENV),
+        };
+        for dir in directives.split(',') {
+            let mut iter = dir.splitn(2, '=');
+            let (target, level) = match (iter.next(), iter.next()) {
+                (Some(first), Some(second)) => (Some(first), second),
+                (Some(first), None) => (None, first),
+                (_, _) => unreachable!(),
+            };
+            let level: LevelFilter = match level.parse() {
+                Ok(l) => l,
+                // Ignore invalid directives.
+                Err(_) => continue,
+            };
+            if let Some(t) = target {
+                if t == "nimiq" {
+                    self = self.with_nimiq_targets(level);
+                } else {
+                    self = self.with_target(t, level);
+                }
+            } else {
+                self = self.with_default(level);
+            }
+        }
+        self
+    }
+}
+
+pub struct Formatting<T: FormatTime>(pub T);
+
+impl<S, N, T: FormatTime> FormatEvent<S, N> for Formatting<T>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let (bold, dim) = if writer.has_ansi_escapes() {
+            (Style::default().bold(), Style::default().dimmed())
+        } else {
+            (Style::default(), Style::default())
+        };
+        write!(&mut writer, "{}", dim.prefix())?;
+        self.0.format_time(&mut writer)?;
+        write!(&mut writer, "{}", dim.suffix())?;
+
+        // Format values from the event's metadata:
+        let normalized_metadata = event.normalized_metadata();
+        let metadata = normalized_metadata
+            .as_ref()
+            .unwrap_or_else(|| event.metadata());
+
+        let color = if writer.has_ansi_escapes() {
+            Style::from(match *metadata.level() {
+                Level::TRACE => Color::Purple,
+                Level::DEBUG => Color::Blue,
+                Level::INFO => Color::Green,
+                Level::WARN => Color::Yellow,
+                Level::ERROR => Color::Red,
+            })
+        } else {
+            Style::default()
+        };
+
+        let mut target = metadata.target();
+        // Drop everything except the module name.
+        if let Some(pos) = target.rfind("::") {
+            target = &target[pos + 2..];
+        }
+        // Pretend `target` is ASCII-only
+        const MAX_MODULE_WIDTH: usize = 20;
+        let truncate = target.len() > MAX_MODULE_WIDTH;
+        if truncate {
+            for i in (0..MAX_MODULE_WIDTH).rev() {
+                if target.is_char_boundary(i) {
+                    target = &target[..i];
+                    break;
+                }
+            }
+        }
+        let indicator = if truncate {
+            "…"
+        } else if target.len() < MAX_MODULE_WIDTH {
+            " "
+        } else {
+            ""
+        };
+
+        write!(
+            &mut writer,
+            " {}{:5}{} {}{:width$}{}{} | ",
+            color.prefix(),
+            metadata.level(),
+            color.suffix(),
+            dim.prefix(),
+            target,
+            indicator,
+            dim.suffix(),
+            width = MAX_MODULE_WIDTH - 1,
+        )?;
+
+        // Write fields on the event
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+
+        // Format all the spans in the event's span context.
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                write!(
+                    writer,
+                    ", {}{}{{{}",
+                    bold.prefix(),
+                    span.name(),
+                    bold.suffix()
+                )?;
+
+                // `FormattedFields` is a formatted representation of the span's
+                // fields, which is stored in its extensions by the `fmt` layer's
+                // `new_span` method. The fields will have been formatted
+                // by the same field formatter that's provided to the event
+                // formatter in the `FmtContext`.
+                let ext = span.extensions();
+                let fields = &ext
+                    .get::<FormattedFields<N>>()
+                    .expect("will never be `None`");
+
+                // Skip formatting the fields if the span had no fields.
+                if !fields.is_empty() {
+                    write!(writer, "{}{}}}{}", fields, bold.prefix(), bold.suffix())?;
+                }
+            }
+        }
+
+        writeln!(writer)?;
+
+        Ok(())
+    }
+}
+
+pub struct MaybeSystemTime(pub bool);
+
+impl FormatTime for MaybeSystemTime {
+    fn format_time(&self, w: &mut Writer) -> fmt::Result {
+        if self.0 {
+            SystemTime.format_time(w)
+        } else {
+            ().format_time(w)
+        }
+    }
+}

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+log = { package = "tracing", version = "0.1", features = ["log"] }
+nimiq-log = { path = "../log" }
 nimiq-test-log-proc-macro = { path = "proc-macro" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/test-log/src/lib.rs
+++ b/test-log/src/lib.rs
@@ -1,4 +1,9 @@
+use log::level_filters::LevelFilter;
+use nimiq_log::TargetsExt;
 use parking_lot::Once;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 pub use nimiq_test_log_proc_macro::test;
 
@@ -7,9 +12,14 @@ static INITIALIZE: Once = Once::new();
 #[doc(hidden)]
 pub fn initialize() {
     INITIALIZE.call_once(|| {
-        tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_test_writer())
+            .with(
+                Targets::new()
+                    .with_default(LevelFilter::INFO)
+                    .with_nimiq_targets(LevelFilter::DEBUG)
+                    .with_env(),
+            )
             .init();
     });
 }

--- a/test-log/src/lib.rs
+++ b/test-log/src/lib.rs
@@ -18,6 +18,7 @@ pub fn initialize() {
                 Targets::new()
                     .with_default(LevelFilter::INFO)
                     .with_nimiq_targets(LevelFilter::DEBUG)
+                    .with_target("r1cs", LevelFilter::WARN)
                     .with_env(),
             )
             .init();


### PR DESCRIPTION
Log nimiq crates with `TRACE` level and everything else with `INFO`.
This can still be customized with the `RUST_LOG` environment variable.

To do this, some logging-related code was extracted into the `nimiq-log`
crate.

Fixes #723.