### PR TITLE
Second (control) mempool implementation

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -696,11 +696,13 @@ impl ClientConfigBuilder {
     pub fn mempool(
         &mut self,
         size_limit: usize,
+        control_size_limit: usize,
         filter_rules: MempoolRules,
         filter_limit: usize,
     ) -> &mut Self {
         self.mempool = Some(MempoolConfig {
             size_limit,
+            control_size_limit,
             filter_rules,
             filter_limit,
         });

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -382,6 +382,7 @@ pub struct DatabaseSettings {
 pub struct MempoolSettings {
     pub filter: Option<MempoolFilterSettings>,
     pub size_limit: Option<usize>,
+    pub control_size_limit: Option<usize>,
     pub blacklist_limit: Option<usize>,
 }
 
@@ -427,6 +428,9 @@ impl From<MempoolSettings> for MempoolConfig {
     fn from(mempool: MempoolSettings) -> Self {
         Self {
             size_limit: mempool.size_limit.unwrap_or(Mempool::DEFAULT_SIZE_LIMIT),
+            control_size_limit: mempool
+                .control_size_limit
+                .unwrap_or(Mempool::DEFAULT_CONTROL_SIZE_LIMIT),
             filter_limit: mempool
                 .blacklist_limit
                 .unwrap_or(MempoolFilter::DEFAULT_BLACKLIST_SIZE),

--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -4,8 +4,10 @@ use crate::mempool::Mempool;
 /// Struct defining a Mempool configuration
 #[derive(Debug, Clone)]
 pub struct MempoolConfig {
-    /// Total size limit of transactions in the mempool (bytes)
+    /// Total size limit of transactions in the regular mempool (bytes)
     pub size_limit: usize,
+    /// Total size limit of transactions in the control mempool (bytes)
+    pub control_size_limit: usize,
     /// Mempool filter rules
     pub filter_rules: MempoolRules,
     /// Mempool filter limit or size
@@ -16,6 +18,7 @@ impl Default for MempoolConfig {
     fn default() -> MempoolConfig {
         MempoolConfig {
             size_limit: Mempool::DEFAULT_SIZE_LIMIT,
+            control_size_limit: Mempool::DEFAULT_CONTROL_SIZE_LIMIT,
             filter_rules: MempoolRules::default(),
             filter_limit: MempoolFilter::DEFAULT_BLACKLIST_SIZE,
         }

--- a/mempool/src/executor.rs
+++ b/mempool/src/executor.rs
@@ -13,7 +13,7 @@ use nimiq_primitives::networks::NetworkId;
 use nimiq_transaction::Transaction;
 
 use crate::filter::MempoolFilter;
-use crate::mempool::{MempoolState, TransactionTopic};
+use crate::mempool::{ControlTransactionTopic, MempoolState, TransactionTopic};
 use crate::verify::{verify_tx, VerifyErr};
 
 const CONCURRENT_VERIF_TASKS: u32 = 1000;
@@ -31,7 +31,7 @@ pub(crate) struct MempoolExecutor<N: Network> {
     // Ongoing verification tasks counter
     verification_tasks: Arc<AtomicU32>,
 
-    // Reference to the network, to alow for message validation
+    // Reference to the network, to allow for message validation
     network: Arc<N>,
 
     // Network ID, used for tx verification
@@ -104,6 +104,103 @@ impl<N: Network> Future for MempoolExecutor<N> {
                 };
 
                 network.validate_message::<TransactionTopic>(pubsub_id, acceptance);
+
+                tasks_count.fetch_sub(1, AtomicOrdering::SeqCst);
+            });
+        }
+
+        // We have exited the loop, so poll_next() must have returned Poll::Ready(None).
+        // Thus, we terminate the executor future.
+        Poll::Ready(())
+    }
+}
+
+pub(crate) struct ControlMempoolExecutor<N: Network> {
+    // Blockchain reference
+    blockchain: Arc<RwLock<Blockchain>>,
+
+    // The mempool state: the data structure where the transactions are stored
+    state: Arc<RwLock<MempoolState>>,
+
+    // Mempool filter
+    filter: Arc<RwLock<MempoolFilter>>,
+
+    // Ongoing verification tasks counter
+    verification_tasks: Arc<AtomicU32>,
+
+    // Reference to the network, to allow for message validation
+    network: Arc<N>,
+
+    // Network ID, used for tx verification
+    network_id: Arc<NetworkId>,
+
+    // Transaction stream that is used to listen to transactions from the network
+    txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
+}
+
+impl<N: Network> ControlMempoolExecutor<N> {
+    pub fn new(
+        blockchain: Arc<RwLock<Blockchain>>,
+        state: Arc<RwLock<MempoolState>>,
+        filter: Arc<RwLock<MempoolFilter>>,
+        network: Arc<N>,
+        txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
+    ) -> Self {
+        Self {
+            blockchain: blockchain.clone(),
+            state,
+            filter,
+            network,
+            network_id: Arc::new(blockchain.read().network_id),
+            verification_tasks: Arc::new(AtomicU32::new(0)),
+            txn_stream,
+        }
+    }
+}
+
+impl<N: Network> Future for ControlMempoolExecutor<N> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        while let Some((tx, pubsub_id)) = ready!(self.txn_stream.as_mut().poll_next_unpin(cx)) {
+            if self.verification_tasks.fetch_add(0, AtomicOrdering::SeqCst)
+                >= CONCURRENT_VERIF_TASKS
+            {
+                log::debug!("Reached the max number of verification tasks");
+                continue;
+            }
+
+            let blockchain = Arc::clone(&self.blockchain);
+            let mempool_state = Arc::clone(&self.state);
+            let filter = Arc::clone(&self.filter);
+            let tasks_count = Arc::clone(&self.verification_tasks);
+            let network_id = Arc::clone(&self.network_id);
+            let network = Arc::clone(&self.network);
+
+            // Spawn the transaction verification task
+            tokio::task::spawn(async move {
+                tasks_count.fetch_add(1, AtomicOrdering::SeqCst);
+
+                // Verifying and pushing the TX in a separate scope to drop the lock that is returned by
+                // the verify_tx function immediately
+                let acceptance = {
+                    let verify_tx_ret =
+                        verify_tx(&tx, blockchain, network_id, &mempool_state, filter).await;
+
+                    match verify_tx_ret {
+                        Ok(mempool_state_lock) => {
+                            RwLockUpgradableReadGuard::upgrade(mempool_state_lock).put(&tx);
+                            MsgAcceptance::Accept
+                        }
+                        // Reject the message if signature verification fails or transaction is invalid
+                        // for current validation window
+                        Err(VerifyErr::InvalidSignature) => MsgAcceptance::Reject,
+                        Err(VerifyErr::InvalidTxWindow) => MsgAcceptance::Reject,
+                        Err(_) => MsgAcceptance::Ignore,
+                    }
+                };
+
+                network.validate_message::<ControlTransactionTopic>(pubsub_id, acceptance);
 
                 tasks_count.fetch_sub(1, AtomicOrdering::SeqCst);
             });

--- a/mempool/src/executor.rs
+++ b/mempool/src/executor.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::sync::Arc;
@@ -8,17 +9,17 @@ use futures::{ready, stream::BoxStream, StreamExt};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 
 use nimiq_blockchain::Blockchain;
-use nimiq_network_interface::network::{MsgAcceptance, Network};
+use nimiq_network_interface::network::{MsgAcceptance, Network, Topic};
 use nimiq_primitives::networks::NetworkId;
 use nimiq_transaction::Transaction;
 
 use crate::filter::MempoolFilter;
-use crate::mempool::{ControlTransactionTopic, MempoolState, TransactionTopic};
+use crate::mempool_state::MempoolState;
 use crate::verify::{verify_tx, VerifyErr};
 
 const CONCURRENT_VERIF_TASKS: u32 = 1000;
 
-pub(crate) struct MempoolExecutor<N: Network> {
+pub(crate) struct MempoolExecutor<N: Network, T: Topic + Unpin + Sync> {
     // Blockchain reference
     blockchain: Arc<RwLock<Blockchain>>,
 
@@ -39,9 +40,12 @@ pub(crate) struct MempoolExecutor<N: Network> {
 
     // Transaction stream that is used to listen to transactions from the network
     txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
+
+    // Phantom data for the unused type T
+    _phantom: PhantomData<T>,
 }
 
-impl<N: Network> MempoolExecutor<N> {
+impl<N: Network, T: Topic + Unpin + Sync> MempoolExecutor<N, T> {
     pub fn new(
         blockchain: Arc<RwLock<Blockchain>>,
         state: Arc<RwLock<MempoolState>>,
@@ -57,11 +61,12 @@ impl<N: Network> MempoolExecutor<N> {
             network_id: Arc::new(blockchain.read().network_id),
             verification_tasks: Arc::new(AtomicU32::new(0)),
             txn_stream,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<N: Network> Future for MempoolExecutor<N> {
+impl<N: Network, T: Topic + Unpin + Sync> Future for MempoolExecutor<N, T> {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -103,104 +108,7 @@ impl<N: Network> Future for MempoolExecutor<N> {
                     }
                 };
 
-                network.validate_message::<TransactionTopic>(pubsub_id, acceptance);
-
-                tasks_count.fetch_sub(1, AtomicOrdering::SeqCst);
-            });
-        }
-
-        // We have exited the loop, so poll_next() must have returned Poll::Ready(None).
-        // Thus, we terminate the executor future.
-        Poll::Ready(())
-    }
-}
-
-pub(crate) struct ControlMempoolExecutor<N: Network> {
-    // Blockchain reference
-    blockchain: Arc<RwLock<Blockchain>>,
-
-    // The mempool state: the data structure where the transactions are stored
-    state: Arc<RwLock<MempoolState>>,
-
-    // Mempool filter
-    filter: Arc<RwLock<MempoolFilter>>,
-
-    // Ongoing verification tasks counter
-    verification_tasks: Arc<AtomicU32>,
-
-    // Reference to the network, to allow for message validation
-    network: Arc<N>,
-
-    // Network ID, used for tx verification
-    network_id: Arc<NetworkId>,
-
-    // Transaction stream that is used to listen to transactions from the network
-    txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
-}
-
-impl<N: Network> ControlMempoolExecutor<N> {
-    pub fn new(
-        blockchain: Arc<RwLock<Blockchain>>,
-        state: Arc<RwLock<MempoolState>>,
-        filter: Arc<RwLock<MempoolFilter>>,
-        network: Arc<N>,
-        txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
-    ) -> Self {
-        Self {
-            blockchain: blockchain.clone(),
-            state,
-            filter,
-            network,
-            network_id: Arc::new(blockchain.read().network_id),
-            verification_tasks: Arc::new(AtomicU32::new(0)),
-            txn_stream,
-        }
-    }
-}
-
-impl<N: Network> Future for ControlMempoolExecutor<N> {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        while let Some((tx, pubsub_id)) = ready!(self.txn_stream.as_mut().poll_next_unpin(cx)) {
-            if self.verification_tasks.fetch_add(0, AtomicOrdering::SeqCst)
-                >= CONCURRENT_VERIF_TASKS
-            {
-                log::debug!("Reached the max number of verification tasks");
-                continue;
-            }
-
-            let blockchain = Arc::clone(&self.blockchain);
-            let mempool_state = Arc::clone(&self.state);
-            let filter = Arc::clone(&self.filter);
-            let tasks_count = Arc::clone(&self.verification_tasks);
-            let network_id = Arc::clone(&self.network_id);
-            let network = Arc::clone(&self.network);
-
-            // Spawn the transaction verification task
-            tokio::task::spawn(async move {
-                tasks_count.fetch_add(1, AtomicOrdering::SeqCst);
-
-                // Verifying and pushing the TX in a separate scope to drop the lock that is returned by
-                // the verify_tx function immediately
-                let acceptance = {
-                    let verify_tx_ret =
-                        verify_tx(&tx, blockchain, network_id, &mempool_state, filter).await;
-
-                    match verify_tx_ret {
-                        Ok(mempool_state_lock) => {
-                            RwLockUpgradableReadGuard::upgrade(mempool_state_lock).put(&tx);
-                            MsgAcceptance::Accept
-                        }
-                        // Reject the message if signature verification fails or transaction is invalid
-                        // for current validation window
-                        Err(VerifyErr::InvalidSignature) => MsgAcceptance::Reject,
-                        Err(VerifyErr::InvalidTxWindow) => MsgAcceptance::Reject,
-                        Err(_) => MsgAcceptance::Ignore,
-                    }
-                };
-
-                network.validate_message::<ControlTransactionTopic>(pubsub_id, acceptance);
+                network.validate_message::<T>(pubsub_id, acceptance);
 
                 tasks_count.fetch_sub(1, AtomicOrdering::SeqCst);
             });

--- a/mempool/src/executor.rs
+++ b/mempool/src/executor.rs
@@ -52,6 +52,7 @@ impl<N: Network, T: Topic + Unpin + Sync> MempoolExecutor<N, T> {
         filter: Arc<RwLock<MempoolFilter>>,
         network: Arc<N>,
         txn_stream: BoxStream<'static, (Transaction, <N as Network>::PubsubId)>,
+        verification_tasks: Arc<AtomicU32>,
     ) -> Self {
         Self {
             blockchain: blockchain.clone(),
@@ -59,7 +60,7 @@ impl<N: Network, T: Topic + Unpin + Sync> MempoolExecutor<N, T> {
             filter,
             network,
             network_id: Arc::new(blockchain.read().network_id),
-            verification_tasks: Arc::new(AtomicU32::new(0)),
+            verification_tasks,
             txn_stream,
             _phantom: PhantomData,
         }

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -8,6 +8,12 @@
 #[macro_use]
 extern crate log;
 
+/// Mempool transaction module
+mod mempool_transactions;
+
+/// Mempool state module
+mod mempool_state;
+
 /// Mempool config module
 pub mod config;
 /// Mempool executor module

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -73,7 +73,10 @@ pub struct Mempool {
 
 impl Mempool {
     /// Default total size limit of transactions in the mempool (bytes)
-    pub const DEFAULT_SIZE_LIMIT: usize = 12000000;
+    pub const DEFAULT_SIZE_LIMIT: usize = 12_000_000;
+
+    /// Default total size limit of control transactions in the mempool (bytes)
+    pub const DEFAULT_CONTROL_SIZE_LIMIT: usize = 6_000_000;
 
     /// Creates a new mempool
     pub fn new(blockchain: Arc<RwLock<Blockchain>>, config: MempoolConfig) -> Self {

--- a/mempool/src/mempool_metrics.rs
+++ b/mempool/src/mempool_metrics.rs
@@ -1,4 +1,4 @@
-use crate::mempool::EvictionReason;
+use crate::mempool_state::EvictionReason;
 use prometheus_client::encoding::text::Encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;

--- a/mempool/src/mempool_state.rs
+++ b/mempool/src/mempool_state.rs
@@ -1,0 +1,271 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_keys::Address;
+use nimiq_primitives::{account::AccountType, coin::Coin};
+use nimiq_transaction::{
+    account::staking_contract::{IncomingStakingTransactionData, OutgoingStakingTransactionProof},
+    Transaction,
+};
+
+use crate::{mempool_metrics::MempoolMetrics, mempool_transactions::MempoolTransactions};
+
+pub(crate) struct MempoolState {
+    // Container where the regular transactions are stored
+    pub(crate) regular_transactions: MempoolTransactions,
+
+    // Container where the control transactions are stored
+    pub(crate) control_transactions: MempoolTransactions,
+
+    // The pending balance per sender.
+    pub(crate) state_by_sender: HashMap<Address, SenderPendingState>,
+
+    // The sets of all senders of staking transactions. For simplicity, each validator/staker can
+    // only have one outgoing staking transaction in the mempool. This makes sure that the outgoing
+    // staking transaction can actually pay its fee.
+    pub(crate) outgoing_validators: HashMap<Address, Transaction>,
+    pub(crate) outgoing_stakers: HashMap<Address, Transaction>,
+
+    // The sets of all recipients of creation staking transactions. For simplicity, each
+    // validator/staker can only have one creation staking transaction in the mempool. This makes
+    // sure that the creation staking transactions do not interfere with one another.
+    pub(crate) creating_validators: HashMap<Address, Transaction>,
+    pub(crate) creating_stakers: HashMap<Address, Transaction>,
+
+    #[cfg(feature = "metrics")]
+    pub(crate) metrics: Arc<MempoolMetrics>,
+}
+
+impl MempoolState {
+    pub fn contains(&self, hash: &Blake2bHash) -> bool {
+        self.regular_transactions.contains_key(hash) || self.control_transactions.contains_key(hash)
+    }
+
+    pub fn get(&self, hash: &Blake2bHash) -> Option<&Transaction> {
+        if let Some(transaction) = self.regular_transactions.get(hash) {
+            Some(transaction)
+        } else if let Some(transaction) = self.control_transactions.get(hash) {
+            Some(transaction)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn put(&mut self, tx: &Transaction) -> bool {
+        let tx_hash = tx.hash();
+
+        if self.regular_transactions.contains_key(&tx_hash)
+            || self.control_transactions.contains_key(&tx_hash)
+        {
+            return false;
+        }
+
+        // If we are adding a stacking transaction we insert it into the control txns container
+        // Staking txns are control txns
+        if tx.sender_type == AccountType::Staking || tx.recipient_type == AccountType::Staking {
+            self.control_transactions.insert(tx);
+        } else {
+            self.regular_transactions.insert(tx);
+        }
+
+        // Update the per sender state
+        match self.state_by_sender.get_mut(&tx.sender) {
+            None => {
+                let mut txns = HashSet::new();
+                txns.insert(tx_hash);
+
+                self.state_by_sender.insert(
+                    tx.sender.clone(),
+                    SenderPendingState {
+                        total: tx.total_value(),
+                        txns,
+                    },
+                );
+            }
+            Some(sender_state) => {
+                sender_state.total += tx.total_value();
+                sender_state.txns.insert(tx_hash);
+            }
+        }
+
+        // If it is an outgoing staking transaction then we have additional work.
+        if tx.sender_type == AccountType::Staking {
+            // Parse transaction data.
+            let data = OutgoingStakingTransactionProof::parse(tx)
+                .expect("The proof should have already been parsed before, so this cannot panic!");
+
+            // Insert the sender address in the correct set.
+            match data {
+                OutgoingStakingTransactionProof::DeleteValidator { proof } => {
+                    assert_eq!(
+                        self.outgoing_validators
+                            .insert(proof.compute_signer(), tx.clone()),
+                        None
+                    );
+                }
+                OutgoingStakingTransactionProof::Unstake { proof } => {
+                    assert_eq!(
+                        self.outgoing_stakers
+                            .insert(proof.compute_signer(), tx.clone()),
+                        None
+                    );
+                }
+            }
+        }
+
+        // If it is an incoming staking transaction then we have additional work.
+        if tx.recipient_type == AccountType::Staking {
+            // Parse transaction data.
+            let data = IncomingStakingTransactionData::parse(tx)
+                .expect("The data should have already been parsed before, so this cannot panic!");
+
+            // Insert the recipient address in the correct set, if it is a creation transaction.
+            match data {
+                IncomingStakingTransactionData::CreateValidator { proof, .. } => {
+                    assert_eq!(
+                        self.creating_validators
+                            .insert(proof.compute_signer(), tx.clone()),
+                        None
+                    );
+                }
+                IncomingStakingTransactionData::CreateStaker { proof, .. } => {
+                    assert_eq!(
+                        self.creating_stakers
+                            .insert(proof.compute_signer(), tx.clone()),
+                        None
+                    );
+                }
+                _ => {}
+            }
+        }
+        // After inserting the new txn, check if we need to remove txns
+        while self.regular_transactions.total_size > self.regular_transactions.total_size_limit {
+            let (tx_hash, _) = self.regular_transactions.worst_transactions.pop().unwrap();
+            self.remove(&tx_hash, EvictionReason::TooFull);
+        }
+
+        while self.control_transactions.total_size > self.control_transactions.total_size_limit {
+            let (tx_hash, _) = self.control_transactions.worst_transactions.pop().unwrap();
+            self.remove(&tx_hash, EvictionReason::TooFull);
+        }
+
+        true
+    }
+
+    pub(crate) fn remove(
+        &mut self,
+        tx_hash: &Blake2bHash,
+        reason: EvictionReason,
+    ) -> Option<Transaction> {
+        if let Some(tx) = self
+            .regular_transactions
+            .delete(tx_hash)
+            .or_else(|| self.control_transactions.delete(tx_hash))
+        {
+            let sender_state = self.state_by_sender.get_mut(&tx.sender).unwrap();
+
+            sender_state.total -= tx.total_value();
+            sender_state.txns.remove(tx_hash);
+
+            if sender_state.txns.is_empty() {
+                self.state_by_sender.remove(&tx.sender);
+            }
+
+            self.remove_from_staking_state(&tx);
+
+            #[cfg(feature = "metrics")]
+            self.metrics.note_evicted(reason);
+
+            Some(tx)
+        } else {
+            None
+        }
+    }
+
+    // Removes all the transactions sent by some specific address
+    pub(crate) fn remove_sender_txns(&mut self, sender_address: &Address) {
+        if let Some(sender_state) = &self.state_by_sender.remove(sender_address) {
+            for tx_hash in &sender_state.txns {
+                if let Some(tx) = self
+                    .regular_transactions
+                    .delete(tx_hash)
+                    .or_else(|| self.control_transactions.delete(tx_hash))
+                {
+                    self.remove_from_staking_state(&tx);
+                }
+            }
+        }
+    }
+
+    // Internal helper function that takes care of removing staking transactions from the mempool state
+    fn remove_from_staking_state(&mut self, tx: &Transaction) {
+        // If it is an outgoing staking transaction then we have additional work.
+        if tx.sender_type == AccountType::Staking {
+            // Parse transaction data.
+            let data = OutgoingStakingTransactionProof::parse(tx)
+                .expect("The proof should have already been parsed before, so this cannot panic!");
+
+            // Remove the sender address from the correct set.
+            match data {
+                OutgoingStakingTransactionProof::DeleteValidator { proof } => {
+                    assert_ne!(
+                        self.outgoing_validators.remove(&proof.compute_signer()),
+                        None
+                    );
+                }
+                OutgoingStakingTransactionProof::Unstake { proof } => {
+                    assert_ne!(self.outgoing_stakers.remove(&proof.compute_signer()), None);
+                }
+            }
+        }
+
+        // If it is an incoming staking transaction then we have additional work.
+        if tx.recipient_type == AccountType::Staking {
+            // Parse transaction data.
+            let data = IncomingStakingTransactionData::parse(tx)
+                .expect("The data should have already been parsed before, so this cannot panic!");
+
+            // Remove the recipient address from the correct set, if it is a creation transaction.
+            match data {
+                IncomingStakingTransactionData::CreateValidator { proof, .. } => {
+                    assert_ne!(
+                        self.creating_validators.remove(&proof.compute_signer()),
+                        None
+                    );
+                }
+                IncomingStakingTransactionData::CreateStaker { proof, .. } => {
+                    assert_ne!(self.creating_stakers.remove(&proof.compute_signer()), None);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Retrieves all expired transaction hashes from both the `regular_transactions` and `control_transactions` Vectors
+    pub fn get_expired_txns(&mut self, block_height: u32) -> Vec<Blake2bHash> {
+        let mut expired_txns = self.control_transactions.get_expired_txns(block_height);
+        expired_txns.append(&mut self.regular_transactions.get_expired_txns(block_height));
+
+        expired_txns
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum EvictionReason {
+    BlockBuilding,
+    Expired,
+    AlreadyIncluded,
+    Invalid,
+    TooFull,
+}
+
+pub(crate) struct SenderPendingState {
+    // The sum of the txns that are currently stored in the mempool for this sender
+    pub(crate) total: Coin,
+
+    // Transaction hashes for this sender.
+    pub(crate) txns: HashSet<Blake2bHash>,
+}

--- a/mempool/src/mempool_transactions.rs
+++ b/mempool/src/mempool_transactions.rs
@@ -1,0 +1,196 @@
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::HashMap,
+};
+
+use beserial::Serialize;
+use keyed_priority_queue::KeyedPriorityQueue;
+
+use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_transaction::Transaction;
+
+/// Ordering in which transactions removed from the mempool to be included in blocks.
+/// This is stored on a max-heap, so the greater transaction comes first.
+/// Compares by fee per byte (higher first), then by insertion order (lower i.e. older first).
+// TODO: Maybe use this wrapper to do more fine ordering. For example, we might prefer small size
+//       transactions over large size transactions (assuming they have the same fee per byte). Or
+//       we might prefer basic transactions over staking contract transactions, etc, etc.
+#[derive(PartialEq)]
+pub struct BestTxOrder {
+    fee_per_byte: f64,
+    insertion_order: u64,
+}
+
+impl Eq for BestTxOrder {}
+
+impl PartialOrd for BestTxOrder {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BestTxOrder {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.fee_per_byte
+            .partial_cmp(&other.fee_per_byte)
+            .expect("fees can't be NaN")
+            .then(self.insertion_order.cmp(&other.insertion_order).reverse())
+    }
+}
+
+/// Ordering in which transactions are evicted when the mempool is full.
+/// This is stored on a max-heap, so the greater transaction comes first.
+/// Compares by fee per byte (lower first), then by insertion order (higher i.e. newer first).
+#[derive(PartialEq)]
+pub struct WorstTxOrder {
+    fee_per_byte: f64,
+    insertion_order: u64,
+}
+
+impl Eq for WorstTxOrder {}
+
+impl PartialOrd for WorstTxOrder {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for WorstTxOrder {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.fee_per_byte
+            .partial_cmp(&other.fee_per_byte)
+            .expect("fees can't be NaN")
+            .reverse()
+            .then(self.insertion_order.cmp(&other.insertion_order))
+    }
+}
+
+// This is a container where all mempool transactions are stored.
+// It provides simple functions to insert/delete/get transactions
+// And mantains internal structures to keep track of the best/worst transactions
+pub(crate) struct MempoolTransactions {
+    // A hashmap containing the transactions indexed by their hash.
+    pub(crate) transactions: HashMap<Blake2bHash, Transaction>,
+
+    // Transactions ordered by fee per byte (highest to lowest) and insertion order (oldest to newest).
+    // This is the ordering in which transactions are included in blocks by the validator.
+    pub(crate) best_transactions: KeyedPriorityQueue<Blake2bHash, BestTxOrder>,
+
+    // Transactions ordered by fee per byte (lowest to highest) and insertion order (newest to oldest).
+    // This is the ordering used to evict transactions from the mempool when it becomes full.
+    pub(crate) worst_transactions: KeyedPriorityQueue<Blake2bHash, WorstTxOrder>,
+
+    // Transactions ordered by validity_start_height (oldest to newest).
+    // This ordering is used to evict expired transactions from the mempool.
+    pub(crate) oldest_transactions: KeyedPriorityQueue<Blake2bHash, Reverse<u32>>,
+
+    // Maximum allowed total size (in bytes) of all transactions in the mempool.
+    pub(crate) total_size_limit: usize,
+
+    // Total size (in bytes) of the transactions currently in mempool.
+    pub(crate) total_size: usize,
+
+    // Counter that increases for every added transaction, to order them for removal.
+    pub(crate) tx_counter: u64,
+}
+
+impl MempoolTransactions {
+    pub fn new(size_limit: usize) -> Self {
+        Self {
+            transactions: HashMap::new(),
+            best_transactions: KeyedPriorityQueue::new(),
+            worst_transactions: KeyedPriorityQueue::new(),
+            oldest_transactions: KeyedPriorityQueue::new(),
+            total_size_limit: size_limit,
+            total_size: 0,
+            tx_counter: 0,
+        }
+    }
+
+    pub fn contains_key(&self, hash: &Blake2bHash) -> bool {
+        self.transactions.contains_key(hash)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
+    }
+
+    // This function is used to remove the transactions that are no longer valid at a given block height
+    pub fn get_expired_txns(&mut self, block_height: u32) -> Vec<Blake2bHash> {
+        let mut expired_txns = vec![];
+        loop {
+            // Get the hash of the oldest transaction.
+            let tx_hash = match self.oldest_transactions.peek() {
+                None => {
+                    break;
+                }
+                Some((tx_hash, _)) => tx_hash.clone(),
+            };
+
+            // Get a reference to the transaction.
+            let tx = self.get(&tx_hash).unwrap();
+
+            // Check if it is still valid.
+            if tx.is_valid_at(block_height) {
+                // No need to process more transactions, since we arrived to the oldest one that is valid
+                break;
+            } else {
+                // Remove the transaction from the oldest struct to continue collecting expired txns.
+                self.oldest_transactions.remove(&tx_hash);
+                expired_txns.push(tx_hash);
+            }
+        }
+        expired_txns
+    }
+
+    pub fn get(&self, hash: &Blake2bHash) -> Option<&Transaction> {
+        self.transactions.get(hash)
+    }
+
+    pub(crate) fn insert(&mut self, tx: &Transaction) -> bool {
+        let tx_hash = tx.hash();
+
+        if self.transactions.contains_key(&tx_hash) {
+            return false;
+        }
+
+        self.transactions.insert(tx_hash.clone(), tx.clone());
+
+        self.best_transactions.push(
+            tx_hash.clone(),
+            BestTxOrder {
+                fee_per_byte: tx.fee_per_byte(),
+                insertion_order: self.tx_counter,
+            },
+        );
+        self.worst_transactions.push(
+            tx_hash.clone(),
+            WorstTxOrder {
+                fee_per_byte: tx.fee_per_byte(),
+                insertion_order: self.tx_counter,
+            },
+        );
+
+        self.tx_counter += 1;
+
+        self.oldest_transactions
+            .push(tx_hash, Reverse(tx.validity_start_height));
+
+        // Update total tx size
+        self.total_size += tx.serialized_size();
+
+        true
+    }
+
+    pub(crate) fn delete(&mut self, tx_hash: &Blake2bHash) -> Option<Transaction> {
+        let tx = self.transactions.remove(tx_hash)?;
+
+        self.best_transactions.remove(tx_hash);
+        self.worst_transactions.remove(tx_hash);
+        self.oldest_transactions.remove(tx_hash);
+
+        self.total_size -= tx.serialized_size();
+
+        Some(tx)
+    }
+}

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -17,7 +17,7 @@ use nimiq_transaction::account::staking_contract::{
 use nimiq_transaction::Transaction;
 
 use crate::filter::MempoolFilter;
-use crate::mempool::MempoolState;
+use crate::mempool_state::MempoolState;
 
 /// Return codes for transaction signature verification
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
- Introduced a second mempool, used for control transactions
- When blocks are produced, first we try to include control txns
- If there is space left, we include regular txns
- This means that control txns have a higher priority over reg txns.

