### PR TITLE
Fix features compilation for several crates

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -311,6 +311,7 @@ impl Blockchain {
         let this = RwLockWriteGuard::downgrade_to_upgradable(this);
 
         let num_transactions = this.state.main_chain.head.num_transactions();
+        #[cfg(feature = "metrics")]
         this.metrics.note_extend(num_transactions);
         debug!(
             block = %this.state.main_chain.head,
@@ -558,6 +559,7 @@ impl Blockchain {
             num_adopted_blocks = adopted_blocks.len(),
             "Rebranched",
         );
+        #[cfg(feature = "metrics")]
         this.metrics
             .note_rebranch(&reverted_blocks, &adopted_blocks);
 

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -5,6 +5,7 @@ use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::policy;
 use nimiq_utils::observer::{Listener, ListenerHandle};
+#[cfg(feature = "metrics")]
 use std::sync::Arc;
 
 use crate::blockchain_state::BlockchainState;

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3" }
+futures = { package = "futures-util", version = "0.3", features = ["sink"] }
 lazy_static = "1.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -53,7 +53,7 @@ nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git" }
 nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git" }
 nimiq-keys = { path = "../keys" }
 nimiq-log = { path = "../log", optional = true }
-nimiq-mempool = { path = "../mempool", features = ["metrics"] }
+nimiq-mempool = { path = "../mempool" }
 nimiq-metrics-server = { path = "../metrics-server" }
 nimiq-network-libp2p = { path = "../network-libp2p", features = ["metrics"] }
 nimiq-network-interface = { path = "../network-interface" }
@@ -74,7 +74,7 @@ default = []
 launcher = []
 signal-handling = ["signal-hook", "tokio"]
 logging = ["console-subscriber", "nimiq-log", "serde_json", "tokio", "tracing-loki", "tracing-subscriber"]
-metrics-server = []
+metrics-server = ["nimiq-validator/metrics"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -10,6 +10,7 @@ use nimiq_consensus::{
 };
 use nimiq_database::Environment;
 use nimiq_genesis::NetworkInfo;
+#[cfg(feature = "validator")]
 use nimiq_mempool::mempool::Mempool;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_libp2p::{

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "rpc-server")]
 use std::net::IpAddr;
+#[cfg(feature = "metrics-server")]
 use std::net::SocketAddr;
 use std::{
     path::{Path, PathBuf},
@@ -13,6 +14,7 @@ use beserial::Deserialize;
 #[cfg(feature = "validator")]
 use nimiq_bls::{KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
 use nimiq_database::{mdbx::MdbxEnvironment, volatile::VolatileEnvironment, Environment};
+#[cfg(feature = "validator")]
 use nimiq_keys::{Address, KeyPair, PrivateKey};
 use nimiq_mempool::{config::MempoolConfig, filter::MempoolRules};
 use nimiq_network_libp2p::{Keypair as IdentityKeypair, Multiaddr};
@@ -23,6 +25,7 @@ use nimiq_utils::key_rng::SecureGenerate;
 
 #[cfg(any(feature = "rpc-server", feature = "metrics-server"))]
 use crate::config::consts;
+#[cfg(feature = "metrics-server")]
 use crate::config::consts::default_bind;
 use crate::{
     client::Client,

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -6,7 +6,6 @@ use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use std::cmp::{Ordering, Reverse};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-#[cfg(feature = "metrics")]
 use tokio_metrics::TaskMonitor;
 
 use beserial::Serialize;

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -29,8 +29,8 @@ tokio = { version = "1.18", features = [
 ] }
 tokio-metrics = "0.1"
 
-nimiq-blockchain = { path = "../blockchain", features=["metrics"] }
+nimiq-blockchain = { path = "../blockchain", features = ["metrics"] }
 nimiq-consensus = { path = "../consensus" }
-nimiq-mempool = { path = "../mempool" }
+nimiq-mempool = { path = "../mempool", features = ["metrics"] }
 nimiq-network-interface = { path = "../network-interface" }
-nimiq-network-libp2p = { path = "../network-libp2p" }
+nimiq-network-libp2p = { path = "../network-libp2p", features = ["metrics"] }

--- a/metrics-server/src/lib.rs
+++ b/metrics-server/src/lib.rs
@@ -112,8 +112,8 @@ pub fn start_metrics_server<TNetwork: Network>(
         let mut tokio_rt_metrics = TokioRuntimeMetrics::new();
         tokio_rt_metrics.register(nimiq_registry);
         let tokio_rt_metrics = Arc::new(RwLock::new(tokio_rt_metrics));
-        // Spawn Tokio runtime metrics updater
 
+        // Spawn Tokio runtime metrics updater
         tokio::spawn(TokioRuntimeMetrics::update_metric_values(
             tokio_rt_metrics,
             tokio_rt_monitor,

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -8,6 +8,7 @@ pub mod discovery;
 pub mod dispatch;
 mod error;
 mod network;
+#[cfg(feature = "metrics")]
 mod network_metrics;
 
 pub const REQRES_PROTOCOL: &[u8] = b"/nimiq/reqres/0.0.1";

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+#[cfg(feature = "metrics")]
 use std::time::Instant;
 
 use async_trait::async_trait;

--- a/transaction-builder/Cargo.toml
+++ b/transaction-builder/Cargo.toml
@@ -30,4 +30,4 @@ nimiq-test-log = { path = "../test-log" }
 rand = "0.8"
 
 [features]
-serde-derive = ["serde", "nimiq-primitives/serde-derive"]
+serde-derive = ["serde", "nimiq-primitives/serde-derive", "nimiq-transaction/serde-derive"]

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -22,7 +22,7 @@ beserial = { path = "../beserial", features = ["derive", "libp2p"] }
 futures = { package = "futures-util", version = "0.3" }
 thiserror = "1.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-tokio = "1.18"
+tokio = { version = "1.18", features = ["rt"] }
 
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-bls = { path = "../bls" }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -65,5 +65,5 @@ nimiq-test-log = { path = "../test-log" }
 nimiq-test-utils = { path = "../test-utils" }
 
 [features]
-metrics = []
+metrics = ["nimiq-mempool/metrics"]
 trusted_push = []


### PR DESCRIPTION
- Fix features compilation for several crates:
  - blockchain
  - handel
  - metrics-server
  - network-libp2p
  - transaction-builder
  - validator-network
- Change validator and mempool such that the mempool executor abortable
  future is not instrumented when the `metrics` feature is disabled.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
