### PR TITLE
Iicruz/automatic validator activation

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -156,7 +156,7 @@ impl ClientInner {
                 let validator_address = validator_config.validator_address;
 
                 // Load validator address
-                let automatic_activate = validator_config.automatic_activate;
+                let automatic_reactivate = validator_config.automatic_reactivate;
 
                 // Load signing key (before we give away ownership of the storage config)
                 let signing_key = config.storage.signing_keypair()?;
@@ -173,7 +173,7 @@ impl ClientInner {
                     &consensus,
                     validator_network,
                     validator_address,
-                    automatic_activate,
+                    automatic_reactivate,
                     signing_key,
                     voting_key,
                     fee_key,

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -155,6 +155,9 @@ impl ClientInner {
                 // Load validator address
                 let validator_address = validator_config.validator_address;
 
+                // Load validator address
+                let automatic_activate = validator_config.automatic_activate;
+
                 // Load signing key (before we give away ownership of the storage config)
                 let signing_key = config.storage.signing_keypair()?;
 
@@ -170,6 +173,7 @@ impl ClientInner {
                     &consensus,
                     validator_network,
                     validator_address,
+                    automatic_activate,
                     signing_key,
                     voting_key,
                     fee_key,

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -505,6 +505,9 @@ impl Default for StorageConfig {
 pub struct ValidatorConfig {
     /// The validator address.
     pub validator_address: Address,
+
+    /// Config if the validator automatically activates.
+    pub automatic_activate: bool,
 }
 
 /// Credentials for JSON RPC server, metrics server or websocket RPC server
@@ -760,6 +763,7 @@ impl ClientConfigBuilder {
         if let Some(validator_config) = config_file.validator.as_ref() {
             self.validator(ValidatorConfig {
                 validator_address: Address::from_any_str(&validator_config.validator_address)?,
+                automatic_activate: validator_config.automatic_activation,
             });
 
             if let Some(key_path) = &validator_config.voting_key_file {

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -506,8 +506,8 @@ pub struct ValidatorConfig {
     /// The validator address.
     pub validator_address: Address,
 
-    /// Config if the validator automatically activates.
-    pub automatic_activate: bool,
+    /// Config if the validator automatically reactivates itself.
+    pub automatic_reactivate: bool,
 }
 
 /// Credentials for JSON RPC server, metrics server or websocket RPC server
@@ -763,7 +763,7 @@ impl ClientConfigBuilder {
         if let Some(validator_config) = config_file.validator.as_ref() {
             self.validator(ValidatorConfig {
                 validator_address: Address::from_any_str(&validator_config.validator_address)?,
-                automatic_activate: validator_config.automatic_activation,
+                automatic_reactivate: validator_config.automatic_reactivate,
             });
 
             if let Some(key_path) = &validator_config.voting_key_file {

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -244,4 +244,4 @@ fee_key_file = "fee_key.dat"
 #signing_key = "Schnorr Private Key"
 #fee_key = "Schnorr Private Key"
 #voting_key = "BLS Private Key"
-#automatic_activation = false
+automatic_reactivate = true

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -244,4 +244,4 @@ fee_key_file = "fee_key.dat"
 #signing_key = "Schnorr Private Key"
 #fee_key = "Schnorr Private Key"
 #voting_key = "BLS Private Key"
-#automatic_activation = true
+#automatic_activation = false

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -244,3 +244,4 @@ fee_key_file = "fee_key.dat"
 #signing_key = "Schnorr Private Key"
 #fee_key = "Schnorr Private Key"
 #voting_key = "BLS Private Key"
+#automatic_activation = true

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -469,4 +469,6 @@ pub struct ValidatorSettings {
     pub voting_key: Option<String>,
     pub fee_key_file: Option<String>,
     pub fee_key: Option<String>,
+    #[serde(default)]
+    pub automatic_activation: bool,
 }

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -470,5 +470,5 @@ pub struct ValidatorSettings {
     pub fee_key_file: Option<String>,
     pub fee_key: Option<String>,
     #[serde(default)]
-    pub automatic_activation: bool,
+    pub automatic_reactivate: bool,
 }

--- a/primitives/account/src/staking_contract/validator.rs
+++ b/primitives/account/src/staking_contract/validator.rs
@@ -27,20 +27,23 @@ use crate::{Account, AccountError, AccountsTrie, Receipt, StakingContract};
 /// 6. Delete: Deletes a validator (validator must have been inactive for the cooldown period).
 ///
 /// The actions can be summarized by the following state diagram:
-///        +--------+   retire    +----------+
-/// create |        +------------>+          | drop
-///+------>+ active |             | inactive +------>
-///        |        +<------------+          |
-///        +-+--+---+  reactivate +-----+----+
-///          |  ^                       ^
-///          |  |                       |
-///          |  | unpark                | automatically
-/// slashing |  |                       |
-///          |  |     +--------+        |
-///          |  +-----+        |        |
-///          |        | parked +--------+
-///          +------->+        |
-///                   +--------+
+///        +--------+          retire           +----------+
+/// create |        +-------------------------->+          | drop
+///+------>+ active |                           | inactive +------>
+///        |        +<-- -- -- -- -- -- -- -- --+          |
+///        +-+--+---+        reactivate         +-----+----+
+///          |  ^     (*optional) automatically       ^
+///          |  |                                     |
+///          |  | unpark                              | automatically
+/// slashing |  |                                     |
+///          |  |             +--------+              |
+///          |  +-------------+        |              |
+///          |                | parked +--------------+
+///          +--------------->+        |
+///                           +--------+
+///
+///         (*optional) The validator my be set to automatically reactivate itself upon incativation.
+///                     If this setting is not enabled the state change is triggered manually.
 ///
 /// Create, Update, Retire, Re-activate and Unpark are incoming transactions to the staking contract.
 /// Drop is an outgoing transaction from the staking contract.

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -12,6 +12,7 @@ use nimiq_rpc_interface::{
     consensus::{ConsensusInterface, ConsensusProxy},
     mempool::MempoolProxy,
     types::{BlockNumberOrHash, LogType, ValidityStartHeight},
+    validator::{ValidatorInterface, ValidatorProxy},
     wallet::{WalletInterface, WalletProxy},
 };
 
@@ -72,6 +73,32 @@ enum Command {
     /// Create, sign and send transactions.
     #[clap(name = "tx", flatten)]
     Transaction(TransactionCommand),
+
+    /// Changes the automatic reactivation setting for the current validator.
+    ValidatorSetAutoReactivate {
+        /// The validator setting for automatic reactivation to be applied.
+        #[clap(short, long)]
+        auto_reactivate_activate: bool,
+    },
+
+    /// Sends a transaction to inactivate this validator.
+    InactivateValidator {
+        /// The stake will be sent from this wallet.
+        wallet: Address,
+
+        /// The associated transaction fee to be payed from the sender_wallet. If absent it defaults to 0 NIM.
+        #[clap(short, long, default_value = "0")]
+        fee: Coin,
+
+        /// The block height from which on the unstake could be applied. The maximum amount of blocks the transaction is valid for is specified in `TRANSACTION_VALIDITY_WINDOW`.
+        /// If absent it defaults to the current block height at time of processing.
+        #[clap(short, long, default_value_t)]
+        validity_start_height: ValidityStartHeight,
+
+        /// Don't actually send the transaction, but output the transaction as hex string.
+        #[clap(long = "dry")]
+        dry: bool,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -264,6 +291,49 @@ impl Command {
                     println!("{:#?}", blocklog);
                 }
             }
+            Command::ValidatorSetAutoReactivate {
+                auto_reactivate_activate,
+            } => {
+                let result = client
+                    .validator
+                    .set_automatic_activation(auto_reactivate_activate)
+                    .await?;
+                println!("Auto reacivate set to {}", result);
+            }
+            Command::InactivateValidator {
+                wallet,
+                fee,
+                validity_start_height,
+                dry,
+            } => {
+                let validator_address = client.validator.get_address().await?;
+                let key_data = client.validator.get_signing_key().await?;
+                if dry {
+                    let tx = client
+                        .consensus
+                        .create_inactivate_validator_transaction(
+                            wallet,
+                            validator_address,
+                            key_data,
+                            fee,
+                            validity_start_height,
+                        )
+                        .await?;
+                    println!("{}", tx);
+                } else {
+                    let txid = client
+                        .consensus
+                        .send_inactivate_validator_transaction(
+                            wallet,
+                            validator_address,
+                            key_data,
+                            fee,
+                            validity_start_height,
+                        )
+                        .await?;
+                    println!("{}", txid);
+                }
+            }
 
             Command::Account(command) => {
                 match command {
@@ -430,6 +500,7 @@ pub struct Client {
     pub consensus: ConsensusProxy<ArcClient<WebsocketClient>>,
     pub mempool: MempoolProxy<ArcClient<WebsocketClient>>,
     pub wallet: WalletProxy<ArcClient<WebsocketClient>>,
+    pub validator: ValidatorProxy<ArcClient<WebsocketClient>>,
 }
 
 impl Client {
@@ -440,7 +511,8 @@ impl Client {
             blockchain: BlockchainProxy::new(client.clone()),
             consensus: ConsensusProxy::new(client.clone()),
             mempool: MempoolProxy::new(client.clone()),
-            wallet: WalletProxy::new(client),
+            wallet: WalletProxy::new(client.clone()),
+            validator: ValidatorProxy::new(client),
         })
     }
 }

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -13,8 +13,8 @@ pub trait ValidatorInterface {
 
     async fn get_voting_key(&mut self) -> Result<String, Self::Error>;
 
-    async fn set_automatic_activation(
+    async fn set_automatic_reactivation(
         &mut self,
-        automatic_activation: bool,
+        automatic_reactivate: bool,
     ) -> Result<bool, Self::Error>;
 }

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -12,4 +12,9 @@ pub trait ValidatorInterface {
     async fn get_signing_key(&mut self) -> Result<String, Self::Error>;
 
     async fn get_voting_key(&mut self) -> Result<String, Self::Error>;
+
+    async fn set_automatic_activation(
+        &mut self,
+        automatic_activation: bool,
+    ) -> Result<bool, Self::Error>;
 }

--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -46,7 +46,7 @@ pub trait WalletInterface {
         address: Address,
         passphrase: Option<String>,
         duration: Option<u64>,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<bool, Self::Error>;
 
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use async_trait::async_trait;
 use beserial::Serialize;
 
@@ -43,5 +45,15 @@ impl ValidatorInterface for ValidatorDispatcher {
                 .secret_key
                 .serialize_to_vec(),
         ))
+    }
+
+    async fn set_automatic_activation(
+        &mut self,
+        automatic_activation: bool,
+    ) -> Result<bool, Self::Error> {
+        self.validator
+            .automatic_activate
+            .store(automatic_activation, Ordering::Release);
+        Ok(automatic_activation)
     }
 }

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -47,13 +47,16 @@ impl ValidatorInterface for ValidatorDispatcher {
         ))
     }
 
-    async fn set_automatic_activation(
+    /// Updates the configuration setting to automatically reactivate our validator.
+    async fn set_automatic_reactivation(
         &mut self,
-        automatic_activation: bool,
+        automatic_reactivate: bool,
     ) -> Result<bool, Self::Error> {
         self.validator
-            .automatic_activate
-            .store(automatic_activation, Ordering::Release);
-        Ok(automatic_activation)
+            .automatic_reactivate
+            .store(automatic_reactivate, Ordering::Release);
+
+        log::debug!("Automatic reactivation set to {}.", automatic_reactivate);
+        Ok(automatic_reactivate)
     }
 }

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -101,7 +101,7 @@ impl WalletInterface for WalletDispatcher {
         address: Address,
         passphrase: Option<String>,
         _duration: Option<u64>,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         let passphrase = passphrase.unwrap_or_default();
         let account = self
             .wallet_store
@@ -114,7 +114,7 @@ impl WalletInterface for WalletDispatcher {
 
         self.unlocked_wallets.write().insert(unlocked_account);
 
-        Ok(())
+        Ok(true)
     }
 
     async fn is_account_unlocked(&mut self, address: Address) -> Result<bool, Error> {

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -26,6 +26,7 @@ pub fn seeded_rng(seed: u64) -> StdRng {
 pub async fn build_validator<N: TestNetwork + NetworkInterface>(
     peer_id: u64,
     validator_address: Address,
+    automatic_activate: bool,
     signing_key: SchnorrKeyPair,
     voting_key: BlsKeyPair,
     fee_key: SchnorrKeyPair,
@@ -46,6 +47,7 @@ where
             &consensus,
             validator_network,
             validator_address,
+            automatic_activate,
             signing_key,
             voting_key,
             fee_key,
@@ -100,6 +102,7 @@ where
         let (v, c) = build_validator(
             peer_ids[i] as u64,
             Address::from(&validator_keys[i]),
+            false,
             signing_keys[i].clone(),
             voting_keys[i].clone(),
             fee_keys[i].clone(),

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -26,7 +26,7 @@ pub fn seeded_rng(seed: u64) -> StdRng {
 pub async fn build_validator<N: TestNetwork + NetworkInterface>(
     peer_id: u64,
     validator_address: Address,
-    automatic_activate: bool,
+    automatic_reactivate: bool,
     signing_key: SchnorrKeyPair,
     voting_key: BlsKeyPair,
     fee_key: SchnorrKeyPair,
@@ -47,7 +47,7 @@ where
             &consensus,
             validator_network,
             validator_address,
-            automatic_activate,
+            automatic_reactivate,
             signing_key,
             voting_key,
             fee_key,

--- a/transaction-builder/src/recipient/staking_contract.rs
+++ b/transaction-builder/src/recipient/staking_contract.rs
@@ -97,6 +97,7 @@ impl StakingRecipientBuilder {
 
     /// This method allows to reactivate a validator. This reverts the inactivation of a validator
     /// and will result in the validator being considered for the validator selection again.
+    /// This is also used for the automatic reactivation of a validator if the setting is active.
     /// It needs to be signed by the key pair corresponding to the signing key.
     pub fn reactivate_validator(&mut self, validator_address: Address) -> &mut Self {
         self.data = Some(IncomingStakingTransactionData::ReactivateValidator {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -683,12 +683,16 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         .unwrap(); // TODO: Handle transaction creation error
         let tx_hash = reactivate_transaction.hash();
 
-        let cn = self.consensus.clone();
+        let mempool = self.mempool.clone();
         tokio::spawn(async move {
-            if cn.send_transaction(reactivate_transaction).await.is_err() {
-                error!("Failed to send reactivate transaction");
+            debug!("Adding reactivate transaction to mempool");
+            if mempool
+                .add_transaction(reactivate_transaction, Some(TxPriority::HighPriority))
+                .await
+                .is_err()
+            {
+                error!("Failed adding reactivate transaction into mempool");
             }
-            debug!("Sent reactivate transaction.");
         });
 
         ValidatorState::InactivityState {

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -46,6 +46,7 @@ async fn one_validator_can_create_micro_blocks() {
     let (validator, mut consensus1) = build_validator::<Network>(
         0,
         Address::from(&validator_key),
+        false,
         signing_key,
         voting_key,
         fee_key,


### PR DESCRIPTION
## What's in this pull request?
The automatic reactivation is introduced to the validator. This configuration is provided upon creation. It may also be changed using the rpc server commands. 
When a validator intentionally wants to inactivate itself, it should first ensure the automatic reactivation configuration is disabled, otherwise, the validator will send a reactivate transaction automatically.

Other changes:
- RPC server: added a command to inactivate the validator for testing purposes and to allow the feature to be fully used.
- RPC server: Corrected the unlock return type. It was giving a JSON parsing error.

## Pull request checklist
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.