### PR TITLE
Add tokio metrics and remove old spammer metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,7 @@ dependencies = [
  "futures",
  "nimiq-lib",
  "tokio",
+ "tokio-metrics",
  "tracing",
 ]
 
@@ -2840,7 +2841,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "warp 0.3.1",
+ "warp",
 ]
 
 [[package]]
@@ -2972,6 +2973,7 @@ dependencies = [
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "rand 0.8.5",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tracing",
 ]
@@ -2990,6 +2992,7 @@ dependencies = [
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "prometheus-client 0.16.0",
  "tokio",
+ "tokio-metrics",
  "tracing",
 ]
 
@@ -3287,7 +3290,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures",
- "lazy_static",
  "nimiq-block",
  "nimiq-blockchain",
  "nimiq-keys",
@@ -3296,13 +3298,12 @@ dependencies = [
  "nimiq-primitives",
  "nimiq-transaction",
  "nimiq-transaction-builder",
- "prometheus",
  "rand 0.8.5",
  "serde",
  "tokio",
+ "tokio-metrics",
  "toml",
  "tracing",
- "warp 0.3.2",
 ]
 
 [[package]]
@@ -3534,6 +3535,7 @@ dependencies = [
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "rand 0.8.5",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tracing",
  "tracing-core",
@@ -3999,37 +4001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e344cafeaeefe487300c361654bcfc85db3ac53619eeccced29f5ea18c4c70"
-dependencies = [
- "bitflags",
- "byteorder",
- "flate2",
- "hex",
- "lazy_static",
- "libc",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "libc",
- "memchr",
- "parking_lot 0.11.2",
- "procfs",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
 name = "prometheus-client"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,12 +4120,6 @@ dependencies = [
  "bytes",
  "prost 0.10.0",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quick-error"
@@ -5017,6 +4982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb585a0069b53171684e22d5255984ec30d1c7304fd0a4a9a603ffd8c765cdd"
+dependencies = [
+ "futures-util",
+ "pin-project-lite 0.2.9",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-native-tls"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5518,36 +5494,6 @@ source = "git+https://github.com/vlvrd/warp.git?branch=sergio/auth#45ac5ae52c072
 dependencies = [
  "bytes",
  "futures",
- "headers",
- "http",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "multipart",
- "percent-encoding",
- "pin-project 1.0.10",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tokio-util 0.6.9",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
  "headers",
  "http",
  "hyper",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,6 +21,7 @@ maintenance = { status = "experimental" }
 futures = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 tokio = { version = "1.18", features = ["rt-multi-thread", "time", "tracing"] }
+tokio-metrics = "0.1"
 
 [dependencies.nimiq]
 package = "nimiq-lib"

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::fs::{self, File};
 use std::io;
+#[cfg(tokio_unstable)]
+use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
 use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};

--- a/lib/src/extras/metrics_server.rs
+++ b/lib/src/extras/metrics_server.rs
@@ -6,12 +6,22 @@ use parking_lot::RwLock;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+pub use nimiq_metrics_server::NimiqTaskMonitor;
+
 pub fn start_metrics_server<TNetwork: Network>(
     addr: SocketAddr,
     blockchain: Arc<RwLock<Blockchain>>,
     mempool: Option<Arc<Mempool>>,
     consensus_proxy: ConsensusProxy<TNetwork>,
     network: Arc<nimiq_network_libp2p::Network>,
+    task_monitors: &[NimiqTaskMonitor],
 ) {
-    nimiq_metrics_server::start_metrics_server(addr, blockchain, mempool, consensus_proxy, network);
+    nimiq_metrics_server::start_metrics_server(
+        addr,
+        blockchain,
+        mempool,
+        consensus_proxy,
+        network,
+        task_monitors,
+    );
 }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -22,7 +22,10 @@ parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 futures = "0.3"
 keyed_priority_queue = "0.4"
 tokio = { version = "1.18", features = ["full", "tracing"] }
+tokio-metrics = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
+
+
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account" }
 nimiq-block = { path = "../primitives/block" }

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -27,9 +27,10 @@ tokio = { version = "1.18", features = [
     "rt-multi-thread",
     "tracing",
 ] }
+tokio-metrics = "0.1"
 
 nimiq-blockchain = { path = "../blockchain", features=["metrics"] }
-nimiq-mempool = { path = "../mempool" }
 nimiq-consensus = { path = "../consensus" }
+nimiq-mempool = { path = "../mempool" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-network-libp2p = { path = "../network-libp2p" }

--- a/metrics-server/src/lib.rs
+++ b/metrics-server/src/lib.rs
@@ -4,24 +4,39 @@ use prometheus_client::encoding::text::{Encode, EncodeMetric, Encoder};
 use prometheus_client::registry::Registry;
 
 use parking_lot::RwLock;
+use tokio_metrics::TaskMonitor;
 
 use crate::chain::BlockMetrics;
 use crate::consensus::ConsensusMetrics;
 use crate::mempool::MempoolMetrics;
 use crate::network::NetworkMetrics;
 use crate::server::metrics_server;
+#[cfg(tokio_unstable)]
+use crate::tokio_runtime::TokioRuntimeMetrics;
+use crate::tokio_task::TokioTaskMetrics;
 use nimiq_blockchain::Blockchain;
 use nimiq_consensus::ConsensusProxy;
 use nimiq_mempool::mempool::Mempool;
 use nimiq_network_interface::network::Network;
 use prometheus_client::metrics::MetricType;
 use std::sync::Arc;
+#[cfg(tokio_unstable)]
+use tokio_metrics::RuntimeMonitor;
 
 mod chain;
 mod consensus;
 mod mempool;
 mod network;
 mod server;
+#[cfg(tokio_unstable)]
+mod tokio_runtime;
+mod tokio_task;
+
+#[derive(Clone)]
+pub struct NimiqTaskMonitor {
+    pub name: String,
+    pub monitor: TaskMonitor,
+}
 
 struct NumericClosureMetric<T: Encode + Sized> {
     metric_type: MetricType,
@@ -70,6 +85,7 @@ pub fn start_metrics_server<TNetwork: Network>(
     mempool: Option<Arc<Mempool>>,
     consensus_proxy: ConsensusProxy<TNetwork>,
     network: Arc<nimiq_network_libp2p::Network>,
+    task_monitors: &[NimiqTaskMonitor],
 ) {
     let mut registry = Registry::default();
     let nimiq_registry = registry.sub_registry_with_prefix("nimiq");
@@ -82,5 +98,49 @@ pub fn start_metrics_server<TNetwork: Network>(
         MempoolMetrics::register(nimiq_registry, mempool);
     }
 
+    // Setup the task metrics
+    let task_metrics = Arc::new(RwLock::new(TokioTaskMetrics::new()));
+    task_metrics.write().register(
+        nimiq_registry,
+        &task_monitors
+            .iter()
+            .map(|e| e.name.clone())
+            .collect::<Vec<String>>()[..],
+    );
+
+    #[cfg(tokio_unstable)]
+    {
+        // Setup the tokio runtime metrics
+        let handle = tokio::runtime::Handle::current();
+        let tokio_rt_monitor = RuntimeMonitor::new(&handle);
+        let mut tokio_rt_metrics = TokioRuntimeMetrics::new();
+        tokio_rt_metrics.register(nimiq_registry);
+        let tokio_rt_metrics = Arc::new(RwLock::new(tokio_rt_metrics));
+        // Spawn Tokio runtime metrics updater
+
+        tokio::spawn(TokioRuntimeMetrics::update_metric_values(
+            tokio_rt_metrics,
+            tokio_rt_monitor,
+        ));
+    }
+
+    // Spawn the metrics server
     tokio::spawn(metrics_server(addr, registry));
+
+    // Spawn Tokio task monitor updaters
+    for i in 0..task_monitors.len() {
+        let task_monitors = task_monitors.to_vec();
+        tokio::spawn({
+            let task_metrics = Arc::clone(&task_metrics);
+            let task_monitors = task_monitors;
+            async move {
+                TokioTaskMetrics::update_metric_values(
+                    task_metrics,
+                    &task_monitors[i].name,
+                    task_monitors[i].monitor.clone(),
+                )
+                .await;
+            }
+        });
+    }
 }

--- a/metrics-server/src/tokio_runtime.rs
+++ b/metrics-server/src/tokio_runtime.rs
@@ -1,0 +1,177 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use parking_lot::RwLock;
+use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
+use tokio_metrics::{RuntimeMetrics, RuntimeMonitor};
+
+const TOKIO_METRICS_FREQ_SECS: u64 = 1;
+
+static TOKIO_RT_METRICS_NAME: &[&str] = &[
+    "worker_count",
+    "total_park_count",
+    "max_park_count",
+    "min_park_count",
+    "total_noop_count",
+    "max_noop_count",
+    "min_noop_count",
+    "total_steal_count",
+    "max_steal_count",
+    "min_steal_count",
+    "remote_schedules",
+    "total_local_sched_count",
+    "max_local_sched_count",
+    "min_local_sched_count",
+    "total_overflow_count",
+    "max_overflow_count",
+    "min_overflow_count",
+    "total_polls_count",
+    "max_polls_count",
+    "min_polls_count",
+    "total_busy_duration",
+    "max_busy_duration",
+    "min_busy_duration",
+    "injection_queue_depth",
+    "total_local_queue_depth",
+    "max_local_queue_depth",
+    "min_local_queue_depth",
+    "elapsed",
+];
+
+static TOKIO_RT_METRICS_DESC: &[&str] = &[
+    "Tokio workers count",
+    "Tokio total park count",
+    "Tokio maximum park count",
+    "Tokio minimum park count",
+    "Tokio noop count",
+    "Tokio maximum noop count",
+    "Tokio minimum noop count",
+    "Tokio total steal count",
+    "Tokio maximum steal count",
+    "Tokio minimum steal count",
+    "Tokio number of remote schedules",
+    "Tokio total local schedules count",
+    "Tokio maximum local schedules count",
+    "Tokio minimum local schedules count",
+    "Tokio total overflow count",
+    "Tokio maximum overflow count",
+    "Tokio minimum overflow count",
+    "Tokio total polls count",
+    "Tokio maximum polls count",
+    "Tokio minimum polls count",
+    "Tokio total busy duration",
+    "Tokio maximum busy duration",
+    "Tokio minimum busy duration",
+    "Tokio injection queue depth",
+    "Tokio total local queue depth",
+    "Tokio maximum local queue depth",
+    "Tokio minimum local queue depth",
+    "Tokio elapsed time",
+];
+
+pub struct TokioRuntimeMetrics {
+    pub metric_gauges: HashMap<String, Gauge>,
+}
+
+impl TokioRuntimeMetrics {
+    pub fn new() -> Self {
+        TokioRuntimeMetrics {
+            metric_gauges: HashMap::new(),
+        }
+    }
+    pub fn register(&mut self, registry: &mut Registry) {
+        let sub_registry = registry.sub_registry_with_prefix("tokio");
+
+        for i in 0..TOKIO_RT_METRICS_NAME.len() {
+            let gauge: Gauge = Gauge::default();
+            sub_registry.register(
+                TOKIO_RT_METRICS_NAME[i],
+                TOKIO_RT_METRICS_DESC[i],
+                Box::new(gauge.clone()),
+            );
+            self.metric_gauges
+                .insert(TOKIO_RT_METRICS_NAME[i].to_string(), gauge);
+        }
+    }
+
+    pub async fn update_metric_values(
+        tokio_rt_metrics: Arc<RwLock<Self>>,
+        runtime_monitor: RuntimeMonitor,
+    ) {
+        let tokio_rt_metrics = tokio_rt_metrics.clone();
+        let mut interval = tokio::time::interval(Duration::from_secs(TOKIO_METRICS_FREQ_SECS));
+        let mut runtime_intervals = runtime_monitor.intervals();
+
+        loop {
+            interval.tick().await;
+            if let Some(interval) = runtime_intervals.next() {
+                tokio_rt_metrics.write().update_tokio_metrics(interval);
+            }
+        }
+    }
+
+    pub fn update_metric_value(&mut self, name: &str, value: u64) {
+        if let Some(gauge) = self.metric_gauges.get(&name.to_string()) {
+            gauge.set(value);
+        } else {
+            panic!("Unexpected metric name: {}", name);
+        }
+    }
+
+    pub fn update_tokio_metrics(&mut self, interval: RuntimeMetrics) {
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[0], interval.workers_count as u64);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[1], interval.total_park_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[2], interval.max_park_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[3], interval.min_park_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[4], interval.total_noop_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[5], interval.max_noop_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[6], interval.min_noop_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[7], interval.total_steal_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[8], interval.max_steal_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[9], interval.min_steal_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[10], interval.num_remote_schedules);
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[11],
+            interval.total_local_schedule_count,
+        );
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[12], interval.max_local_schedule_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[13], interval.min_local_schedule_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[14], interval.total_overflow_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[15], interval.max_overflow_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[16], interval.min_overflow_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[17], interval.total_polls_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[18], interval.max_polls_count);
+        self.update_metric_value(TOKIO_RT_METRICS_NAME[19], interval.min_polls_count);
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[20],
+            interval.total_busy_duration.as_millis() as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[21],
+            interval.max_busy_duration.as_millis() as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[22],
+            interval.min_busy_duration.as_millis() as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[23],
+            interval.injection_queue_depth as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[24],
+            interval.total_local_queue_depth as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[25],
+            interval.max_local_queue_depth as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[26],
+            interval.min_local_queue_depth as u64,
+        );
+        self.update_metric_value(
+            TOKIO_RT_METRICS_NAME[27],
+            interval.elapsed.as_micros() as u64,
+        );
+    }
+}

--- a/metrics-server/src/tokio_task.rs
+++ b/metrics-server/src/tokio_task.rs
@@ -1,0 +1,157 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use parking_lot::RwLock;
+use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
+use tokio_metrics::{TaskMetrics, TaskMonitor};
+
+const TOKIO_METRICS_FREQ_SECS: u64 = 1;
+
+static TOKIO_TASK_METRICS_NAME: &[&str] = &[
+    "instrumented_count",
+    "dropped_count",
+    "first_poll_count",
+    "total_first_poll_delay",
+    "total_idled_count",
+    "total_idle_duration",
+    "total_schedule_count",
+    "total_schedule_duration",
+    "total_poll_count",
+    "total_poll_duration",
+    "total_fast_poll_count",
+    "total_fast_poll_duration",
+    "total_slow_poll_count",
+    "total_slow_poll_duration",
+];
+
+static TOKIO_TASK_METRICS_DESC: &[&str] = &[
+    "instrumented count",
+    "dropped count",
+    "first poll count",
+    "total first poll delay",
+    "total idled count",
+    "total idle duration",
+    "total schedule count count",
+    "total schedule duration",
+    "total poll count",
+    "total poll duration",
+    "total fast poll count",
+    "total fast poll duration",
+    "total slow poll count",
+    "total slow poll duration",
+];
+
+pub struct TokioTaskMetrics {
+    pub metric_gauges: HashMap<String, Gauge>,
+}
+
+impl TokioTaskMetrics {
+    pub fn new() -> Self {
+        TokioTaskMetrics {
+            metric_gauges: HashMap::new(),
+        }
+    }
+    pub fn register(&mut self, registry: &mut Registry, task_names: &[String]) {
+        let sub_registry = registry.sub_registry_with_prefix("tokio");
+
+        for task_name in task_names {
+            for i in 0..TOKIO_TASK_METRICS_NAME.len() {
+                let gauge: Gauge = Gauge::default();
+                sub_registry.register(
+                    format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[i]),
+                    format!("{} {}", task_name, TOKIO_TASK_METRICS_DESC[i]),
+                    Box::new(gauge.clone()),
+                );
+                self.metric_gauges.insert(
+                    format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[i]),
+                    gauge,
+                );
+            }
+        }
+    }
+
+    pub async fn update_metric_values(
+        tokio_task_metrics: Arc<RwLock<Self>>,
+        task_name: &str,
+        runtime_monitor: TaskMonitor,
+    ) {
+        let tokio_task_metrics = tokio_task_metrics.clone();
+        let mut interval = tokio::time::interval(Duration::from_secs(TOKIO_METRICS_FREQ_SECS));
+        let mut runtime_intervals = runtime_monitor.intervals();
+
+        loop {
+            interval.tick().await;
+            if let Some(interval) = runtime_intervals.next() {
+                tokio_task_metrics
+                    .write()
+                    .update_tokio_task_metrics(task_name, interval);
+            }
+        }
+    }
+
+    pub fn update_metric_value(&mut self, name: String, value: u64) {
+        if let Some(gauge) = self.metric_gauges.get(&name) {
+            gauge.set(value);
+        } else {
+            panic!("Unexpected metric name: {}", name);
+        }
+    }
+
+    pub fn update_tokio_task_metrics(&mut self, task_name: &str, interval: TaskMetrics) {
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[0]),
+            interval.instrumented_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[1]),
+            interval.dropped_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[2]),
+            interval.first_poll_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[3]),
+            interval.total_first_poll_delay.as_micros() as u64,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[4]),
+            interval.total_idled_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[5]),
+            interval.total_idle_duration.as_micros() as u64,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[6]),
+            interval.total_scheduled_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[7]),
+            interval.total_scheduled_duration.as_micros() as u64,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[8]),
+            interval.total_poll_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[9]),
+            interval.total_poll_duration.as_micros() as u64,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[10]),
+            interval.total_fast_poll_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[11]),
+            interval.total_fast_poll_duration.as_micros() as u64,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[12]),
+            interval.total_slow_poll_count,
+        );
+        self.update_metric_value(
+            format!("{}_{}", task_name, TOKIO_TASK_METRICS_NAME[13]),
+            interval.total_slow_poll_duration.as_micros() as u64,
+        );
+    }
+}

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -20,12 +20,10 @@ maintenance = { status = "experimental" }
 [dependencies]
 clap = { version = "3.1", features = ["derive"] }
 futures = "0.3"
