### PR TITLE
Improve mempool log to aid debugging

### DIFF
--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -144,6 +144,7 @@ pub(crate) async fn verify_tx<'a>(
     if !transaction.is_valid_at(block_height) {
         debug!(
             block_height = block_height,
+            validity_start_height = transaction.validity_start_height,
             "Mempool-verify tx invalid at this block height"
         );
         return Err(VerifyErr::InvalidBlockHeight);


### PR DESCRIPTION
Improved the mempool verify log to include the validity start height of the transaction.
