### PR TITLE
Separate network messages into two types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,7 +2609,7 @@ dependencies = [
 name = "nimiq-client"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures-util",
  "nimiq-lib",
  "tokio",
  "tokio-metrics",
@@ -2635,7 +2635,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "hex",
  "lazy_static",
  "nimiq-block",
@@ -2735,7 +2735,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "lazy_static",
  "nimiq-bls",
  "nimiq-collections",
@@ -2947,7 +2947,7 @@ name = "nimiq-mempool"
 version = "0.1.0"
 dependencies = [
  "beserial",
- "futures",
+ "futures-util",
  "hex",
  "keyed_priority_queue",
  "nimiq-account",
@@ -3090,7 +3090,7 @@ dependencies = [
  "async-trait",
  "beserial",
  "derive_more",
- "futures",
+ "futures-util",
  "nimiq-test-log",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "thiserror",
@@ -3109,7 +3109,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "derive_more",
- "futures",
+ "futures-util",
  "hex",
  "ip_network",
  "libp2p",
@@ -3141,7 +3141,7 @@ dependencies = [
  "async-trait",
  "beserial",
  "derive_more",
- "futures",
+ "futures-util",
  "nimiq-network-interface",
  "nimiq-test-log",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
@@ -3201,7 +3201,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "futures",
+ "futures-util",
  "nimiq-account",
  "nimiq-bls",
  "nimiq-hash",
@@ -3222,7 +3222,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "hex",
  "nimiq-account",
  "nimiq-block",
@@ -3248,7 +3248,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "hex",
  "nimiq-account",
  "nimiq-block",
@@ -3289,7 +3289,7 @@ name = "nimiq-spammer"
 version = "0.1.0"
 dependencies = [
  "clap",
- "futures",
+ "futures-util",
  "nimiq-block",
  "nimiq-blockchain",
  "nimiq-keys",
@@ -3329,7 +3329,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "nimiq-block",
  "nimiq-hash",
  "nimiq-primitives",
@@ -3366,7 +3366,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "hex",
  "nimiq-block",
  "nimiq-block-production",
@@ -3478,7 +3478,7 @@ version = "0.1.0"
 dependencies = [
  "beserial",
  "clear_on_drop",
- "futures",
+ "futures-util",
  "hex",
  "libp2p",
  "nimiq-collections",
@@ -3502,7 +3502,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "hex",
  "lazy_static",
  "linked-hash-map",
@@ -3548,7 +3548,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
- "futures",
+ "futures-util",
  "nimiq-bls",
  "nimiq-network-interface",
  "nimiq-utils",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 tokio = { version = "1.18", features = ["rt-multi-thread", "time", "tracing"] }
 tokio-metrics = "0.1"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 lazy_static = "1.4.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
+use std::future::Future;
 use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
-use futures::task::{Context, Poll};
-use futures::{Future, FutureExt, StreamExt};
+use futures::{FutureExt, StreamExt};
 use parking_lot::RwLock;
 
 use nimiq_block::Block;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1,10 +1,11 @@
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use futures::task::{Context, Poll};
-use futures::{Future, FutureExt, StreamExt};
+use futures::{FutureExt, StreamExt};
 use parking_lot::RwLock;
 use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 use tokio::time::Sleep;

--- a/consensus/src/consensus/request_response.rs
+++ b/consensus/src/consensus/request_response.rs
@@ -40,7 +40,7 @@ impl<N: Network> Consensus<N> {
         tokio::spawn(Self::request_handler(network, stream, blockchain));
     }
 
-    pub(crate) fn request_handler<Req: Handle<<Req as Request>::Response> + Request>(
+    pub(crate) fn request_handler<Req: Handle<Req::Response> + Request>(
         network: &Arc<N>,
         stream: BoxStream<'static, (Req, N::RequestId, N::PeerId)>,
         blockchain: &Arc<RwLock<Blockchain>>,

--- a/consensus/src/consensus/request_response.rs
+++ b/consensus/src/consensus/request_response.rs
@@ -1,8 +1,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use futures::stream::BoxStream;
-use futures::StreamExt;
+use futures::{stream::BoxStream, StreamExt};
 use parking_lot::RwLock;
 
 use nimiq_blockchain::Blockchain;

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -113,7 +113,7 @@ impl Handle<HistoryChunk> for RequestHistoryChunk {
     }
 }
 
-impl Handle<<RequestBlock as Request>::Response> for RequestBlock {
+impl Handle<Option<Block>> for RequestBlock {
     fn handle(&self, blockchain: &Arc<RwLock<Blockchain>>) -> Option<Block> {
         blockchain.read().get_block(&self.hash, true, None)
     }
@@ -167,7 +167,7 @@ impl Handle<ResponseBlocks> for RequestMissingBlocks {
     }
 }
 
-impl Handle<<RequestHead as Request>::Response> for RequestHead {
+impl Handle<Blake2bHash> for RequestHead {
     fn handle(&self, blockchain: &Arc<RwLock<Blockchain>>) -> Blake2bHash {
         blockchain.read().head_hash()
     }

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -4,7 +4,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::HistoryTreeChunk;
 use nimiq_hash::Blake2bHash;
-use nimiq_network_interface::request::Request;
+use nimiq_network_interface::request::{RequestCommon, RequestMarker};
 
 pub(crate) mod handlers;
 
@@ -54,7 +54,8 @@ pub struct RequestMacroChain {
     pub max_epochs: u16,
 }
 
-impl Request for RequestMacroChain {
+impl RequestCommon for RequestMacroChain {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 200;
     type Response = MacroChain;
 }
@@ -64,7 +65,8 @@ pub struct RequestBatchSet {
     pub hash: Blake2bHash,
 }
 
-impl Request for RequestBatchSet {
+impl RequestCommon for RequestBatchSet {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 202;
     type Response = BatchSetInfo;
 }
@@ -99,7 +101,8 @@ pub struct RequestHistoryChunk {
     pub chunk_index: u64,
 }
 
-impl Request for RequestHistoryChunk {
+impl RequestCommon for RequestHistoryChunk {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 204;
     type Response = HistoryChunk;
 }
@@ -115,7 +118,8 @@ pub struct RequestBlock {
     pub hash: Blake2bHash,
 }
 
-impl Request for RequestBlock {
+impl RequestCommon for RequestBlock {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 207;
     type Response = Option<Block>;
 }
@@ -151,7 +155,8 @@ pub struct RequestMissingBlocks {
     pub locators: Vec<Blake2bHash>,
 }
 
-impl Request for RequestMissingBlocks {
+impl RequestCommon for RequestMissingBlocks {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 209;
     type Response = ResponseBlocks;
 }
@@ -159,7 +164,8 @@ impl Request for RequestMissingBlocks {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestHead {}
 
-impl Request for RequestHead {
+impl RequestCommon for RequestHead {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 210;
     type Response = Blake2bHash;
 }

--- a/consensus/src/sync/block_queue.rs
+++ b/consensus/src/sync/block_queue.rs
@@ -5,10 +5,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-use futures::future::BoxFuture;
-use futures::ready;
-use futures::stream::{BoxStream, Stream, StreamExt};
-use futures::FutureExt;
+use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, Stream, StreamExt};
 use parking_lot::RwLock;
 use pin_project::pin_project;
 use tokio::task::spawn_blocking;

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -3,8 +3,8 @@ use std::fmt::Formatter;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::task::{Context, Poll};
 use futures::{FutureExt, Stream, StreamExt};
 use lazy_static::lazy_static;
 use parking_lot::RwLock;

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -2,9 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::task::Waker;
 
-use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
-use futures::FutureExt;
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
 use parking_lot::RwLock;
 
 use nimiq_blockchain::Blockchain;

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -1,9 +1,8 @@
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::stream::Stream;
-use futures::task::{Context, Poll};
-use futures::{FutureExt, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use tokio::task::spawn_blocking;
 
 use nimiq_block::Block;

--- a/consensus/src/sync/request_component.rs
+++ b/consensus/src/sync/request_component.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use futures::task::{Context, Poll};
 use futures::{FutureExt, Stream, StreamExt};
 
 use nimiq_block::Block;

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -3,14 +3,12 @@ use std::cmp::Ordering;
 use std::collections::binary_heap::PeekMut;
 use std::collections::{BinaryHeap, VecDeque};
 use std::fmt::Debug;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Waker;
+use std::task::{Context, Poll, Waker};
 
-use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
-use futures::task::{Context, Poll};
-use futures::{ready, Future, Stream, StreamExt};
+use futures::{future::BoxFuture, ready, stream::FuturesUnordered, Stream, StreamExt};
 use pin_project::pin_project;
 
 use nimiq_macros::store_waker;

--- a/consensus/tests/block_queue.rs
+++ b/consensus/tests/block_queue.rs
@@ -5,10 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{
-    stream::{Stream, StreamExt},
-    task::noop_waker_ref,
-};
+use futures::{task::noop_waker_ref, Stream, StreamExt};
 use parking_lot::RwLock;
 use pin_project::pin_project;
 use rand::Rng;

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -1,8 +1,8 @@
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::task::{Context, Poll};
 use futures::{Stream, StreamExt};
 use parking_lot::RwLock;
 

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 lazy_static = "1.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -1,10 +1,11 @@
 use std::fmt::Debug;
+use std::future::Future;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use futures::future::BoxFuture;
-use futures::stream::BoxStream;
-use futures::task::{Context, Poll};
-use futures::{ready, select, Future, FutureExt, Sink, Stream, StreamExt};
+use futures::{
+    future::BoxFuture, ready, select, stream::BoxStream, FutureExt, Sink, Stream, StreamExt,
+};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio::time::{interval_at, Instant};

--- a/handel/src/todo.rs
+++ b/handel/src/todo.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::task::Waker;
 
-use futures::stream::{BoxStream, Stream, StreamExt};
+use futures::{stream::BoxStream, Stream, StreamExt};
 
 use nimiq_macros::store_waker;
 

--- a/handel/src/update.rs
+++ b/handel/src/update.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use beserial::{Deserialize, Serialize};
-use nimiq_network_interface::request::Request;
+use nimiq_network_interface::request::{MessageMarker, RequestCommon};
 
 use crate::contribution::AggregatableContribution;
 
@@ -74,11 +74,12 @@ pub struct LevelUpdateMessage<
 impl<
         C: AggregatableContribution + 'static,
         T: Clone + Debug + Serialize + Deserialize + Send + Sync + Unpin + 'static,
-    > Request for LevelUpdateMessage<C, T>
+    > RequestCommon for LevelUpdateMessage<C, T>
 {
-    // The Type ID to use will come from the AggregatableContribution implementation
+    type Kind = MessageMarker;
+    // The type to use will come from the AggregatableContribution implementation
     // since having a fixed value here would imply that there could be different
-    // types using the same type ID which would confuse the network at decoding
+    // types using the same type, which would confuse the network at decoding
     // messages upon receiving them.
     const TYPE_ID: u16 = C::TYPE_ID;
     type Response = ();

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -1,13 +1,12 @@
+use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::{fmt::Formatter, time::Duration};
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use async_trait::async_trait;
-use futures::future::BoxFuture;
-use futures::sink::Sink;
-use futures::stream::StreamExt;
-use futures::task::{Context, Poll};
+use futures::{future::BoxFuture, stream::StreamExt, Sink};
 use parking_lot::RwLock;
 
 use beserial::{Deserialize, Serialize};

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 keyed_priority_queue = "0.4"
 tokio = { version = "1.18", features = ["full", "tracing"] }
 tokio-metrics = "0.1"

--- a/mempool/src/executor.rs
+++ b/mempool/src/executor.rs
@@ -1,10 +1,10 @@
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::ready;
-use futures::task::{Context, Poll};
-use futures::{stream::BoxStream, Future, StreamExt};
+use futures::{ready, stream::BoxStream, StreamExt};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 
 use nimiq_blockchain::Blockchain;

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-trait = "0.1"
 derive_more = "0.99"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 thiserror = "1.0"
 tokio = { version = "1.18", features = [

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.13"
 bitflags = "1.2"
 bytes = "1.0"
 derive_more = "0.99"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 hex = "0.4"
 ip_network = "0.4"
 libp2p = { version = "0.44", default-features = false, features = [

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -1,10 +1,10 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     sync::Arc,
+    task::{Context, Poll, Waker},
     time::{Duration, Instant, SystemTime},
 };
 
-use futures::task::{Context, Poll, Waker};
 use ip_network::IpNetwork;
 use libp2p::swarm::dial_opts::PeerCondition;
 use libp2p::{

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -1,4 +1,3 @@
-use futures::task::{Context, Poll};
 use libp2p::{
     core::upgrade::{DeniedUpgrade, InboundUpgrade, OutboundUpgrade},
     swarm::{
@@ -6,6 +5,7 @@ use libp2p::{
         NegotiatedSubstream, SubstreamProtocol,
     },
 };
+use std::task::{Context, Poll};
 use thiserror::Error;
 
 #[derive(Default)]

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -1,13 +1,11 @@
 use std::{
     collections::{HashSet, VecDeque},
     sync::Arc,
+    task::{Context, Poll},
     time::Duration,
 };
 
-use futures::{
-    task::{Context, Poll},
-    StreamExt,
-};
+use futures::StreamExt;
 use libp2p::{
     core::connection::{ConnectedPoint, ConnectionId},
     identity::Keypair,

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -1,13 +1,11 @@
 use std::{
     pin::Pin,
     sync::Arc,
+    task::{Context, Poll, Waker},
     time::{Duration, Instant},
 };
 
-use futures::{
-    task::{Context, Poll, Waker},
-    Sink, SinkExt, StreamExt,
-};
+use futures::{Sink, SinkExt, StreamExt};
 use libp2p::{
     identity::Keypair,
     swarm::{

--- a/network-libp2p/src/discovery/message_codec/reader.rs
+++ b/network-libp2p/src/discovery/message_codec/reader.rs
@@ -1,10 +1,9 @@
-use std::{marker::PhantomData, pin::Pin};
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use bytes::{Buf, BytesMut};
-use futures::{
-    task::{Context, Poll},
-    AsyncRead, Stream,
-};
+use futures::{AsyncRead, Stream};
 use pin_project::pin_project;
 
 use beserial::{Deserialize, SerializingError};

--- a/network-libp2p/src/discovery/message_codec/writer.rs
+++ b/network-libp2p/src/discovery/message_codec/writer.rs
@@ -1,11 +1,9 @@
-use std::{marker::PhantomData, pin::Pin};
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use bytes::{Buf, BufMut, BytesMut};
-use futures::{
-    ready,
-    task::{Context, Poll},
-    AsyncWrite, Sink,
-};
+use futures::{ready, AsyncWrite, Sink};
 use pin_project::pin_project;
 
 use beserial::{Serialize, SerializingError};

--- a/network-libp2p/src/discovery/protocol.rs
+++ b/network-libp2p/src/discovery/protocol.rs
@@ -1,7 +1,4 @@
-use futures::{
-    future,
-    io::{AsyncRead, AsyncWrite},
-};
+use futures::{future, AsyncRead, AsyncWrite};
 use libp2p::{core::UpgradeInfo, identity::Keypair, InboundUpgrade, Multiaddr, OutboundUpgrade};
 use rand::{thread_rng, RngCore};
 

--- a/network-libp2p/src/dispatch/codecs/tokio_adapter.rs
+++ b/network-libp2p/src/dispatch/codecs/tokio_adapter.rs
@@ -35,7 +35,7 @@ impl<T> TokioAdapter<T> {
     }
 }
 
-impl<T> futures::io::AsyncRead for TokioAdapter<T>
+impl<T> futures::AsyncRead for TokioAdapter<T>
 where
     T: tokio::io::AsyncRead,
 {
@@ -54,7 +54,7 @@ where
     }
 }
 
-impl<T> futures::io::AsyncWrite for TokioAdapter<T>
+impl<T> futures::AsyncWrite for TokioAdapter<T>
 where
     T: tokio::io::AsyncWrite,
 {
@@ -77,7 +77,7 @@ where
 
 impl<T> tokio::io::AsyncRead for TokioAdapter<T>
 where
-    T: futures::io::AsyncRead,
+    T: futures::AsyncRead,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -86,7 +86,7 @@ where
     ) -> Poll<io::Result<()>> {
         // TODO: It's not optimal to initialize the buffer
         let buffer = buf.initialize_unfilled();
-        let n = ready!(futures::io::AsyncRead::poll_read(
+        let n = ready!(futures::AsyncRead::poll_read(
             self.project().inner,
             cx,
             buffer
@@ -98,21 +98,21 @@ where
 
 impl<T> tokio::io::AsyncWrite for TokioAdapter<T>
 where
-    T: futures::io::AsyncWrite,
+    T: futures::AsyncWrite,
 {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        futures::io::AsyncWrite::poll_write(self.project().inner, cx, buf)
+        futures::AsyncWrite::poll_write(self.project().inner, cx, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        futures::io::AsyncWrite::poll_flush(self.project().inner, cx)
+        futures::AsyncWrite::poll_flush(self.project().inner, cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        futures::io::AsyncWrite::poll_close(self.project().inner, cx)
+        futures::AsyncWrite::poll_close(self.project().inner, cx)
     }
 }

--- a/network-libp2p/src/dispatch/codecs/typed.rs
+++ b/network-libp2p/src/dispatch/codecs/typed.rs
@@ -6,10 +6,8 @@
 //! message, extracting the type ID and performing consistency checks.
 //!
 
-use std::{
-    fmt::Debug,
-    io::{self},
-};
+use std::fmt::Debug;
+use std::io;
 
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use libp2p::core::{upgrade, ProtocolName};

--- a/network-libp2p/src/dispatch/codecs/typed.rs
+++ b/network-libp2p/src/dispatch/codecs/typed.rs
@@ -11,7 +11,7 @@ use std::{
     io::{self},
 };
 
-use futures::prelude::*;
+use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use libp2p::core::{upgrade, ProtocolName};
 use libp2p::request_response::RequestResponseCodec;
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -12,7 +12,10 @@ use rand::{thread_rng, Rng};
 use beserial::{Deserialize, Serialize};
 use nimiq_network_interface::{
     network::{Network as NetworkInterface, NetworkEvent},
-    request::{InboundRequestError, OutboundRequestError, Request, RequestError},
+    request::{
+        InboundRequestError, OutboundRequestError, Request, RequestCommon, RequestError,
+        RequestMarker,
+    },
 };
 use nimiq_network_libp2p::{
     discovery::{
@@ -28,7 +31,8 @@ use nimiq_utils::time::OffsetTime;
 struct TestRequest {
     request: u64,
 }
-impl Request for TestRequest {
+impl RequestCommon for TestRequest {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 42;
     type Response = TestResponse;
 }
@@ -42,7 +46,8 @@ struct TestResponse {
 struct TestRequest2 {
     request: u64,
 }
-impl Request for TestRequest2 {
+impl RequestCommon for TestRequest2 {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 42;
     type Response = TestResponse2;
 }
@@ -56,7 +61,8 @@ struct TestResponse2 {
 struct TestRequest3 {
     request: u64,
 }
-impl Request for TestRequest3 {
+impl RequestCommon for TestRequest3 {
+    type Kind = RequestMarker;
     const TYPE_ID: u16 = 42;
     type Response = TestResponse3;
 }
@@ -153,7 +159,7 @@ fn assert_peer_joined(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
 /// replies to the request using the `Req` type.
 async fn respond_requests<Req: Request, ExpReq: Request + std::cmp::PartialEq>(
     network: Arc<Network>,
-    response: Option<<Req as Request>::Response>,
+    response: Option<Req::Response>,
     expected_request: ExpReq,
 ) {
     // Subscribe for receiving requests

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-trait = "0.1"
 derive_more = "0.99"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 thiserror = "1.0"

--- a/network-mock/src/hub.rs
+++ b/network-mock/src/hub.rs
@@ -7,6 +7,8 @@ use std::{
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::{broadcast, mpsc, oneshot};
 
+use nimiq_network_interface::request::RequestType;
+
 use crate::network::{MockNetwork, MockRequestId};
 use crate::{MockAddress, MockPeerId, ObservableHashMap};
 
@@ -20,7 +22,7 @@ pub(crate) struct SenderKey {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RequestKey {
     pub recipient: MockAddress,
-    pub message_type: u16,
+    pub message_type: RequestType,
 }
 
 #[derive(Debug)]

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -5,7 +5,7 @@ use std::sync::{
 use std::time::Duration;
 
 use async_trait::async_trait;
-use futures::stream::{BoxStream, StreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use parking_lot::{Mutex, RwLock};
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc, oneshot};

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -24,7 +24,7 @@ maintenance = { status = "experimental" }
 anyhow = "1.0"
 clap = { version = "3.1", features = ["derive"] }
 dotenv = "0.15"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 tokio = { version = "1.18", features = [
     "macros",
     "rt-multi-thread",

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Error};
 use clap::Parser;
-use futures::stream::StreamExt;
+use futures::StreamExt;
 use url::Url;
 
 use nimiq_jsonrpc_client::{websocket::WebsocketClient, ArcClient};

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-trait = "0.1"
 hex = "0.4"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.13"
 thiserror = "1.0"

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 hex = "0.4.2"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
-use futures::stream::{BoxStream, StreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use parking_lot::RwLock;
 
 use nimiq_account::StakingContract;

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 clap = { version = "3.1", features = ["derive"] }
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 rand = "0.8.5"
 tokio = { version = "1.18", features = ["rt-multi-thread", "time", "tracing"] }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 thiserror = "1.0"
 

--- a/tendermint/src/stream.rs
+++ b/tendermint/src/stream.rs
@@ -5,10 +5,8 @@ use crate::outside_deps::TendermintOutsideDeps;
 use crate::state::TendermintState;
 use crate::tendermint::Tendermint;
 use crate::utils::{StreamResult, TendermintReturn};
-use futures::{
-    future::FutureExt,
-    stream::{BoxStream, SelectAll, Stream, StreamExt},
-};
+use futures::stream::{BoxStream, SelectAll};
+use futures::{FutureExt, Stream, StreamExt};
 
 /// This is the main struct of the Tendermint crate. It implements Stream which,
 /// when called repeatedly, yields state updates, errors and results produced by the Tendermint

--- a/tendermint/tests/mod.rs
+++ b/tendermint/tests/mod.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use beserial::{Deserialize, Serialize};
-use futures::{FutureExt, StreamExt};
+use futures::{future, future::BoxFuture, FutureExt, StreamExt};
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_primitives::policy::{SLOTS, TWO_F_PLUS_ONE};
 use nimiq_tendermint::*;
@@ -249,8 +249,8 @@ impl TendermintOutsideDeps for TestValidator {
         proposal.hash()
     }
 
-    fn get_background_task(&mut self) -> futures::future::BoxFuture<'static, ()> {
-        futures::future::pending().boxed()
+    fn get_background_task(&mut self) -> BoxFuture<'static, ()> {
+        future::pending().boxed()
     }
 }
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 rand = "0.8"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 clear_on_drop = { version = "0.2", optional = true }
-futures = { version = "0.3" }
+futures = { package = "futures-util", version = "0.3" }
 hex = { version = "0.4", optional = true }
 libp2p = { version = "0.44", default-features = false, optional = true }
 log = { package = "tracing", version = "0.1", optional = true, features = ["log"] }

--- a/utils/src/observer.rs
+++ b/utils/src/observer.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll};
 
-use futures::stream::Stream;
+use futures::Stream;
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-trait = "0.1"
 beserial = { path = "../beserial", features = ["derive", "libp2p"] }
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 thiserror = "1.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 tokio = "1.18"

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -10,7 +10,7 @@ use futures::{stream::BoxStream, Stream};
 use nimiq_bls::{CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
     network::{MsgAcceptance, Network, PubsubId, Topic},
-    request::Request,
+    request::Message,
 };
 
 pub use crate::error::NetworkError;
@@ -32,16 +32,16 @@ pub trait ValidatorNetwork: Send + Sync {
 
     /// must make a reasonable effort to establish a connection to the peer denoted with `validator_address`
     /// before returning a connection not established error.
-    async fn send_to<Req: Request + Clone>(
+    async fn send_to<M: Message + Clone>(
         &self,
         validator_ids: &[usize],
-        msg: Req,
+        msg: M,
     ) -> Vec<Result<(), Self::Error>>;
 
     /// Will receive from all connected peers
-    fn receive<Req>(&self) -> MessageStream<Req, <Self::NetworkType as Network>::PeerId>
+    fn receive<M>(&self) -> MessageStream<M, <Self::NetworkType as Network>::PeerId>
     where
-        Req: Request<Response = ()> + Clone;
+        M: Message + Clone;
 
     async fn publish<TTopic: Topic + Sync>(&self, item: TTopic::Item) -> Result<(), Self::Error>;
 
@@ -52,7 +52,7 @@ pub trait ValidatorNetwork: Send + Sync {
     /// registers a cache for the specified message type.
     /// Incoming messages of this type should be held in a FIFO queue of total size `buffer_size`, each with a lifetime of `lifetime`
     /// `lifetime` or `buffer_size` of 0 should disable the cache.
-    fn cache<Req: Request>(&self, buffer_size: usize, lifetime: Duration);
+    fn cache<M: Message>(&self, buffer_size: usize, lifetime: Duration);
 
     async fn set_public_key(
         &self,

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -30,6 +30,7 @@ where
     N::PeerId: Serialize + Deserialize,
 {
     network: Arc<N>,
+    // TODO: check if this should be a parking_lot::Mutex
     state: Mutex<State<N::PeerId>>,
 }
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -14,7 +14,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { package = "futures-util", version = "0.3" }
 lazy_static = "1.3"
 linked-hash-map = "0.5.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/validator/src/aggregation/network_sink.rs
+++ b/validator/src/aggregation/network_sink.rs
@@ -1,10 +1,9 @@
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::future::{BoxFuture, FutureExt};
-use futures::sink::Sink;
-use futures::task::{Context, Poll};
+use futures::{future::BoxFuture, FutureExt, Sink};
 
 use nimiq_network_interface::request::Request;
 use nimiq_validator_network::ValidatorNetwork;

--- a/validator/src/aggregation/tendermint/aggregations.rs
+++ b/validator/src/aggregation/tendermint/aggregations.rs
@@ -134,7 +134,7 @@ impl<N: ValidatorNetwork> TendermintAggregations<N> {
                 .map(|((r, s), v)| ((r, s), v.is_running.load(Ordering::Relaxed)))
                 .collect();
 
-            trace!("Aggregation_descriptors: {:?}", &tmp_desc,);
+            trace!("Aggregation_descriptors: {:?}", &tmp_desc);
 
             // copy round_number for use in `retain` couple of lines down so that id can be moved into closure.
             let round_number = id.round_number;

--- a/validator/src/aggregation/tendermint/background_task.rs
+++ b/validator/src/aggregation/tendermint/background_task.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::task::Poll;
 
-use futures::{ready, Future, StreamExt};
+use futures::{ready, StreamExt};
 use parking_lot::RwLock;
 
 use nimiq_block::TendermintStep;

--- a/validator/src/aggregation/view_change.rs
+++ b/validator/src/aggregation/view_change.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::ready;
-use futures::stream::{BoxStream, Stream, StreamExt};
-use futures::task::{Context, Poll};
+use futures::{ready, stream::select, stream::BoxStream, Stream, StreamExt};
 use parking_lot::RwLock;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -282,7 +281,7 @@ impl ViewChangeAggregation {
                 >::new(network.clone())),
             );
 
-            let mut stream = futures::stream::select(
+            let mut stream = select(
                 aggregation.map(ViewChangeResult::ViewChange),
                 UnboundedReceiverStream::new(receiver),
             );

--- a/validator/src/macro.rs
+++ b/validator/src/macro.rs
@@ -1,9 +1,9 @@
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::stream::{BoxStream, Stream, StreamExt};
-use futures::task::{Context, Poll};
+use futures::{stream::BoxStream, Stream, StreamExt};
 use parking_lot::RwLock;
 
 use beserial::{Deserialize, Serialize};

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -1,10 +1,9 @@
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
 
-use futures::future::BoxFuture;
-use futures::task::{Context, Poll};
-use futures::{ready, FutureExt, Stream};
+use futures::{future::BoxFuture, ready, FutureExt, Stream};
 use parking_lot::RwLock;
 use tokio::time;
 

--- a/validator/src/mock.rs
+++ b/validator/src/mock.rs
@@ -1,6 +1,6 @@
-use failure::_core::pin::Pin;
-use futures::task::{Context, Poll};
-use futures::Future;
+use std::future::::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use nimiq_block::{MacroBlock, SignedViewChange, ViewChangeProof};
 use nimiq_network::Network;

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -4,10 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use beserial::Serialize;
-use futures::{
-    future::{BoxFuture, FutureExt},
-    stream::{BoxStream, StreamExt},
-};
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
 use nimiq_primitives::policy;
 use parking_lot::RwLock;
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1,12 +1,11 @@
 use std::error::Error;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
-use futures::{
-    task::{Context, Poll, Waker},
-    Future, Stream, StreamExt,
-};
+use futures::{Stream, StreamExt};
 use linked_hash_map::LinkedHashMap;
 use parking_lot::RwLock;
 use tokio_metrics::TaskMonitor;

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -241,7 +241,7 @@ async fn validator_can_catch_up() {
     for network in &networks {
         for peer_id in network.get_peers() {
             network
-                .request::<LevelUpdateMessage<SignedViewChangeMessage, ViewChange>>(
+                .message::<LevelUpdateMessage<SignedViewChangeMessage, ViewChange>>(
                     vc.clone(),
                     peer_id,
                 )


### PR DESCRIPTION
These two types are messages that need a response and those that don't.
Since libp2p wants all request-response messages to have a response,
autoreply in case the higher level protocol doesn't want a response.

Fixes #796.

And a couple of other fixes.