### PR TITLE
RPC: Move get_transaction_by_hash function from mempool into blockchain dispatcher

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -45,6 +45,11 @@ pub trait BlockchainInterface {
         view_number: Option<u32>,
     ) -> Result<Slot, Self::Error>;
 
+    async fn get_transaction_by_hash(
+        &mut self,
+        hash: Blake2bHash,
+    ) -> Result<Transaction, Self::Error>;
+
     async fn get_transactions_by_block_number(
         &mut self,
         block_number: u32,

--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::types::{HashOrTx, MempoolInfo, Transaction};
+use crate::types::{HashOrTx, MempoolInfo};
 use nimiq_hash::Blake2bHash;
 
 #[nimiq_jsonrpc_derive::proxy(name = "MempoolProxy", rename_all = "camelCase")]
@@ -9,12 +9,6 @@ pub trait MempoolInterface {
     type Error;
 
     async fn push_transaction(&mut self, raw_tx: String) -> Result<Blake2bHash, Self::Error>;
-
-    async fn get_transaction_by_hash(
-        &mut self,
-        hash: Blake2bHash,
-        check_mempool: Option<bool>,
-    ) -> Result<Transaction, Self::Error>;
 
     async fn mempool_content(
         &mut self,

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -128,6 +128,40 @@ impl BlockchainInterface for BlockchainDispatcher {
         Ok(Slot::from(blockchain.deref(), block_number, view_number))
     }
 
+    /// Tries to fetch a transaction (including reward transactions) given its hash.
+    async fn get_transaction_by_hash(&mut self, hash: Blake2bHash) -> Result<Transaction, Error> {
+        let blockchain = self.blockchain.read();
+
+        // Get all the extended transactions that correspond to this hash.
+        let mut extended_tx_vec = blockchain.history_store.get_ext_tx_by_hash(&hash, None);
+
+        // Unpack the transaction or raise an error.
+        let extended_tx = match extended_tx_vec.len() {
+            0 => {
+                return Err(Error::TransactionNotFound(hash));
+            }
+            1 => extended_tx_vec.pop().unwrap(),
+            _ => {
+                return Err(Error::MultipleTransactionsFound(hash));
+            }
+        };
+
+        // Convert the extended transaction into a regular transaction. This will also convert
+        // reward inherents.
+        let block_number = extended_tx.block_number;
+        let timestamp = extended_tx.block_time;
+
+        return match extended_tx.into_transaction() {
+            Ok(tx) => Ok(Transaction::from_blockchain(
+                tx,
+                block_number,
+                timestamp,
+                blockchain.block_number(),
+            )),
+            Err(_) => Err(Error::TransactionNotFound(hash)),
+        };
+    }
+
     /// Returns all the transactions (including reward transactions) for the given block number. Note
     /// that this only considers blocks in the main chain.
     async fn get_transactions_by_block_number(

--- a/rpc-server/src/dispatchers/mempool.rs
+++ b/rpc-server/src/dispatchers/mempool.rs
@@ -3,12 +3,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use beserial::Deserialize;
 
-use nimiq_blockchain::AbstractBlockchain;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_mempool::mempool::Mempool;
 
 use nimiq_rpc_interface::mempool::MempoolInterface;
-use nimiq_rpc_interface::types::{HashOrTx, MempoolInfo, Transaction};
+use nimiq_rpc_interface::types::{HashOrTx, MempoolInfo};
 
 use crate::error::Error;
 
@@ -38,53 +37,6 @@ impl MempoolInterface for MempoolDispatcher {
             Ok(_) => Ok(txid),
             Err(e) => Err(Error::MempoolError(e)),
         }
-    }
-
-    /// Tries to fetch a transaction (including reward transactions) given its hash. It has an option
-    /// to also search the mempool for the transaction, it defaults to false.
-    async fn get_transaction_by_hash(
-        &mut self,
-        hash: Blake2bHash,
-        check_mempool: Option<bool>,
-    ) -> Result<Transaction, Error> {
-        // First check the mempool.
-        if check_mempool == Some(true) {
-            if let Some(tx) = self.mempool.get_transaction_by_hash(&hash) {
-                return Ok(Transaction::from_transaction(tx));
-            }
-        }
-
-        // Now check the blockchain.
-        let blockchain = self.mempool.blockchain.read();
-
-        // Get all the extended transactions that correspond to this hash.
-        let mut extended_tx_vec = blockchain.history_store.get_ext_tx_by_hash(&hash, None);
-
-        // Unpack the transaction or raise an error.
-        let extended_tx = match extended_tx_vec.len() {
-            0 => {
-                return Err(Error::TransactionNotFound(hash));
-            }
-            1 => extended_tx_vec.pop().unwrap(),
-            _ => {
-                return Err(Error::MultipleTransactionsFound(hash));
-            }
-        };
-
-        // Convert the extended transaction into a regular transaction. This will also convert
-        // reward inherents.
-        let block_number = extended_tx.block_number;
-        let timestamp = extended_tx.block_time;
-
-        return match extended_tx.into_transaction() {
-            Ok(tx) => Ok(Transaction::from_blockchain(
-                tx,
-                block_number,
-                timestamp,
-                blockchain.block_number(),
-            )),
-            Err(_) => Err(Error::TransactionNotFound(hash)),
-        };
     }
 
     async fn mempool_content(


### PR DESCRIPTION
Seed nodes do not have a mempool, because they do not run a validator, so this change makes the method accessible on the devnet seed node. It loses the ability to query the mempool, but transactions are confirmed (included into block) near-instantly, so mempool querying should not be necessary.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

Tested and verified with a local node.
