### PR TITLE
Exclude dependabot pushes from clippy runs

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -82,6 +82,7 @@ jobs:
         verbose: true
 
   clippy:
+    if: github.event_name != "push" || github.event.pusher.name != "dependabot[bot]"
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
They always fail due to permission problems.