### PR TITLE
WIP: Global static NETWORK_ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-utils",
  "num-traits",
+ "once_cell",
  "parking_lot 0.12.0 (git+https://github.com/styppo/parking_lot.git)",
  "regex",
  "serde",
@@ -3671,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"

--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -85,7 +85,7 @@ impl BlockProducer {
 
         // Calculate the extended transactions from the transactions and the inherents.
         let ext_txs = ExtendedTransaction::from(
-            blockchain.network_id,
+            None,
             block_number,
             timestamp,
             transactions.clone(),
@@ -201,13 +201,7 @@ impl BlockProducer {
             .expect("Failed to compute accounts hash during block production.");
 
         // Calculate the extended transactions from the transactions and the inherents.
-        let ext_txs = ExtendedTransaction::from(
-            blockchain.network_id,
-            block_number,
-            timestamp,
-            vec![],
-            inherents,
-        );
+        let ext_txs = ExtendedTransaction::from(None, block_number, timestamp, vec![], inherents);
 
         // Store the extended transactions into the history tree and calculate the history root.
         let mut txn = blockchain.write_transaction();

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -88,13 +88,7 @@ pub fn next_micro_block(
             .expect("Failed to compute accounts hash during block production")
     });
 
-    let ext_txs = ExtendedTransaction::from(
-        blockchain.network_id,
-        block_number,
-        timestamp,
-        transactions,
-        inherents,
-    );
+    let ext_txs = ExtendedTransaction::from(None, block_number, timestamp, transactions, inherents);
 
     let mut txn = blockchain.write_transaction();
 
@@ -202,13 +196,7 @@ fn next_macro_block_proposal(
         .get_root_with(&[], &inherents, block_number, timestamp)
         .expect("Failed to compute accounts hash during block production.");
 
-    let ext_txs = ExtendedTransaction::from(
-        blockchain.network_id,
-        block_number,
-        timestamp,
-        vec![],
-        inherents,
-    );
+    let ext_txs = ExtendedTransaction::from(None, block_number, timestamp, vec![], inherents);
 
     let mut txn = blockchain.write_transaction();
 

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -297,7 +297,7 @@ fn it_can_revert_unpark_transactions() {
         &key_pair,
         Coin::ZERO,
         1,
-        NetworkId::UnitAlbatross,
+        None,
     )
     .unwrap();
 
@@ -396,7 +396,7 @@ fn it_can_revert_create_stacker_transaction() {
         100_000_000.try_into().unwrap(),
         100.try_into().unwrap(),
         1,
-        NetworkId::UnitAlbatross,
+        None,
     )
     .unwrap();
 

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -49,7 +49,7 @@ impl Blockchain {
 
                 // Store the transactions and the inherents into the History tree.
                 let ext_txs = ExtendedTransaction::from(
-                    self.network_id,
+                    None,
                     macro_block.header.block_number,
                     macro_block.header.timestamp,
                     vec![],
@@ -110,7 +110,7 @@ impl Blockchain {
 
                 // Store the transactions and the inherents into the History tree.
                 let ext_txs = ExtendedTransaction::from(
-                    self.network_id,
+                    None,
                     micro_block.header.block_number,
                     micro_block.header.timestamp,
                     body.transactions.clone(),

--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -6,6 +6,7 @@ use nimiq_database::{Environment, ReadTransaction, WriteTransaction};
 use nimiq_genesis::NetworkInfo;
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::coin::Coin;
+use nimiq_primitives::globals::NETWORK_ID;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_primitives::policy;
 use nimiq_primitives::slots::Validators;
@@ -78,6 +79,8 @@ impl Blockchain {
     ) -> Result<Self, BlockchainError> {
         let chain_store = ChainStore::new(env.clone());
         let history_store = HistoryStore::new(env.clone());
+
+        NETWORK_ID.get_or_init(|| network_id);
 
         Ok(match chain_store.get_head(None) {
             Some(head_hash) => Blockchain::load(

--- a/blockchain/src/history/extended_transaction.rs
+++ b/blockchain/src/history/extended_transaction.rs
@@ -8,6 +8,7 @@ use nimiq_database::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_mmr::hash::Hash as MMRHash;
 use nimiq_primitives::coin::Coin;
+use nimiq_primitives::globals::NETWORK_ID;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_primitives::policy::COINBASE_ADDRESS;
 use nimiq_transaction::Transaction as BlockchainTransaction;
@@ -49,8 +50,7 @@ impl ExtendedTransaction {
     /// number and a block timestamp) into a vector of extended transactions.
     /// We only want to store slash and reward inherents, so we ignore the other inherent types.
     pub fn from(
-        // TODO: Make into an Option<NetworkId>
-        network_id: NetworkId,
+        network_id: Option<NetworkId>,
         block_number: u32,
         block_time: u64,
         transactions: Vec<BlockchainTransaction>,
@@ -60,7 +60,8 @@ impl ExtendedTransaction {
 
         for transaction in transactions {
             ext_txs.push(ExtendedTransaction {
-                network_id,
+                network_id: network_id
+                    .unwrap_or_else(|| *NETWORK_ID.get().expect("Network ID not set")),
                 block_number,
                 block_time,
                 data: ExtTxData::Basic(transaction),
@@ -70,7 +71,8 @@ impl ExtendedTransaction {
         for inherent in inherents {
             if inherent.ty == InherentType::Slash || inherent.ty == InherentType::Reward {
                 ext_txs.push(ExtendedTransaction {
-                    network_id,
+                    network_id: network_id
+                        .unwrap_or_else(|| *NETWORK_ID.get().expect("Network ID not set")),
                     block_number,
                     block_time,
                     data: ExtTxData::Inherent(inherent),

--- a/blockchain/src/history/extended_transaction.rs
+++ b/blockchain/src/history/extended_transaction.rs
@@ -49,6 +49,7 @@ impl ExtendedTransaction {
     /// number and a block timestamp) into a vector of extended transactions.
     /// We only want to store slash and reward inherents, so we ignore the other inherent types.
     pub fn from(
+        // TODO: Make into an Option<NetworkId>
         network_id: NetworkId,
         block_number: u32,
         block_time: u64,
@@ -152,7 +153,7 @@ impl ExtendedTransaction {
                         x.value,
                         Coin::ZERO,
                         self.block_number,
-                        self.network_id,
+                        Some(self.network_id),
                     ))
                 } else {
                     Err(IntoTransactionError::NoBasicTransactionMapping)

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1501,7 +1501,7 @@ mod tests {
                 Coin::from_u64_unchecked(value),
                 Coin::from_u64_unchecked(0),
                 0,
-                NetworkId::Dummy,
+                Some(NetworkId::Dummy),
             )),
         }
     }

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -17,6 +17,7 @@ use nimiq_network_libp2p::{
     discovery::peer_contacts::{PeerContact, Services},
     Config as NetworkConfig, Multiaddr, Network,
 };
+use nimiq_primitives::globals::NETWORK_ID;
 use nimiq_utils::time::OffsetTime;
 #[cfg(feature = "validator")]
 use nimiq_validator::validator::Validator as AbstractValidator;
@@ -75,6 +76,7 @@ impl ClientInner {
             )));
         }
         let network_info = NetworkInfo::from_network_id(config.network_id);
+        NETWORK_ID.set(network_info.network_id()).unwrap();
 
         // Initialize clock
         let time = Arc::new(OffsetTime::new());

--- a/mempool/tests/filter.rs
+++ b/mempool/tests/filter.rs
@@ -18,7 +18,7 @@ fn it_can_blacklist_transactions() {
         Coin::try_from(100).unwrap(),
         Coin::try_from(1).unwrap(),
         123,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
 
     let hash: Blake2bHash = tx.hash();
@@ -41,7 +41,7 @@ fn it_accepts_and_rejects_transactions() {
         Coin::try_from(0).unwrap(),
         Coin::try_from(0).unwrap(),
         0,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
 
     assert!(!f.accepts_transaction(&tx));

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1414,7 +1414,7 @@ async fn mempool_update_create_staker_twice() {
         100_000_000.try_into().unwrap(),
         100.try_into().unwrap(),
         1,
-        NetworkId::UnitAlbatross,
+        Some(NetworkId::UnitAlbatross),
     )
     .unwrap();
 
@@ -1426,7 +1426,7 @@ async fn mempool_update_create_staker_twice() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         1,
-        NetworkId::UnitAlbatross,
+        Some(NetworkId::UnitAlbatross),
     )
     .unwrap();
 
@@ -1539,7 +1539,7 @@ async fn mempool_update_create_staker_non_existant_delegation_addr() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         1,
-        NetworkId::UnitAlbatross,
+        Some(NetworkId::UnitAlbatross),
     )
     .unwrap();
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,6 +28,7 @@ regex = { version = "1.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.24"
 thiserror = { version = "1.0.31", optional = true }
+once_cell = "1.13.0"
 
 beserial = { path = "../beserial", features = ["derive"] }
 nimiq-bls = { path = "../bls", features = ["beserial"], optional = true }

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -87,7 +87,7 @@ fn it_can_commit_and_revert_a_block_body() {
         Coin::from_u64_unchecked(10),
         Coin::ZERO,
         1,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
 
     let transactions = vec![tx.clone()];
@@ -249,7 +249,7 @@ fn it_correctly_rewards_validators() {
         value1,
         fee1,
         2,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
 
     let tx2 = Transaction::new_basic(
@@ -258,7 +258,7 @@ fn it_correctly_rewards_validators() {
         value2,
         fee2,
         2,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
 
     // Validator 2 mines second block.
@@ -331,7 +331,7 @@ fn it_checks_for_sufficient_funds() {
         Coin::try_from(10).unwrap(),
         Coin::ZERO,
         1,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
 
     let reward = Inherent {

--- a/primitives/account/tests/basic_account.rs
+++ b/primitives/account/tests/basic_account.rs
@@ -32,7 +32,7 @@ fn it_does_not_allow_creation() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     assert_eq!(
@@ -264,7 +264,7 @@ fn make_signed_transaction(value: u64, recipient: Address) -> Transaction {
         value.try_into().unwrap(),
         1.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let key_pair = KeyPair::from(

--- a/primitives/account/tests/htlc_contract.rs
+++ b/primitives/account/tests/htlc_contract.rs
@@ -93,7 +93,7 @@ fn it_can_verify_creation_transaction() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     // Invalid data
@@ -169,7 +169,7 @@ fn it_can_create_contract_from_transaction() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     HashedTimeLockedContract::create(&accounts_tree, &mut db_txn, &transaction, 0, 0);
@@ -202,7 +202,7 @@ fn it_does_not_support_incoming_transactions() {
         1.try_into().unwrap(),
         1000.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.recipient_type = AccountType::HTLC;
 
@@ -277,7 +277,7 @@ fn prepare_outgoing_transaction() -> (
         1000.try_into().unwrap(),
         0.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let sender_signature = sender_key_pair.sign(&tx.serialize_content()[..]);

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -2313,7 +2313,7 @@ fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -
             100.try_into().unwrap(),
             data.serialize_to_vec(),
             1,
-            NetworkId::Dummy,
+            Some(NetworkId::Dummy),
         ),
         _ => Transaction::new_signalling(
             Address::from_any_str(STAKER_ADDRESS).unwrap(),
@@ -2324,7 +2324,7 @@ fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -
             100.try_into().unwrap(),
             data.serialize_to_vec(),
             1,
-            NetworkId::Dummy,
+            Some(NetworkId::Dummy),
         ),
     }
 }
@@ -2369,7 +2369,7 @@ fn make_delete_validator_transaction() -> Transaction {
         100.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let private_key =
@@ -2396,7 +2396,7 @@ fn make_unstake_transaction(value: u64) -> Transaction {
         100.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let private_key =

--- a/primitives/account/tests/vesting_contract.rs
+++ b/primitives/account/tests/vesting_contract.rs
@@ -74,7 +74,7 @@ fn it_can_verify_creation_transaction() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     // Invalid data
@@ -156,7 +156,7 @@ fn it_can_create_contract_from_transaction() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     VestingContract::create(&accounts_tree, &mut db_txn, &transaction, 0, 0);
@@ -254,7 +254,7 @@ fn it_does_not_support_incoming_transactions() {
         1.try_into().unwrap(),
         1000.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.recipient_type = AccountType::Vesting;
 
@@ -282,7 +282,7 @@ fn it_can_verify_outgoing_transactions() {
         1.try_into().unwrap(),
         1000.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.sender_type = AccountType::Vesting;
 
@@ -346,7 +346,7 @@ fn it_can_apply_and_revert_valid_transaction() {
         200.try_into().unwrap(),
         0.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.sender_type = AccountType::Vesting;
 
@@ -443,7 +443,7 @@ fn it_refuses_invalid_transaction() {
         200.try_into().unwrap(),
         0.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.sender_type = AccountType::Vesting;
 

--- a/primitives/src/globals.rs
+++ b/primitives/src/globals.rs
@@ -1,0 +1,5 @@
+use once_cell::sync::OnceCell;
+
+use crate::networks::NetworkId;
+
+pub static NETWORK_ID: OnceCell<NetworkId> = OnceCell::new();

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod account;
 #[cfg(feature = "coin")]
 pub mod coin;
+pub mod globals;
 #[cfg(feature = "networks")]
 pub mod networks;
 #[cfg(feature = "policy")]

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -19,6 +19,7 @@ use nimiq_keys::Address;
 use nimiq_keys::{PublicKey, Signature};
 use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
+use nimiq_primitives::globals::NETWORK_ID;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_primitives::policy;
 use nimiq_utils::merkle::{Blake2bMerklePath, Blake2bMerkleProof};
@@ -150,7 +151,7 @@ impl Transaction {
         value: Coin,
         fee: Coin,
         validity_start_height: u32,
-        network_id: NetworkId,
+        network_id: Option<NetworkId>,
     ) -> Self {
         Self {
             data: Vec::new(),
@@ -161,7 +162,8 @@ impl Transaction {
             value,
             fee,
             validity_start_height,
-            network_id,
+            network_id: network_id
+                .unwrap_or_else(|| *NETWORK_ID.get().expect("Network ID not set")),
             flags: TransactionFlags::empty(),
             proof: Vec::new(),
             valid: false,
@@ -177,7 +179,7 @@ impl Transaction {
         fee: Coin,
         data: Vec<u8>,
         validity_start_height: u32,
-        network_id: NetworkId,
+        network_id: Option<NetworkId>,
     ) -> Self {
         Self {
             data,
@@ -188,7 +190,8 @@ impl Transaction {
             value,
             fee,
             validity_start_height,
-            network_id,
+            network_id: network_id
+                .unwrap_or_else(|| *NETWORK_ID.get().expect("Network ID not set")),
             flags: TransactionFlags::empty(),
             proof: Vec::new(),
             valid: false,
@@ -204,7 +207,7 @@ impl Transaction {
         fee: Coin,
         data: Vec<u8>,
         validity_start_height: u32,
-        network_id: NetworkId,
+        network_id: Option<NetworkId>,
     ) -> Self {
         Self {
             data,
@@ -215,7 +218,8 @@ impl Transaction {
             value,
             fee,
             validity_start_height,
-            network_id,
+            network_id: network_id
+                .unwrap_or_else(|| *NETWORK_ID.get().expect("Network ID not set")),
             flags: TransactionFlags::SIGNALLING,
             proof: Vec::new(),
             valid: false,
@@ -230,7 +234,7 @@ impl Transaction {
         value: Coin,
         fee: Coin,
         validity_start_height: u32,
-        network_id: NetworkId,
+        network_id: Option<NetworkId>,
     ) -> Self {
         let mut tx = Self {
             data,
@@ -241,7 +245,8 @@ impl Transaction {
             value,
             fee,
             validity_start_height,
-            network_id,
+            network_id: network_id
+                .unwrap_or_else(|| *NETWORK_ID.get().expect("Network ID not set")),
             flags: TransactionFlags::CONTRACT_CREATION,
             proof: Vec::new(),
             valid: false,

--- a/primitives/transaction/tests/staking_contract.rs
+++ b/primitives/transaction/tests/staking_contract.rs
@@ -48,7 +48,7 @@ fn it_does_not_support_contract_creation() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     assert_eq!(
@@ -679,7 +679,7 @@ fn make_incoming_tx(data: IncomingStakingTransactionData, value: u64) -> Transac
             100.try_into().unwrap(),
             data.serialize_to_vec(),
             1,
-            NetworkId::Dummy,
+            Some(NetworkId::Dummy),
         ),
         _ => Transaction::new_signalling(
             Address::from_any_str(STAKER_ADDRESS).unwrap(),
@@ -690,7 +690,7 @@ fn make_incoming_tx(data: IncomingStakingTransactionData, value: u64) -> Transac
             100.try_into().unwrap(),
             data.serialize_to_vec(),
             1,
-            NetworkId::Dummy,
+            Some(NetworkId::Dummy),
         ),
     }
 }
@@ -739,7 +739,7 @@ fn make_delete_validator_tx(value: u64, wrong_sig: bool) -> Transaction {
         100.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let private_key =
@@ -777,7 +777,7 @@ fn make_unstake_tx(wrong_sig: bool) -> Transaction {
         100.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let private_key =

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -10,7 +10,7 @@ use nimiq_consensus::ConsensusProxy;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::{Address, KeyPair, PrivateKey, PublicKey};
 use nimiq_network_libp2p::Network;
-use nimiq_primitives::{coin::Coin, networks::NetworkId};
+use nimiq_primitives::coin::Coin;
 use nimiq_rpc_interface::{
     consensus::ConsensusInterface,
     types::{Transaction as RPCTransaction, ValidityStartHeight},
@@ -48,11 +48,6 @@ impl ConsensusDispatcher {
             .ok_or_else(|| Error::UnlockedWalletNotFound(address.clone()))?
             .key_pair
             .clone())
-    }
-
-    /// Returns the network ID for our current blockchain.
-    fn get_network_id(&self) -> NetworkId {
-        self.consensus.blockchain.read().network_id
     }
 
     /// Calculates the actual block number for the validity start height given the ValidityStartHeight
@@ -108,7 +103,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -146,7 +141,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -196,7 +191,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -246,7 +241,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -300,7 +295,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -363,7 +358,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -419,7 +414,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -476,7 +471,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -526,7 +521,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(hex::encode(&sig.serialize_to_vec()))
@@ -550,7 +545,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -596,7 +591,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -646,7 +641,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             new_delegation,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -691,7 +686,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             value,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -759,7 +754,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             signal_data,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -861,7 +856,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             new_signal_data,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -920,7 +915,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             &signing_key_pair,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -968,7 +963,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             &signing_key_pair,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -1016,7 +1011,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             &signing_key_pair,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))
@@ -1058,7 +1053,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             &self.get_wallet_keypair(&validator_wallet)?,
             fee,
             self.validity_start_height(validity_start_height),
-            self.get_network_id(),
+            None,
         )?;
 
         Ok(transaction_to_hex_string(&transaction))

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -50,7 +50,7 @@ pub fn generate_transactions(
             Coin::from_u64_unchecked(1),
             Coin::from_u64_unchecked(2),
             start_height,
-            network_id,
+            Some(network_id),
         )
         .unwrap();
         txs.push(tx);

--- a/test-utils/src/test_transaction.rs
+++ b/test-utils/src/test_transaction.rs
@@ -59,7 +59,7 @@ pub fn generate_transactions(
             Coin::from_u64_unchecked(mempool_transaction.value),
             Coin::from_u64_unchecked(mempool_transaction.fee),
             1,
-            NetworkId::UnitAlbatross,
+            Some(NetworkId::UnitAlbatross),
         );
 
         if signature {

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -114,7 +114,7 @@ fn run_app() -> Result<(), Error> {
             value,
             fee,
             validity_start_height,
-            network_id,
+            Some(network_id),
         )
     };
 

--- a/transaction-builder/src/proof/htlc_contract.rs
+++ b/transaction-builder/src/proof/htlc_contract.rs
@@ -150,7 +150,6 @@ impl HtlcProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
@@ -198,7 +197,6 @@ impl HtlcProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
@@ -250,7 +248,6 @@ impl HtlcProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
@@ -352,7 +349,6 @@ impl HtlcProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
@@ -430,7 +426,6 @@ impl HtlcProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///

--- a/transaction-builder/src/proof/mod.rs
+++ b/transaction-builder/src/proof/mod.rs
@@ -85,7 +85,6 @@ impl TransactionProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
@@ -124,7 +123,6 @@ impl TransactionProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_fee(Coin::from_u64_unchecked(1337));
     ///
@@ -178,7 +176,6 @@ impl TransactionProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// builder.with_sender_type(AccountType::HTLC);
     ///
@@ -230,7 +227,6 @@ impl TransactionProofBuilder {
     ///     recipient.generate().unwrap(),
     ///     Coin::from_u64_unchecked(0), // must be zero because of signalling transaction
     ///     1,
-    ///     NetworkId::Main
     /// );
     ///
     /// let proof_builder = tx_builder.generate().unwrap();
@@ -282,7 +278,6 @@ impl TransactionProofBuilder {
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,
-    ///     NetworkId::Main
     /// );
     /// tx_builder.with_sender_type(AccountType::Staking);
     ///

--- a/transaction-builder/tests/htlc_contract.rs
+++ b/transaction-builder/tests/htlc_contract.rs
@@ -31,7 +31,7 @@ fn it_can_create_creation_transaction() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let mut htlc_builder = Recipient::new_htlc_builder();
@@ -94,7 +94,7 @@ fn prepare_outgoing_transaction() -> (
         0.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     let sender_signature = sender_key_pair.sign(&tx.serialize_content()[..]);

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -42,7 +42,7 @@ fn it_can_create_staker_transactions() {
         100_000_000.try_into().unwrap(),
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -63,7 +63,7 @@ fn it_can_create_staker_transactions() {
         100_000_000.try_into().unwrap(),
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -85,7 +85,7 @@ fn it_can_create_staker_transactions() {
         None,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -106,7 +106,7 @@ fn it_can_create_staker_transactions() {
         None,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -121,7 +121,7 @@ fn it_can_create_staker_transactions() {
         150_000_000.try_into().unwrap(),
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -140,7 +140,7 @@ fn it_can_fail_creating_staker_transactions() {
         0.try_into().unwrap(), // InvalidValue
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .err();
 
@@ -180,7 +180,7 @@ fn it_can_create_validator_transactions() {
         Some(Blake2bHash::default()),
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -209,7 +209,7 @@ fn it_can_create_validator_transactions() {
         None,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -231,7 +231,7 @@ fn it_can_create_validator_transactions() {
         &key_pair,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -253,7 +253,7 @@ fn it_can_create_validator_transactions() {
         &key_pair,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -275,7 +275,7 @@ fn it_can_create_validator_transactions() {
         &key_pair,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -289,7 +289,7 @@ fn it_can_create_validator_transactions() {
         &key_pair,
         100.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     )
     .unwrap();
 
@@ -309,7 +309,7 @@ fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -
             100.try_into().unwrap(),
             data.serialize_to_vec(),
             1,
-            NetworkId::Dummy,
+            Some(NetworkId::Dummy),
         ),
         _ => Transaction::new_signalling(
             Address::from_any_str(ADDRESS).unwrap(),
@@ -320,7 +320,7 @@ fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -
             100.try_into().unwrap(),
             data.serialize_to_vec(),
             1,
-            NetworkId::Dummy,
+            Some(NetworkId::Dummy),
         ),
     }
 }
@@ -352,7 +352,7 @@ fn make_unstake_transaction(key_pair: &KeyPair, value: u64) -> Transaction {
         100.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     let proof = OutgoingStakingTransactionProof::Unstake {
         proof: SignatureProof::from(key_pair.public, key_pair.sign(&tx.serialize_content())),
@@ -371,7 +371,7 @@ fn make_delete_transaction(key_pair: &KeyPair, value: u64) -> Transaction {
         100.try_into().unwrap(),
         vec![],
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     let proof = OutgoingStakingTransactionProof::DeleteValidator {
         proof: SignatureProof::from(key_pair.public, key_pair.sign(&tx.serialize_content())),
@@ -390,7 +390,7 @@ fn make_self_transaction(data: IncomingStakingTransactionData, key_pair: &KeyPai
         100.try_into().unwrap(),
         data.serialize_to_vec(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.data = IncomingStakingTransactionData::set_signature_on_data(
         &tx.data,

--- a/transaction-builder/tests/vesting_contract.rs
+++ b/transaction-builder/tests/vesting_contract.rs
@@ -25,7 +25,7 @@ fn it_can_create_creation_transaction() {
         100.try_into().unwrap(),
         0.try_into().unwrap(),
         0,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
 
     // Valid
@@ -121,7 +121,7 @@ fn it_can_create_outgoing_transactions() {
         1.try_into().unwrap(),
         1000.try_into().unwrap(),
         1,
-        NetworkId::Dummy,
+        Some(NetworkId::Dummy),
     );
     tx.sender_type = AccountType::Vesting;
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -615,7 +615,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             &self.signing_key(),
             Coin::ZERO,
             validity_start_height,
-            blockchain.network_id(),
+            None,
         )
         .unwrap(); // TODO: Handle transaction creation error
         let tx_hash = unpark_transaction.hash();

--- a/wallet/src/wallet_account.rs
+++ b/wallet/src/wallet_account.rs
@@ -36,7 +36,7 @@ impl WalletAccount {
         value: Coin,
         fee: Coin,
         validity_start_height: u32,
-        network_id: NetworkId,
+        network_id: Option<NetworkId>,
     ) -> Transaction {
         let mut transaction = Transaction::new_basic(
             self.address.clone(),

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -30,7 +30,7 @@ fn test_create_transaction() {
         Coin::from_u64_unchecked(42),
         Coin::ZERO,
         0,
-        NetworkId::Main,
+        Some(NetworkId::Main),
     );
     assert_eq!(Ok(()), transaction.verify(NetworkId::Main));
 }


### PR DESCRIPTION
:warning: **DRAFT PR - Treat this as a suggestion**

Based on a recent discussion with @nibhar and the need to access the node's configured `NetworkId` deep in some parts of the code, especially in #923, this PR makes the configured network ID into a global "lazy" `static` that can be imported and accessed anywhere in the code base.

It is especially used when creating transactions; it makes the passing-down of a `network_id` optional, and not-needed in most cases.