### PR TITLE
Add delay before terminating process for `SIGINT`

### DIFF
--- a/lib/src/extras/signal_handling.rs
+++ b/lib/src/extras/signal_handling.rs
@@ -1,4 +1,5 @@
 use signal_hook::{consts::SIGINT, iterator::Signals};
+use tokio::time::{sleep, Duration};
 
 pub fn initialize_signal_handler() {
     let signals = Signals::new(&[SIGINT]);
@@ -7,6 +8,8 @@ pub fn initialize_signal_handler() {
         tokio::spawn(async move {
             for _ in signals.forever() {
                 log::warn!("Received Ctrl+C. Closing client");
+                // Add some delay for the log message to propagate into loki
+                sleep(Duration::from_millis(200)).await;
                 std::process::exit(0);
             }
         });


### PR DESCRIPTION
Add delay before terminating the process when `SIGINT` is handled in
order to allow the log message to reach the Loki DB.
