### PR TITLE
RPC validator by address change stakers model

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -2,7 +2,6 @@
 ///!
 ///! [1] https://github.com/nimiq/core-js/wiki/JSON-RPC-API#common-data-types
 use std::{
-    collections::HashMap,
     fmt::{self, Display, Formatter},
     str::FromStr,
 };
@@ -672,13 +671,13 @@ pub struct Validator {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inactivity_flag: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stakers: Option<HashMap<Address, Coin>>,
+    pub stakers: Option<Vec<Staker>>,
 }
 
 impl Validator {
     pub fn from_validator(
         validator: &nimiq_account::Validator,
-        stakers: Option<HashMap<Address, Coin>>,
+        stakers: Option<Vec<Staker>>,
     ) -> Self {
         Validator {
             address: validator.address.clone(),

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -75,11 +75,9 @@ fn get_validator_by_address(
 
         for address in staker_addresses {
             let mut staker = StakingContract::get_staker(accounts_tree, &db_txn, &address).unwrap();
-            if !staker.balance.is_zero() {
-                // Delegation is unnecessary because the address is in the parent struct.
-                staker.delegation = None;
-                stakers_list.push(Staker::from_staker(&staker));
-            }
+            // Delegation is unnecessary because the address is in the parent struct.
+            staker.delegation = None;
+            stakers_list.push(Staker::from_staker(&staker));
         }
 
         stakers = Some(stakers_list);

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -74,8 +74,10 @@ fn get_validator_by_address(
         let mut stakers_list: Vec<Staker> = vec![];
 
         for address in staker_addresses {
-            let staker = StakingContract::get_staker(accounts_tree, &db_txn, &address).unwrap();
+            let mut staker = StakingContract::get_staker(accounts_tree, &db_txn, &address).unwrap();
             if !staker.balance.is_zero() {
+                // Delegation is unnecessary because the address is in the parent struct.
+                staker.delegation = None;
                 stakers_list.push(Staker::from_staker(&staker));
             }
         }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -71,16 +71,16 @@ fn get_validator_by_address(
         let staker_addresses =
             StakingContract::get_validator_stakers(accounts_tree, &db_txn, address);
 
-        let mut stakers_map = HashMap::new();
+        let mut stakers_list: Vec<Staker> = vec![];
 
         for address in staker_addresses {
             let staker = StakingContract::get_staker(accounts_tree, &db_txn, &address).unwrap();
             if !staker.balance.is_zero() {
-                stakers_map.insert(address, staker.balance);
+                stakers_list.push(Staker::from_staker(&staker));
             }
         }
 
-        stakers = Some(stakers_map);
+        stakers = Some(stakers_list);
     }
 
     let block_number = blockchain.block_number();


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Currently the `get_validator_by_address` RPC method returns a list of stakers something like this:

```
{
    ...
    stakers: {
        'NQ68 SN2E JS5Y 81K0 LFCD PDQM 1Q3U CFQC M3EB': 5019227844,
        'NQ84 9YK6 GGAD QDJG G36V DSC0 T5CE 70J0 35FA': 5345850189,
        'NQ26 9VB9 BYG6 P2A8 L9VX N5UD JNNN VDK2 3F1J': 2500452602,
        'NQ79 JA7K CKTA NA1Y 132A 27DR 8DD9 KSGK YPL1': 4280474570,
        'NQ06 LN8U XASN DULU 7E0E S5J0 X98Y 9XX3 2T01': 5279178854,
        'NQ37 M3DJ 4H9M J1G0 M8FT 8JRC PMR2 3KF8 BLVH': 2501716832,
        'NQ82 QAGH NMDY 05QN 6PEU A8Y1 295A 8EYS KVVL': 1026045298,
        'NQ56 XBC7 YNRV 426X RYJA 1D5Q A6BL J0NX 7C3N': 5447595387,
        'NQ77 2EHU RFRN PYMR NT2A DE7B QSQH R274 CVT6': 2076636785,
        'NQ95 BDRT AXGU YKLF DXPA SY49 XM61 RDYQ Q3CH': 5259736823,
        'NQ56 M3J9 N18Y 5KE4 PT1J YTAE Q0G8 31JE FFCB': 150280652,
        'NQ47 QHA5 04RC A2GF BSRL DVA8 NR65 3VNA ATL0': 31101308333,
        'NQ91 YJNG P54M J335 JRVQ QDLY 4CYJ X5K9 R8RT': 1000000,
        'NQ15 447K N4UD EFGG T7DE SX90 XLXH 87D9 SBNV': 15767555561,
        'NQ75 YK89 T1CP PP91 BT30 S4TA 9SAK R9C3 SX0V': 5291847757,
        'NQ53 CFRG QYYC HNFT XLKR RH6X H381 K1K2 K985': 4949844002,
        'NQ27 F703 GJUQ YBQ6 Y5B5 B3XS A56Q CDM6 S6NQ': 5271704262
    }
    ...
}
```

However to me this works a bit awkward in terms of usability since the key is a unique Nimiq address. Also the `stakers` object is not a list so you can't iterate over it easily. This PR proposes a different staker object as it re-uses the `Staker` struct defined elsewhere in the RPC server. It will look like this:

```
{
    ...
    stakers: [
        {
            "address": "NQ58 VL4Q ALUE CU9N NUEA 1NYU EY6P HDCA 7GUE",
            "balance": 100000000,
            "delegation": "NQ69 MH90 3M5H DFNU 8E84 53FX JSY6 XYQS N2CE"
        },
        {
            "address": "NQ58 VL4Q ALUE CU9N NUEA 1NYU EY6P HDCA 7GUE",
            "balance": 100000000,
            "delegation": "NQ69 MH90 3M5H DFNU 8E84 53FX JSY6 XYQS N2CE"
        }
    ]
    ...
}
```

With this approach you can more easy iterate over the list of stakers as it becomes a list and also access each property easier. The only point to notice here is that the `delegation` property is always the same per validator. A solution could be to set this value to `None` during the iteration and Serde will skip serialisation.