### PR TITLE
Fix compilation for metrics-server and lib crates

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -72,7 +72,7 @@ nimiq-test-log = { path = "../test-log" }
 deadlock = []
 default = []
 launcher = []
-signal-handling = ["signal-hook"]
+signal-handling = ["signal-hook", "tokio"]
 logging = ["console-subscriber", "nimiq-log", "serde_json", "tokio", "tracing-loki", "tracing-subscriber"]
 metrics-server = []
 panic = ["log-panics"]

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -21,7 +21,7 @@ use nimiq_utils::file_store::FileStore;
 #[cfg(feature = "validator")]
 use nimiq_utils::key_rng::SecureGenerate;
 
-#[cfg(feature = "rpc-server")]
+#[cfg(any(feature = "rpc-server", feature = "metrics-server"))]
 use crate::config::consts;
 use crate::config::consts::default_bind;
 use crate::{

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -17,17 +17,16 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-prometheus-client = "0.16.0"
-hyper = "0.14.18"
-log = { package = "tracing", version = "0.1", features = ["log"] }
 futures = "0.3"
+hyper = { version = "0.14.18", features = ["server", "tcp", "http2"] }
+log = { package = "tracing", version = "0.1", features = ["log"] }
+parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+prometheus-client = "0.16.0"
 tokio = { version = "1.18", features = [
     "macros",
     "rt-multi-thread",
     "tracing",
 ] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
-
 
 nimiq-blockchain = { path = "../blockchain", features=["metrics"] }
 nimiq-mempool = { path = "../mempool" }


### PR DESCRIPTION
Fix compilation for `metrics-server` and `lib` crates when compiling
with or without features. Specifically the compilation for:
- `lib` with the following features enabled:
  - `metrics-server`
  - `signal-handling`
- `metrics-server` with the following features enabled:
  - No features.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.