### PR TITLE
Clean up some clippy warnings

### DIFF
--- a/database/src/cursor.rs
+++ b/database/src/cursor.rs
@@ -146,7 +146,7 @@ pub trait ReadCursor {
 
 macro_rules! impl_read_cursor_from_raw {
     ($t: ty, $raw: ident) => {
-        impl<'txn, 'db> ReadCursor for $t {
+        impl<'txn> ReadCursor for $t {
             fn first<K, V>(&mut self) -> Option<(K, V)>
             where
                 K: FromDatabaseValue,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -349,7 +349,7 @@ macro_rules! gen_cursor_match {
     };
 }
 
-impl<'txn, 'db> ReadCursor for Cursor<'txn> {
+impl<'txn> ReadCursor for Cursor<'txn> {
     fn first<K, V>(&mut self) -> Option<(K, V)>
     where
         K: FromDatabaseValue,
@@ -465,7 +465,7 @@ impl<'txn, 'db> ReadCursor for Cursor<'txn> {
     }
 }
 
-impl<'txn, 'db> ReadCursor for WriteCursor<'txn> {
+impl<'txn> ReadCursor for WriteCursor<'txn> {
     fn first<K, V>(&mut self) -> Option<(K, V)>
     where
         K: FromDatabaseValue,
@@ -581,7 +581,7 @@ impl<'txn, 'db> ReadCursor for WriteCursor<'txn> {
     }
 }
 
-impl<'txn, 'db> WriteCursorTrait for WriteCursor<'txn> {
+impl<'txn> WriteCursorTrait for WriteCursor<'txn> {
     fn remove(&mut self) {
         gen_cursor_match!(self, remove, WriteCursor)
     }

--- a/database/src/mdbx.rs
+++ b/database/src/mdbx.rs
@@ -330,7 +330,7 @@ pub struct RawWriteLmdbCursor<'txn> {
     cursor: libmdbx::Cursor<'txn, RW>,
 }
 
-impl<'txn, 'db> RawReadCursor for RawMDBXCursor<'txn> {
+impl<'txn> RawReadCursor for RawMDBXCursor<'txn> {
     fn first<K, V>(&mut self) -> Option<(K, V)>
     where
         K: FromDatabaseValue,
@@ -685,7 +685,7 @@ impl<'txn, 'db> RawReadCursor for RawMDBXCursor<'txn> {
     }
 }
 
-impl<'txn, 'db> RawReadCursor for RawWriteLmdbCursor<'txn> {
+impl<'txn> RawReadCursor for RawWriteLmdbCursor<'txn> {
     fn first<K, V>(&mut self) -> Option<(K, V)>
     where
         K: FromDatabaseValue,
@@ -874,7 +874,7 @@ pub struct MdbxWriteCursor<'txn> {
 
 impl_read_cursor_from_raw!(MdbxWriteCursor<'txn>, raw);
 
-impl<'txn, 'db> WriteCursorTrait for MdbxWriteCursor<'txn> {
+impl<'txn> WriteCursorTrait for MdbxWriteCursor<'txn> {
     fn remove(&mut self) {
         self.raw.cursor.del(WriteFlags::empty()).unwrap();
     }

--- a/database/src/volatile.rs
+++ b/database/src/volatile.rs
@@ -270,7 +270,7 @@ impl<'txn> ReadCursor for VolatileCursor<'txn> {
 
 pub struct VolatileWriteCursor<'txn>(MdbxWriteCursor<'txn>);
 
-impl<'txn, 'db> ReadCursor for VolatileWriteCursor<'txn> {
+impl<'txn> ReadCursor for VolatileWriteCursor<'txn> {
     fn first<K, V>(&mut self) -> Option<(K, V)>
     where
         K: FromDatabaseValue,

--- a/peer-address/src/address/peer_uri.rs
+++ b/peer-address/src/address/peer_uri.rs
@@ -83,7 +83,7 @@ pub struct PeerUri {
     public_key: Option<String>,
 }
 
-impl<'a> FromStr for PeerUri {
+impl FromStr for PeerUri {
     type Err = PeerUriError;
 
     fn from_str(s: &str) -> Result<Self, PeerUriError> {
@@ -92,7 +92,7 @@ impl<'a> FromStr for PeerUri {
     }
 }
 
-impl<'a> fmt::Display for PeerUri {
+impl fmt::Display for PeerUri {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.protocol {
             Protocol::Dumb | Protocol::Rtc => {

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -222,7 +222,7 @@ async fn main_inner() -> Result<(), Error> {
     // Initialize metrics server
     if let Some(metrics_config) = metrics_config {
         use nimiq::extras::metrics_server::start_metrics_server;
-        let _ = start_metrics_server(
+        start_metrics_server(
             metrics_config.addr,
             Arc::clone(&consensus.blockchain),
             client.mempool(),

--- a/utils/src/time.rs
+++ b/utils/src/time.rs
@@ -25,7 +25,7 @@ impl OffsetTime {
 
     pub fn now(&self) -> u64 {
         let offset = self.offset.load(Ordering::Relaxed);
-        let abs_offset = offset.abs() as u64;
+        let abs_offset = offset.unsigned_abs();
         let system_time = if offset > 0 {
             SystemTime::now() + Duration::from_millis(abs_offset)
         } else {


### PR DESCRIPTION
Clean up some clippy warnings related to:
- Unused lifetimes.
- Casting result of `abs` to `u64`.
- Let-binding unit value.

Changes were performed in the following crates:
- `database`
- `peer-address`
- `spammer`
- `utils`

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.