### PR TITLE
To keep macro_state around .clone() it instead of .take() it.

### DIFF
--- a/validator/src/macro.rs
+++ b/validator/src/macro.rs
@@ -17,6 +17,7 @@ use nimiq_validator_network::ValidatorNetwork;
 use nimiq_vrf::VrfSeed;
 
 use crate::tendermint::TendermintInterface;
+
 pub(crate) struct PersistedMacroState<TValidatorNetwork: ValidatorNetwork + 'static>(
     pub  TendermintState<
         <TendermintInterface<TValidatorNetwork> as TendermintOutsideDeps>::ProposalTy,
@@ -24,6 +25,15 @@ pub(crate) struct PersistedMacroState<TValidatorNetwork: ValidatorNetwork + 'sta
         <TendermintInterface<TValidatorNetwork> as TendermintOutsideDeps>::ProofTy,
     >,
 );
+
+// Don't know why this is necessary. #[derive(Clone)] does not work.
+impl<TValidatorNetwork: ValidatorNetwork + 'static> Clone
+    for PersistedMacroState<TValidatorNetwork>
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<TValidatorNetwork: ValidatorNetwork> IntoDatabaseValue
     for PersistedMacroState<TValidatorNetwork>

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -342,7 +342,9 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                     head.seed().clone(),
                     next_block_number,
                     next_view_number,
-                    self.macro_state.take(),
+                    // This cannot be .take() as there is a chance init_epoch is called multiple times without
+                    // poll_macro being called creating a new macro_state that is Some(...).
+                    self.macro_state.clone(),
                     proposal_stream,
                 ));
             }


### PR DESCRIPTION
After a restart there is a chance that a node will initialize Tendermint at least twice without calling `poll_macro()` in the Validator. The first initialization takes the `macro_state` and leaves the second initialization without one. 
This leads to faulty behaviour and with this PR the state is cloned instead of taken.