### PR TITLE
history_sync: Use chunks for pushing history

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -330,11 +330,11 @@ fn it_can_revert_unpark_transactions() {
 
     let result = bc.revert_blocks(3, &mut txn);
 
-    assert_eq!(result, Ok(()));
+    assert!(result.is_ok());
 }
 
 #[test]
-fn it_can_revert_create_stacker_transaction() {
+fn it_can_revert_create_staker_transaction() {
     let time = Arc::new(OffsetTime::new());
     let env = VolatileEnvironment::new(10).unwrap();
     let blockchain = Arc::new(RwLock::new(
@@ -428,7 +428,7 @@ fn it_can_revert_create_stacker_transaction() {
     let mut txn = bc.write_transaction();
     let result = bc.revert_blocks(3, &mut txn);
 
-    assert_eq!(result, Ok(()));
+    assert!(result.is_ok());
 }
 
 fn ed25519_key_pair(secret_key: &str) -> SchnorrKeyPair {

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -2,85 +2,230 @@ use std::error::Error;
 
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 
-use nimiq_block::{Block, BlockError, TendermintProof};
+use nimiq_block::{Block, BlockError, MacroBlock, TendermintProof};
 use nimiq_database::WriteTransaction;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::policy;
 
 use crate::chain_info::ChainInfo;
-use crate::history::{ExtTxData, ExtendedTransaction, HistoryStore};
-use crate::{AbstractBlockchain, Blockchain, BlockchainEvent, PushError, PushResult};
+use crate::history::{ExtTxData, ExtendedTransaction};
+use crate::{
+    AbstractBlockchain, Blockchain, BlockchainEvent, HistoryTreeChunk, PushError, PushResult,
+};
 use nimiq_account::{Inherent, InherentType};
 
-/// Implements methods to push macro blocks into the chain when an history node is syncing. This
-/// type of syncing is called history syncing. It works by having the node get all the election
-/// macro blocks since genesis plus the last macro block (most likely it will be a checkpoint block,
-/// but it might be an election block). For these macro blocks the node must also get the
-/// corresponding history tree. When the macro blocks are synced, then the node gets all the micro
-/// blocks in the current batch and pushes them normally.
-/// Note that, when pushing the macro blocks, we rely on the assumption that they were produced by
-/// honest validator sets (defined as having less than 1/3 malicious validators). Because of that
-/// we don't actually check the validity of the blocks, we just perform the minimal amount of checks
-/// necessary to verify that the given block is a successor of our current chain so far and that the
-/// corresponding history tree is actually part of the block.
-impl Blockchain {
-    /// Pushes a macro block (election or checkpoint) into the chain using the history sync method.
-    /// You can push election blocks after checkpoint blocks and vice-versa. You can also push macro
-    /// blocks even after you pushed micro blocks.
-    /// You just cannot push micro blocks with this method.
-    pub fn push_history_sync(
-        this: RwLockUpgradableReadGuard<Self>,
-        block: Block,
-        history: &[ExtendedTransaction],
+/// Struct produced after starting history sync.
+/// The object provides methods for adding history chunks and finally commit
+/// it to the history store.
+pub struct HistoryPusher {
+    /// Macro block for which the history chunks will be added
+    pub block: MacroBlock,
+    /// Number of transactions added to this HistoryPusher instance
+    pub tx_count: u64,
+    /// Cumulative transaction fees for the transactions added to this
+    /// HistoryPusher instance
+    pub cum_tx_fees: Coin,
+}
+
+impl HistoryPusher {
+    /// Adds transactions to the history pusher.
+    /// Transactions are only received in chunks using the `HistoryTreeChunk`
+    /// struct. This means that the chunks must come with a proof that relates
+    /// them with this object macro block's history root.
+    /// The proof is checked against the provided macro block's history root.
+    /// The blockchain state may be changed if a need to reverse some micro
+    /// blocks is detected in cases such as a partially known epoch or
+    /// different adopted history.
+    pub fn add_history_chunk(
+        &mut self,
+        blockchain: RwLockUpgradableReadGuard<Blockchain>,
+        history_chunk: HistoryTreeChunk,
+        chunk_index: usize,
+        chunk_size: usize,
     ) -> Result<PushResult, PushError> {
-        // Check that it is a macro block. We can't push micro blocks with this function.
-        assert!(
-            block.is_macro(),
-            "You can't push micro blocks with history sync!"
+        let macro_block = self.block.clone();
+        let staking_contract_address = blockchain.staking_contract_address();
+
+        // Check the history chunk proof against the macro block history root
+        if !history_chunk
+            .verify(macro_block.header.history_root, chunk_index * chunk_size)
+            .unwrap_or(false)
+        {
+            log::warn!(
+                "History Chunk failed to verify (chunk {} of epoch {})",
+                chunk_index,
+                self.block.epoch_number()
+            );
+            return Err(PushError::InvalidHistoryChunk);
+        }
+
+        // Create a new database write transaction.
+        let mut txn = blockchain.write_transaction();
+
+        // Get the block hash.
+        let syncing_batch = policy::batch_at(self.block.block_number());
+
+        // Calculate the cumulative transaction fees for the given batch. This is necessary to
+        // create the chain info for the block.
+        for i in (0..history_chunk.history.len()).rev() {
+            if policy::batch_at(history_chunk.history[i].block_number) != syncing_batch {
+                // We have reached the end of the batch we're interested in
+                // We only need the same batch the macro block is at to calculate
+                // the `cum_tx_fees` for later updating the blockchain `ChainInfo`
+                break;
+            }
+            if let ExtTxData::Basic(tx) = &history_chunk.history[i].data {
+                self.cum_tx_fees += tx.fee;
+            }
+        }
+
+        // We might already know the given epoch partially.
+        // Revert our chain to a common ancestor state in case we have adopted a different history.
+        // Also skip over any transactions that we already know.
+        let (current_chain_info, first_new_ext_tx_idx) =
+            self.revert_to_common_state(&blockchain, &history_chunk.history, &mut txn);
+
+        // Separate the extended transactions by block number and type.
+        // We know it comes sorted because we already checked it against the history root and
+        // extended transactions in the history tree come sorted by block number and type.
+        // Ignore the extended transactions that were already added in past macro blocks.
+        let mut block_numbers = vec![];
+        let mut block_timestamps = vec![];
+        let mut block_transactions = vec![];
+        let mut block_inherents = vec![];
+        let mut prev = 0;
+
+        for ext_tx in history_chunk.history.iter().skip(first_new_ext_tx_idx) {
+            if ext_tx.block_number > prev {
+                block_numbers.push(ext_tx.block_number);
+                block_timestamps.push(ext_tx.block_time);
+                block_transactions.push(vec![]);
+                block_inherents.push(vec![]);
+                prev = ext_tx.block_number;
+            }
+
+            match &ext_tx.data {
+                ExtTxData::Basic(tx) => block_transactions.last_mut().unwrap().push(tx.clone()),
+                ExtTxData::Inherent(tx) => block_inherents.last_mut().unwrap().push(tx.clone()),
+            }
+        }
+
+        // We go over the blocks one more time and add the FinalizeBatch and FinalizeEpoch inherents
+        // to the macro blocks. This is necessary because the History Store doesn't store those inherents
+        // so we need to add them again in order to correctly sync.
+        for (i, block_number) in block_numbers.iter().enumerate() {
+            if policy::is_macro_block_at(*block_number) {
+                let finalize_batch = Inherent {
+                    ty: InherentType::FinalizeBatch,
+                    target: staking_contract_address.clone(),
+                    value: Coin::ZERO,
+                    data: vec![],
+                };
+
+                block_inherents.get_mut(i).unwrap().push(finalize_batch);
+
+                if policy::is_election_block_at(*block_number) {
+                    let finalize_epoch = Inherent {
+                        ty: InherentType::FinalizeEpoch,
+                        target: staking_contract_address.clone(),
+                        value: Coin::ZERO,
+                        data: vec![],
+                    };
+
+                    block_inherents.get_mut(i).unwrap().push(finalize_epoch);
+                }
+            }
+        }
+
+        // Update the accounts tree, one block at a time.
+        for i in 0..block_numbers.len() {
+            // Commit block to AccountsTree and create the receipts.
+            let receipts = blockchain.state.accounts.commit_batch(
+                &mut txn,
+                &block_transactions[i],
+                &block_inherents[i],
+                block_numbers[i],
+                block_timestamps[i],
+            );
+
+            // Check if the receipts contain an error.
+            if let Err(e) = receipts {
+                warn!(
+                    %self.block,
+                    reason = "commit of macro block failed",
+                    block_no = block_numbers[i],
+                    num_inherents = block_inherents[i].len(),
+                    error = &e as &dyn Error,
+                    "Rejecting block",
+                );
+
+                txn.abort();
+                #[cfg(feature = "metrics")]
+                blockchain.metrics.note_invalid_block();
+                return Err(PushError::AccountsError(e));
+            }
+        }
+        blockchain.state.accounts.finalize_batch(&mut txn);
+
+        // Store the new extended transactions into the History tree.
+        blockchain.history_store.add_to_history(
+            &mut txn,
+            self.block.epoch_number(),
+            &history_chunk.history[first_new_ext_tx_idx..],
         );
 
-        // Create a new database read transaction.
-        let read_txn = this.read_transaction();
+        // Give up database transactions and push lock before creating notifications.
+        txn.commit();
 
-        // Unwrap the block.
-        let macro_block = block.unwrap_macro_ref();
+        // Update the blockchain state
+        let mut blockchain = RwLockUpgradableReadGuard::upgrade(blockchain);
+        blockchain.state.head_hash = current_chain_info.head.hash();
+        blockchain.state.main_chain = current_chain_info;
 
-        // Check the version
-        if macro_block.header.version != policy::VERSION {
-            warn!(
-                %block,
-                reason = "wrong version",
-                version = macro_block.header.version,
-                wanted_version = policy::VERSION,
-                "Rejecting block",
-            );
-            return Err(PushError::InvalidBlock(BlockError::UnsupportedVersion));
-        }
+        self.tx_count += history_chunk.history.len() as u64;
 
-        // Check if we already know this block.
-        if this
-            .chain_store
-            .get_chain_info(&macro_block.hash(), false, Some(&read_txn))
-            .is_some()
-        {
-            return Ok(PushResult::Known);
-        }
+        // Return result.
+        Ok(PushResult::Extended)
+    }
+
+    /// Commits the history pusher. This function performs the final checks to
+    /// push the macro block provided and advance the blockchain state.
+    /// This methods should only be called when no more history chunks are
+    /// expected. A final check is also performed to verify that the accounts
+    /// tree root matches the macro block's history root.
+    pub fn commit(
+        &self,
+        blockchain: RwLockUpgradableReadGuard<Blockchain>,
+    ) -> Result<PushResult, PushError> {
+        let mut txn = blockchain.write_transaction();
+        let block_hash = self.block.hash();
+        let mut prev_macro_info = blockchain.state.macro_info.clone();
+        let macro_block = &self.block;
 
         // Get the current macro head.
-        let macro_head = &this.state.macro_info.head;
+        let macro_head = &blockchain.state.macro_info.head;
+
+        // Check (again) if we already know this block.
+        if blockchain
+            .chain_store
+            .get_chain_info(&macro_block.hash(), false, Some(&txn))
+            .is_some()
+        {
+            return Err(PushError::AlreadyKnown);
+        }
 
         // Check if we have this block's parent. The checks change depending if the last macro block
         // that we pushed was an election block or not.
         if macro_head.is_election() {
             // We only need to check that the parent election block of this block is the same as our
             // head block.
-            if macro_block.header.parent_election_hash != this.state.macro_head_hash {
+            if macro_block.header.parent_election_hash != blockchain.state.macro_head_hash {
                 warn!(
                     block = %macro_block,
                     reason = "wrong parent election hash",
                     parent_election_hash = %macro_block.header.parent_election_hash,
-                    wanted_parent_election_hash = %this.state.macro_head_hash,
+                    wanted_parent_election_hash = %blockchain.state.macro_head_hash,
                     "Rejecting block",
                 );
                 return Err(PushError::Orphan);
@@ -109,41 +254,247 @@ impl Blockchain {
                     previous_block_no = macro_head.block_number(),
                     "Rejecting block",
                 );
-                return Ok(PushResult::Ignored);
+                return Err(PushError::AlreadyKnown);
             }
         }
 
-        // Check the history root.
-        // The given history might be incomplete if we already know parts of it.
-        // Reconstruct the full history to compute the root hash if necessary.
-        let last_macro_block = policy::last_macro_block(this.block_number());
-        let mut known_history = this.history_store.get_final_epoch_transactions(
-            policy::epoch_at(this.block_number() + 1),
-            Some(&read_txn),
+        // Check the justification.
+        if !TendermintProof::verify(macro_block, &blockchain.current_validators().unwrap()) {
+            warn!(
+                block = %macro_block,
+                reason = "bad justification",
+                "Rejecting block",
+            );
+            return Err(PushError::InvalidBlock(BlockError::InvalidJustification));
+        }
+
+        // Create the chain info for the given block and store it.
+        let chain_info = ChainInfo {
+            on_main_chain: true,
+            main_chain_successor: None,
+            head: Block::Macro(macro_block.clone()),
+            cum_tx_fees: self.cum_tx_fees,
+        };
+
+        blockchain
+            .chain_store
+            .put_chain_info(&mut txn, &block_hash, &chain_info, true);
+
+        // Update the chain info for the previous macro block and store it.
+        prev_macro_info.main_chain_successor = Some(chain_info.head.hash());
+
+        blockchain.chain_store.put_chain_info(
+            &mut txn,
+            &prev_macro_info.head.hash(),
+            &prev_macro_info,
+            false,
         );
-        let first_new_ext_tx = history
+
+        // Set the head of the chain store to the current block.
+        blockchain.chain_store.set_head(&mut txn, &block_hash);
+
+        // Check the state_root hash against the one in the block.
+        let wanted_state_root = blockchain.state.accounts.get_root(Some(&txn));
+        if macro_block.header.state_root != wanted_state_root {
+            warn!(
+                block = %macro_block,
+                reason = "header accounts hash doesn't match real accounts hash",
+                state_root = %macro_block.header.state_root,
+                %wanted_state_root,
+                "Rejecting block",
+            );
+            txn.abort();
+            #[cfg(feature = "metrics")]
+            blockchain.metrics.note_invalid_block();
+            return Err(PushError::InvalidBlock(BlockError::AccountsHashMismatch));
+        }
+
+        // Macro blocks are final and receipts for the previous batch are no longer necessary
+        // as rebranching across this block is not possible.
+        blockchain.chain_store.clear_receipts(&mut txn);
+
+        // Give up database transactions and push lock before creating notifications.
+        txn.commit();
+
+        // Update the blockchain state.
+        let mut blockchain = RwLockUpgradableReadGuard::upgrade(blockchain);
+        blockchain.state.main_chain = chain_info.clone();
+        blockchain.state.head_hash = block_hash.clone();
+        blockchain.state.macro_info = chain_info;
+        blockchain.state.macro_head_hash = block_hash.clone();
+
+        // Check if this block is an election block.
+        let is_election_block = macro_block.is_election_block();
+        if is_election_block {
+            blockchain.state.election_head = macro_block.clone();
+            blockchain.state.election_head_hash = block_hash.clone();
+            blockchain.state.previous_slots = blockchain.state.current_slots.take();
+            blockchain.state.current_slots = macro_block.get_validators();
+        }
+
+        let blockchain = RwLockWriteGuard::downgrade_to_upgradable(blockchain);
+
+        debug!(
+            %macro_block,
+            kind = "history_sync",
+            "Accepted macro block",
+        );
+
+        debug!(
+            epoch_no = macro_block.epoch_number(),
+            num_items = self.tx_count,
+            kind = "history_sync",
+            "Accepted epoch",
+        );
+
+        if is_election_block {
+            blockchain
+                .notifier
+                .notify(BlockchainEvent::EpochFinalized(block_hash));
+        } else {
+            blockchain
+                .notifier
+                .notify(BlockchainEvent::Finalized(block_hash));
+        }
+
+        Ok(PushResult::Extended)
+    }
+
+    /// Reverts the history store to a common state.
+    /// This function is used to revert the chain to a common ancestor state
+    /// in case a different history has been adopted.
+    /// Also skip over any transactions that we already know.
+    /// Note that this function doesn't change the blockchain state and leaves
+    /// this responsibility to the caller who should update it based on the
+    /// returned `ChainInfo`.
+    fn revert_to_common_state(
+        &self,
+        blockchain: &RwLockUpgradableReadGuard<Blockchain>,
+        history: &[ExtendedTransaction],
+        txn: &mut WriteTransaction,
+    ) -> (ChainInfo, usize) {
+        // Find the index of the first extended transaction in the current batch.
+        let last_macro_block = policy::last_macro_block(blockchain.block_number());
+        // Get the chain info for the head of the chain.
+        let mut current_info = blockchain
+            .get_chain_info(&blockchain.head_hash(), true, Some(txn))
+            .expect("Couldn't fetch chain info for the head of the chain!");
+        let mut first_new_ext_tx_idx = history
             .iter()
             .position(|ext_tx| ext_tx.block_number > last_macro_block)
             .unwrap_or(history.len());
-        let full_history = if first_new_ext_tx < known_history.len() {
-            known_history.extend_from_slice(&history[first_new_ext_tx..]);
-            known_history.as_slice()
-        } else {
-            history
+
+        // Check if our adopted non-final history matches the given history.
+        // Revert any blocks that don't match.
+        let known_history = blockchain
+            .history_store
+            .get_nonfinal_epoch_transactions(self.block.epoch_number(), Some(txn));
+        if !known_history.is_empty() {
+            // Iterate over the known history and the given history in parallel to find the block
+            // where the histories diverge (if they do).
+            let mut known = known_history.iter();
+            let mut given = history.iter().skip(first_new_ext_tx_idx);
+            let mut last_known_block = None;
+            let diverging_block = loop {
+                match (known.next(), given.next()) {
+                    (Some(known_tx), Some(given_tx)) => {
+                        last_known_block = Some(known_tx.block_number);
+                        if *known_tx != *given_tx {
+                            break Some(known_tx.block_number);
+                        }
+                    }
+                    (None, Some(given_tx)) => {
+                        break match last_known_block {
+                            Some(block_number) if block_number == given_tx.block_number => {
+                                Some(block_number)
+                            }
+                            _ => None,
+                        };
+                    }
+                    (Some(known_tx), None) => break Some(known_tx.block_number),
+                    (None, None) => break None,
+                }
+            };
+
+            if let Some(diverging_block) = diverging_block {
+                // The histories diverge, so revert our state to the block before the divergence.
+                let num_blocks_to_revert = blockchain.block_number() - diverging_block + 1;
+                current_info = Blockchain::revert_blocks(blockchain, num_blocks_to_revert, txn)
+                    .expect("Failed to revert chain");
+
+                // TODO We could incorporate this into the parallel iteration loop above.
+                first_new_ext_tx_idx += history
+                    .iter()
+                    .skip(first_new_ext_tx_idx)
+                    .position(|ext_tx| ext_tx.block_number >= diverging_block)
+                    .unwrap_or(history.len() - first_new_ext_tx_idx);
+            } else {
+                // The histories match, so we can skip over all known transactions.
+                first_new_ext_tx_idx += known_history.len();
+            }
+        } else if blockchain.state.main_chain.head.is_micro()
+            && first_new_ext_tx_idx < history.len()
+        {
+            // We have micro blocks for the current batch but the known history is empty.
+            // Check if the given history contains any items before our current block; if so, we
+            // need to revert.
+            let first_block_number = history[first_new_ext_tx_idx].block_number;
+            if first_block_number <= blockchain.block_number() {
+                let num_blocks_to_revert = blockchain.block_number() - first_block_number + 1;
+                current_info = Blockchain::revert_blocks(blockchain, num_blocks_to_revert, txn)
+                    .expect("Failed to revert chain");
+            }
         };
 
-        let wanted_history_root = HistoryStore::root_from_ext_txs(full_history)
-            .ok_or(PushError::InvalidBlock(BlockError::InvalidHistoryRoot))?;
+        (current_info, first_new_ext_tx_idx)
+    }
+}
 
-        if *block.history_root() != wanted_history_root {
+/// Implements methods to push macro blocks into the chain when an history node is syncing. This
+/// type of syncing is called history syncing. It works by having the node get all the election
+/// macro blocks since genesis plus the last macro block (most likely it will be a checkpoint block,
+/// but it might be an election block). For these macro blocks the node must also get the
+/// corresponding history tree. When the macro blocks are synced, then the node gets all the micro
+/// blocks in the current batch and pushes them normally.
+/// Note that, when pushing the macro blocks, we rely on the assumption that they were produced by
+/// honest validator sets (defined as having less than 1/3 malicious validators). Because of that
+/// we don't actually check the validity of the blocks, we just perform the minimal amount of checks
+/// necessary to verify that the given block is a successor of our current chain so far and that the
+/// corresponding history tree is actually part of the block.
+impl Blockchain {
+    /// Starts history sync for a specific macro block (election or checkpoint).
+    /// This function performs basic checks on the macro block provided and
+    /// then returns a `HistoryPusher` instance where history chunks can be
+    /// added later.
+    /// Note that this function doesn't alter the blockchain state nor pushes
+    /// anything to the history store. These changes must be performed with the
+    /// `HistoryPusher` instance.
+    pub fn start_history_sync(
+        this: RwLockUpgradableReadGuard<Self>,
+        macro_block: MacroBlock,
+    ) -> Result<HistoryPusher, PushError> {
+        // Create a new database read transaction.
+        let read_txn = this.read_transaction();
+
+        // Check the version
+        if macro_block.header.version != policy::VERSION {
             warn!(
-                block = %macro_block,
-                reason = "wrong history root",
-                history_root = %block.history_root(),
-                %wanted_history_root,
+                %macro_block,
+                reason = "wrong version",
+                version = macro_block.header.version,
+                wanted_version = policy::VERSION,
                 "Rejecting block",
             );
-            return Err(PushError::InvalidBlock(BlockError::InvalidHistoryRoot));
+            return Err(PushError::InvalidBlock(BlockError::UnsupportedVersion));
+        }
+
+        // Check if we already know this block.
+        if this
+            .chain_store
+            .get_chain_info(&macro_block.hash(), false, Some(&read_txn))
+            .is_some()
+        {
+            return Err(PushError::AlreadyKnown);
         }
 
         // Checks if the body exists.
@@ -169,319 +520,27 @@ impl Blockchain {
             return Err(PushError::InvalidBlock(BlockError::BodyHashMismatch));
         }
 
-        // Check the justification.
-        if !TendermintProof::verify(macro_block, &this.current_validators().unwrap()) {
-            warn!(
-                block = %macro_block,
-                reason = "bad justification",
-                "Rejecting block",
-            );
-            return Err(PushError::InvalidBlock(BlockError::InvalidJustification));
-        }
-
         drop(read_txn);
 
         // Extend the chain with this block.
-        let prev_macro_info = this.state.macro_info.clone();
-        Blockchain::extend_history_sync(this, block, history, prev_macro_info)
-    }
-
-    /// Extends the current chain with a macro block (election or checkpoint) during history sync.
-    fn extend_history_sync(
-        this: RwLockUpgradableReadGuard<Blockchain>,
-        block: Block,
-        history: &[ExtendedTransaction],
-        mut prev_macro_info: ChainInfo,
-    ) -> Result<PushResult, PushError> {
-        // Create a new database write transaction.
-        let mut txn = this.write_transaction();
-
-        // Get the block hash.
-        let block_hash = block.hash();
-
-        // Calculate the cumulative transaction fees for the given batch. This is necessary to
-        // create the chain info for the block.
-        let mut cum_tx_fees = Coin::ZERO;
-        let current_batch = policy::batch_at(block.block_number());
-        for i in (0..history.len()).rev() {
-            if policy::batch_at(history[i].block_number) != current_batch {
-                break;
-            }
-            if let ExtTxData::Basic(tx) = &history[i].data {
-                cum_tx_fees += tx.fee;
-            }
-        }
-
-        // Create the chain info for the given block and store it.
-        let chain_info = ChainInfo {
-            on_main_chain: true,
-            main_chain_successor: None,
-            head: block.clone(),
-            cum_tx_fees,
-        };
-
-        this.chain_store
-            .put_chain_info(&mut txn, &block_hash, &chain_info, true);
-
-        // Update the chain info for the previous macro block and store it.
-        prev_macro_info.main_chain_successor = Some(chain_info.head.hash());
-
-        this.chain_store.put_chain_info(
-            &mut txn,
-            &prev_macro_info.head.hash(),
-            &prev_macro_info,
-            false,
-        );
-
-        // Set the head of the chain store to the current block.
-        this.chain_store.set_head(&mut txn, &block_hash);
-
-        // We might already know the given epoch partially.
-        // Revert our chain to a common ancestor state in case we have adopted a different history.
-        // Also skip over any transactions that we already know.
-        let first_new_ext_tx = this.revert_to_common_state(&block, history, &mut txn);
-
-        // Separate the extended transactions by block number and type.
-        // We know it comes sorted because we already checked it against the history root and
-        // extended transactions in the history tree come sorted by block number and type.
-        // Ignore the extended transactions that were already added in past macro blocks.
-        let mut block_numbers = vec![];
-        let mut block_timestamps = vec![];
-        let mut block_transactions = vec![];
-        let mut block_inherents = vec![];
-        let mut prev = 0;
-
-        for ext_tx in history.iter().skip(first_new_ext_tx) {
-            if ext_tx.block_number > prev {
-                block_numbers.push(ext_tx.block_number);
-                block_timestamps.push(ext_tx.block_time);
-                block_transactions.push(vec![]);
-                block_inherents.push(vec![]);
-                prev = ext_tx.block_number;
-            }
-
-            match &ext_tx.data {
-                ExtTxData::Basic(tx) => block_transactions.last_mut().unwrap().push(tx.clone()),
-                ExtTxData::Inherent(tx) => block_inherents.last_mut().unwrap().push(tx.clone()),
-            }
-        }
-
-        // We go over the blocks one more time and add the FinalizeBatch and FinalizeEpoch inherents
-        // to the macro blocks. This is necessary because the History Store doesn't store those inherents
-        // so we need to add them again in order to correctly sync.
-        for (i, block_number) in block_numbers.iter().enumerate() {
-            if policy::is_macro_block_at(*block_number) {
-                let finalize_batch = Inherent {
-                    ty: InherentType::FinalizeBatch,
-                    target: this.staking_contract_address(),
-                    value: Coin::ZERO,
-                    data: vec![],
-                };
-
-                block_inherents.get_mut(i).unwrap().push(finalize_batch);
-
-                if policy::is_election_block_at(*block_number) {
-                    let finalize_epoch = Inherent {
-                        ty: InherentType::FinalizeEpoch,
-                        target: this.staking_contract_address(),
-                        value: Coin::ZERO,
-                        data: vec![],
-                    };
-
-                    block_inherents.get_mut(i).unwrap().push(finalize_epoch);
-                }
-            }
-        }
-
-        // Update the accounts tree, one block at a time.
-        for i in 0..block_numbers.len() {
-            // Commit block to AccountsTree and create the receipts.
-            let receipts = this.state.accounts.commit_batch(
-                &mut txn,
-                &block_transactions[i],
-                &block_inherents[i],
-                block_numbers[i],
-                block_timestamps[i],
-            );
-
-            // Check if the receipts contain an error.
-            if let Err(e) = receipts {
-                warn!(
-                    %block,
-                    reason = "commit of block failed",
-                    block_no = block_numbers[i],
-                    num_transactions = block_transactions[i].len(),
-                    num_inherents = block_inherents[i].len(),
-                    error = &e as &dyn Error,
-                    "Rejecting block",
-                );
-
-                txn.abort();
-                #[cfg(feature = "metrics")]
-                this.metrics.note_invalid_block();
-                return Err(PushError::AccountsError(e));
-            }
-        }
-        this.state.accounts.finalize_batch(&mut txn);
-
-        // Unwrap the block.
-        let macro_block = block.unwrap_macro_ref();
-
-        // Check the state_root hash against the one in the block.
-        let wanted_state_root = this.state.accounts.get_root(Some(&txn));
-        if macro_block.header.state_root != wanted_state_root {
-            warn!(
-                block = %macro_block,
-                reason = "header accounts hash doesn't match real accounts hash",
-                state_root = %macro_block.header.state_root,
-                %wanted_state_root,
-                "Rejecting block",
-            );
-            txn.abort();
-            #[cfg(feature = "metrics")]
-            this.metrics.note_invalid_block();
-            return Err(PushError::InvalidBlock(BlockError::AccountsHashMismatch));
-        }
-
-        // Macro blocks are final and receipts for the previous batch are no longer necessary
-        // as rebranching across this block is not possible.
-        this.chain_store.clear_receipts(&mut txn);
-
-        // Store the new extended transactions into the History tree.
-        this.history_store.add_to_history(
-            &mut txn,
-            block.epoch_number(),
-            &history[first_new_ext_tx..],
-        );
-
-        // Give up database transactions and push lock before creating notifications.
-        txn.commit();
-
-        // Update the blockchain state.
-        let mut this = RwLockUpgradableReadGuard::upgrade(this);
-        this.state.main_chain = chain_info.clone();
-        this.state.head_hash = block_hash.clone();
-        this.state.macro_info = chain_info;
-        this.state.macro_head_hash = block_hash.clone();
-
-        // Check if this block is an election block.
-        let is_election_block = macro_block.is_election_block();
-        if is_election_block {
-            this.state.election_head = macro_block.clone();
-            this.state.election_head_hash = block_hash.clone();
-            this.state.previous_slots = this.state.current_slots.take();
-            this.state.current_slots = macro_block.get_validators();
-        }
-
-        let this = RwLockWriteGuard::downgrade_to_upgradable(this);
-
-        debug!(
-            %block,
-            num_transactions = block.num_transactions(),
-            kind = "history_sync",
-            "Accepted block",
-        );
-
-        debug!(
-            epoch_no = block.epoch_number(),
-            num_items = history.len(),
-            kind = "history_sync",
-            "Accepted epoch",
-        );
-
-        if is_election_block {
-            this.notifier
-                .notify(BlockchainEvent::EpochFinalized(block_hash));
-        } else {
-            this.notifier.notify(BlockchainEvent::Finalized(block_hash));
-        }
-
-        // Return result.
-        Ok(PushResult::Extended)
-    }
-
-    fn revert_to_common_state(
-        &self,
-        block: &Block,
-        history: &[ExtendedTransaction],
-        txn: &mut WriteTransaction,
-    ) -> usize {
-        // Find the index of the first extended transaction in the current batch.
-        let last_macro_block = policy::last_macro_block(self.block_number());
-        let mut first_new_ext_tx = history
-            .iter()
-            .position(|ext_tx| ext_tx.block_number > last_macro_block)
-            .unwrap_or(history.len());
-
-        // Check if our adopted non-final history matches the given history.
-        // Revert any blocks that don't match.
-        let known_history = self
-            .history_store
-            .get_nonfinal_epoch_transactions(block.epoch_number(), Some(txn));
-        if !known_history.is_empty() {
-            // Iterate over the known history and the given history in parallel to find the block
-            // where the histories diverge (if they do).
-            let mut known = known_history.iter();
-            let mut given = history.iter().skip(first_new_ext_tx);
-            let mut last_known_block = None;
-            let diverging_block = loop {
-                match (known.next(), given.next()) {
-                    (Some(known_tx), Some(given_tx)) => {
-                        last_known_block = Some(known_tx.block_number);
-                        if *known_tx != *given_tx {
-                            break Some(known_tx.block_number);
-                        }
-                    }
-                    (None, Some(given_tx)) => {
-                        break match last_known_block {
-                            Some(block_number) if block_number == given_tx.block_number => {
-                                Some(block_number)
-                            }
-                            _ => None,
-                        };
-                    }
-                    (Some(known_tx), None) => break Some(known_tx.block_number),
-                    (None, None) => break None,
-                }
-            };
-
-            if let Some(diverging_block) = diverging_block {
-                // The histories diverge, so revert our state to the block before the divergence.
-                let num_blocks_to_revert = self.block_number() - diverging_block + 1;
-                self.revert_blocks(num_blocks_to_revert, txn)
-                    .expect("Failed to revert chain");
-
-                // TODO We could incorporate this into the parallel iteration loop above.
-                first_new_ext_tx += history
-                    .iter()
-                    .skip(first_new_ext_tx)
-                    .position(|ext_tx| ext_tx.block_number >= diverging_block)
-                    .unwrap_or(history.len() - first_new_ext_tx);
-            } else {
-                // The histories match, so we can skip over all known transactions.
-                first_new_ext_tx += known_history.len();
-            }
-        } else if self.state.main_chain.head.is_micro() && first_new_ext_tx < history.len() {
-            // We have micro blocks for the current batch but the history is empty.
-            // Check if the given history contains any items before our current block; if so, we
-            // need to revert.
-            let first_block_number = history[first_new_ext_tx].block_number;
-            if first_block_number <= self.block_number() {
-                let num_blocks_to_revert = self.block_number() - first_block_number + 1;
-                self.revert_blocks(num_blocks_to_revert, txn)
-                    .expect("Failed to revert chain");
-            }
-        };
-
-        first_new_ext_tx
+        //let prev_macro_info = this.state.macro_info.clone();
+        //Blockchain::extend_history_sync(this, block, history, prev_macro_info)
+        Ok(HistoryPusher {
+            block: macro_block,
+            tx_count: 0,
+            cum_tx_fees: Coin::ZERO,
+        })
     }
 
     /// Reverts a given number of micro blocks from the blockchain.
+    /// This function updates the history store but doesn't alter the
+    /// blockchain state. This function returns a `ChainInfo` struct such
+    /// that the caller makes the proper state changes.
     pub fn revert_blocks(
         &self,
         num_blocks: u32,
         write_txn: &mut WriteTransaction,
-    ) -> Result<(), PushError> {
+    ) -> Result<ChainInfo, PushError> {
         debug!(
             num_blocks,
             "Need to revert micro blocks from the current epoch",
@@ -517,6 +576,15 @@ impl Blockchain {
             }
         }
 
-        Ok(())
+        // Update the blockchain
+        let block_hash = current_info.head.hash();
+
+        self.chain_store
+            .put_chain_info(write_txn, &block_hash, &current_info, true);
+
+        // Set the head of the chain store to the current block.
+        self.chain_store.set_head(write_txn, &block_hash);
+
+        Ok(current_info)
     }
 }

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -60,6 +60,10 @@ pub enum PushResult {
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PushError {
+    #[error("Already known")]
+    AlreadyKnown,
+    #[error("Invalid history chunk")]
+    InvalidHistoryChunk,
     #[error("Orphan block")]
     Orphan,
     #[error("Invalid zk proof")]

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -2,7 +2,10 @@
 extern crate log;
 
 pub use abstract_blockchain::AbstractBlockchain;
-pub use blockchain::blockchain::{Blockchain, TransactionVerificationCache};
+pub use blockchain::{
+    blockchain::{Blockchain, TransactionVerificationCache},
+    history_sync::HistoryPusher,
+};
 pub use chain_info::ChainInfo;
 pub use chain_ordering::ChainOrdering;
 pub use error::*;

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use nimiq_block_production::BlockProducer;
-use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushResult};
+use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushResult, CHUNK_SIZE};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
 use nimiq_primitives::policy::{BATCHES_PER_EPOCH, BLOCKS_PER_BATCH, BLOCKS_PER_EPOCH};
@@ -43,14 +43,32 @@ fn history_sync_works() {
         .get_block_at(BLOCKS_PER_EPOCH, true, None)
         .unwrap();
 
-    let election_txs_1 = blockchain.history_store.get_epoch_transactions(1, None);
+    let election_txs_1 = blockchain
+        .history_store
+        .prove_chunk(
+            election_block_1.epoch_number(),
+            election_block_1.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     let election_block_2 = blockchain
         .chain_store
         .get_block_at(2 * BLOCKS_PER_EPOCH, true, None)
         .unwrap();
 
-    let election_txs_2 = blockchain.history_store.get_epoch_transactions(2, None);
+    let election_txs_2 = blockchain
+        .history_store
+        .prove_chunk(
+            election_block_2.epoch_number(),
+            election_block_2.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     // Get the checkpoint blocks and corresponding history tree transactions.
     let checkpoint_block_2_1 = blockchain
@@ -58,37 +76,48 @@ fn history_sync_works() {
         .get_block_at(BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH, true, None)
         .unwrap();
 
-    let mut checkpoint_txs_2_1 = vec![];
-
-    for ext_tx in &election_txs_2 {
-        if ext_tx.block_number > BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH {
-            break;
-        }
-
-        checkpoint_txs_2_1.push(ext_tx.clone());
-    }
+    let checkpoint_txs_2_1 = blockchain
+        .history_store
+        .prove_chunk(
+            checkpoint_block_2_1.epoch_number(),
+            checkpoint_block_2_1.block_number(),
+            CHUNK_SIZE as usize,
+            0,
+            None,
+        )
+        .unwrap();
 
     let checkpoint_block_2_3 = blockchain
         .chain_store
         .get_block_at(BLOCKS_PER_EPOCH + 3 * BLOCKS_PER_BATCH, true, None)
         .unwrap();
 
-    let mut checkpoint_txs_2_3 = vec![];
-
-    for ext_tx in &election_txs_2 {
-        if ext_tx.block_number > BLOCKS_PER_EPOCH + 3 * BLOCKS_PER_BATCH {
-            break;
-        }
-
-        checkpoint_txs_2_3.push(ext_tx.clone());
-    }
+    let checkpoint_txs_2_3 = blockchain
+        .history_store
+        .prove_chunk(
+            checkpoint_block_2_3.epoch_number(),
+            checkpoint_block_2_3.block_number(),
+            CHUNK_SIZE as usize,
+            0,
+            None,
+        )
+        .unwrap();
 
     let checkpoint_block_3_1 = blockchain
         .chain_store
         .get_block_at(2 * BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH, true, None)
         .unwrap();
 
-    let checkpoint_txs_3_1 = blockchain.history_store.get_epoch_transactions(3, None);
+    let checkpoint_txs_3_1 = blockchain
+        .history_store
+        .prove_chunk(
+            checkpoint_block_3_1.epoch_number(),
+            checkpoint_block_3_1.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     let time = Arc::new(OffsetTime::new());
     // Create a second blockchain to push these blocks.
@@ -98,49 +127,113 @@ fn history_sync_works() {
         Blockchain::new(env2, NetworkId::UnitAlbatross, time).unwrap(),
     ));
 
+    // Push election_block_1 associated transactions
+
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        election_block_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
     // Push blocks using history sync.
     assert_eq!(
-        Blockchain::push_history_sync(
+        pusher.add_history_chunk(blockchain2.upgradable_read(), election_txs_1, 0, CHUNK_SIZE),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
+        Ok(PushResult::Extended)
+    );
+
+    // Push checkpoint_block_2_1 associated transactions
+
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        checkpoint_block_2_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
+    assert_eq!(
+        pusher.add_history_chunk(
             blockchain2.upgradable_read(),
-            election_block_1,
-            &election_txs_1
+            checkpoint_txs_2_1,
+            0,
+            CHUNK_SIZE
         ),
         Ok(PushResult::Extended)
     );
 
     assert_eq!(
-        Blockchain::push_history_sync(
+        pusher.commit(blockchain2.upgradable_read()),
+        Ok(PushResult::Extended)
+    );
+
+    // Push checkpoint_block_2_3 associated transactions
+
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        checkpoint_block_2_3.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
+    assert_eq!(
+        pusher.add_history_chunk(
             blockchain2.upgradable_read(),
-            checkpoint_block_2_1,
-            &checkpoint_txs_2_1
+            checkpoint_txs_2_3,
+            0,
+            CHUNK_SIZE
         ),
         Ok(PushResult::Extended)
     );
 
     assert_eq!(
-        Blockchain::push_history_sync(
+        pusher.commit(blockchain2.upgradable_read()),
+        Ok(PushResult::Extended)
+    );
+
+    // Push election_block_2 associated transactions
+
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        election_block_2.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
+    assert_eq!(
+        pusher.add_history_chunk(blockchain2.upgradable_read(), election_txs_2, 0, CHUNK_SIZE),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
+        Ok(PushResult::Extended)
+    );
+
+    // Push checkpoint_block_3_1 associated transactions
+
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        checkpoint_block_3_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
+    assert_eq!(
+        pusher.add_history_chunk(
             blockchain2.upgradable_read(),
-            checkpoint_block_2_3,
-            &checkpoint_txs_2_3
+            checkpoint_txs_3_1,
+            0,
+            CHUNK_SIZE
         ),
         Ok(PushResult::Extended)
     );
 
     assert_eq!(
-        Blockchain::push_history_sync(
-            blockchain2.upgradable_read(),
-            election_block_2,
-            &election_txs_2
-        ),
-        Ok(PushResult::Extended)
-    );
-
-    assert_eq!(
-        Blockchain::push_history_sync(
-            blockchain2.upgradable_read(),
-            checkpoint_block_3_1,
-            &checkpoint_txs_3_1
-        ),
+        pusher.commit(blockchain2.upgradable_read()),
         Ok(PushResult::Extended)
     );
 }
@@ -174,14 +267,32 @@ fn history_sync_works_with_micro_blocks() {
         .get_block_at(BLOCKS_PER_EPOCH, true, None)
         .unwrap();
 
-    let election_txs_1 = blockchain.history_store.get_epoch_transactions(1, None);
+    let election_txs_1 = blockchain
+        .history_store
+        .prove_chunk(
+            election_block_1.epoch_number(),
+            election_block_1.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     let election_block_2 = blockchain
         .chain_store
         .get_block_at(2 * BLOCKS_PER_EPOCH, true, None)
         .unwrap();
 
-    let election_txs_2 = blockchain.history_store.get_epoch_transactions(2, None);
+    let election_txs_2 = blockchain
+        .history_store
+        .prove_chunk(
+            election_block_2.epoch_number(),
+            election_block_2.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     // Get the checkpoint blocks and corresponding history tree transactions.
     let checkpoint_block_2_1 = blockchain
@@ -189,22 +300,32 @@ fn history_sync_works_with_micro_blocks() {
         .get_block_at(BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH, true, None)
         .unwrap();
 
-    let mut checkpoint_txs_2_1 = vec![];
-
-    for ext_tx in &election_txs_2 {
-        if ext_tx.block_number > BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH {
-            break;
-        }
-
-        checkpoint_txs_2_1.push(ext_tx.clone());
-    }
+    let checkpoint_txs_2_1 = blockchain
+        .history_store
+        .prove_chunk(
+            checkpoint_block_2_1.epoch_number(),
+            checkpoint_block_2_1.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     let checkpoint_block_3_2 = blockchain
         .chain_store
         .get_block_at(2 * BLOCKS_PER_EPOCH + 2 * BLOCKS_PER_BATCH, true, None)
         .unwrap();
 
-    let checkpoint_txs_3_2 = blockchain.history_store.get_epoch_transactions(3, None);
+    let checkpoint_txs_3_2 = blockchain
+        .history_store
+        .prove_chunk(
+            checkpoint_block_3_2.epoch_number(),
+            checkpoint_block_3_2.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     // Get the micro blocks.
     let mut micro_blocks_2_2 = vec![];
@@ -238,21 +359,43 @@ fn history_sync_works_with_micro_blocks() {
     ));
 
     // Push blocks using history sync.
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        election_block_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
     assert_eq!(
-        Blockchain::push_history_sync(
+        pusher.add_history_chunk(blockchain2.upgradable_read(), election_txs_1, 0, CHUNK_SIZE),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
+        Ok(PushResult::Extended)
+    );
+
+    // Push blocks using history sync.
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        checkpoint_block_2_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
+    assert_eq!(
+        pusher.add_history_chunk(
             blockchain2.upgradable_read(),
-            election_block_1,
-            &election_txs_1
+            checkpoint_txs_2_1,
+            0,
+            CHUNK_SIZE
         ),
         Ok(PushResult::Extended)
     );
 
     assert_eq!(
-        Blockchain::push_history_sync(
-            blockchain2.upgradable_read(),
-            checkpoint_block_2_1,
-            &checkpoint_txs_2_1
-        ),
+        pusher.commit(blockchain2.upgradable_read()),
         Ok(PushResult::Extended)
     );
 
@@ -265,12 +408,20 @@ fn history_sync_works_with_micro_blocks() {
     }
 
     // Now go back into history sync.
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        election_block_2.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
     assert_eq!(
-        Blockchain::push_history_sync(
-            blockchain2.upgradable_read(),
-            election_block_2,
-            &election_txs_2
-        ),
+        pusher.add_history_chunk(blockchain2.upgradable_read(), election_txs_2, 0, CHUNK_SIZE),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
         Ok(PushResult::Extended)
     );
 
@@ -283,12 +434,25 @@ fn history_sync_works_with_micro_blocks() {
     }
 
     // End by going into history sync.
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        checkpoint_block_3_2.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
     assert_eq!(
-        Blockchain::push_history_sync(
+        pusher.add_history_chunk(
             blockchain2.upgradable_read(),
-            checkpoint_block_3_2,
-            &checkpoint_txs_3_2
+            checkpoint_txs_3_2,
+            0,
+            CHUNK_SIZE
         ),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
         Ok(PushResult::Extended)
     );
 }
@@ -324,15 +488,110 @@ fn history_sync_works_with_diverging_history() {
         .chain_store
         .get_block_at(BLOCKS_PER_EPOCH, true, None)
         .unwrap();
-    let election_txs_1 = blockchain.history_store.get_epoch_transactions(1, None);
+
+    let election_txs_1 = blockchain
+        .history_store
+        .prove_chunk(
+            election_block_1.epoch_number(),
+            election_block_1.block_number(),
+            CHUNK_SIZE,
+            0,
+            None,
+        )
+        .unwrap();
 
     // Push the epoch to blockchain2.
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        election_block_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    // Push blocks using history sync.
     assert_eq!(
-        Blockchain::push_history_sync(
-            blockchain2.upgradable_read(),
-            election_block_1,
-            &election_txs_1
-        ),
+        pusher.add_history_chunk(blockchain2.upgradable_read(), election_txs_1, 0, CHUNK_SIZE),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
+        Ok(PushResult::Extended)
+    );
+
+    assert_eq!(blockchain.head(), blockchain2.read().head());
+}
+
+// Tests if the history sync works when micro blocks have already been pushed in the blockchain,
+// and tries to push history in multiple chunks
+#[test]
+fn history_sync_works_with_multiple_chunks() {
+    // Produce macro blocks to complete one epoch in blockchain1.
+    let env = VolatileEnvironment::new(10).unwrap();
+    let time = Arc::new(OffsetTime::new());
+    let blockchain1 = Arc::new(RwLock::new(
+        Blockchain::new(env, NetworkId::UnitAlbatross, time).unwrap(),
+    ));
+
+    // Build blockchain2.
+    let env = VolatileEnvironment::new(10).unwrap();
+    let time = Arc::new(OffsetTime::new());
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(env, NetworkId::UnitAlbatross, time).unwrap(),
+    ));
+
+    let num_macro_blocks = BATCHES_PER_EPOCH as usize;
+    let num_chunks = 4;
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    produce_macro_blocks_with_txns(&producer, &blockchain1, num_macro_blocks, 2, 0);
+    assert_eq!(blockchain1.read().block_number(), BLOCKS_PER_EPOCH);
+
+    // Get the election block and corresponding history tree transactions from blockchain1.
+    let blockchain = blockchain1.read();
+    let election_block_1 = blockchain
+        .chain_store
+        .get_block_at(BLOCKS_PER_EPOCH, true, None)
+        .unwrap();
+
+    let mut election_txs_1 = vec![];
+    for i in 0..num_chunks {
+        election_txs_1.push(
+            blockchain
+                .history_store
+                .prove_chunk(
+                    election_block_1.epoch_number(),
+                    election_block_1.block_number(),
+                    2 * BLOCKS_PER_EPOCH as usize / num_chunks,
+                    i,
+                    None,
+                )
+                .unwrap(),
+        );
+    }
+
+    // Push the epoch to blockchain1.
+    let mut pusher = Blockchain::start_history_sync(
+        blockchain2.upgradable_read(),
+        election_block_1.unwrap_macro(),
+    )
+    .expect("Failed starting history sync");
+
+    let mut chunk_index = 0;
+    for chunk in election_txs_1 {
+        // Push blocks using history sync.
+        assert_eq!(
+            pusher.add_history_chunk(
+                blockchain2.upgradable_read(),
+                chunk,
+                chunk_index,
+                2 * BLOCKS_PER_EPOCH as usize / num_chunks
+            ),
+            Ok(PushResult::Extended)
+        );
+        chunk_index += 1;
+    }
+
+    assert_eq!(
+        pusher.commit(blockchain2.upgradable_read()),
         Ok(PushResult::Extended)
     );
 

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -5,13 +5,14 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 
 use nimiq_block::MacroBlock;
 use nimiq_blockchain::{
-    AbstractBlockchain, Blockchain, ExtendedTransaction, PushError, PushResult, CHUNK_SIZE,
+    AbstractBlockchain, Blockchain, HistoryPusher, HistoryTreeChunk, PushError, PushResult,
+    CHUNK_SIZE,
 };
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network, request::RequestError};
@@ -22,41 +23,15 @@ use crate::messages::{BatchSetInfo, HistoryChunk, RequestBatchSet, RequestHistor
 use crate::sync::sync_queue::{SyncQueue, SyncQueuePeer};
 
 struct PendingBatchSet {
-    block: MacroBlock,
+    pusher: Arc<RwLock<HistoryPusher>>,
+    epoch_number: u32,
     history_len: usize,
     history_offset: usize,
-    history: Vec<ExtendedTransaction>,
+    history_received: usize,
 }
 impl PendingBatchSet {
     fn is_complete(&self) -> bool {
-        self.history_len == self.history.len() + self.history_offset
-    }
-
-    fn epoch_number(&self) -> u32 {
-        self.block.epoch_number()
-    }
-}
-
-pub struct BatchSet {
-    pub block: MacroBlock,
-    pub history: Vec<ExtendedTransaction>,
-}
-
-impl std::fmt::Debug for BatchSet {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut dbg = f.debug_struct("BatchSet");
-        dbg.field("epoch_number", &self.block.epoch_number());
-        dbg.field("history_len", &self.history.len());
-        dbg.finish()
-    }
-}
-
-impl From<PendingBatchSet> for BatchSet {
-    fn from(batch_set: PendingBatchSet) -> Self {
-        Self {
-            block: batch_set.block,
-            history: batch_set.history,
-        }
+        self.history_len == self.history_received + self.history_offset
     }
 }
 
@@ -181,7 +156,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         }
     }
 
-    fn on_epoch_received(&mut self, epoch: BatchSetInfo) -> Result<(), SyncClusterResult> {
+    fn on_epoch_received(&mut self, epoch: BatchSetInfo) -> Result<MacroBlock, SyncClusterResult> {
         // `epoch.block` is Some, since we filtered it accordingly in the `request_fn`
         let block = epoch.block.expect("epoch.block should exist");
 
@@ -194,57 +169,63 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
 
         // TODO Verify macro blocks and their ordering
         // Currently we only do a very basic check here
-        let blockchain = self.blockchain.read();
+        let blockchain = self.blockchain.upgradable_read();
         let current_block_number = blockchain.block_number();
+        let current_epoch_number = blockchain.epoch_number();
         if block.header.block_number <= current_block_number {
             debug!("Received outdated epoch at block {}", current_block_number);
             return Err(SyncClusterResult::Outdated);
         }
 
-        // Prepare pending info.
-        let mut pending_batch_set = PendingBatchSet {
-            block,
-            history_len: epoch.history_len as usize,
-            history_offset: 0,
-            history: Vec::new(),
-        };
+        let epoch_number = block.epoch_number();
+        let num_known_txs = blockchain
+            .history_store
+            .get_final_epoch_transactions(epoch_number, None)
+            .len();
 
-        // If the block is in the same epoch, add already known history.
-        let epoch_number = pending_batch_set.block.epoch_number();
+        if let Ok(pusher) = Blockchain::start_history_sync(blockchain, block.clone()) {
+            // Prepare pending info.
+            let mut pending_batch_set = PendingBatchSet {
+                pusher: Arc::new(RwLock::new(pusher)),
+                epoch_number,
+                history_len: epoch.history_len as usize,
+                history_offset: 0,
+                history_received: 0,
+            };
 
-        let mut start_index = 0;
-        if blockchain.epoch_number() == epoch_number {
-            let num_known_txs = blockchain
-                .history_store
-                .get_final_epoch_transactions(epoch_number, None)
-                .len();
-            start_index = num_known_txs / CHUNK_SIZE;
-            pending_batch_set.history_offset = start_index * CHUNK_SIZE;
+            let epoch_number = pending_batch_set.epoch_number;
+
+            let mut start_index = 0;
+            if current_epoch_number == epoch_number {
+                start_index = num_known_txs / CHUNK_SIZE;
+                pending_batch_set.history_offset = start_index * CHUNK_SIZE;
+            }
+
+            // Queue history chunks for the given epoch for download.
+            let history_chunk_ids = (start_index
+                ..((epoch.history_len as usize).ceiling_div(CHUNK_SIZE)))
+                .map(|i| (epoch_number, block.header.block_number, i))
+                .collect();
+            self.history_queue.add_ids(history_chunk_ids);
+
+            // We keep the epoch in pending_epochs while the history is downloading.
+            self.pending_batch_sets.push_back(pending_batch_set);
+
+            Ok(block)
+        } else {
+            Err(SyncClusterResult::Error)
         }
-
-        // Queue history chunks for the given epoch for download.
-        let history_chunk_ids = (start_index
-            ..((epoch.history_len as usize).ceiling_div(CHUNK_SIZE)))
-            .map(|i| (epoch_number, pending_batch_set.block.header.block_number, i))
-            .collect();
-        self.history_queue.add_ids(history_chunk_ids);
-
-        // We keep the epoch in pending_epochs while the history is downloading.
-        self.pending_batch_sets.push_back(pending_batch_set);
-
-        Ok(())
     }
 
     fn on_history_chunk_received(
         &mut self,
         epoch_number: u32,
-        chunk_index: usize,
         history_chunk: HistoryChunk,
-    ) -> Result<(), SyncClusterResult> {
+    ) -> Result<(usize, HistoryTreeChunk), SyncClusterResult> {
         // Find epoch in pending_epochs.
         // TODO: This assumes that epochs are always dense in `pending_batch_sets`
         //  which might not be the case for misbehaving peers.
-        let first_epoch_number = self.pending_batch_sets[0].epoch_number();
+        let first_epoch_number = self.pending_batch_sets[0].epoch_number;
         let epoch_index = (epoch_number - first_epoch_number) as usize;
         let epoch = &mut self.pending_batch_sets[epoch_index];
 
@@ -254,38 +235,21 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             return Err(SyncClusterResult::Error);
         }
 
-        // Verify chunk.
-        let chunk = history_chunk.chunk.expect("History chunk missing");
-        if !chunk
-            .verify(
-                epoch.block.header.history_root.clone(),
-                chunk_index * CHUNK_SIZE,
-            )
-            .unwrap_or(false)
-        {
-            log::warn!(
-                "History Chunk failed to verify (chunk {} of epoch {})",
-                chunk_index,
-                epoch_number
-            );
-            return Err(SyncClusterResult::Error);
-        }
-
         // Add the received history chunk to the pending epoch.
-        let mut chunk = chunk.history;
-        epoch.history.append(&mut chunk);
+        let history_chunk = history_chunk.chunk.expect("History chunk missing");
+        epoch.history_received += history_chunk.history.len();
 
         if epoch.history_len > CHUNK_SIZE {
             log::info!(
                 "Downloading history for epoch #{}: {}/{} ({:.0}%)",
-                epoch.epoch_number(),
-                epoch.history.len(),
+                epoch.epoch_number,
+                epoch.history_received,
                 epoch.history_len,
-                (epoch.history.len() as f64 / epoch.history_len as f64) * 100f64
+                (epoch.history_received as f64 / epoch.history_len as f64) * 100f64
             );
         }
 
-        Ok(())
+        Ok((epoch_index, history_chunk))
     }
 
     pub(crate) fn add_peer(&mut self, peer_id: TNetwork::PeerId) -> bool {
@@ -410,7 +374,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
 }
 
 impl<TNetwork: Network + 'static> Stream for SyncCluster<TNetwork> {
-    type Item = Result<BatchSet, SyncClusterResult>;
+    type Item = Result<(Blake2bHash, BoxFuture<'static, SyncClusterResult>), SyncClusterResult>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         while self.pending_batch_sets.len() < Self::NUM_PENDING_BATCH_SETS {
@@ -433,7 +397,20 @@ impl<TNetwork: Network + 'static> Stream for SyncCluster<TNetwork> {
                     if self.pending_batch_sets[0].is_complete() {
                         self.num_epochs_finished += 1;
                         let batch_set = self.pending_batch_sets.pop_front().unwrap();
-                        return Poll::Ready(Some(Ok(batch_set.into())));
+                        let blockchain = Arc::clone(&self.blockchain);
+                        let pusher = batch_set.pusher;
+                        let epoch_number = batch_set.epoch_number;
+                        let block_hash = { pusher.read().block.hash() };
+                        let future = async move {
+                            debug!("Processing epoch #{} (no history items)", epoch_number);
+                            let pusher = pusher.read();
+                            if pusher.commit(blockchain.upgradable_read()).is_err() {
+                                return SyncClusterResult::Error;
+                            }
+                            SyncClusterResult::EpochSuccessful
+                        }
+                        .boxed();
+                        return Poll::Ready(Some(Ok((block_hash, future))));
                     }
                 }
                 Err(e) => {
@@ -447,20 +424,53 @@ impl<TNetwork: Network + 'static> Stream for SyncCluster<TNetwork> {
             }
         }
 
-        while let Poll::Ready(Some(result)) = self.history_queue.poll_next_unpin(cx) {
+        if let Poll::Ready(Some(result)) = self.history_queue.poll_next_unpin(cx) {
             match result {
                 Ok((epoch_number, chunk_index, history_chunk)) => {
-                    if let Err(e) =
-                        self.on_history_chunk_received(epoch_number, chunk_index, history_chunk)
-                    {
-                        return Poll::Ready(Some(Err(e)));
-                    }
-
-                    // Emit finished epochs.
-                    if self.pending_batch_sets[0].is_complete() {
-                        self.num_epochs_finished += 1;
-                        let batch_set = self.pending_batch_sets.pop_front().unwrap();
-                        return Poll::Ready(Some(Ok(batch_set.into())));
+                    match self.on_history_chunk_received(epoch_number, history_chunk) {
+                        Err(e) => return Poll::Ready(Some(Err(e))),
+                        Ok((epoch_idx, history_chunk)) => {
+                            let blockchain = Arc::clone(&self.blockchain);
+                            let pusher = Arc::clone(&self.pending_batch_sets[epoch_idx].pusher);
+                            let block_hash = { pusher.read().block.hash() };
+                            let is_complete = self.pending_batch_sets[epoch_idx].is_complete();
+                            let epoch_len = self.pending_batch_sets[epoch_idx].history_len;
+                            let future = async move {
+                                debug!(
+                                    "Processing epoch #{} ({} history items, chunk {}/{})",
+                                    epoch_number,
+                                    history_chunk.history.len(),
+                                    chunk_index,
+                                    epoch_len
+                                );
+                                let mut pusher = pusher.write();
+                                match pusher.add_history_chunk(
+                                    blockchain.upgradable_read(),
+                                    history_chunk,
+                                    chunk_index,
+                                    CHUNK_SIZE,
+                                ) {
+                                    Err(_) => SyncClusterResult::Error,
+                                    Ok(_) => {
+                                        if is_complete {
+                                            debug!("Committing epoch #{}", epoch_number);
+                                            if pusher.commit(blockchain.upgradable_read()).is_err()
+                                            {
+                                                return SyncClusterResult::Error;
+                                            }
+                                        }
+                                        SyncClusterResult::EpochSuccessful
+                                    }
+                                }
+                            }
+                            .boxed();
+                            // Mark finished epochs.
+                            if is_complete {
+                                self.num_epochs_finished += 1;
+                                self.pending_batch_sets.remove(epoch_idx);
+                            }
+                            return Poll::Ready(Some(Ok((block_hash, future))));
+                        }
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
Change the `push_history_sync` functionality in the `blockchain` to
receive `HistoryTreeChunks` progressively instead of a full epoch.
This includes the following changes:
- Remove `push_history_sync` method.
- Add `start_history_sync` method that only takes a `MacroBlock` and
  returns a `HistoryPusher` instance.
- Add `HistoryPusher` struct with associated functions to:
  - Add history chunks in the form of `HistoryTreeChunk`s.
  - Commit changes when no more history chunks are expected.
Also changed the consensus `cluster` and `sync_stream` functionality
to use the new APIs and call the appropriate functions as soon as new
history chunks are received.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
