### PR TITLE
Bypass creating block producer for events unrelated to head hash

### DIFF
--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -19,6 +19,24 @@ pub enum BlockchainEvent {
     EpochFinalized(Blake2bHash),
 }
 
+impl BlockchainEvent {
+    pub fn get_newest_hash(&self) -> Blake2bHash {
+        match self {
+            Self::Extended(h) => h,
+            Self::Rebranched(_, new_chain) => {
+                if let Some((h, _)) = new_chain.last() {
+                    h
+                } else {
+                    unreachable!()
+                }
+            }
+            Self::Finalized(h) => h,
+            Self::EpochFinalized(h) => h,
+        }
+        .clone()
+    }
+}
+
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BlockchainError {
     #[error("Invalid genesis block stored. Are you on the right network?")]


### PR DESCRIPTION
Closes #737, which was caused by starting the block producer before the HEAD state has been
properly propagated and applied.

