### PR TITLE
metrics-server: Remove accounts tree size metric

### DIFF
--- a/metrics-server/src/chain.rs
+++ b/metrics-server/src/chain.rs
@@ -11,7 +11,6 @@ pub struct BlockMetrics {}
 impl BlockMetrics {
     pub fn register(registry: &mut Registry, blockchain: Arc<RwLock<Blockchain>>) {
         BlockMetrics::register_staking(registry, blockchain.clone());
-        BlockMetrics::register_accounts_tree(registry, blockchain.clone());
         BlockMetrics::register_chain(registry, blockchain.clone());
         BlockMetrics::register_block_stats(registry, blockchain);
     }
@@ -29,15 +28,6 @@ impl BlockMetrics {
             blockchain.read().get_staking_contract().parked_set.len() as u32
         })));
         sub_registry.register("parked_validators", "Number of parked validators", closure);
-    }
-
-    fn register_accounts_tree(registry: &mut Registry, blockchain: Arc<RwLock<Blockchain>>) {
-        let sub_registry = registry.sub_registry_with_prefix("accounts_tree");
-
-        let closure = Box::new(NumericClosureMetric::new_gauge(Box::new(move || {
-            blockchain.read().state.accounts.size(None) as u32
-        })));
-        sub_registry.register("size", "Size of accounts tree", closure);
     }
 
     fn register_chain(registry: &mut Registry, blockchain: Arc<RwLock<Blockchain>>) {


### PR DESCRIPTION
Remove the blockchain metric that gets the accounts tree size since
the function as it is now traverses the accounts tree to compute its
size which depends on the size of the tree and may result in long
lock blockchain lock acquisition times.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.