### PR TITLE
Cache `MacroBody` in `TendermintState` instead of in `TendermintInterface`

### DIFF
--- a/tendermint/src/lib.rs
+++ b/tendermint/src/lib.rs
@@ -28,6 +28,15 @@ impl<T: Clone + Debug + PartialEq + Deserialize + Serialize + Unpin + Send + Syn
 {
 }
 
+pub trait ProposalCacheTrait:
+    Clone + Debug + Deserialize + Serialize + Unpin + Send + Sync + 'static
+{
+}
+impl<T: Clone + Debug + Deserialize + Serialize + Unpin + Send + Sync + 'static> ProposalCacheTrait
+    for T
+{
+}
+
 pub trait ProposalHashTrait:
     Clone + Debug + PartialEq + Ord + Deserialize + Serialize + Unpin + Send + 'static
 {

--- a/tendermint/src/state.rs
+++ b/tendermint/src/state.rs
@@ -4,7 +4,7 @@ use beserial::{Deserialize, Serialize};
 
 use crate::{
     utils::{Checkpoint, Step},
-    AggregationResult, ProofTrait, ProposalHashTrait, ProposalTrait,
+    AggregationResult, ProofTrait, ProposalCacheTrait, ProposalHashTrait, ProposalTrait,
 };
 
 /// necessary for serialization/deserialization derivation
@@ -38,6 +38,7 @@ pub struct ExtendedProposal<ProposalTy: ProposalTrait, ProposalHashTy: ProposalH
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct TendermintState<
     ProposalTy: ProposalTrait,
+    ProposalCacheTy: ProposalCacheTrait,
     ProposalHashTy: ProposalHashTrait,
     ProofTy: ProofTrait,
 > {
@@ -52,6 +53,9 @@ pub struct TendermintState<
     pub current_proposal: Option<Option<(ProposalTy, ProposalHashTy)>>,
     pub current_proposal_vr: Option<u32>,
     pub current_proof: Option<ProofTy>,
+
+    pub proposal_cache: Option<ProposalCacheTy>,
+    pub vr_proposal_cache: Option<ProposalCacheTy>,
 
     // Map over all votes this node did in the past for this block height.
     // Necessary in case it would ever need to re-request an old aggregation,
@@ -74,8 +78,12 @@ pub struct TendermintState<
     pub best_votes: BTreeMap<(u32, Step), Aggregate<ProposalHashTy, ProofTy>>,
 }
 
-impl<ProposalTy: ProposalTrait, ProposalHashTy: ProposalHashTrait, ProofTy: ProofTrait>
-    TendermintState<ProposalTy, ProposalHashTy, ProofTy>
+impl<
+        ProposalTy: ProposalTrait,
+        ProposalCacheTy: ProposalCacheTrait,
+        ProposalHashTy: ProposalHashTrait,
+        ProofTy: ProofTrait,
+    > TendermintState<ProposalTy, ProposalCacheTy, ProposalHashTy, ProofTy>
 {
     pub fn new(height: u32, initial_round: u32) -> Self {
         Self {
@@ -89,6 +97,8 @@ impl<ProposalTy: ProposalTrait, ProposalHashTy: ProposalHashTrait, ProofTy: Proo
             current_proposal: None,
             current_proposal_vr: None,
             current_proof: None,
+            proposal_cache: None,
+            vr_proposal_cache: None,
             own_votes: BTreeMap::new(),
             known_proposals: BTreeMap::new(),
             best_votes: BTreeMap::new(),

--- a/tendermint/src/stream.rs
+++ b/tendermint/src/stream.rs
@@ -34,7 +34,12 @@ impl<DepsTy: TendermintOutsideDeps> TendermintStreamWrapper<DepsTy> {
         mut deps: DepsTy,
         // An optional input for the TendermintState.
         state_opt: Option<
-            TendermintState<DepsTy::ProposalTy, DepsTy::ProposalHashTy, DepsTy::ProofTy>,
+            TendermintState<
+                DepsTy::ProposalTy,
+                DepsTy::ProposalCacheTy,
+                DepsTy::ProposalHashTy,
+                DepsTy::ProofTy,
+            >,
         >,
     ) -> Result<Self, DepsTy> {
         debug!(

--- a/tendermint/src/utils.rs
+++ b/tendermint/src/utils.rs
@@ -1,5 +1,7 @@
 use crate::state::TendermintState;
-use crate::{ProofTrait, ProposalHashTrait, ProposalTrait, TendermintOutsideDeps};
+use crate::{
+    ProofTrait, ProposalCacheTrait, ProposalHashTrait, ProposalTrait, TendermintOutsideDeps,
+};
 use beserial::{Deserialize, Serialize};
 use nimiq_block::TendermintStep;
 use nimiq_primitives::policy::TWO_F_PLUS_ONE;
@@ -48,10 +50,10 @@ pub enum VoteDecision {
 
 /// Represents the results we can get when waiting for a proposal message.
 #[derive(Clone, Debug)]
-pub enum ProposalResult<ProposalTy: ProposalTrait> {
+pub enum ProposalResult<ProposalTy: ProposalTrait, ProposalCacheTy: ProposalCacheTrait> {
     // Means we have received a proposal message. The first field is the actual proposal, the second
     // one is the valid round of the proposer (being None is equal to the -1 used in the protocol).
-    Proposal(ProposalTy, Option<u32>),
+    Proposal((ProposalTy, ProposalCacheTy), Option<u32>),
     // Means that we have timed out while waiting for the proposal message.
     Timeout,
 }
@@ -90,7 +92,14 @@ pub enum TendermintReturn<DepsTy: TendermintOutsideDeps> {
     Result(DepsTy::ResultTy),
     // This just sends our current state. It is useful in case we go down for some reason and need
     // to start from the point where we left off.
-    StateUpdate(TendermintState<DepsTy::ProposalTy, DepsTy::ProposalHashTy, DepsTy::ProofTy>),
+    StateUpdate(
+        TendermintState<
+            DepsTy::ProposalTy,
+            DepsTy::ProposalCacheTy,
+            DepsTy::ProposalHashTy,
+            DepsTy::ProofTy,
+        >,
+    ),
     // Just means that we encountered an error.
     Error(TendermintError),
 }

--- a/validator/src/macro.rs
+++ b/validator/src/macro.rs
@@ -21,6 +21,7 @@ use crate::tendermint::TendermintInterface;
 pub(crate) struct PersistedMacroState<TValidatorNetwork: ValidatorNetwork + 'static>(
     pub  TendermintState<
         <TendermintInterface<TValidatorNetwork> as TendermintOutsideDeps>::ProposalTy,
+        <TendermintInterface<TValidatorNetwork> as TendermintOutsideDeps>::ProposalCacheTy,
         <TendermintInterface<TValidatorNetwork> as TendermintOutsideDeps>::ProposalHashTy,
         <TendermintInterface<TValidatorNetwork> as TendermintOutsideDeps>::ProofTy,
     >,


### PR DESCRIPTION
This PR moves the caching of `MacroBody` during `MacroBlock`  production into the `TendermintState` struct.  Creating the MacroBody is somewhat of an expensive operation and thus it should be avoided to create it on the fly. At most two bodies will be cached. The currently voted on body and if applicable the body of the valid proposal this node is locked on. 

In case a body does not exist when finishing Tendermint a fallback is added computing it on the fly and displaying a warning.

Resolves #794 