### PR TITLE
Fix error in zkp setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,7 @@ opt-level = 3
 
 [profile.release]
 lto = "thin"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/nano-zkp/Cargo.toml
+++ b/nano-zkp/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography::cryptocurrencies"]
 keywords = ["nimiq", "cryptocurrency", "blockchain"]
 
 [dependencies]
-thiserror = "1.0.31"
+thiserror = "1.0"
 rand = { version = "0.8", features = ["small_rng"] }
 
 ark-crypto-primitives = "0.3"


### PR DESCRIPTION
## Summary
This pull request fixes the ZKP setup phase.
It also introduces a new optimised build profile with debug symbols, which is useful for ZKPs (as they are too slow otherwise).

## Problem being fixed
During the ZKP setup, no specific inputs are required (which is why inputs are always declared in closures).
In fact, the setup often deliberately sets these inputs to `Err(SynthesisError::AssignmentMissing)` during the setup.
However, the setup was failing with exactly this error.

The problem was that the vector allocation `Vec::new_witness` does evaluate the closure and passes on the error.
The reason is simple: it needs to have a value to know the size of the vector to be allocated on the circuit.

## Proposed fix
The fix is to return a dummy value of the correct length in this case.