### PR TITLE
Adjust transaction validity check

### DIFF
--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -329,7 +329,10 @@ impl Transaction {
 
     pub fn is_valid_at(&self, block_height: u32) -> bool {
         let window = policy::TRANSACTION_VALIDITY_WINDOW;
-        block_height >= self.validity_start_height
+        block_height
+            >= self
+                .validity_start_height
+                .saturating_sub(policy::BLOCKS_PER_BATCH)
             && block_height < self.validity_start_height + window
     }
 


### PR DESCRIPTION
A transaction is valid if:
- The validity start height minus a batch is less than the block height
  (this is to give some time to all validators to be in sync and catch up,
   otherwise the tx can be rejected by some of them if the one sending the tx
   is at the tip of the chain and others are a bit behind)
- The transaction its within the transaction validity window
