### PR TITLE
fixed the test of: push tx with wrong signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /cov
-/target
+target
 **/*.rs.bk
 /.idea
 *.iml


### PR DESCRIPTION
The push_tx_with_wrong_signature function was wrong. The transaction with the wrong signature failed because it didn't have a valid sender account, not because of the wrong signature.