### PR TITLE
Add accounts tree perf test

### DIFF
--- a/test-utils/src/test_transaction.rs
+++ b/test-utils/src/test_transaction.rs
@@ -51,8 +51,6 @@ pub fn generate_transactions(
     let mut txns_len = 0;
     let mut txns: Vec<Transaction> = vec![];
 
-    log::debug!("Generating transactions and accounts");
-
     for mempool_transaction in mempool_transactions {
         // Generate transactions
         let mut txn = Transaction::new_basic(


### PR DESCRIPTION
Add a couple of accounts tree performance test to simulate what we do during history sync.
The goal of the test is to measure is how long it takes to push batches, in two different configurations:
- Single sender, multiple random recipients
- Multiple sender, multiple recipients all existing