### PR TITLE
Add client `SIGINT` handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "signal-hook",
  "strum_macros",
  "thiserror",
  "tokio",
@@ -4694,6 +4695,16 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -31,6 +31,7 @@ features = [
     "rpc-server",
     "deadlock",
     "logging",
+    "signal-handling",
     "wallet",
     "panic",
 ]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -11,6 +11,7 @@ pub use nimiq::{
         deadlock::initialize_deadlock_detection,
         logging::{initialize_logging, log_error_cause_chain},
         panic::initialize_panic_reporting,
+        signal_handling::initialize_signal_handler,
     },
 };
 
@@ -31,6 +32,9 @@ async fn main_inner() -> Result<(), Error> {
 
     // Initialize panic hook.
     initialize_panic_reporting();
+
+    // Initialize signal handler
+    initialize_signal_handler();
 
     // Create config builder and apply command line and config file.
     // You usually want the command line to override config settings, so the order is important.

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
+signal-hook = { version = "0.3", optional = true }
 strum_macros = "0.24"
 toml = "0.5"
 url = { version = "2.2", features = ["serde"] }
@@ -70,6 +71,7 @@ nimiq-test-log = { path = "../test-log" }
 deadlock = []
 default = []
 launcher = []
+signal-handling = ["signal-hook"]
 logging = ["console-subscriber", "nimiq-log", "serde_json", "tokio", "tracing-loki", "tracing-subscriber"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]

--- a/lib/src/extras/mod.rs
+++ b/lib/src/extras/mod.rs
@@ -6,6 +6,8 @@ pub mod logging;
 pub mod panic;
 #[cfg(feature = "rpc-server")]
 pub mod rpc_server;
+#[cfg(feature = "signal-handling")]
+pub mod signal_handling;
 
 #[cfg(feature = "launcher")]
 pub mod launcher;

--- a/lib/src/extras/signal_handling.rs
+++ b/lib/src/extras/signal_handling.rs
@@ -1,0 +1,16 @@
+use signal_hook::{consts::SIGINT, iterator::Signals};
+
+pub fn initialize_signal_handler() {
+    let signals = Signals::new(&[SIGINT]);
+
+    if let Ok(mut signals) = signals {
+        tokio::spawn(async move {
+            for _ in signals.forever() {
+                log::warn!("Received Ctrl+C. Closing client");
+                std::process::exit(0);
+            }
+        });
+    } else {
+        log::error!("Could not obtain SIGINT signal");
+    }
+}

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -32,11 +32,11 @@ trap cleanup_exit INT
 function cleanup_exit() {
     echo "Killing all validators..."
     for pid in ${vpids[@]}; do
-        kill $pid || true
+        kill -2 $pid || true
     done
     echo "Killing seed/spammer..."
     for pid in ${spids[@]}; do
-        kill $pid || true
+        kill -2 $pid || true
     done
     echo "Done."
 
@@ -313,7 +313,7 @@ do
             kindexes+=($index)
             echo "  Killing validator: $(($index + 1 ))"
 
-            kill ${vpids[$index]}
+            kill -2 ${vpids[$index]}
             sleep 1
 
             if [ "$ERASE" = true ] ; then

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -40,7 +40,7 @@ nimiq-transaction-builder = { path = "../transaction-builder" }
 package = "nimiq-lib"
 path = "../lib"
 version = "0.1"
-features = ["validator", "rpc-server", "deadlock", "logging", "wallet", "panic"]
+features = ["deadlock", "logging", "panic", "rpc-server", "signal-handling", "validator", "wallet"]
 
 [features]
 metrics = ["lazy_static", "prometheus", "warp"]

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -30,6 +30,7 @@ pub use nimiq::{
         deadlock::initialize_deadlock_detection,
         logging::{initialize_logging, log_error_cause_chain},
         panic::initialize_panic_reporting,
+        signal_handling::initialize_signal_handler,
     },
 };
 use nimiq_block::BlockType;
@@ -233,6 +234,9 @@ async fn main_inner() -> Result<(), Error> {
 
     // Initialize panic hook.
     initialize_panic_reporting();
+
+    // Initialize signal handler
+    initialize_signal_handler();
 
     // Register metrics
     #[cfg(feature = "metrics")]


### PR DESCRIPTION
- Add client `SIGINT` handler to log when a client is stopped due to
  this signal. This applies to the regular client and the spammer.
- Change `devnet.sh` script to send `SIGINT` instead of `SIGTERM`
  when restarting or killing nodes.
