### PR TITLE
Use arguments to enable metrics in the devnet script and change default port

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -569,7 +569,7 @@ pub struct RpcServerConfig {
 pub struct MetricsServerConfig {
     /// Bind the server to the specified ip and port.
     ///
-    /// Default: `127.0.0.1:8649`
+    /// Default: `127.0.0.1:9100`
     ///
     pub addr: SocketAddr,
 

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -128,8 +128,8 @@ bind = "127.0.0.1"
 
 # Port to use to create a listening socket for the metrics server.
 # Possible values: any valid port number
-# Default: 8649
-port = 8649
+# Default: 9100
+port = 9100
 
 # Declare a username and password required to access the metrics server.
 # Default: none

--- a/lib/src/config/consts.rs
+++ b/lib/src/config/consts.rs
@@ -10,7 +10,7 @@ pub const REVERSE_PROXY_DEFAULT_PORT: u16 = 8444;
 pub const RPC_DEFAULT_PORT: u16 = 8648;
 
 /// The default port for the metrics server
-pub const METRICS_DEFAULT_PORT: u16 = 8649;
+pub const METRICS_DEFAULT_PORT: u16 = 9100;
 
 /// Returns the default bind, i.e. localhost
 pub fn default_bind() -> IpAddr {

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -240,8 +240,7 @@ if [ "$RELEASE" = true ] ; then
 fi
 
 if [ "$METRICS" = true ] ; then
-    cargo+=" --features nimiq-spammer/metrics"
-    cargo_build+=" --features nimiq-spammer/metrics"
+    export RUSTFLAGS="--cfg tokio_unstable"
 fi
 
 echo "Number of validators: $MAX_VALIDATORS"
@@ -260,11 +259,17 @@ do
 done
 
 echo "Building config files..."
+devnet_command="python3 $devnet_create $MAX_VALIDATORS --run-environment $RUN_ENVIRONMENT -o $configdir"
 if [ "$SPAMMER" = true ] ; then
-    python3 $devnet_create $MAX_VALIDATORS --run-environment "$RUN_ENVIRONMENT" -o $configdir -s
-else
-    python3 $devnet_create $MAX_VALIDATORS --run-environment "$RUN_ENVIRONMENT" -o $configdir
+    devnet_command="$devnet_command -s"
 fi
+if [ "$METRICS" = true ] ; then
+    devnet_command="$devnet_command -m"
+fi
+
+# Execute the devnet command
+$devnet_command
+
 echo "Config files generated in '$configdir'"
 export NIMIQ_OVERRIDE_DEVNET_CONFIG="$PWD/$configdir/dev-albatross.toml"
 echo "Overriding genesis with '$NIMIQ_OVERRIDE_DEVNET_CONFIG' ..."


### PR DESCRIPTION
- Change the devnet script to enable metrics only when the arguments
  indicates it. This could be done manually or using the `-s` option
  in the `devnet.sh` script.
  This also starts to remove support for the old spammer metrics.  
- Use a more standard default port for metrics.
