### PR TITLE
Output reward inherent logs as transaction logs

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -113,7 +113,13 @@ impl BlockProducer {
         let (state_root, executed_txns) = blockchain
             .state()
             .accounts
-            .exercise_transactions(&transactions, &inherents, block_number, timestamp)
+            .exercise_transactions(
+                &transactions,
+                &inherents,
+                block_number,
+                timestamp,
+                blockchain.network_id,
+            )
             .expect("Failed to compute accounts hash during block production");
 
         // Calculate the extended transactions from the transactions and the inherents.
@@ -260,7 +266,13 @@ impl BlockProducer {
         // Update the state and add the state root to the header.
         let (root, _) = state
             .accounts
-            .exercise_transactions(&[], &inherents, block_number, timestamp)
+            .exercise_transactions(
+                &[],
+                &inherents,
+                block_number,
+                timestamp,
+                blockchain.network_id,
+            )
             .expect("Failed to compute accounts hash during block production.");
 
         header.state_root = root;

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -69,7 +69,13 @@ pub fn next_micro_block(
     let (state_root, executed_txns) = blockchain
         .state()
         .accounts
-        .exercise_transactions(&transactions, &inherents, block_number, timestamp)
+        .exercise_transactions(
+            &transactions,
+            &inherents,
+            block_number,
+            timestamp,
+            blockchain.network_id,
+        )
         .expect("Failed to compute accounts hash during block production");
 
     let ext_txs = ExtendedTransaction::from(
@@ -156,7 +162,13 @@ pub fn next_skip_block(
         let (state_root, _) = blockchain
             .state()
             .accounts
-            .exercise_transactions(&[], &inherents, block_number, timestamp)
+            .exercise_transactions(
+                &[],
+                &inherents,
+                block_number,
+                timestamp,
+                blockchain.network_id,
+            )
             .expect("Failed to compute accounts hash during block production");
         state_root
     });
@@ -255,7 +267,13 @@ fn next_macro_block_proposal(
 
     let (root, _) = state
         .accounts
-        .exercise_transactions(&[], &inherents, block_number, timestamp)
+        .exercise_transactions(
+            &[],
+            &inherents,
+            block_number,
+            timestamp,
+            blockchain.network_id,
+        )
         .expect("Failed to compute accounts hash during block production.");
 
     header.state_root = root;

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -32,6 +32,7 @@ impl Blockchain {
                     &inherents,
                     macro_block.header.block_number,
                     macro_block.header.timestamp,
+                    self.network_id,
                 );
 
                 // Check if the receipts contain an error.
@@ -93,6 +94,7 @@ impl Blockchain {
                     &inherents,
                     micro_block.header.block_number,
                     micro_block.header.timestamp,
+                    self.network_id,
                 );
                 let (batch_info, executed_txns) = match batch_info {
                     Ok(batch_info) => batch_info,
@@ -193,6 +195,7 @@ impl Blockchain {
                     micro_block.header.block_number,
                     micro_block.header.timestamp,
                     &receipts,
+                    self.network_id,
                 );
                 let batch_info = match batch_info {
                     Ok(batch_info) => batch_info,

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -213,6 +213,7 @@ impl Blockchain {
         let mut block_timestamps = vec![];
         let mut block_transactions = vec![];
         let mut block_inherents = vec![];
+        let mut network_ids = vec![];
         let mut prev = 0;
 
         for ext_tx in history.iter().skip(first_new_ext_tx) {
@@ -221,6 +222,7 @@ impl Blockchain {
                 block_timestamps.push(ext_tx.block_time);
                 block_transactions.push(vec![]);
                 block_inherents.push(vec![]);
+                network_ids.push(ext_tx.network_id);
                 prev = ext_tx.block_number;
             }
 
@@ -272,6 +274,7 @@ impl Blockchain {
                 &block_inherents[i],
                 block_numbers[i],
                 block_timestamps[i],
+                network_ids[i],
             );
 
             // Check if the receipts contain an error.

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -87,6 +87,7 @@ fn it_can_create_batch_finalization_inherents() {
             &[slash_inherent],
             Policy::blocks_per_batch() + 1,
             0,
+            NetworkId::UnitAlbatross,
         )
         .is_ok());
     txn.commit();

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -801,7 +801,8 @@ impl Accounts {
             // If the tx_logs are empty, overwrite them with the senders_logs
             batch_info.tx_logs = senders_logs
         } else if !senders_logs.is_empty() {
-            unreachable!("Block contains both regular transactions and reward inherents");
+            warn!("Block contains both regular transactions and reward inherents");
+            batch_info.tx_logs.append(&mut senders_logs);
         }
         batch_info
     }

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -66,7 +66,14 @@ fn it_can_commit_and_revert_a_block_body() {
     let mut txn = WriteTransaction::new(&env);
 
     let (batch_info, _) = accounts
-        .commit(&mut txn, &[], &[reward.clone()], 1, 1)
+        .commit(
+            &mut txn,
+            &[],
+            &[reward.clone()],
+            1,
+            1,
+            NetworkId::UnitAlbatross,
+        )
         .unwrap();
 
     assert_eq!(
@@ -138,7 +145,14 @@ fn it_can_commit_and_revert_a_block_body() {
     let mut txn = WriteTransaction::new(&env);
 
     let (batch_info, executed_txns) = accounts
-        .commit(&mut txn, &transactions, &[reward.clone()], 2, 2)
+        .commit(
+            &mut txn,
+            &transactions,
+            &[reward.clone()],
+            2,
+            2,
+            NetworkId::UnitAlbatross,
+        )
         .unwrap();
 
     assert_eq!(
@@ -175,7 +189,8 @@ fn it_can_commit_and_revert_a_block_body() {
             &[reward],
             2,
             2,
-            &Receipts::from(receipts.clone())
+            &Receipts::from(receipts.clone()),
+            NetworkId::UnitAlbatross,
         ),
         Ok(BatchInfo::new(vec![], tx_logs, inherent_logs))
     );
@@ -227,7 +242,9 @@ fn it_correctly_rewards_validators() {
 
     let mut txn = WriteTransaction::new(&env);
 
-    assert!(accounts.commit(&mut txn, &[], &[reward], 1, 1).is_ok());
+    assert!(accounts
+        .commit(&mut txn, &[], &[reward], 1, 1, NetworkId::UnitAlbatross)
+        .is_ok());
 
     txn.commit();
 
@@ -282,7 +299,14 @@ fn it_correctly_rewards_validators() {
     let mut txn = WriteTransaction::new(&env);
 
     assert!(accounts
-        .commit(&mut txn, &vec![tx1, tx2], &[reward], 2, 2)
+        .commit(
+            &mut txn,
+            &vec![tx1, tx2],
+            &[reward],
+            2,
+            2,
+            NetworkId::UnitAlbatross
+        )
         .is_ok());
 
     txn.commit();
@@ -361,7 +385,14 @@ fn it_checks_for_sufficient_funds() {
         let mut txn = WriteTransaction::new(&env);
 
         assert!(accounts
-            .commit(&mut txn, &[tx.clone()], &[reward.clone()], 1, 1)
+            .commit(
+                &mut txn,
+                &[tx.clone()],
+                &[reward.clone()],
+                1,
+                1,
+                NetworkId::UnitAlbatross
+            )
             .is_err());
     }
 
@@ -379,7 +410,14 @@ fn it_checks_for_sufficient_funds() {
     let mut txn = WriteTransaction::new(&env);
 
     assert!(accounts
-        .commit(&mut txn, &[], &[reward.clone()], 1, 1)
+        .commit(
+            &mut txn,
+            &[],
+            &[reward.clone()],
+            1,
+            1,
+            NetworkId::UnitAlbatross
+        )
         .is_ok());
 
     txn.commit();
@@ -408,7 +446,14 @@ fn it_checks_for_sufficient_funds() {
         let mut txn = WriteTransaction::new(&env);
 
         let (_, executed_txns) = accounts
-            .commit(&mut txn, &[tx.clone()], &[reward.clone()], 2, 2)
+            .commit(
+                &mut txn,
+                &[tx.clone()],
+                &[reward.clone()],
+                2,
+                2,
+                NetworkId::UnitAlbatross,
+            )
             .unwrap();
 
         assert_eq!(executed_txns, vec![ExecutedTransaction::Err(tx.clone())]);
@@ -440,7 +485,14 @@ fn it_checks_for_sufficient_funds() {
         let mut txn = WriteTransaction::new(&env);
 
         let (_, executed_txns) = accounts
-            .commit(&mut txn, &vec![tx.clone(), tx2.clone()], &[reward], 2, 2)
+            .commit(
+                &mut txn,
+                &vec![tx.clone(), tx2.clone()],
+                &[reward],
+                2,
+                2,
+                NetworkId::UnitAlbatross,
+            )
             .unwrap();
 
         assert_eq!(
@@ -551,7 +603,14 @@ fn accounts_performance() {
 
     let mut txn = WriteTransaction::new(&env);
     let start = Instant::now();
-    let result = accounts.commit(&mut txn, &txns[..], &rewards[..], 1, 1);
+    let result = accounts.commit(
+        &mut txn,
+        &txns[..],
+        &rewards[..],
+        1,
+        1,
+        NetworkId::UnitAlbatross,
+    );
     match result {
         Ok(_) => assert!(true),
         Err(err) => assert!(false, "Received {}", err),
@@ -674,6 +733,7 @@ fn accounts_performance_history_sync_batches_single_sender() {
                 &rewards[..],
                 block_index,
                 1,
+                NetworkId::UnitAlbatross,
             );
             match result {
                 Ok(_) => assert!(true),
@@ -795,6 +855,7 @@ fn accounts_performance_history_sync_batches_many_to_many() {
                 &rewards[..],
                 block_index,
                 1,
+                NetworkId::UnitAlbatross,
             );
             match result {
                 Ok(_) => assert!(true),
@@ -877,7 +938,14 @@ fn it_commits_valid_and_failing_txns() {
     tx.proof = signature_proof.serialize_to_vec();
 
     let (_, executed_txns) = accounts
-        .commit(&mut db_txn, &vec![tx.clone()], &[], 1, 200)
+        .commit(
+            &mut db_txn,
+            &vec![tx.clone()],
+            &[],
+            1,
+            200,
+            NetworkId::UnitAlbatross,
+        )
         .unwrap();
 
     assert_eq!(executed_txns, vec![ExecutedTransaction::Err(tx.clone())]);
@@ -920,7 +988,14 @@ fn it_commits_valid_and_failing_txns() {
     tx.proof = signature_proof.serialize_to_vec();
 
     let (_, executed_txns) = accounts
-        .commit(&mut db_txn, &vec![tx.clone()], &[], 1, 200)
+        .commit(
+            &mut db_txn,
+            &vec![tx.clone()],
+            &[],
+            1,
+            200,
+            NetworkId::UnitAlbatross,
+        )
         .unwrap();
 
     assert_eq!(executed_txns, vec![ExecutedTransaction::Err(tx.clone())]);

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -51,12 +51,23 @@ fn it_can_commit_and_revert_a_block_body() {
         data: None,
     }];
 
-    let mut tx_logs = Vec::new();
-
-    let inherent_logs = vec![Log::PayoutReward {
-        to: reward.target.clone(),
-        value: reward.value,
+    let mut tx_logs = vec![TransactionLog {
+        tx_hash: Transaction::new_basic(
+            Policy::COINBASE_ADDRESS,
+            reward.target.clone(),
+            reward.value,
+            Coin::ZERO,
+            1,
+            NetworkId::UnitAlbatross,
+        )
+        .hash(),
+        logs: vec![Log::PayoutReward {
+            to: reward.target.clone(),
+            value: reward.value,
+        }],
     }];
+
+    let inherent_logs = Vec::new();
 
     assert_eq!(
         accounts.get(&KeyNibbles::from(&address_validator), None),
@@ -149,8 +160,8 @@ fn it_can_commit_and_revert_a_block_body() {
             &mut txn,
             &transactions,
             &[reward.clone()],
-            2,
-            2,
+            1,
+            1,
             NetworkId::UnitAlbatross,
         )
         .unwrap();
@@ -187,8 +198,8 @@ fn it_can_commit_and_revert_a_block_body() {
             &mut txn,
             &executed_txns,
             &[reward],
-            2,
-            2,
+            1,
+            1,
             &Receipts::from(receipts.clone()),
             NetworkId::UnitAlbatross,
         ),


### PR DESCRIPTION
Validator rewards are publicly represented as transactions with transaction hashes. They are represented as coinbase transactions in macro blocks, they are returned in the `get_transaction_by_address` RPC call and can be queried by their transaction hash with `get_transaction_by_hash`.

Therefore I found it to be consistent that rewards are also represented in the transaction logs of block event subscriptions.

This requires a transaction to be created from the inherent however, to compute the transaction hash under which it will be accessible.

