### PR TITLE
Include data into transfer logs if present and if recipient is a basi…

### DIFF
--- a/primitives/account/src/basic_account.rs
+++ b/primitives/account/src/basic_account.rs
@@ -153,11 +153,7 @@ impl AccountTransactionInteraction for BasicAccount {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ];
         Ok(AccountInfo::new(None, logs))
     }
@@ -189,11 +185,7 @@ impl AccountTransactionInteraction for BasicAccount {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ];
         // If the new balance is zero, it means this account didnt exist before, so we don't need to create it.
         if new_balance == Coin::ZERO {

--- a/primitives/account/src/basic_account.rs
+++ b/primitives/account/src/basic_account.rs
@@ -153,7 +153,7 @@ impl AccountTransactionInteraction for BasicAccount {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ];
         Ok(AccountInfo::new(None, logs))
     }
@@ -185,7 +185,7 @@ impl AccountTransactionInteraction for BasicAccount {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ];
         // If the new balance is zero, it means this account didnt exist before, so we don't need to create it.
         if new_balance == Coin::ZERO {

--- a/primitives/account/src/htlc_contract.rs
+++ b/primitives/account/src/htlc_contract.rs
@@ -261,7 +261,7 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ];
 
         match proof_type {
@@ -355,7 +355,7 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ];
 
         let proof_buf = &mut &transaction.proof[..];

--- a/primitives/account/src/htlc_contract.rs
+++ b/primitives/account/src/htlc_contract.rs
@@ -261,11 +261,7 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ];
 
         match proof_type {
@@ -359,11 +355,7 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ];
 
         let proof_buf = &mut &transaction.proof[..];

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -152,7 +152,7 @@ pub enum Log {
 }
 
 impl Log {
-    pub fn transfer_from_transaction(transaction: &Transaction) -> Self {
+    pub fn transfer_log_from_transaction(transaction: &Transaction) -> Self {
         Log::Transfer {
             from: transaction.sender.clone(),
             to: transaction.recipient.clone(),

--- a/primitives/account/src/staking_contract/traits.rs
+++ b/primitives/account/src/staking_contract/traits.rs
@@ -372,7 +372,7 @@ impl AccountTransactionInteraction for StakingContract {
         // Ordering matters here for testing purposes. The vec will be very small, therefore the performance hit is irrelevant.
         acc_info
             .logs
-            .insert(0, Log::transfer_from_transaction(transaction));
+            .insert(0, Log::transfer_log_from_transaction(transaction));
         acc_info.logs.insert(
             0,
             Log::PayFee {
@@ -399,7 +399,7 @@ impl AccountTransactionInteraction for StakingContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ];
         match data {
             OutgoingStakingTransactionProof::DeleteValidator { proof } => {

--- a/primitives/account/src/staking_contract/traits.rs
+++ b/primitives/account/src/staking_contract/traits.rs
@@ -338,10 +338,10 @@ impl AccountTransactionInteraction for StakingContract {
             return Err(AccountError::InvalidForSender);
         }
 
-        // Parse transaction data.
-        let data = OutgoingStakingTransactionProof::parse(transaction)?;
+        // Parse transaction proof.
+        let proof = OutgoingStakingTransactionProof::parse(transaction)?;
 
-        let mut acc_info: AccountInfo = match data {
+        let mut acc_info: AccountInfo = match proof {
             OutgoingStakingTransactionProof::DeleteValidator { proof } => {
                 // Get the validator address from the proof.
                 let validator_address = proof.compute_signer();
@@ -370,14 +370,9 @@ impl AccountTransactionInteraction for StakingContract {
         };
 
         // Ordering matters here for testing purposes. The vec will be very small, therefore the performance hit is irrelevant.
-        acc_info.logs.insert(
-            0,
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
-        );
+        acc_info
+            .logs
+            .insert(0, Log::transfer_from_transaction(transaction));
         acc_info.logs.insert(
             0,
             Log::PayFee {
@@ -404,11 +399,7 @@ impl AccountTransactionInteraction for StakingContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ];
         match data {
             OutgoingStakingTransactionProof::DeleteValidator { proof } => {

--- a/primitives/account/src/vesting_contract.rs
+++ b/primitives/account/src/vesting_contract.rs
@@ -192,7 +192,7 @@ impl AccountTransactionInteraction for VestingContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ];
         Ok(AccountInfo::new(receipt, logs))
     }
@@ -245,7 +245,7 @@ impl AccountTransactionInteraction for VestingContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::transfer_from_transaction(transaction),
+            Log::transfer_log_from_transaction(transaction),
         ])
     }
     fn commit_failed_transaction(

--- a/primitives/account/src/vesting_contract.rs
+++ b/primitives/account/src/vesting_contract.rs
@@ -192,11 +192,7 @@ impl AccountTransactionInteraction for VestingContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ];
         Ok(AccountInfo::new(receipt, logs))
     }
@@ -249,11 +245,7 @@ impl AccountTransactionInteraction for VestingContract {
                 from: transaction.sender.clone(),
                 fee: transaction.fee,
             },
-            Log::Transfer {
-                from: transaction.sender.clone(),
-                to: transaction.recipient.clone(),
-                amount: transaction.value,
-            },
+            Log::transfer_from_transaction(transaction),
         ])
     }
     fn commit_failed_transaction(

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -126,6 +126,7 @@ fn it_can_commit_and_revert_a_block_body() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
         ],
     ));

--- a/primitives/account/tests/basic_account.rs
+++ b/primitives/account/tests/basic_account.rs
@@ -72,6 +72,7 @@ fn basic_transfer_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
         ],
     );
@@ -130,6 +131,7 @@ fn basic_transfer_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
         ])
     );
@@ -183,6 +185,7 @@ fn create_and_prune_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
         ]
     );
@@ -217,6 +220,7 @@ fn create_and_prune_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
         ]
     );

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -1032,6 +1032,7 @@ fn delete_validator_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
             Log::DeleteValidator {
                 validator_address: validator_address.clone(),
@@ -1085,6 +1086,7 @@ fn delete_validator_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
             Log::DeleteValidator {
                 validator_address: validator_address.clone(),
@@ -1661,6 +1663,7 @@ fn unstake_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
             Log::Unstake {
                 staker_address: staker_address.clone(),
@@ -1734,6 +1737,7 @@ fn unstake_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
             Log::Unstake {
                 staker_address: staker_address.clone(),
@@ -1797,6 +1801,7 @@ fn unstake_works() {
                 from: tx.sender.clone(),
                 to: tx.recipient.clone(),
                 amount: tx.value,
+                data: None,
             },
             Log::Unstake {
                 staker_address: staker_address.clone(),


### PR DESCRIPTION
This PR adds a `data: Option<Vec<u8>>` field to the `Log::Transfer` struct. This is to represent custom data that is added to a regular transaction **to a _basic_ account**.

To not repeat the recipient account-type check and data length everywhere, I opted to extract the `Log::Transfer` creation into a static method on the `Log` enum.