-lazy_static = { version = "1.4", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-prometheus = { version = "0.13", features = ["process"], optional = true }
 rand = "0.8.5"
 tokio = { version = "1.18", features = ["rt-multi-thread", "time", "tracing"] }
-warp = { version = "0.3.2", optional = true }
+tokio-metrics = { version = "0.1" }
 toml = "0.5"
 serde = "1.0.137"
 nimiq-block = { path = "../primitives/block" }
@@ -40,7 +38,4 @@ nimiq-transaction-builder = { path = "../transaction-builder" }
 package = "nimiq-lib"
 path = "../lib"
 version = "0.1"
-features = ["deadlock", "logging", "panic", "rpc-server", "signal-handling", "validator", "wallet"]
-
-[features]
-metrics = ["lazy_static", "prometheus", "warp"]
+features = ["deadlock", "logging", "metrics-server", "panic", "rpc-server", "signal-handling", "validator", "wallet"]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,6 +21,7 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = "0.8"
 tokio = { version = "1.18", features = ["rt", "time", "tracing"] }
+tokio-metrics = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 beserial = { path = "../beserial", features = ["derive"] }


### PR DESCRIPTION
Remove old spammer metrics and add tokio metrics like:
- Tokio runtime metrics.
- Tokio task metrics for:
  - Consensus
  - Mempool
  - Validator

Also added changes to instrument the above tasks.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
