### PR TITLE
Update policy constants and change how they are initialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-utils",
  "num-traits",
+ "once_cell",
  "parking_lot 0.12.0",
  "regex",
  "serde",
@@ -3363,6 +3364,7 @@ name = "nimiq-test-log"
 version = "0.1.0"
 dependencies = [
  "nimiq-log",
+ "nimiq-primitives",
  "nimiq-test-log-proc-macro",
  "parking_lot 0.12.0",
  "tracing",

--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -7,7 +7,7 @@ use nimiq_blockchain::{AbstractBlockchain, Blockchain, ExtendedTransaction};
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::KeyPair as SchnorrKeyPair;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_transaction::Transaction;
 use rand::{CryptoRng, Rng, RngCore};
 
@@ -130,7 +130,7 @@ impl BlockProducer {
 
         let (history_root, _) = blockchain
             .history_store
-            .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
+            .add_to_history(&mut txn, Policy::epoch_at(block_number), &ext_txs)
             .expect("Failed to compute history root during block production.");
 
         // Not strictly necessary to drop the lock here, but sign as well as compress might be somewhat expensive
@@ -146,7 +146,7 @@ impl BlockProducer {
 
         // Create the micro block header.
         let header = MicroHeader {
-            version: policy::VERSION,
+            version: Policy::VERSION,
             block_number,
             timestamp,
             parent_hash,
@@ -239,7 +239,7 @@ impl BlockProducer {
         // We need several fields of this header in order to calculate the transactions and the
         // state.
         let mut header = MacroHeader {
-            version: policy::VERSION,
+            version: Policy::VERSION,
             block_number,
             round,
             timestamp,
@@ -279,7 +279,7 @@ impl BlockProducer {
 
         header.history_root = blockchain
             .history_store
-            .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
+            .add_to_history(&mut txn, Policy::epoch_at(block_number), &ext_txs)
             .expect("Failed to compute history root during block production.")
             .0;
 
@@ -298,7 +298,7 @@ impl BlockProducer {
         let lost_reward_set = blockchain.get_staking_contract().previous_lost_rewards();
 
         // If this is an election block, calculate the validator set for the next epoch.
-        let validators = if policy::is_election_block_at(blockchain.block_number() + 1) {
+        let validators = if Policy::is_election_block_at(blockchain.block_number() + 1) {
             Some(blockchain.next_validators(&header.seed))
         } else {
             None

--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -15,7 +15,7 @@ use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
 use nimiq_hash::Blake2sHash;
 use nimiq_keys::{KeyPair as SchnorrKeyPair, PrivateKey as SchnorrPrivateKey};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_utils::time::OffsetTime;
 
 use crate::BlockProducer;
@@ -71,7 +71,7 @@ impl TemporaryBlockProducer {
 
         let height = blockchain.block_number() + 1;
 
-        let block = if policy::is_macro_block_at(height) {
+        let block = if Policy::is_macro_block_at(height) {
             let macro_block_proposal = self.producer.next_macro_block_proposal(
                 &blockchain,
                 blockchain.time.now() + height as u64 * 1000,
@@ -84,7 +84,7 @@ impl TemporaryBlockProducer {
 
             // Get validator set and make sure it exists.
             let validators = blockchain
-                .get_validators_for_epoch(policy::epoch_at(blockchain.block_number() + 1), None);
+                .get_validators_for_epoch(Policy::epoch_at(blockchain.block_number() + 1), None);
             assert!(validators.is_some());
 
             Block::Macro(TemporaryBlockProducer::finalize_macro_block(
@@ -102,7 +102,7 @@ impl TemporaryBlockProducer {
         } else if skip_block {
             Block::Micro(self.producer.next_micro_block(
                 &blockchain,
-                blockchain.head().timestamp() + policy::BLOCK_PRODUCER_TIMEOUT,
+                blockchain.head().timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT,
                 vec![],
                 vec![],
                 extra_data,
@@ -150,11 +150,11 @@ impl TemporaryBlockProducer {
         let signature = AggregateSignature::from_signatures(&[keypair
             .secret_key
             .sign(&vote)
-            .multiply(policy::SLOTS)]);
+            .multiply(Policy::SLOTS)]);
 
         // create and populate signers BitSet.
         let mut signers = BitSet::new();
-        for i in 0..policy::SLOTS {
+        for i in 0..Policy::SLOTS {
             signers.insert(i as usize);
         }
 
@@ -190,9 +190,9 @@ impl TemporaryBlockProducer {
 
         let signature = AggregateSignature::from_signatures(&[skip_block_info
             .signature
-            .multiply(policy::SLOTS)]);
+            .multiply(Policy::SLOTS)]);
         let mut signers = BitSet::new();
-        for i in 0..policy::SLOTS {
+        for i in 0..Policy::SLOTS {
             signers.insert(i as usize);
         }
 

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -16,7 +16,7 @@ use nimiq_keys::{
     Address, KeyPair as SchnorrKeyPair, PrivateKey as SchnorrPrivateKey, SecureGenerate,
 };
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_test_utils::blockchain::{
     fill_micro_blocks, fill_micro_blocks_with_txns, sign_macro_block, signing_key, voting_key,
@@ -160,7 +160,7 @@ fn it_can_produce_election_blocks() {
     let producer = BlockProducer::new(signing_key(), voting_key());
 
     // push micro and macro blocks until the 3rd epoch is reached
-    while policy::epoch_at(blockchain.read().block_number()) < 2 {
+    while Policy::epoch_at(blockchain.read().block_number()) < 2 {
         fill_micro_blocks(&producer, &blockchain);
 
         let bc = blockchain.upgradable_read();
@@ -854,7 +854,7 @@ fn it_can_consume_all_validator_deposit() {
         address.clone(),
         &key_pair,
         Coin::from_u64_unchecked(100),
-        Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT),
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
         1,
         NetworkId::UnitAlbatross,
     )
@@ -893,7 +893,7 @@ fn it_can_consume_all_validator_deposit() {
 
         assert_eq!(
             validator.deposit,
-            Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT - 100)
+            Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT - 100)
         );
     }
 
@@ -903,8 +903,8 @@ fn it_can_consume_all_validator_deposit() {
     let invalid_tx = TransactionBuilder::new_delete_validator(
         address.clone(),
         &key_pair,
-        Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT - 100),
-        Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT),
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT - 100),
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
         1,
         NetworkId::UnitAlbatross,
     )
@@ -985,7 +985,7 @@ fn it_can_revert_failed_delete_validator() {
         address.clone(),
         &key_pair,
         Coin::from_u64_unchecked(100),
-        Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT),
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
         1,
         NetworkId::UnitAlbatross,
     )
@@ -1024,7 +1024,7 @@ fn it_can_revert_failed_delete_validator() {
 
         assert_eq!(
             validator.deposit,
-            Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT - 100)
+            Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT - 100)
         );
         //Now the validator should be inactive because of the failing txn..
         assert_eq!(validator.inactivity_flag, Some(1));
@@ -1049,7 +1049,7 @@ fn it_can_revert_failed_delete_validator() {
 
     assert_eq!(
         validator.deposit,
-        Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT)
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT)
     );
 }
 

--- a/blockchain/src/abstract_blockchain.rs
+++ b/blockchain/src/abstract_blockchain.rs
@@ -2,7 +2,7 @@ use nimiq_block::{Block, BlockType, MacroBlock};
 use nimiq_database::Transaction;
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::{Validator, Validators};
 
 use crate::{Blockchain, ChainInfo};
@@ -61,7 +61,7 @@ pub trait AbstractBlockchain {
             Some(n) => n,
         };
 
-        if policy::is_macro_block_at(last_block_number + 1) {
+        if Policy::is_macro_block_at(last_block_number + 1) {
             BlockType::Macro
         } else {
             BlockType::Micro

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -5,7 +5,7 @@ use nimiq_account::Accounts;
 use nimiq_account::BlockLog;
 use nimiq_block::{Block, BlockError::TransactionExecutionMismatch, SkipBlockInfo};
 use nimiq_database::WriteTransaction;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 /// Implements methods to handle the accounts.
 impl Blockchain {
@@ -54,7 +54,7 @@ impl Blockchain {
 
                 let hs_result = self.history_store.add_to_history(
                     txn,
-                    policy::epoch_at(macro_block.header.block_number),
+                    Policy::epoch_at(macro_block.header.block_number),
                     &ext_txs,
                 );
 
@@ -125,7 +125,7 @@ impl Blockchain {
 
                 let hs_result = self.history_store.add_to_history(
                     txn,
-                    policy::epoch_at(micro_block.header.block_number),
+                    Policy::epoch_at(micro_block.header.block_number),
                     &ext_txs,
                 );
 
@@ -207,7 +207,7 @@ impl Blockchain {
 
                 let hs_result = self.history_store.remove_partial_history(
                     txn,
-                    policy::epoch_at(micro_block.header.block_number),
+                    Policy::epoch_at(micro_block.header.block_number),
                     num_txs,
                 );
 

--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -7,7 +7,7 @@ use nimiq_genesis::NetworkInfo;
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 use nimiq_utils::observer::Notifier;
 use nimiq_utils::time::OffsetTime;
@@ -144,7 +144,7 @@ impl Blockchain {
         // Load macro chain from store.
         let macro_chain_info = chain_store
             .get_chain_info_at(
-                policy::last_macro_block(main_chain.head.block_number()),
+                Policy::last_macro_block(main_chain.head.block_number()),
                 true,
                 None,
             )
@@ -160,7 +160,7 @@ impl Blockchain {
         // Load election macro chain from store.
         let election_chain_info = chain_store
             .get_chain_info_at(
-                policy::last_election_block(main_chain.head.block_number()),
+                Policy::last_election_block(main_chain.head.block_number()),
                 true,
                 None,
             )

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -4,7 +4,7 @@ use nimiq_block::{ForkProof, MacroHeader, SkipBlockInfo};
 use nimiq_database as db;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::SlashedSlot;
 use nimiq_vrf::{AliasMethod, VrfUseCase};
 
@@ -27,7 +27,7 @@ impl Blockchain {
         inherents.append(&mut self.finalize_previous_batch(state, header));
 
         // If this block is an election block, we also need to finalize the epoch.
-        if policy::is_election_block_at(header.block_number) {
+        if Policy::is_election_block_at(header.block_number) {
             // On election the previous epoch needs to be finalized.
             // We can rely on `state` here, since we cannot revert macro blocks.
             inherents.push(self.finalize_previous_epoch());
@@ -139,13 +139,13 @@ impl Blockchain {
         let staking_contract = self.get_staking_contract();
 
         // Special case for first batch: Batch 0 is finalized by definition.
-        if policy::batch_at(macro_header.block_number) - 1 == 0 {
+        if Policy::batch_at(macro_header.block_number) - 1 == 0 {
             return vec![];
         }
 
         // Get validator slots
         // NOTE: Fields `current_slots` and `previous_slots` are expected to always be set.
-        let validator_slots = if policy::first_batch_of_epoch(macro_header.block_number) {
+        let validator_slots = if Policy::first_batch_of_epoch(macro_header.block_number) {
             state
                 .previous_slots
                 .as_ref()
@@ -178,8 +178,8 @@ impl Blockchain {
         let reward_pot = block_reward + tx_fees;
 
         // Distribute reward between all slots and calculate the remainder
-        let slot_reward = reward_pot / policy::SLOTS as u64;
-        let remainder = reward_pot % policy::SLOTS as u64;
+        let slot_reward = reward_pot / Policy::SLOTS as u64;
+        let remainder = reward_pot % Policy::SLOTS as u64;
 
         // The first slot number of the current validator
         let mut first_slot_number = 0;

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -3,7 +3,7 @@ use nimiq_block::Block;
 use nimiq_database::Transaction;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_utils::observer::{Listener, ListenerHandle};
 #[cfg(feature = "metrics")]
 use std::sync::Arc;
@@ -81,7 +81,7 @@ impl Blockchain {
 
     pub fn get_account(&self, address: &Address) -> Option<Account> {
         // TODO: Find a better place for this differentiation, it should be in a more general location.
-        let key = if *address == policy::STAKING_CONTRACT_ADDRESS {
+        let key = if *address == Policy::STAKING_CONTRACT_ADDRESS {
             StakingContract::get_key_staking_contract()
         } else {
             KeyNibbles::from(address)
@@ -125,12 +125,12 @@ impl Blockchain {
     ) -> bool {
         let max_block_number = self
             .block_number()
-            .saturating_sub(policy::TRANSACTION_VALIDITY_WINDOW);
+            .saturating_sub(Policy::TRANSACTION_VALIDITY_WINDOW);
         self.tx_in_validity_window(tx_hash, max_block_number, txn_opt)
     }
 
     pub fn staking_contract_address(&self) -> Address {
-        policy::STAKING_CONTRACT_ADDRESS
+        Policy::STAKING_CONTRACT_ADDRESS
     }
 
     #[cfg(feature = "metrics")]

--- a/blockchain/src/chain_info.rs
+++ b/blockchain/src/chain_info.rs
@@ -9,7 +9,7 @@ use nimiq_block::{
 use nimiq_database::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 /// Struct that, for each block, keeps information relative to the chain the block is on.
 #[derive(Clone, Debug)]
@@ -48,7 +48,7 @@ impl ChainInfo {
 
         // Reset the transaction fee accumulator if this is the first block of a batch. Otherwise,
         // just add the transactions fees of this block to the accumulator.
-        let cum_tx_fees = if policy::is_macro_block_at(prev_info.head.block_number()) {
+        let cum_tx_fees = if Policy::is_macro_block_at(prev_info.head.block_number()) {
             block.sum_transaction_fees()
         } else {
             prev_info.cum_tx_fees + block.sum_transaction_fees()
@@ -72,13 +72,13 @@ impl ChainInfo {
         // was an election macro block or it was a checkpoint macro block and such checkpoint macro
         // block was not pruned.
         // Also set prunable to `false` if we exceeded the policy::HISTORY_CHUNKS_MAX_SIZE
-        if policy::is_election_block_at(prev_info.head.block_number())
-            || (policy::is_macro_block_at(prev_info.head.block_number()) && !prev_info.prunable)
+        if Policy::is_election_block_at(prev_info.head.block_number())
+            || (Policy::is_macro_block_at(prev_info.head.block_number()) && !prev_info.prunable)
         {
             self.cum_ext_tx_size = block_ext_tx_size;
             self.prunable = true;
-        } else if policy::is_macro_block_at(self.head.block_number())
-            && prev_info.cum_ext_tx_size + block_ext_tx_size > policy::HISTORY_CHUNKS_MAX_SIZE
+        } else if Policy::is_macro_block_at(self.head.block_number())
+            && prev_info.cum_ext_tx_size + block_ext_tx_size > Policy::HISTORY_CHUNKS_MAX_SIZE
         {
             self.cum_ext_tx_size = prev_info.cum_ext_tx_size + block_ext_tx_size;
             self.prunable = false;

--- a/blockchain/src/history/extended_transaction.rs
+++ b/blockchain/src/history/extended_transaction.rs
@@ -9,7 +9,7 @@ use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_mmr::hash::Hash as MMRHash;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::COINBASE_ADDRESS;
+use nimiq_primitives::policy::Policy;
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_transaction::Transaction as BlockchainTransaction;
 
@@ -148,7 +148,7 @@ impl ExtendedTransaction {
             ExtTxData::Inherent(x) => {
                 if x.ty == InherentType::Reward {
                     let txn = BlockchainTransaction::new_basic(
-                        COINBASE_ADDRESS,
+                        Policy::COINBASE_ADDRESS,
                         x.target,
                         x.value,
                         Coin::ZERO,

--- a/blockchain/src/reward.rs
+++ b/blockchain/src/reward.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use nimiq_block::MacroHeader;
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 /// Parses the genesis supply and timestamp from the genesis block. We require both values to
 /// calculate the block rewards.
@@ -41,10 +41,10 @@ pub fn block_reward_for_batch(
 
     let genesis_supply_u64 = u64::from(genesis_supply);
 
-    let prev_supply = policy::supply_at(genesis_supply_u64, genesis_timestamp, previous_timestamp);
+    let prev_supply = Policy::supply_at(genesis_supply_u64, genesis_timestamp, previous_timestamp);
 
     let current_supply =
-        policy::supply_at(genesis_supply_u64, genesis_timestamp, current_timestamp);
+        Policy::supply_at(genesis_supply_u64, genesis_timestamp, current_timestamp);
 
     Coin::from_u64_unchecked(current_supply - prev_supply)
 }

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -6,7 +6,7 @@ use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushResult};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
-use nimiq_primitives::policy::{BATCHES_PER_EPOCH, BLOCKS_PER_BATCH, BLOCKS_PER_EPOCH};
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_test_utils::blockchain::{
     fill_micro_blocks_with_txns, produce_macro_blocks, produce_macro_blocks_with_txns, signing_key,
@@ -21,7 +21,7 @@ use nimiq_utils::time::OffsetTime;
 fn history_sync_works() {
     // The minimum number of macro blocks necessary so that we have two election blocks and a few
     // checkpoint blocks to push.
-    let num_macro_blocks = (2 * BATCHES_PER_EPOCH + 1) as usize;
+    let num_macro_blocks = (2 * Policy::batches_per_epoch() + 1) as usize;
 
     let time = Arc::new(OffsetTime::new());
 
@@ -40,14 +40,14 @@ fn history_sync_works() {
     // Get the election blocks and corresponding history tree transactions.
     let election_block_1 = blockchain
         .chain_store
-        .get_block_at(BLOCKS_PER_EPOCH, true, None)
+        .get_block_at(Policy::blocks_per_epoch(), true, None)
         .unwrap();
 
     let election_txs_1 = blockchain.history_store.get_epoch_transactions(1, None);
 
     let election_block_2 = blockchain
         .chain_store
-        .get_block_at(2 * BLOCKS_PER_EPOCH, true, None)
+        .get_block_at(2 * Policy::blocks_per_epoch(), true, None)
         .unwrap();
 
     let election_txs_2 = blockchain.history_store.get_epoch_transactions(2, None);
@@ -55,13 +55,17 @@ fn history_sync_works() {
     // Get the checkpoint blocks and corresponding history tree transactions.
     let checkpoint_block_2_1 = blockchain
         .chain_store
-        .get_block_at(BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH, true, None)
+        .get_block_at(
+            Policy::blocks_per_epoch() + Policy::blocks_per_batch(),
+            true,
+            None,
+        )
         .unwrap();
 
     let mut checkpoint_txs_2_1 = vec![];
 
     for ext_tx in &election_txs_2 {
-        if ext_tx.block_number > BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH {
+        if ext_tx.block_number > Policy::blocks_per_epoch() + Policy::blocks_per_batch() {
             break;
         }
 
@@ -70,13 +74,17 @@ fn history_sync_works() {
 
     let checkpoint_block_2_3 = blockchain
         .chain_store
-        .get_block_at(BLOCKS_PER_EPOCH + 3 * BLOCKS_PER_BATCH, true, None)
+        .get_block_at(
+            Policy::blocks_per_epoch() + 3 * Policy::blocks_per_batch(),
+            true,
+            None,
+        )
         .unwrap();
 
     let mut checkpoint_txs_2_3 = vec![];
 
     for ext_tx in &election_txs_2 {
-        if ext_tx.block_number > BLOCKS_PER_EPOCH + 3 * BLOCKS_PER_BATCH {
+        if ext_tx.block_number > Policy::blocks_per_epoch() + 3 * Policy::blocks_per_batch() {
             break;
         }
 
@@ -85,7 +93,11 @@ fn history_sync_works() {
 
     let checkpoint_block_3_1 = blockchain
         .chain_store
-        .get_block_at(2 * BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH, true, None)
+        .get_block_at(
+            2 * Policy::blocks_per_epoch() + Policy::blocks_per_batch(),
+            true,
+            None,
+        )
         .unwrap();
 
     let checkpoint_txs_3_1 = blockchain.history_store.get_epoch_transactions(3, None);
@@ -151,7 +163,7 @@ fn history_sync_works() {
 fn history_sync_works_with_micro_blocks() {
     // The minimum number of macro blocks necessary so that we have two election blocks and a few
     // checkpoint blocks to push.
-    let num_macro_blocks = (2 * BATCHES_PER_EPOCH + 2) as usize;
+    let num_macro_blocks = (2 * Policy::batches_per_epoch() + 2) as usize;
 
     let time = Arc::new(OffsetTime::new());
 
@@ -171,14 +183,14 @@ fn history_sync_works_with_micro_blocks() {
     // Get the election blocks and corresponding history tree transactions.
     let election_block_1 = blockchain
         .chain_store
-        .get_block_at(BLOCKS_PER_EPOCH, true, None)
+        .get_block_at(Policy::blocks_per_epoch(), true, None)
         .unwrap();
 
     let election_txs_1 = blockchain.history_store.get_epoch_transactions(1, None);
 
     let election_block_2 = blockchain
         .chain_store
-        .get_block_at(2 * BLOCKS_PER_EPOCH, true, None)
+        .get_block_at(2 * Policy::blocks_per_epoch(), true, None)
         .unwrap();
 
     let election_txs_2 = blockchain.history_store.get_epoch_transactions(2, None);
@@ -186,13 +198,17 @@ fn history_sync_works_with_micro_blocks() {
     // Get the checkpoint blocks and corresponding history tree transactions.
     let checkpoint_block_2_1 = blockchain
         .chain_store
-        .get_block_at(BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH, true, None)
+        .get_block_at(
+            Policy::blocks_per_epoch() + Policy::blocks_per_batch(),
+            true,
+            None,
+        )
         .unwrap();
 
     let mut checkpoint_txs_2_1 = vec![];
 
     for ext_tx in &election_txs_2 {
-        if ext_tx.block_number > BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH {
+        if ext_tx.block_number > Policy::blocks_per_epoch() + Policy::blocks_per_batch() {
             break;
         }
 
@@ -201,7 +217,11 @@ fn history_sync_works_with_micro_blocks() {
 
     let checkpoint_block_3_2 = blockchain
         .chain_store
-        .get_block_at(2 * BLOCKS_PER_EPOCH + 2 * BLOCKS_PER_BATCH, true, None)
+        .get_block_at(
+            2 * Policy::blocks_per_epoch() + 2 * Policy::blocks_per_batch(),
+            true,
+            None,
+        )
         .unwrap();
 
     let checkpoint_txs_3_2 = blockchain.history_store.get_epoch_transactions(3, None);
@@ -209,22 +229,26 @@ fn history_sync_works_with_micro_blocks() {
     // Get the micro blocks.
     let mut micro_blocks_2_2 = vec![];
 
-    for i in 1..BLOCKS_PER_BATCH {
+    for i in 1..Policy::blocks_per_batch() {
         micro_blocks_2_2.push(
             blockchain
                 .chain_store
-                .get_block_at(BLOCKS_PER_EPOCH + BLOCKS_PER_BATCH + i, true, None)
+                .get_block_at(
+                    Policy::blocks_per_epoch() + Policy::blocks_per_batch() + i,
+                    true,
+                    None,
+                )
                 .unwrap(),
         )
     }
 
     let mut micro_blocks_3_1 = vec![];
 
-    for i in 1..BLOCKS_PER_BATCH {
+    for i in 1..Policy::blocks_per_batch() {
         micro_blocks_3_1.push(
             blockchain
                 .chain_store
-                .get_block_at(2 * BLOCKS_PER_EPOCH + i, true, None)
+                .get_block_at(2 * Policy::blocks_per_epoch() + i, true, None)
                 .unwrap(),
         )
     }
@@ -304,10 +328,13 @@ fn history_sync_works_with_diverging_history() {
         Blockchain::new(env, NetworkId::UnitAlbatross, time).unwrap(),
     ));
 
-    let num_macro_blocks = BATCHES_PER_EPOCH as usize;
+    let num_macro_blocks = Policy::batches_per_epoch() as usize;
     let producer = BlockProducer::new(signing_key(), voting_key());
     produce_macro_blocks_with_txns(&producer, &blockchain1, num_macro_blocks, 2, 0);
-    assert_eq!(blockchain1.read().block_number(), BLOCKS_PER_EPOCH);
+    assert_eq!(
+        blockchain1.read().block_number(),
+        Policy::blocks_per_epoch()
+    );
 
     // Produce some micro blocks (with a different history) in blockchain2.
     let env = VolatileEnvironment::new(10).unwrap();
@@ -316,13 +343,16 @@ fn history_sync_works_with_diverging_history() {
         Blockchain::new(env, NetworkId::UnitAlbatross, time).unwrap(),
     ));
     fill_micro_blocks_with_txns(&producer, &blockchain2, 3, 1);
-    assert_eq!(blockchain2.read().block_number(), BLOCKS_PER_BATCH - 1);
+    assert_eq!(
+        blockchain2.read().block_number(),
+        Policy::blocks_per_batch() - 1
+    );
 
     // Get the election block and corresponding history tree transactions from blockchain1.
     let blockchain = blockchain1.read();
     let election_block_1 = blockchain
         .chain_store
-        .get_block_at(BLOCKS_PER_EPOCH, true, None)
+        .get_block_at(Policy::blocks_per_epoch(), true, None)
         .unwrap();
     let election_txs_1 = blockchain.history_store.get_epoch_transactions(1, None);
 

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -7,7 +7,7 @@ use nimiq_hash::{Blake2bHasher, Hasher};
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::SlashedSlot;
 use nimiq_test_log::test;
 use nimiq_utils::time::OffsetTime;
@@ -85,7 +85,7 @@ fn it_can_create_batch_finalization_inherents() {
             &mut txn,
             &[],
             &[slash_inherent],
-            policy::BLOCKS_PER_BATCH + 1,
+            Policy::blocks_per_batch() + 1,
             0,
         )
         .is_ok());
@@ -93,7 +93,7 @@ fn it_can_create_batch_finalization_inherents() {
 
     let inherents = blockchain.finalize_previous_batch(blockchain.state(), &macro_header);
     assert_eq!(inherents.len(), 3);
-    let one_slot_reward = 875 / policy::SLOTS as u64;
+    let one_slot_reward = 875 / Policy::SLOTS as u64;
     let mut got_reward = false;
     let mut got_slash = false;
     let mut got_finalize_batch = false;

--- a/blockchain/tests/mod.rs
+++ b/blockchain/tests/mod.rs
@@ -7,7 +7,7 @@ use nimiq_blockchain::{AbstractBlockchain, Blockchain};
 use nimiq_blockchain::{ForkEvent, PushResult};
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_test_utils::blockchain::{signing_key, voting_key};
 use nimiq_utils::time::OffsetTime;
@@ -135,13 +135,13 @@ fn micro_block_works_after_macro_block() {
     let temp_producer = TemporaryBlockProducer::new();
 
     // apply an entire batch including macro block on view_number/round_number zero
-    for _ in 0..policy::BLOCKS_PER_BATCH {
+    for _ in 0..Policy::blocks_per_batch() {
         temp_producer.next_block(vec![], false);
     }
     // make sure we are at the beginning of the batch and all block were applied
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BLOCKS_PER_BATCH
+        Policy::blocks_per_batch()
     );
 
     // Test if a micro block can be rebranched immediately after
@@ -155,24 +155,24 @@ fn micro_block_works_after_macro_block() {
     // make sure this was an extend
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BLOCKS_PER_BATCH + 1
+        Policy::blocks_per_batch() + 1
     );
     // and rebranch it to block the chain with only one skip block
     temp_producer.push(rebranch).unwrap();
     // make sure this was a rebranch
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BLOCKS_PER_BATCH + 1
+        Policy::blocks_per_batch() + 1
     );
 
     // apply the rest of the batch including macro block on view_number/round_number one
-    for _ in 0..policy::BLOCKS_PER_BATCH - 1 {
+    for _ in 0..Policy::blocks_per_batch() - 1 {
         temp_producer.next_block(vec![], false);
     }
     // make sure we are at the beginning of the batch
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BLOCKS_PER_BATCH * 2
+        Policy::blocks_per_batch() * 2
     );
 
     // Test if a micro block can be rebranched immediately after
@@ -189,7 +189,7 @@ fn micro_block_works_after_macro_block() {
 
     assert_eq!(
         temp_producer.blockchain.read().block_number(),
-        policy::BLOCKS_PER_BATCH * 2 + 1
+        Policy::blocks_per_batch() * 2 + 1
     );
 }
 
@@ -274,7 +274,7 @@ fn it_can_rebranch_to_inferior_macro_block() {
     assert_eq!(producer2.push(inferior), Ok(PushResult::Ignored));
 
     // Complete a batch
-    for _ in 1..policy::BLOCKS_PER_BATCH - 1 {
+    for _ in 1..Policy::blocks_per_batch() - 1 {
         let inferior = producer1.next_block(vec![], false);
         producer2.next_block(vec![], false);
         assert_eq!(producer2.push(inferior), Ok(PushResult::Ignored));

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -6,7 +6,8 @@ use nimiq_block_production::test_utils::TemporaryBlockProducer;
 use nimiq_blockchain::PushError::InvalidBlock;
 use nimiq_blockchain::{PushError, PushResult};
 use nimiq_hash::Blake2bHash;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
+use nimiq_test_log::test;
 use nimiq_vrf::VrfSeed;
 
 pub fn expect_push_micro_block(config: BlockConfig, expected_res: Result<PushResult, PushError>) {
@@ -163,7 +164,7 @@ fn push_rebranch_across_epochs(config: BlockConfig) {
     assert_eq!(temp_producer2.push(ancestor), Ok(PushResult::Extended));
 
     // progress the chain across an epoch boundary.
-    for _ in 0..policy::BLOCKS_PER_EPOCH {
+    for _ in 0..Policy::blocks_per_epoch() {
         temp_producer1.next_block(vec![], false);
     }
 
@@ -182,7 +183,7 @@ fn push_rebranch_across_epochs(config: BlockConfig) {
 fn simply_push_macro_block(config: &BlockConfig, expected_res: &Result<PushResult, PushError>) {
     let temp_producer = TemporaryBlockProducer::new();
 
-    for _ in 0..policy::BLOCKS_PER_BATCH - 1 {
+    for _ in 0..Policy::blocks_per_batch() - 1 {
         let block = temp_producer.next_block(vec![], false);
         temp_producer.push(block.clone()).unwrap();
     }
@@ -227,7 +228,7 @@ fn it_works_with_valid_blocks() {
 fn it_validates_version() {
     expect_push_micro_block(
         BlockConfig {
-            version: Some(policy::VERSION - 1),
+            version: Some(Policy::VERSION - 1),
             ..Default::default()
         },
         Err(InvalidBlock(BlockError::UnsupportedVersion)),

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -11,8 +11,10 @@ use nimiq_collections::bitset::BitSet;
 use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis::NetworkId;
 use nimiq_keys::{Address, PublicKey};
-use nimiq_primitives::policy;
-use nimiq_primitives::slots::{Validator, Validators};
+use nimiq_primitives::{
+    policy::Policy,
+    slots::{Validator, Validators},
+};
 use nimiq_test_log::test;
 use nimiq_utils::time::OffsetTime;
 use nimiq_vrf::VrfEntropy;
@@ -42,10 +44,10 @@ fn test_skip_block_single_signature() {
         0,
     )
     .signature
-    .multiply(policy::SLOTS)]);
+    .multiply(Policy::SLOTS)]);
     // SkipBlockProof is just a MultiSignature, but for ease of getting there an individual Signature is created first.
     let mut signers = BitSet::new();
-    for i in 0..policy::SLOTS {
+    for i in 0..Policy::SLOTS {
         signers.insert(i as usize);
     }
 
@@ -58,7 +60,7 @@ fn test_skip_block_single_signature() {
         Address::default(),
         LazyPublicKey::from(key_pair.public_key),
         PublicKey::from([0u8; 32]),
-        (0, policy::SLOTS),
+        (0, Policy::SLOTS),
     )]);
 
     assert!(skip_block_proof.verify(&skip_block_info, &validators));
@@ -98,11 +100,11 @@ fn test_replay() {
     let signature = AggregateSignature::from_signatures(&[key_pair
         .secret_key
         .sign(&vote)
-        .multiply(policy::SLOTS)]);
+        .multiply(Policy::SLOTS)]);
 
     // create and populate signers BitSet.
     let mut signers = BitSet::new();
-    for i in 0..policy::SLOTS {
+    for i in 0..Policy::SLOTS {
         signers.insert(i as usize);
     }
 
@@ -128,11 +130,11 @@ fn test_replay() {
     let signature = AggregateSignature::from_signatures(&[key_pair
         .secret_key
         .sign(&vote)
-        .multiply(policy::SLOTS)]);
+        .multiply(Policy::SLOTS)]);
 
     // create and populate signers BitSet.
     let mut signers = BitSet::new();
-    for i in 0..policy::SLOTS {
+    for i in 0..Policy::SLOTS {
         signers.insert(i as usize);
     }
 

--- a/consensus/src/sync/block_queue.rs
+++ b/consensus/src/sync/block_queue.rs
@@ -17,7 +17,7 @@ use nimiq_blockchain::{Blockchain, PushError, PushResult};
 use nimiq_hash::Blake2bHash;
 use nimiq_macros::store_waker;
 use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId, Topic};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 use crate::sync::request_component::RequestComponentEvent;
 
@@ -57,8 +57,8 @@ pub struct BlockQueueConfig {
 impl Default for BlockQueueConfig {
     fn default() -> Self {
         Self {
-            buffer_max: 4 * policy::BLOCKS_PER_BATCH as usize,
-            window_max: 2 * policy::BLOCKS_PER_BATCH,
+            buffer_max: 4 * Policy::blocks_per_batch() as usize,
+            window_max: 2 * Policy::blocks_per_batch(),
         }
     }
 }
@@ -124,7 +124,7 @@ impl<N: Network, TReq: RequestComponent<N>> Inner<N, TReq> {
         drop(blockchain);
 
         // Check if a macro block boundary was passed. If so prune the block buffer.
-        let macro_height = policy::last_macro_block(head_height);
+        let macro_height = Policy::last_macro_block(head_height);
         if macro_height > self.current_macro_height {
             self.current_macro_height = macro_height;
             self.prune_buffer();
@@ -227,7 +227,7 @@ impl<N: Network, TReq: RequestComponent<N>> Inner<N, TReq> {
         let blockchain = self.blockchain.read();
         let head_hash = blockchain.head_hash();
         let head_height = blockchain.block_number();
-        let macro_height = policy::last_macro_block(head_height);
+        let macro_height = Policy::last_macro_block(head_height);
 
         log::debug!(
             block_number,
@@ -601,7 +601,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockQueue<N, TReq> {
         block_stream: BlockStream<N>,
         bls_cache: Arc<Mutex<PublicKeyCache>>,
     ) -> Self {
-        let current_macro_height = policy::last_macro_block(blockchain.read().block_number());
+        let current_macro_height = Policy::last_macro_block(blockchain.read().block_number());
         Self {
             block_stream,
             inner: Inner {

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -19,7 +19,7 @@ use nimiq_blockchain::{
 };
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network, request::RequestError};
-use nimiq_primitives::{policy, slots::Validators};
+use nimiq_primitives::{policy::Policy, slots::Validators};
 use nimiq_utils::math::CeilingDiv;
 
 use crate::messages::{BatchSetInfo, HistoryChunk, RequestBatchSet, RequestHistoryChunk};
@@ -123,7 +123,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             peers,
             epoch_ids,
             first_epoch_number,
-            first_epoch_number * policy::BLOCKS_PER_EPOCH as usize,
+            first_epoch_number * Policy::blocks_per_epoch() as usize,
         )
     }
 
@@ -781,7 +781,7 @@ impl<TNetwork: Network + 'static> std::fmt::Debug for SyncCluster<TNetwork> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("SyncCluster");
         dbg.field("id", &self.id);
-        if policy::is_election_block_at(self.first_block_number as u32) {
+        if Policy::is_election_block_at(self.first_block_number as u32) {
             // Epoch cluster
             let last_epoch_number =
                 self.first_epoch_number + self.epoch_ids.len().saturating_sub(1);

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain};
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network, peer::CloseReason, request::RequestError};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 use crate::messages::{MacroChain, RequestMacroChain};
 use crate::sync::history::cluster::{SyncCluster, SyncClusterResult};
@@ -67,9 +67,9 @@ impl<TNetwork: Network> HistorySync<TNetwork> {
                 //  * is a non-election macro block
                 if let Some(checkpoint) = &macro_chain.checkpoint {
                     let checkpoint_epoch = epoch_number + epoch_ids.len() as u32 + 1;
-                    if policy::epoch_at(checkpoint.block_number) != checkpoint_epoch
-                        || !policy::is_macro_block_at(checkpoint.block_number)
-                        || policy::is_election_block_at(checkpoint.block_number)
+                    if Policy::epoch_at(checkpoint.block_number) != checkpoint_epoch
+                        || !Policy::is_macro_block_at(checkpoint.block_number)
+                        || Policy::is_election_block_at(checkpoint.block_number)
                     {
                         // Peer provided an invalid checkpoint block number, close connection.
                         log::error!(
@@ -554,7 +554,7 @@ mod tests {
     use nimiq_network_interface::network::Network;
     use nimiq_network_mock::{MockHub, MockNetwork, MockPeerId};
     use nimiq_primitives::networks::NetworkId;
-    use nimiq_primitives::policy;
+    use nimiq_primitives::policy::Policy;
     use nimiq_test_log::test;
     use nimiq_utils::time::OffsetTime;
 
@@ -592,8 +592,8 @@ mod tests {
                 checkpoint_id[9] = 1;
             }
 
-            let block_number = (first_epoch_number + len) as u32 * policy::BLOCKS_PER_EPOCH
-                + policy::BLOCKS_PER_BATCH;
+            let block_number = (first_epoch_number + len) as u32 * Policy::blocks_per_epoch()
+                + Policy::blocks_per_batch();
             Some(Checkpoint {
                 hash: Blake2bHash::from(checkpoint_id),
                 block_number,

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -249,7 +249,7 @@ mod tests {
     use nimiq_network_interface::network::Network;
     use nimiq_network_mock::{MockHub, MockNetwork};
     use nimiq_primitives::networks::NetworkId;
-    use nimiq_primitives::policy;
+    use nimiq_primitives::policy::Policy;
     use nimiq_test_log::test;
     use nimiq_test_utils::blockchain::{produce_macro_blocks_with_txns, signing_key, voting_key};
     use nimiq_utils::time::OffsetTime;
@@ -362,11 +362,11 @@ mod tests {
         produce_macro_blocks_with_txns(
             &producer,
             &chain2,
-            policy::BATCHES_PER_EPOCH as usize,
+            Policy::batches_per_epoch() as usize,
             1,
             0,
         );
-        assert_eq!(chain2.read().block_number(), policy::BLOCKS_PER_EPOCH);
+        assert_eq!(chain2.read().block_number(), Policy::blocks_per_epoch());
 
         let mut sync = HistorySync::<MockNetwork>::new(
             Arc::clone(&chain1),
@@ -399,13 +399,13 @@ mod tests {
         produce_macro_blocks_with_txns(
             &producer,
             &chain2,
-            num_epochs * policy::BATCHES_PER_EPOCH as usize,
+            num_epochs * Policy::batches_per_epoch() as usize,
             1,
             0,
         );
         assert_eq!(
             chain2.read().block_number(),
-            num_epochs as u32 * policy::BLOCKS_PER_EPOCH
+            num_epochs as u32 * Policy::blocks_per_epoch()
         );
 
         let mut sync = HistorySync::<MockNetwork>::new(
@@ -436,7 +436,7 @@ mod tests {
 
         let producer = BlockProducer::new(signing_key(), voting_key());
         produce_macro_blocks_with_txns(&producer, &chain2, 1, 1, 0);
-        assert_eq!(chain2.read().block_number(), policy::BLOCKS_PER_BATCH);
+        assert_eq!(chain2.read().block_number(), Policy::blocks_per_batch());
 
         let mut sync = HistorySync::<MockNetwork>::new(
             Arc::clone(&chain1),
@@ -464,12 +464,12 @@ mod tests {
         let chain1 = blockchain();
         let chain2 = blockchain();
 
-        let num_batches = (policy::BATCHES_PER_EPOCH - 1) as usize;
+        let num_batches = (Policy::batches_per_epoch() - 1) as usize;
         let producer = BlockProducer::new(signing_key(), voting_key());
         produce_macro_blocks_with_txns(&producer, &chain2, num_batches, 1, 0);
         assert_eq!(
             chain2.read().block_number(),
-            num_batches as u32 * policy::BLOCKS_PER_BATCH
+            num_batches as u32 * Policy::blocks_per_batch()
         );
 
         let mut sync = HistorySync::<MockNetwork>::new(
@@ -503,10 +503,10 @@ mod tests {
         produce_macro_blocks_with_txns(&producer, &chain2, num_batches, 50, 0);
         assert_eq!(
             chain2.read().block_number(),
-            num_batches as u32 * policy::BLOCKS_PER_BATCH
+            num_batches as u32 * Policy::blocks_per_batch()
         );
 
-        let num_blocks = policy::BLOCKS_PER_BATCH + policy::BLOCKS_PER_BATCH / 2;
+        let num_blocks = Policy::blocks_per_batch() + Policy::blocks_per_batch() / 2;
         copy_chain_with_limit(&*chain2, &*chain1, num_blocks as usize);
         assert_eq!(chain1.read().block_number(), num_blocks);
 
@@ -542,15 +542,15 @@ mod tests {
 
         let producer = BlockProducer::new(signing_key(), voting_key());
         produce_macro_blocks_with_txns(&producer, &chain2, 1, 1, 0);
-        assert_eq!(chain2.read().block_number(), policy::BLOCKS_PER_BATCH);
+        assert_eq!(chain2.read().block_number(), Policy::blocks_per_batch());
 
         copy_chain(&*chain2, &*chain3);
         produce_macro_blocks_with_txns(&producer, &chain3, 1, 1, 0);
-        assert_eq!(chain3.read().block_number(), 2 * policy::BLOCKS_PER_BATCH);
+        assert_eq!(chain3.read().block_number(), 2 * Policy::blocks_per_batch());
 
         copy_chain(&*chain3, &*chain4);
         produce_macro_blocks_with_txns(&producer, &chain4, 1, 1, 0);
-        assert_eq!(chain4.read().block_number(), 3 * policy::BLOCKS_PER_BATCH);
+        assert_eq!(chain4.read().block_number(), 3 * Policy::blocks_per_batch());
 
         let mut sync = HistorySync::<MockNetwork>::new(
             Arc::clone(&chain1),
@@ -609,7 +609,7 @@ mod tests {
             produce_macro_blocks_with_txns(
                 &producer,
                 &chain_up2date,
-                (num_epochs * policy::BATCHES_PER_EPOCH - 1) as usize,
+                (num_epochs * Policy::batches_per_epoch() - 1) as usize,
                 1,
                 0,
             );

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -22,7 +22,7 @@ use nimiq_genesis::NetworkId;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::MockHub;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_utils::{
     blockchain::{produce_macro_blocks, signing_key, voting_key},
     test_network::TestNetwork,
@@ -63,7 +63,7 @@ async fn peers_can_sync() {
 
     // The minimum number of macro blocks necessary so that we have one election block and one
     // checkpoint block to push.
-    let num_macro_blocks = (policy::BATCHES_PER_EPOCH + 1) as usize;
+    let num_macro_blocks = (Policy::batches_per_epoch() + 1) as usize;
 
     // Produce the blocks.
     produce_macro_blocks(&producer, &blockchain1, num_macro_blocks);
@@ -235,7 +235,7 @@ async fn sync_ingredients() {
 
     // The minimum number of macro blocks necessary so that we have one election block and one
     // checkpoint block to push.
-    let num_macro_blocks = (policy::BATCHES_PER_EPOCH + 1) as usize;
+    let num_macro_blocks = (Policy::batches_per_epoch() + 1) as usize;
 
     // Produce the blocks.
     produce_macro_blocks(&producer, &blockchain1, num_macro_blocks);

--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -6,7 +6,7 @@ use std::fs::{read_to_string, OpenOptions};
 use std::io::Error as IoError;
 use std::path::Path;
 
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use thiserror::Error;
 use time::OffsetDateTime;
 use toml::de::Error as TomlError;
@@ -291,7 +291,7 @@ impl GenesisBuilder {
         StakingContract::create(&accounts.tree, txn);
 
         // Get the deposit value.
-        let deposit = Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT);
+        let deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
 
         for validator in &self.validators {
             StakingContract::create_validator(

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_nano_zkp::NanoZKP;
-use nimiq_primitives::policy::BLS_CACHE_MAX_CAPACITY;
+use nimiq_primitives::policy::Policy;
 use parking_lot::{Mutex, RwLock};
 
 use nimiq_block::Block;
@@ -175,7 +175,9 @@ impl ClientInner {
         .await;
 
         // Initialize consensus
-        let bls_cache = Arc::new(Mutex::new(PublicKeyCache::new(BLS_CACHE_MAX_CAPACITY)));
+        let bls_cache = Arc::new(Mutex::new(PublicKeyCache::new(
+            Policy::BLS_CACHE_MAX_CAPACITY,
+        )));
         let sync = HistorySync::<Network>::new(
             Arc::clone(&blockchain),
             Arc::clone(&network),

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -22,7 +22,7 @@ use nimiq_keys::{
 use nimiq_mempool::mempool::Mempool;
 use nimiq_mempool::{config::MempoolConfig, mempool_transactions::TxPriority};
 use nimiq_network_mock::{MockHub, MockId, MockNetwork, MockPeerId};
-use nimiq_primitives::{networks::NetworkId, policy};
+use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     blockchain::{produce_macro_blocks_with_txns, signing_key, voting_key},
@@ -1102,7 +1102,7 @@ async fn mempool_update_aged_transaction() {
     let producer = BlockProducer::new(signing_key(), voting_key());
 
     let macro_blocks_to_be_produced =
-        policy::TRANSACTION_VALIDITY_WINDOW / policy::BLOCKS_PER_BATCH;
+        Policy::TRANSACTION_VALIDITY_WINDOW / Policy::blocks_per_batch();
 
     // Now we produce blocks past the transaction validity window
     produce_macro_blocks_with_txns(

--- a/nano-blockchain/src/chain_store.rs
+++ b/nano-blockchain/src/chain_store.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use nimiq_block::{Block, MacroHeader};
 use nimiq_blockchain::ChainInfo;
 use nimiq_hash::Blake2bHash;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 /// A struct that stores the blocks for the blockchain.
 #[derive(Debug, Default)]
@@ -94,7 +94,7 @@ impl ChainStore {
     /// Adds an election block header to the ChainStore.
     pub fn put_election(&mut self, header: MacroHeader) {
         self.election_db
-            .insert(policy::epoch_at(header.block_number), header);
+            .insert(Policy::epoch_at(header.block_number), header);
     }
 
     /// Clears the ChainStore of all blocks (except the election blocks). This can be used at the

--- a/nano-blockchain/src/push.rs
+++ b/nano-blockchain/src/push.rs
@@ -3,7 +3,7 @@ use nimiq_blockchain::{
     AbstractBlockchain, Blockchain, ChainInfo, ChainOrdering, NextBlock, PushError, PushResult,
 };
 use nimiq_hash::{Blake2bHash, Hash};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 use crate::blockchain::NanoBlockchain;
 
@@ -229,7 +229,7 @@ impl NanoBlockchain {
         header: MacroHeader,
     ) -> Result<PushResult, PushError> {
         // Get epoch number.
-        let epoch = policy::epoch_at(header.block_number);
+        let epoch = Policy::epoch_at(header.block_number);
 
         // Get read transaction for ChainStore.
         let chain_store_r = self
@@ -244,7 +244,7 @@ impl NanoBlockchain {
 
         // Check if we have this block's successor.
         let prev_block = chain_store_r
-            .get_election(epoch + policy::BLOCKS_PER_EPOCH)
+            .get_election(epoch + Policy::blocks_per_epoch())
             .ok_or(PushError::InvalidSuccessor)?;
 
         // Verify that the block is indeed the predecessor.

--- a/nano-blockchain/src/sync.rs
+++ b/nano-blockchain/src/sync.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use nimiq_block::{Block, BlockError, TendermintProof};
 use nimiq_blockchain::{AbstractBlockchain, ChainInfo, PushError, PushResult};
 use nimiq_nano_zkp::{NanoProof, NanoZKP};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 use crate::blockchain::NanoBlockchain;
 
@@ -18,7 +18,7 @@ impl NanoBlockchain {
         assert!(block.is_election());
 
         // Check the version
-        if block.header().version() != policy::VERSION {
+        if block.header().version() != Policy::VERSION {
             return Err(PushError::InvalidBlock(BlockError::UnsupportedVersion));
         }
 
@@ -116,7 +116,7 @@ impl NanoBlockchain {
         assert!(block.is_macro());
 
         // Check the version
-        if block.header().version() != policy::VERSION {
+        if block.header().version() != Policy::VERSION {
             return Err(PushError::InvalidBlock(BlockError::UnsupportedVersion));
         }
 
@@ -135,7 +135,7 @@ impl NanoBlockchain {
 
         // Check if we have this block's parent. The checks change depending if the last macro block
         // that we pushed was an election block or not.
-        if policy::is_election_block_at(self.block_number()) {
+        if Policy::is_election_block_at(self.block_number()) {
             // We only need to check that the parent election block of this block is the same as our
             // head block.
             if block.header().parent_election_hash().unwrap() != &self.head_hash() {

--- a/nano-primitives/pedersen-generators/src/lib.rs
+++ b/nano-primitives/pedersen-generators/src/lib.rs
@@ -6,7 +6,7 @@ use beserial::Serialize;
 use beserial::SerializeWithLength;
 pub use beserial::SerializingError;
 use nimiq_bls::pedersen::pedersen_generator_powers;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 /// This is the depth of the PKTree circuit.
 const PK_TREE_DEPTH: usize = 5;
@@ -17,7 +17,7 @@ const PK_TREE_BREADTH: usize = 2_usize.pow(PK_TREE_DEPTH as u32);
 const G2_MNT6_SIZE: usize = 285;
 
 pub fn generate_pedersen_generators(dest_path: PathBuf) -> Result<(), SerializingError> {
-    let num_pks = policy::SLOTS as usize;
+    let num_pks = Policy::SLOTS as usize;
     let num_bits = num_pks * G2_MNT6_SIZE * 8;
     let num_bits_per_leaf = num_bits / PK_TREE_BREADTH;
 

--- a/nano-primitives/src/macro_block.rs
+++ b/nano-primitives/src/macro_block.rs
@@ -5,7 +5,7 @@ use num_traits::identities::Zero;
 
 use nimiq_bls::Signature;
 use nimiq_hash::{Blake2sHash, Hash, HashOutput};
-use nimiq_primitives::policy::SLOTS;
+use nimiq_primitives::policy::Policy;
 
 /// A struct representing an election macro block in Albatross.
 #[derive(Clone)]
@@ -30,7 +30,7 @@ impl MacroBlock {
             round_number,
             header_hash,
             signature: G1Projective::zero(),
-            signer_bitmap: vec![false; SLOTS as usize],
+            signer_bitmap: vec![false; Policy::SLOTS as usize],
         }
     }
 
@@ -92,7 +92,7 @@ impl Default for MacroBlock {
             round_number: 0,
             header_hash: [0; 32],
             signature: G1Projective::prime_subgroup_generator(),
-            signer_bitmap: vec![true; SLOTS as usize],
+            signer_bitmap: vec![true; Policy::SLOTS as usize],
         }
     }
 }
@@ -104,7 +104,7 @@ mod tests {
     use nimiq_bls::{AggregateSignature, KeyPair};
     use nimiq_collections::BitSet;
     use nimiq_keys::{Address, PublicKey as SchnorrPK};
-    use nimiq_primitives::policy::SLOTS;
+    use nimiq_primitives::policy::Policy;
     use nimiq_primitives::slots::{Validator, Validators};
     use nimiq_test_log::test;
     use nimiq_utils::key_rng::SecureGenerate;
@@ -119,7 +119,7 @@ mod tests {
         let mut validator_vec = vec![];
         let mut validator_keys = vec![];
 
-        for i in 0..SLOTS {
+        for i in 0..Policy::SLOTS {
             let key_pair = KeyPair::generate(&mut rng);
 
             let val = Validator::new(
@@ -167,7 +167,7 @@ mod tests {
         // Create the TendermintProof using our signature.
         let agg_sig = AggregateSignature::from_signatures(&[Signature::from(nano_block.signature)]);
 
-        let mut bitset = BitSet::with_capacity(SLOTS as usize);
+        let mut bitset = BitSet::with_capacity(Policy::SLOTS as usize);
 
         for (i, b) in nano_block.signer_bitmap.iter().enumerate() {
             if *b {

--- a/nano-primitives/src/pk_tree.rs
+++ b/nano-primitives/src/pk_tree.rs
@@ -2,7 +2,7 @@ use ark_mnt6_753::G2Projective;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use nimiq_bls::utils::bytes_to_bits;
-use nimiq_primitives::policy::SLOTS;
+use nimiq_primitives::policy::Policy;
 
 use crate::merkle_tree::merkle_tree_construct;
 use crate::serialize::serialize_g2_mnt6;
@@ -22,7 +22,7 @@ pub fn pk_tree_construct(public_keys: Vec<G2Projective>) -> Vec<u8> {
     //return Default::default();
 
     // Checking that the number of public keys is equal to the number of validator slots.
-    assert_eq!(public_keys.len(), SLOTS as usize);
+    assert_eq!(public_keys.len(), Policy::SLOTS as usize);
 
     // Checking that the number of public keys is a multiple of the number of leaves.
     assert_eq!(public_keys.len() % PK_TREE_BREADTH, 0);

--- a/nano-zkp/examples/verify.rs
+++ b/nano-zkp/examples/verify.rs
@@ -8,7 +8,7 @@ use ark_serialize::CanonicalDeserialize;
 
 use nimiq_nano_zkp::utils::create_test_blocks;
 use nimiq_nano_zkp::NanoZKP;
-use nimiq_primitives::policy::BLOCKS_PER_EPOCH;
+use nimiq_primitives::policy::Policy;
 
 /// Verifies a proof for a chain of election blocks. The random parameters generation uses always
 /// the same seed, so it will always generate the same data (validators, signatures, etc).
@@ -48,7 +48,7 @@ fn main() {
         0,
         initial_header_hash,
         initial_pks,
-        BLOCKS_PER_EPOCH * number_epochs as u32,
+        Policy::blocks_per_epoch() * number_epochs as u32,
         final_header_hash,
         final_pks,
         proof,

--- a/nano-zkp/src/circuits/mnt4/macro_block.rs
+++ b/nano-zkp/src/circuits/mnt4/macro_block.rs
@@ -12,7 +12,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 
 use nimiq_bls::pedersen::pedersen_generators;
 use nimiq_nano_primitives::MacroBlock;
-use nimiq_primitives::policy::BLOCKS_PER_EPOCH;
+use nimiq_primitives::policy::Policy;
 
 use crate::gadgets::mnt4::{
     MacroBlockGadget, PedersenHashGadget, SerializeGadget, StateCommitmentGadget,
@@ -78,7 +78,8 @@ impl ConstraintSynthesizer<MNT4Fr> for MacroBlockCircuit {
     /// This function generates the constraints for the circuit.
     fn generate_constraints(self, cs: ConstraintSystemRef<MNT4Fr>) -> Result<(), SynthesisError> {
         // Allocate all the constants.
-        let epoch_length_var = UInt32::<MNT4Fr>::new_constant(cs.clone(), BLOCKS_PER_EPOCH)?;
+        let epoch_length_var =
+            UInt32::<MNT4Fr>::new_constant(cs.clone(), Policy::blocks_per_epoch())?;
 
         let pedersen_generators_var =
             Vec::<G1Var>::new_constant(cs.clone(), pedersen_generators(5))?;
@@ -104,11 +105,9 @@ impl ConstraintSynthesizer<MNT4Fr> for MacroBlockCircuit {
 
         let block_var = MacroBlockGadget::new_witness(cs.clone(), || Ok(&self.block))?;
 
-        let initial_block_number_var =
-            UInt32::new_witness(
-                cs.clone(),
-                || Ok(self.block.block_number - BLOCKS_PER_EPOCH),
-            )?;
+        let initial_block_number_var = UInt32::new_witness(cs.clone(), || {
+            Ok(self.block.block_number - Policy::blocks_per_epoch())
+        })?;
 
         // Allocate all the inputs.
         let initial_state_commitment_var =

--- a/nano-zkp/src/circuits/mnt4/pk_tree_leaf.rs
+++ b/nano-zkp/src/circuits/mnt4/pk_tree_leaf.rs
@@ -6,7 +6,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 
 use nimiq_bls::pedersen::pedersen_generators;
 use nimiq_nano_primitives::{PK_TREE_BREADTH, PK_TREE_DEPTH};
-use nimiq_primitives::policy::SLOTS;
+use nimiq_primitives::policy::Policy;
 
 use crate::gadgets::mnt4::{MerkleTreeGadget, PedersenHashGadget, SerializeGadget};
 use crate::utils::unpack_inputs;
@@ -98,7 +98,7 @@ impl ConstraintSynthesizer<MNT4Fr> for PKTreeLeafCircuit {
         let agg_pk_commitment_bits = unpack_inputs(agg_pk_commitment_var)?[..760].to_vec();
 
         let signer_bitmap_chunk_bits = unpack_inputs(vec![signer_bitmap_chunk_var])?
-            [..SLOTS as usize / PK_TREE_BREADTH]
+            [..Policy::SLOTS as usize / PK_TREE_BREADTH]
             .to_vec();
 
         let path_bits = unpack_inputs(vec![path_var])?[..PK_TREE_DEPTH].to_vec();

--- a/nano-zkp/src/circuits/mnt4/pk_tree_node.rs
+++ b/nano-zkp/src/circuits/mnt4/pk_tree_node.rs
@@ -11,7 +11,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 
 use nimiq_bls::pedersen::pedersen_generators;
 use nimiq_nano_primitives::PK_TREE_DEPTH;
-use nimiq_primitives::policy::SLOTS;
+use nimiq_primitives::policy::Policy;
 
 use crate::gadgets::mnt4::{PedersenHashGadget, SerializeGadget};
 use crate::utils::{prepare_inputs, unpack_inputs};
@@ -108,7 +108,7 @@ impl ConstraintSynthesizer<MNT4Fr> for PKTreeNodeCircuit {
         let agg_pk_commitment_bits = unpack_inputs(agg_pk_commitment_var)?[..760].to_vec();
 
         let signer_bitmap_bits = unpack_inputs(vec![signer_bitmap_chunk_var])?
-            [..SLOTS as usize / 2_usize.pow(self.tree_level as u32)]
+            [..Policy::SLOTS as usize / 2_usize.pow(self.tree_level as u32)]
             .to_vec();
 
         let mut path_bits = unpack_inputs(vec![path_var])?[..PK_TREE_DEPTH].to_vec();
@@ -162,8 +162,8 @@ impl ConstraintSynthesizer<MNT4Fr> for PKTreeNodeCircuit {
         let right_path = path_bits;
 
         // Split the signer's bitmap chunk into two, for the left and right child nodes.
-        let (left_signer_bitmap_bits, right_signer_bitmap_bits) =
-            signer_bitmap_bits.split_at(SLOTS as usize / 2_usize.pow((self.tree_level + 1) as u32));
+        let (left_signer_bitmap_bits, right_signer_bitmap_bits) = signer_bitmap_bits
+            .split_at(Policy::SLOTS as usize / 2_usize.pow((self.tree_level + 1) as u32));
 
         // Verify the ZK proof for the left child node.
         let mut proof_inputs = prepare_inputs(pk_tree_root_bits.clone());

--- a/nano-zkp/src/circuits/mnt6/pk_tree_node.rs
+++ b/nano-zkp/src/circuits/mnt6/pk_tree_node.rs
@@ -9,7 +9,7 @@ use ark_r1cs_std::prelude::{AllocVar, Boolean, EqGadget};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 
 use nimiq_nano_primitives::PK_TREE_DEPTH;
-use nimiq_primitives::policy::SLOTS;
+use nimiq_primitives::policy::Policy;
 
 use crate::utils::{prepare_inputs, unpack_inputs};
 
@@ -107,7 +107,7 @@ impl ConstraintSynthesizer<MNT6Fr> for PKTreeNodeCircuit {
             unpack_inputs(right_agg_pk_commitment_var)?[..760].to_vec();
 
         let signer_bitmap_bits = unpack_inputs(vec![signer_bitmap_chunk_var])?
-            [..SLOTS as usize / 2_usize.pow(self.tree_level as u32)]
+            [..Policy::SLOTS as usize / 2_usize.pow(self.tree_level as u32)]
             .to_vec();
 
         let mut path_bits = unpack_inputs(vec![path_var])?[..PK_TREE_DEPTH].to_vec();
@@ -129,8 +129,8 @@ impl ConstraintSynthesizer<MNT6Fr> for PKTreeNodeCircuit {
         let right_path = path_bits;
 
         // Split the signer's bitmap chunk into two, for the left and right child nodes.
-        let (left_signer_bitmap_bits, right_signer_bitmap_bits) =
-            signer_bitmap_bits.split_at(SLOTS as usize / 2_usize.pow((self.tree_level + 1) as u32));
+        let (left_signer_bitmap_bits, right_signer_bitmap_bits) = signer_bitmap_bits
+            .split_at(Policy::SLOTS as usize / 2_usize.pow((self.tree_level + 1) as u32));
 
         // Verify the ZK proof for the left child node.
         let mut proof_inputs = prepare_inputs(pk_tree_root_bits.clone());

--- a/nano-zkp/src/gadgets/mnt4/macro_block.rs
+++ b/nano-zkp/src/gadgets/mnt4/macro_block.rs
@@ -16,7 +16,7 @@ use ark_r1cs_std::prelude::{
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 
 use nimiq_nano_primitives::MacroBlock;
-use nimiq_primitives::policy::{SLOTS, TWO_F_PLUS_ONE};
+use nimiq_primitives::policy::Policy;
 
 use crate::gadgets::mnt4::{CheckSigGadget, HashToCurve};
 use crate::utils::reverse_inner_byte_order;
@@ -183,7 +183,7 @@ impl MacroBlockGadget {
         cs: ConstraintSystemRef<MNT4Fr>,
     ) -> Result<Boolean<MNT4Fr>, SynthesisError> {
         // Get the minimum number of signers.
-        let min_signers = FqVar::new_constant(cs, Fq::from(TWO_F_PLUS_ONE as u64))?;
+        let min_signers = FqVar::new_constant(cs, Fq::from(Policy::TWO_F_PLUS_ONE as u64))?;
 
         // Initialize the running sum.
         let mut num_signers = FqVar::zero();
@@ -231,7 +231,7 @@ impl AllocVar<MacroBlock, MNT4Fr> for MacroBlockGadget {
             Err(_) => empty_block,
         };
 
-        assert_eq!(value.signer_bitmap.len(), SLOTS as usize);
+        assert_eq!(value.signer_bitmap.len(), Policy::SLOTS as usize);
 
         let block_number = UInt32::<MNT4Fr>::new_input(cs.clone(), || Ok(value.block_number))?;
 
@@ -276,7 +276,7 @@ impl AllocVar<MacroBlock, MNT4Fr> for MacroBlockGadget {
             Err(_) => empty_block,
         };
 
-        assert_eq!(value.signer_bitmap.len(), SLOTS as usize);
+        assert_eq!(value.signer_bitmap.len(), Policy::SLOTS as usize);
 
         let block_number = UInt32::<MNT4Fr>::new_witness(cs.clone(), || Ok(value.block_number))?;
 
@@ -324,7 +324,7 @@ mod tests {
 
     use nimiq_bls::utils::bytes_to_bits;
     use nimiq_nano_primitives::MacroBlock;
-    use nimiq_primitives::policy::{SLOTS, TWO_F_PLUS_ONE};
+    use nimiq_primitives::policy::Policy;
     use nimiq_test_log::test;
 
     use super::*;
@@ -345,7 +345,7 @@ mod tests {
         let mut header_hash = [2u8; 32];
         rng.fill_bytes(&mut header_hash);
 
-        let mut bytes = [3u8; SLOTS as usize / 8];
+        let mut bytes = [3u8; Policy::SLOTS as usize / 8];
         rng.fill_bytes(&mut bytes);
         let signer_bitmap = bytes_to_bits(&bytes);
 
@@ -403,7 +403,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -455,7 +455,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -510,7 +510,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -565,7 +565,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -622,7 +622,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -677,7 +677,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -734,7 +734,7 @@ mod tests {
         // Create macro block with correct signers set.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }
@@ -789,7 +789,7 @@ mod tests {
         // Create macro block with too few signers.
         let mut block = MacroBlock::without_signatures(block_number, round_number, header_hash);
 
-        for i in 0..TWO_F_PLUS_ONE as usize - 1 {
+        for i in 0..Policy::TWO_F_PLUS_ONE as usize - 1 {
             block.sign(&sk, i, &pk_tree_root);
             agg_pk += &pk;
         }

--- a/nano-zkp/src/gadgets/mnt4/state_commitment.rs
+++ b/nano-zkp/src/gadgets/mnt4/state_commitment.rs
@@ -63,7 +63,7 @@ mod tests {
     use nimiq_bls::pedersen::pedersen_generators;
     use nimiq_bls::utils::bytes_to_bits;
     use nimiq_nano_primitives::{pk_tree_construct, state_commitment};
-    use nimiq_primitives::policy::SLOTS;
+    use nimiq_primitives::policy::Policy;
     use nimiq_test_log::test;
 
     use super::*;
@@ -78,7 +78,7 @@ mod tests {
 
         // Create random keys.
         let g2_point = G2Projective::rand(rng);
-        let public_keys = vec![g2_point; SLOTS as usize];
+        let public_keys = vec![g2_point; Policy::SLOTS as usize];
 
         // Create random block number.
         let block_number = u32::rand(rng);

--- a/nano-zkp/src/nano_zkp/prove.rs
+++ b/nano-zkp/src/nano_zkp/prove.rs
@@ -18,7 +18,7 @@ use nimiq_nano_primitives::{merkle_tree_prove, serialize_g1_mnt6, serialize_g2_m
 use nimiq_nano_primitives::{
     pk_tree_construct, state_commitment, vk_commitment, MacroBlock, PK_TREE_BREADTH, PK_TREE_DEPTH,
 };
-use nimiq_primitives::policy::{BLOCKS_PER_EPOCH, SLOTS};
+use nimiq_primitives::policy::Policy;
 
 use crate::circuits::mnt4::{
     MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT4, PKTreeNodeCircuit as NodeMNT4,
@@ -312,8 +312,8 @@ impl NanoZKP {
         // Calculate the aggregate public key commitment.
         let mut agg_pk = G2MNT6::zero();
 
-        for i in position * SLOTS as usize / PK_TREE_BREADTH
-            ..(position + 1) * SLOTS as usize / PK_TREE_BREADTH
+        for i in position * Policy::SLOTS as usize / PK_TREE_BREADTH
+            ..(position + 1) * Policy::SLOTS as usize / PK_TREE_BREADTH
         {
             if signer_bitmap[i] {
                 agg_pk += pks[i];
@@ -327,8 +327,8 @@ impl NanoZKP {
         let agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Get the relevant chunk of the signer's bitmap.
-        let signer_bitmap_chunk = &signer_bitmap[position * SLOTS as usize / PK_TREE_BREADTH
-            ..(position + 1) * SLOTS as usize / PK_TREE_BREADTH];
+        let signer_bitmap_chunk = &signer_bitmap[position * Policy::SLOTS as usize / PK_TREE_BREADTH
+            ..(position + 1) * Policy::SLOTS as usize / PK_TREE_BREADTH];
 
         // Calculate inputs.
         let mut pk_tree_root = pack_inputs(bytes_to_bits(pk_tree_root));
@@ -341,8 +341,8 @@ impl NanoZKP {
 
         // Create the circuit.
         let circuit = LeafMNT4::new(
-            pks[position * SLOTS as usize / PK_TREE_BREADTH
-                ..(position + 1) * SLOTS as usize / PK_TREE_BREADTH]
+            pks[position * Policy::SLOTS as usize / PK_TREE_BREADTH
+                ..(position + 1) * Policy::SLOTS as usize / PK_TREE_BREADTH]
                 .to_vec(),
             pk_tree_nodes.to_vec(),
             pk_tree_root.clone(),
@@ -430,8 +430,8 @@ impl NanoZKP {
         // Calculate the left aggregate public key commitment.
         let mut agg_pk = G2MNT6::zero();
 
-        for i in left_position * SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
-            ..(left_position + 1) * SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
+        for i in left_position * Policy::SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
+            ..(left_position + 1) * Policy::SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
         {
             if signer_bitmap[i] {
                 agg_pk += pks[i];
@@ -447,8 +447,8 @@ impl NanoZKP {
         // Calculate the right aggregate public key commitment.
         let mut agg_pk = G2MNT6::zero();
 
-        for i in right_position * SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
-            ..(right_position + 1) * SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
+        for i in right_position * Policy::SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
+            ..(right_position + 1) * Policy::SLOTS as usize / 2_usize.pow((tree_level + 1) as u32)
         {
             if signer_bitmap[i] {
                 agg_pk += pks[i];
@@ -462,9 +462,9 @@ impl NanoZKP {
         let right_agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Get the relevant chunk of the signer's bitmap.
-        let signer_bitmap_chunk = &signer_bitmap[position * SLOTS as usize
+        let signer_bitmap_chunk = &signer_bitmap[position * Policy::SLOTS as usize
             / 2_usize.pow(tree_level as u32)
-            ..(position + 1) * SLOTS as usize / 2_usize.pow(tree_level as u32)];
+            ..(position + 1) * Policy::SLOTS as usize / 2_usize.pow(tree_level as u32)];
 
         // Calculate inputs.
         let mut pk_tree_root = pack_inputs(bytes_to_bits(pk_tree_root));
@@ -571,8 +571,8 @@ impl NanoZKP {
         for i in position * 4..(position + 1) * 4 {
             let mut agg_pk = G2MNT6::zero();
 
-            for j in i * SLOTS as usize / 2_usize.pow((tree_level + 2) as u32)
-                ..(i + 1) * SLOTS as usize / 2_usize.pow((tree_level + 2) as u32)
+            for j in i * Policy::SLOTS as usize / 2_usize.pow((tree_level + 2) as u32)
+                ..(i + 1) * Policy::SLOTS as usize / 2_usize.pow((tree_level + 2) as u32)
             {
                 if signer_bitmap[j] {
                     agg_pk += pks[j];
@@ -596,9 +596,9 @@ impl NanoZKP {
         let agg_pk_comm = bytes_to_bits(&serialize_g1_mnt6(&hash));
 
         // Get the relevant chunk of the signer's bitmap.
-        let signer_bitmap_chunk = &signer_bitmap[position * SLOTS as usize
+        let signer_bitmap_chunk = &signer_bitmap[position * Policy::SLOTS as usize
             / 2_usize.pow(tree_level as u32)
-            ..(position + 1) * SLOTS as usize / 2_usize.pow(tree_level as u32)];
+            ..(position + 1) * Policy::SLOTS as usize / 2_usize.pow(tree_level as u32)];
 
         // Calculate inputs.
         let mut pk_tree_root = pack_inputs(bytes_to_bits(pk_tree_root));
@@ -692,7 +692,7 @@ impl NanoZKP {
             let mut agg_pk = G2MNT6::zero();
 
             #[allow(clippy::needless_range_loop)]
-            for j in i * SLOTS as usize / 2..(i + 1) * SLOTS as usize / 2 {
+            for j in i * Policy::SLOTS as usize / 2..(i + 1) * Policy::SLOTS as usize / 2 {
                 if block.signer_bitmap[j] {
                     agg_pk += initial_pks[j];
                 }
@@ -703,7 +703,7 @@ impl NanoZKP {
 
         // Calculate the inputs.
         let mut initial_state_commitment = pack_inputs(bytes_to_bits(&state_commitment(
-            block.block_number - BLOCKS_PER_EPOCH,
+            block.block_number - Policy::blocks_per_epoch(),
             initial_header_hash,
             initial_pks.to_vec(),
         )));
@@ -786,7 +786,7 @@ impl NanoZKP {
 
         // Calculate the inputs.
         let mut initial_state_commitment = pack_inputs(bytes_to_bits(&state_commitment(
-            block.block_number - BLOCKS_PER_EPOCH,
+            block.block_number - Policy::blocks_per_epoch(),
             initial_header_hash,
             initial_pks.to_vec(),
         )));
@@ -869,7 +869,7 @@ impl NanoZKP {
 
         // Get the intermediate state commitment.
         let intermediate_state_commitment = state_commitment(
-            block.block_number - BLOCKS_PER_EPOCH,
+            block.block_number - Policy::blocks_per_epoch(),
             initial_header_hash,
             initial_pks.to_vec(),
         );
@@ -981,7 +981,7 @@ impl NanoZKP {
         // Calculate the inputs.
         let initial_state_comm_bytes = match genesis_data {
             None => state_commitment(
-                block.block_number - BLOCKS_PER_EPOCH,
+                block.block_number - Policy::blocks_per_epoch(),
                 initial_header_hash,
                 initial_pks.to_vec(),
             ),

--- a/nano-zkp/src/nano_zkp/setup.rs
+++ b/nano-zkp/src/nano_zkp/setup.rs
@@ -12,7 +12,7 @@ use rand::{CryptoRng, Rng};
 
 use nimiq_bls::utils::bytes_to_bits;
 use nimiq_nano_primitives::{MacroBlock, PK_TREE_BREADTH, PK_TREE_DEPTH};
-use nimiq_primitives::policy::SLOTS;
+use nimiq_primitives::policy::Policy;
 
 use crate::circuits::mnt4::{
     MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT4, PKTreeNodeCircuit as NodeMNT4,
@@ -88,7 +88,7 @@ impl NanoZKP {
         name: &str,
     ) -> Result<(), NanoZKPError> {
         // Create dummy inputs.
-        let pks = vec![G2MNT6::rand(rng); SLOTS as usize / PK_TREE_BREADTH];
+        let pks = vec![G2MNT6::rand(rng); Policy::SLOTS as usize / PK_TREE_BREADTH];
 
         let pk_tree_nodes = vec![G1MNT6::rand(rng); PK_TREE_DEPTH];
 
@@ -272,7 +272,7 @@ impl NanoZKP {
 
         let signature = G1MNT6::rand(rng);
 
-        let mut bytes = [0u8; SLOTS as usize / 8];
+        let mut bytes = [0u8; Policy::SLOTS as usize / 8];
         rng.fill_bytes(&mut bytes);
         let signer_bitmap = bytes_to_bits(&bytes);
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -23,6 +23,7 @@ itertools = { version = "0.10", optional = true }
 lazy_static = { version = "1.2", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 num-traits = { version = "0.2", optional = true }
+once_cell = "1.13"
 parking_lot = { git = "https://github.com/styppo/parking_lot.git", optional = true }
 regex = { version = "1.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/primitives/account/src/account.rs
+++ b/primitives/account/src/account.rs
@@ -3,7 +3,7 @@ use nimiq_database::WriteTransaction;
 use nimiq_keys::Address;
 use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::STAKING_CONTRACT_ADDRESS;
+use nimiq_primitives::policy::Policy;
 use nimiq_transaction::Transaction;
 use nimiq_trie::key_nibbles::KeyNibbles;
 
@@ -390,7 +390,7 @@ impl AccountInherentInteraction for Account {
     ) -> Result<AccountInfo, AccountError> {
         // If the inherent target is the staking contract then we forward it to the staking contract
         // right here.
-        if STAKING_CONTRACT_ADDRESS == inherent.target {
+        if Policy::STAKING_CONTRACT_ADDRESS == inherent.target {
             return StakingContract::commit_inherent(
                 accounts_tree,
                 db_txn,
@@ -426,7 +426,7 @@ impl AccountInherentInteraction for Account {
     ) -> Result<Vec<Log>, AccountError> {
         // If the inherent target is the staking contract then we forward it to the staking contract
         // right here.
-        if STAKING_CONTRACT_ADDRESS == inherent.target {
+        if Policy::STAKING_CONTRACT_ADDRESS == inherent.target {
             return StakingContract::revert_inherent(
                 accounts_tree,
                 db_txn,

--- a/primitives/account/src/staking_contract/mod.rs
+++ b/primitives/account/src/staking_contract/mod.rs
@@ -9,7 +9,7 @@ use nimiq_collections::BitSet;
 use nimiq_database::{Transaction as DBTransaction, WriteTransaction};
 use nimiq_keys::Address;
 use nimiq_primitives::slots::{Validators, ValidatorsBuilder};
-use nimiq_primitives::{coin::Coin, policy};
+use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_transaction::account::staking_contract::{
     IncomingStakingTransactionData, OutgoingStakingTransactionProof,
 };
@@ -98,7 +98,7 @@ impl StakingContract {
     /// Returns the key in the AccountsTrie for the Staking contract struct.
     pub fn get_key_staking_contract() -> KeyNibbles {
         let mut bytes = Vec::with_capacity(21);
-        bytes.extend(policy::STAKING_CONTRACT_ADDRESS.as_bytes());
+        bytes.extend(Policy::STAKING_CONTRACT_ADDRESS.as_bytes());
         bytes.push(StakingContract::PATH_CONTRACT_MAIN);
 
         KeyNibbles::from(bytes.as_slice())
@@ -107,7 +107,7 @@ impl StakingContract {
     /// Returns the key in the AccountsTrie for a Validator struct with a given validator address.
     pub fn get_key_validator(validator_address: &Address) -> KeyNibbles {
         let mut bytes = Vec::with_capacity(42);
-        bytes.extend(policy::STAKING_CONTRACT_ADDRESS.as_bytes());
+        bytes.extend(Policy::STAKING_CONTRACT_ADDRESS.as_bytes());
         bytes.push(StakingContract::PATH_VALIDATORS_LIST);
         bytes.extend(validator_address.as_slice());
         bytes.push(StakingContract::PATH_VALIDATOR_MAIN);
@@ -121,7 +121,7 @@ impl StakingContract {
         staker_address: &Address,
     ) -> KeyNibbles {
         let mut bytes = Vec::with_capacity(62);
-        bytes.extend(policy::STAKING_CONTRACT_ADDRESS.as_bytes());
+        bytes.extend(Policy::STAKING_CONTRACT_ADDRESS.as_bytes());
         bytes.push(StakingContract::PATH_VALIDATORS_LIST);
         bytes.extend(validator_address.as_slice());
         bytes.push(StakingContract::PATH_VALIDATOR_STAKERS_LIST);
@@ -133,7 +133,7 @@ impl StakingContract {
     /// Returns the key in the AccountsTrie for a Staker struct with a given staker address.
     pub fn get_key_staker(staker_address: &Address) -> KeyNibbles {
         let mut bytes = Vec::with_capacity(41);
-        bytes.extend(policy::STAKING_CONTRACT_ADDRESS.as_bytes());
+        bytes.extend(Policy::STAKING_CONTRACT_ADDRESS.as_bytes());
         bytes.push(StakingContract::PATH_STAKERS_LIST);
         bytes.extend(staker_address.as_bytes());
 
@@ -252,7 +252,7 @@ impl StakingContract {
 
         let mut slots_builder = ValidatorsBuilder::default();
 
-        for _ in 0..policy::SLOTS {
+        for _ in 0..Policy::SLOTS {
             let index = lookup.sample(&mut rng);
 
             let chosen_validator =
@@ -347,7 +347,7 @@ impl StakingContract {
                     }
                     Some(time) => {
                         if block_height
-                            <= policy::election_block_after(time) + policy::BLOCKS_PER_BATCH
+                            <= Policy::election_block_after(time) + Policy::blocks_per_batch()
                         {
                             warn!(
                     "Cannot pay fees for transaction because validator hasn't been inactive for long enough."

--- a/primitives/account/src/staking_contract/traits.rs
+++ b/primitives/account/src/staking_contract/traits.rs
@@ -4,9 +4,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_collections::BitSet;
 use nimiq_database::WriteTransaction;
 use nimiq_keys::Address;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
-use nimiq_primitives::slots::SlashedSlot;
+use nimiq_primitives::{coin::Coin, policy::Policy, slots::SlashedSlot};
 use nimiq_transaction::account::staking_contract::{
     IncomingStakingTransactionData, OutgoingStakingTransactionProof,
 };
@@ -62,7 +60,7 @@ impl AccountTransactionInteraction for StakingContract {
         _block_time: u64,
     ) -> Result<AccountInfo, AccountError> {
         // Check that the address is that of the Staking contract.
-        if transaction.recipient != policy::STAKING_CONTRACT_ADDRESS {
+        if transaction.recipient != Policy::STAKING_CONTRACT_ADDRESS {
             return Err(AccountError::InvalidForRecipient);
         }
 
@@ -81,7 +79,7 @@ impl AccountTransactionInteraction for StakingContract {
                 let validator_address = proof.compute_signer();
 
                 // Get the deposit value.
-                let deposit = Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT);
+                let deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
 
                 // Verify the transaction was formed properly
                 if transaction.value != deposit {
@@ -336,7 +334,7 @@ impl AccountTransactionInteraction for StakingContract {
         _block_time: u64,
     ) -> Result<AccountInfo, AccountError> {
         // Check that the address is that of the Staking contract.
-        if transaction.sender != policy::STAKING_CONTRACT_ADDRESS {
+        if transaction.sender != Policy::STAKING_CONTRACT_ADDRESS {
             return Err(AccountError::InvalidForSender);
         }
 
@@ -457,7 +455,7 @@ impl AccountTransactionInteraction for StakingContract {
         block_height: u32,
     ) -> Result<AccountInfo, AccountError> {
         // Check that the address is that of the Staking contract.
-        if transaction.sender != policy::STAKING_CONTRACT_ADDRESS {
+        if transaction.sender != Policy::STAKING_CONTRACT_ADDRESS {
             return Err(AccountError::InvalidForSender);
         }
 
@@ -557,7 +555,7 @@ impl AccountTransactionInteraction for StakingContract {
         receipt: Option<&Vec<u8>>,
     ) -> Result<Vec<Log>, AccountError> {
         // Check that the address is that of the Staking contract.
-        if transaction.sender != policy::STAKING_CONTRACT_ADDRESS {
+        if transaction.sender != Policy::STAKING_CONTRACT_ADDRESS {
             return Err(AccountError::InvalidForSender);
         }
 
@@ -734,7 +732,7 @@ impl AccountInherentInteraction for StakingContract {
                 let newly_disabled;
                 let newly_lost_rewards;
 
-                if policy::epoch_at(slot.event_block) < policy::epoch_at(block_height) {
+                if Policy::epoch_at(slot.event_block) < Policy::epoch_at(block_height) {
                     newly_lost_rewards = !staking_contract
                         .previous_lost_rewards
                         .contains(slot.slot as usize);
@@ -744,7 +742,7 @@ impl AccountInherentInteraction for StakingContract {
                         .insert(slot.slot as usize);
 
                     newly_disabled = false;
-                } else if policy::batch_at(slot.event_block) < policy::batch_at(block_height) {
+                } else if Policy::batch_at(slot.event_block) < Policy::batch_at(block_height) {
                     newly_lost_rewards = !staking_contract
                         .previous_lost_rewards
                         .contains(slot.slot as usize);
@@ -910,7 +908,7 @@ impl AccountInherentInteraction for StakingContract {
                 // - current_lost_rewards
                 // - current_disabled_slots
                 if receipt.newly_disabled {
-                    if policy::epoch_at(slot.event_block) < policy::epoch_at(block_height) {
+                    if Policy::epoch_at(slot.event_block) < Policy::epoch_at(block_height) {
                         // Nothing to do.
                     } else {
                         let is_empty = {
@@ -929,8 +927,8 @@ impl AccountInherentInteraction for StakingContract {
                     }
                 }
                 if receipt.newly_lost_rewards {
-                    if policy::epoch_at(slot.event_block) < policy::epoch_at(block_height)
-                        || policy::batch_at(slot.event_block) < policy::batch_at(block_height)
+                    if Policy::epoch_at(slot.event_block) < Policy::epoch_at(block_height)
+                        || Policy::batch_at(slot.event_block) < Policy::batch_at(block_height)
                     {
                         staking_contract
                             .previous_lost_rewards

--- a/primitives/account/src/staking_contract/validator.rs
+++ b/primitives/account/src/staking_contract/validator.rs
@@ -7,8 +7,7 @@ use nimiq_bls::{CompressedPublicKey as BlsPublicKey, CompressedPublicKey};
 use nimiq_database::WriteTransaction;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::{coin::Coin, policy::Policy};
 
 use crate::logs::{Log, OperationInfo};
 use crate::staking_contract::receipts::{
@@ -150,7 +149,7 @@ impl StakingContract {
         reward_address: Address,
     ) -> Result<Vec<Log>, AccountError> {
         // Get the deposit value.
-        let deposit = Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT);
+        let deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
 
         // See if the validator does not exist.
         if StakingContract::get_validator(accounts_tree, db_txn, validator_address).is_none() {
@@ -749,10 +748,10 @@ impl StakingContract {
                 return Err(AccountError::InvalidForSender);
             }
             Some(_time) => {
-                //  This check was removed because of the nature of the failed delete validator transaction
-                // (which can delete the validator if the deposit is consumed, regardles of the inactivity state)
+                // This check was removed because of the nature of the failed delete validator transaction
+                // (which can delete the validator if the deposit is consumed, regardless of the inactivity state)
                 // However, if slashing is implemented, then this strategy needs to be revisited.
-                //if block_height <= policy::election_block_after(time) + policy::BLOCKS_PER_BATCH {
+                // if block_height <= policy::election_block_after(time) + policy::BLOCKS_PER_BATCH {
                 //    return Err(AccountError::InvalidForSender);
                 //}
             }
@@ -901,10 +900,10 @@ impl StakingContract {
             voting_key: receipt.voting_key,
             reward_address: receipt.reward_address,
             signal_data: receipt.signal_data,
-            balance: Coin::from_u64_unchecked(balance + policy::VALIDATOR_DEPOSIT),
+            balance: Coin::from_u64_unchecked(balance + Policy::VALIDATOR_DEPOSIT),
             num_stakers,
             inactivity_flag: Some(receipt.retire_time),
-            deposit: Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT),
+            deposit: Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
         };
 
         accounts_tree.put(
@@ -916,7 +915,7 @@ impl StakingContract {
         // Get the staking contract main and update it.
         let mut staking_contract = StakingContract::get_staking_contract(accounts_tree, db_txn);
 
-        let deposit = Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT);
+        let deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
 
         staking_contract.balance = Account::balance_add(staking_contract.balance, deposit)?;
 

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -18,7 +18,7 @@ use nimiq_genesis_builder::GenesisBuilder;
 use nimiq_keys::{Address, KeyPair, PrivateKey, PublicKey, SecureGenerate};
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_test_utils::test_transaction::{
     generate_accounts, generate_transactions, TestTransaction,
@@ -590,7 +590,7 @@ fn accounts_performance_history_sync_batches_single_sender() {
         (env, num_txns)
     };
 
-    let total_txns = num_batches * policy::BLOCKS_PER_BATCH * num_txns;
+    let total_txns = num_batches * Policy::blocks_per_batch() * num_txns;
 
     // Generate and sign transaction from an address
     let mut rng = StdRng::seed_from_u64(0);
@@ -604,7 +604,7 @@ fn accounts_performance_history_sync_batches_single_sender() {
     let recipient_accounts = generate_accounts(recipient_balances, &mut genesis_builder, false);
     let sender_accounts = generate_accounts(sender_balances, &mut genesis_builder, true);
 
-    let total_blocks = num_batches * policy::BLOCKS_PER_BATCH;
+    let total_blocks = num_batches * Policy::blocks_per_batch();
 
     let mut block_transactions = vec![];
 
@@ -667,7 +667,7 @@ fn accounts_performance_history_sync_batches_single_sender() {
 
         let batch_start = Instant::now();
 
-        for _blocks in 0..policy::BLOCKS_PER_BATCH {
+        for _blocks in 0..Policy::blocks_per_batch() {
             let result = accounts.commit_batch(
                 &mut txn,
                 &block_transactions[block_index as usize],
@@ -713,7 +713,7 @@ fn accounts_performance_history_sync_batches_many_to_many() {
         (env, num_txns)
     };
 
-    let total_txns = num_batches * policy::BLOCKS_PER_BATCH * num_txns;
+    let total_txns = num_batches * Policy::blocks_per_batch() * num_txns;
 
     // Generate and sign transaction from an address
     let mut rng = StdRng::seed_from_u64(0);
@@ -727,7 +727,7 @@ fn accounts_performance_history_sync_batches_many_to_many() {
     let recipient_accounts = generate_accounts(recipient_balances, &mut genesis_builder, true);
     let sender_accounts = generate_accounts(sender_balances, &mut genesis_builder, true);
 
-    let total_blocks = num_batches * policy::BLOCKS_PER_BATCH;
+    let total_blocks = num_batches * Policy::blocks_per_batch();
 
     let mut block_transactions = vec![];
 
@@ -788,7 +788,7 @@ fn accounts_performance_history_sync_batches_many_to_many() {
 
         let batch_start = Instant::now();
 
-        for _blocks in 0..policy::BLOCKS_PER_BATCH {
+        for _blocks in 0..Policy::blocks_per_batch() {
             let result = accounts.commit_batch(
                 &mut txn,
                 &block_transactions[block_index as usize],

--- a/primitives/block/benches/pk_tree.rs
+++ b/primitives/block/benches/pk_tree.rs
@@ -6,7 +6,7 @@ use nimiq_block::MacroBlock;
 use nimiq_bls::lazy::LazyPublicKey;
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::{Validators, ValidatorsBuilder};
 use nimiq_test_utils::zkp_test_data::get_base_seed;
 
@@ -18,7 +18,7 @@ fn generate_uncompressed_validators() -> Validators {
     let mut rng = get_base_seed();
     let mut validators = ValidatorsBuilder::new();
 
-    for _ in 0..policy::SLOTS {
+    for _ in 0..Policy::SLOTS {
         let keypair = SchnorrKeyPair::generate(&mut rng);
         let address = Address::from(&keypair.public);
         let bls_keypair = BlsKeyPair::generate(&mut rng);

--- a/primitives/block/examples/pk_tree.rs
+++ b/primitives/block/examples/pk_tree.rs
@@ -1,7 +1,7 @@
 use nimiq_block::MacroBlock;
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::{Validators, ValidatorsBuilder};
 use nimiq_test_utils::zkp_test_data::get_base_seed;
 
@@ -13,7 +13,7 @@ fn generate_uncompressed_validators() -> Validators {
     let mut rng = get_base_seed();
     let mut validators = ValidatorsBuilder::new();
 
-    for _ in 0..policy::SLOTS {
+    for _ in 0..Policy::SLOTS {
         let keypair = SchnorrKeyPair::generate(&mut rng);
         let address = Address::from(&keypair.public);
         let bls_keypair = BlsKeyPair::generate(&mut rng);

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -9,7 +9,7 @@ use nimiq_database::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_vrf::VrfSeed;
@@ -62,7 +62,7 @@ impl Block {
 
     /// Returns the epoch number of the block.
     pub fn epoch_number(&self) -> u32 {
-        policy::epoch_at(self.block_number())
+        Policy::epoch_at(self.block_number())
     }
 
     /// Returns the timestamp of the block.

--- a/primitives/block/src/fork_proof.rs
+++ b/primitives/block/src/fork_proof.rs
@@ -4,7 +4,7 @@ use std::io;
 use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Blake2bHash, Hash, HashOutput, SerializeContent};
 use nimiq_keys::{PublicKey as SchnorrPublicKey, Signature as SchnorrSignature};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_vrf::VrfSeed;
 
 use crate::MicroHeader;
@@ -66,9 +66,9 @@ impl ForkProof {
     /// Check if a fork proof is valid at a given block height. Fork proofs are only during the
     /// batch when the fork was created and during batch immediately after.
     pub fn is_valid_at(&self, block_number: u32) -> bool {
-        let given_batch = policy::batch_at(block_number);
+        let given_batch = Policy::batch_at(block_number);
 
-        let proof_batch = policy::batch_at(self.header1.block_number);
+        let proof_batch = Policy::batch_at(self.header1.block_number);
 
         proof_batch == given_batch || proof_batch + 1 == given_batch
     }

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -8,7 +8,7 @@ use nimiq_collections::bitset::BitSet;
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, SerializeContent};
 use nimiq_nano_primitives::pk_tree_construct;
 use nimiq_nano_primitives::MacroBlock as ZKPMacroBlock;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 use nimiq_vrf::VrfSeed;
 
@@ -96,7 +96,7 @@ impl<'a> TryFrom<&'a MacroBlock> for ZKPMacroBlock {
                     .sig
                     .signers
                     .iter_bits()
-                    .take(policy::SLOTS as usize)
+                    .take(Policy::SLOTS as usize)
                     .collect(),
             })
         } else {
@@ -168,7 +168,7 @@ impl MacroBlock {
 
     /// Returns whether or not this macro block is an election block.
     pub fn is_election_block(&self) -> bool {
-        policy::is_election_block_at(self.header.block_number)
+        Policy::is_election_block_at(self.header.block_number)
     }
 
     /// Returns a copy of the validator slots. Only returns Some if it is an election block.
@@ -188,7 +188,7 @@ impl MacroBlock {
 
     /// Returns the epoch number of this macro block.
     pub fn epoch_number(&self) -> u32 {
-        policy::epoch_at(self.header.block_number)
+        Policy::epoch_at(self.header.block_number)
     }
 }
 

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -6,7 +6,7 @@ use nimiq_database::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_keys::Signature;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_transaction::Transaction;
 use nimiq_vrf::VrfSeed;
@@ -105,7 +105,7 @@ impl MicroBlock {
 
     // Returns the available size, in bytes, in a micro block body for transactions.
     pub fn get_available_bytes(num_fork_proofs: usize) -> usize {
-        policy::MAX_SIZE_MICRO_BODY
+        Policy::MAX_SIZE_MICRO_BODY
             - (/*fork_proofs vector length*/2 + num_fork_proofs * ForkProof::SIZE
             + /*transactions vector length*/ 2)
     }

--- a/primitives/block/src/skip_block.rs
+++ b/primitives/block/src/skip_block.rs
@@ -4,7 +4,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_primitives::policy::TWO_F_PLUS_ONE;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 use nimiq_vrf::VrfEntropy;
 
@@ -45,7 +45,7 @@ impl SkipBlockProof {
     /// the skip block itself is valid.
     pub fn verify(&self, skip_block: &SkipBlockInfo, validators: &Validators) -> bool {
         // Check if there are enough votes.
-        if self.sig.signers.len() < TWO_F_PLUS_ONE as usize {
+        if self.sig.signers.len() < Policy::TWO_F_PLUS_ONE as usize {
             error!(
                 "SkipBlockProof verification failed: Not enough slots signed the skip block message."
             );

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -5,7 +5,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_primitives::policy::TWO_F_PLUS_ONE;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 
 use crate::signed::{
@@ -60,7 +60,7 @@ impl TendermintProof {
         };
 
         // Check if there are enough votes.
-        if justification.votes() < TWO_F_PLUS_ONE {
+        if justification.votes() < Policy::TWO_F_PLUS_ONE {
             error!("Invalid justification - not enough votes!");
             return false;
         }

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -49,10 +49,10 @@ pub const TWO_F_PLUS_ONE: u16 = (2 * SLOTS + 3 - 1) / 3;
 pub const F_PLUS_ONE: u16 = (SLOTS + 3 - 1) / 3;
 
 /// Length of a batch including the macro block
-pub const BLOCKS_PER_BATCH: u32 = 32; // TODO Set
+pub const BLOCKS_PER_BATCH: u32 = 60; // TODO Set
 
 /// How many batches constitute an epoch
-pub const BATCHES_PER_EPOCH: u16 = 4; // TODO Set
+pub const BATCHES_PER_EPOCH: u16 = 360; // TODO Set
 
 /// Length of epoch including election macro block
 pub const BLOCKS_PER_EPOCH: u32 = BLOCKS_PER_BATCH * BATCHES_PER_EPOCH as u32;

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -1,242 +1,307 @@
 use std::cmp;
 
+use once_cell::sync::OnceCell;
+
 use nimiq_keys::Address;
 
-/// This is the address for the staking contract. Corresponds to
-/// 'NQ38 STAK 1NG0 0000 0000 C0NT RACT 0000 0000'
-#[rustfmt::skip]
-pub const STAKING_CONTRACT_ADDRESS: Address = Address([
-    0xd6, 0xd5, 0x30, 0xda, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x60, 0x2d, 0xbc, 0xa9, 0x9b, 0x00, 0x00, 0x00, 0x00, 0x00,
-]);
+/// Global policy
+static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
 
-/// This is the address for the coinbase. Note that this is not a real account, it is just the
-/// address we use to denote that some coins originated from a coinbase event. Corresponds to
-/// 'NQ81 C01N BASE 0000 0000 0000 0000 0000 0000'
-#[rustfmt::skip]
-pub const COINBASE_ADDRESS: Address = Address([
-    0x60, 0x03, 0x65, 0xab, 0x4e, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-]);
-
-/// Number of blocks a transaction is valid with Albatross consensus.
-pub const TRANSACTION_VALIDITY_WINDOW: u32 = 7200;
-
-/// The maximum allowed size, in bytes, for a micro block body.
-pub const MAX_SIZE_MICRO_BODY: usize = 100_000;
-
-/// The current version number of the protocol. Changing this always results in a hard fork.
-pub const VERSION: u16 = 1;
-
-/// Number of available validator slots. Note that a single validator may own several validator slots.
-pub const SLOTS: u16 = 512;
-
-/// Calculates 2f+1 slots which is the minimum number of slots necessary to produce a macro block,
-/// a skip block and other actions.
-/// It is also the minimum number of slots necessary to be guaranteed to have a majority of honest
-/// slots. That's because from a total of 3f+1 slots at most f will be malicious. If in a group of
-/// 2f+1 slots we have f malicious ones (which is the worst case scenario), that still leaves us
-/// with f+1 honest slots. Which is more than the f slots that are not in this group (which must all
-/// be honest).
-/// It is calculated as `ceil(SLOTS*2/3)` and we use the formula `ceil(x/y) = (x+y-1)/y` for the
-/// ceiling division.
-pub const TWO_F_PLUS_ONE: u16 = (2 * SLOTS + 3 - 1) / 3;
-
-/// Calculates f+1 slots which is the minimum number of slots necessary to be guaranteed to have at
-/// least one honest slots. That's because from a total of 3f+1 slots at most f will be malicious.
-/// It is calculated as `ceil(SLOTS/3)` and we use the formula `ceil(x/y) = (x+y-1)/y` for the
-/// ceiling division.
-pub const F_PLUS_ONE: u16 = (SLOTS + 3 - 1) / 3;
-
-/// Length of a batch including the macro block
-pub const BLOCKS_PER_BATCH: u32 = 60; // TODO Set
-
-/// How many batches constitute an epoch
-pub const BATCHES_PER_EPOCH: u16 = 360; // TODO Set
-
-/// Length of epoch including election macro block
-pub const BLOCKS_PER_EPOCH: u32 = BLOCKS_PER_BATCH * BATCHES_PER_EPOCH as u32;
-
-/// The timeout in milliseconds for a validator to produce a block (4s)
-pub const BLOCK_PRODUCER_TIMEOUT: u64 = 4 * 1000;
-
-/// The maximum drift, in milliseconds, that is allowed between any block's timestamp and the node's
-/// system time. We only care about drifting to the future.
-pub const TIMESTAMP_MAX_DRIFT: u64 = 600000;
-
-/// Tendermint's initial timeout, in milliseconds.
-/// See https://arxiv.org/abs/1807.04938v3 for more information.
-pub const TENDERMINT_TIMEOUT_INIT: u64 = 1000; // TODO: Set
-
-/// Tendermint's timeout delta, in milliseconds.
-/// See https://arxiv.org/abs/1807.04938v3 for more information.
-pub const TENDERMINT_TIMEOUT_DELTA: u64 = 1000; // TODO: Set
-
-/// The deposit necessary to create a validator in Lunas (1 NIM = 100,000 Lunas).
-/// A validator is someone who actually participates in block production. They are akin to miners
-/// in proof-of-work.
-pub const VALIDATOR_DEPOSIT: u64 = 1_000_000_000;
-
-/// Total supply in units.
-pub const TOTAL_SUPPLY: u64 = 2_100_000_000_000_000;
-
-/// This is the number of Lunas (1 NIM = 100,000 Lunas) created by millisecond at the genesis of the
-/// Nimiq 2.0 chain. The velocity then decreases following the formula:
-/// Supply_velocity (t) = Initial_supply_velocity * e^(- Supply_decay * t)
-/// Where e is the exponential function and t is the time in milliseconds since the genesis block.
-pub const INITIAL_SUPPLY_VELOCITY: f64 = 875.0;
-
-/// The supply decay is a constant that is calculated so that the supply velocity decreases at a
-/// steady 1.47% per year.
-pub const SUPPLY_DECAY: f64 = 4.692821935e-13;
-
-/// The maximum size of the BLS public key cache.
-pub const BLS_CACHE_MAX_CAPACITY: usize = 1000;
-
-/// Maximum size of history chunks
-/// 25 MB
-pub const HISTORY_CHUNKS_MAX_SIZE: u64 = 25 * 1024 * 1024;
-
-/// Returns the epoch number at a given block number (height).
-#[inline]
-pub fn epoch_at(block_number: u32) -> u32 {
-    (block_number + BLOCKS_PER_EPOCH - 1) / BLOCKS_PER_EPOCH
+#[derive(Clone, Copy)]
+pub struct Policy {
+    /// Length of a batch including the macro block
+    pub blocks_per_batch: u32,
+    /// How many batches constitute an epoch
+    pub batches_per_epoch: u16,
+    /// Tendermint's initial timeout, in milliseconds.
+    /// See https://arxiv.org/abs/1807.04938v3 for more information.
+    pub tendermint_timeout_init: u64,
+    /// Tendermint's timeout delta, in milliseconds.
+    /// See https://arxiv.org/abs/1807.04938v3 for more information.
+    pub tendermint_timeout_delta: u64,
 }
 
-/// Returns the epoch index at a given block number. The epoch index is the number of a block relative
-/// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
-#[inline]
-pub fn epoch_index_at(block_number: u32) -> u32 {
-    (block_number + BLOCKS_PER_EPOCH - 1) % BLOCKS_PER_EPOCH
-}
+impl Policy {
+    /// This is the address for the staking contract. Corresponds to
+    /// 'NQ38 STAK 1NG0 0000 0000 C0NT RACT 0000 0000'
+    pub const STAKING_CONTRACT_ADDRESS: Address = Address([
+        0xd6, 0xd5, 0x30, 0xda, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x2d, 0xbc, 0xa9, 0x9b,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
 
-/// Returns the batch number at a given `block_number` (height)
-#[inline]
-pub fn batch_at(block_number: u32) -> u32 {
-    (block_number + BLOCKS_PER_BATCH - 1) / BLOCKS_PER_BATCH
-}
+    /// This is the address for the coinbase. Note that this is not a real account, it is just the
+    /// address we use to denote that some coins originated from a coinbase event. Corresponds to
+    /// 'NQ81 C01N BASE 0000 0000 0000 0000 0000 0000'
+    pub const COINBASE_ADDRESS: Address = Address([
+        0x60, 0x03, 0x65, 0xab, 0x4e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
 
-/// Returns the batch index at a given block number. The batch index is the number of a block relative
-/// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
-#[inline]
-pub fn batch_index_at(block_number: u32) -> u32 {
-    (block_number + BLOCKS_PER_BATCH - 1) % BLOCKS_PER_BATCH
-}
+    /// Number of blocks a transaction is valid with Albatross consensus.
+    pub const TRANSACTION_VALIDITY_WINDOW: u32 = 7200;
 
-/// Returns the number (height) of the next election macro block after a given block number (height).
-#[inline]
-pub fn election_block_after(block_number: u32) -> u32 {
-    (block_number / BLOCKS_PER_EPOCH + 1) * BLOCKS_PER_EPOCH
-}
+    /// The maximum allowed size, in bytes, for a micro block body.
+    pub const MAX_SIZE_MICRO_BODY: usize = 100_000;
 
-/// Returns the block number (height) of the preceding election macro block before a given block number (height).
-/// If the given block number is an election macro block, it returns the election macro block before it.
-#[inline]
-pub fn election_block_before(block_number: u32) -> u32 {
-    if block_number == 0 {
-        panic!("Called macro_block_before with block_number 0");
+    /// The current version number of the protocol. Changing this always results in a hard fork.
+    pub const VERSION: u16 = 1;
+
+    /// Number of available validator slots. Note that a single validator may own several validator slots.
+    pub const SLOTS: u16 = 512;
+
+    /// Calculates 2f+1 slots which is the minimum number of slots necessary to produce a macro block,
+    /// a skip block and other actions.
+    /// It is also the minimum number of slots necessary to be guaranteed to have a majority of honest
+    /// slots. That's because from a total of 3f+1 slots at most f will be malicious. If in a group of
+    /// 2f+1 slots we have f malicious ones (which is the worst case scenario), that still leaves us
+    /// with f+1 honest slots. Which is more than the f slots that are not in this group (which must all
+    /// be honest).
+    /// It is calculated as `ceil(SLOTS*2/3)` and we use the formula `ceil(x/y) = (x+y-1)/y` for the
+    /// ceiling division.
+    pub const TWO_F_PLUS_ONE: u16 = (2 * Self::SLOTS + 3 - 1) / 3;
+
+    /// Calculates f+1 slots which is the minimum number of slots necessary to be guaranteed to have at
+    /// least one honest slots. That's because from a total of 3f+1 slots at most f will be malicious.
+    /// It is calculated as `ceil(SLOTS/3)` and we use the formula `ceil(x/y) = (x+y-1)/y` for the
+    /// ceiling division.
+    pub const F_PLUS_ONE: u16 = (Self::SLOTS + 3 - 1) / 3;
+
+    /// The timeout in milliseconds for a validator to produce a block (4s)
+    pub const BLOCK_PRODUCER_TIMEOUT: u64 = 4 * 1000;
+
+    /// The maximum drift, in milliseconds, that is allowed between any block's timestamp and the node's
+    /// system time. We only care about drifting to the future.
+    pub const TIMESTAMP_MAX_DRIFT: u64 = 600000;
+
+    /// The deposit necessary to create a validator in Lunas (1 NIM = 100,000 Lunas).
+    /// A validator is someone who actually participates in block production. They are akin to miners
+    /// in proof-of-work.
+    pub const VALIDATOR_DEPOSIT: u64 = 1_000_000_000;
+
+    /// Total supply in units.
+    pub const TOTAL_SUPPLY: u64 = 2_100_000_000_000_000;
+
+    /// This is the number of Lunas (1 NIM = 100,000 Lunas) created by millisecond at the genesis of the
+    /// Nimiq 2.0 chain. The velocity then decreases following the formula:
+    /// Supply_velocity (t) = Initial_supply_velocity * e^(- Supply_decay * t)
+    /// Where e is the exponential function and t is the time in milliseconds since the genesis block.
+    pub const INITIAL_SUPPLY_VELOCITY: f64 = 875.0;
+
+    /// The supply decay is a constant that is calculated so that the supply velocity decreases at a
+    /// steady 1.47% per year.
+    pub const SUPPLY_DECAY: f64 = 4.692821935e-13;
+
+    /// The maximum size of the BLS public key cache.
+    pub const BLS_CACHE_MAX_CAPACITY: usize = 1000;
+
+    /// Maximum size of history chunks
+    /// 25 MB
+    pub const HISTORY_CHUNKS_MAX_SIZE: u64 = 25 * 1024 * 1024;
+
+    #[inline]
+    fn get_blocks_per_epoch(&self) -> u32 {
+        self.blocks_per_batch * self.batches_per_epoch as u32
     }
-    (block_number - 1) / BLOCKS_PER_EPOCH * BLOCKS_PER_EPOCH
-}
 
-/// Returns the block number (height) of the last election macro block at a given block number (height).
-/// If the given block number is an election macro block, then it returns that block number.
-#[inline]
-pub fn last_election_block(block_number: u32) -> u32 {
-    block_number / BLOCKS_PER_EPOCH * BLOCKS_PER_EPOCH
-}
-
-/// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
-#[inline]
-pub fn is_election_block_at(block_number: u32) -> bool {
-    epoch_index_at(block_number) == BLOCKS_PER_EPOCH - 1
-}
-
-/// Returns the block number (height) of the next macro block after a given block number (height).
-#[inline]
-pub fn macro_block_after(block_number: u32) -> u32 {
-    (block_number / BLOCKS_PER_BATCH + 1) * BLOCKS_PER_BATCH
-}
-
-/// Returns the block number (height) of the preceding macro block before a given block number (height).
-/// If the given block number is a macro block, it returns the macro block before it.
-#[inline]
-pub fn macro_block_before(block_number: u32) -> u32 {
-    if block_number == 0 {
-        panic!("Called macro_block_before with block_number 0");
+    #[inline]
+    pub fn batches_per_epoch() -> u16 {
+        GLOBAL_POLICY.get_or_init(Policy::default).batches_per_epoch
     }
-    (block_number - 1) / BLOCKS_PER_BATCH * BLOCKS_PER_BATCH
-}
 
-/// Returns the block number (height) of the last macro block at a given block number (height).
-/// If the given block number is a macro block, then it returns that block number.
-#[inline]
-pub fn last_macro_block(block_number: u32) -> u32 {
-    block_number / BLOCKS_PER_BATCH * BLOCKS_PER_BATCH
-}
-
-/// Returns a boolean expressing if the block at a given block number (height) is a macro block.
-#[inline]
-pub fn is_macro_block_at(block_number: u32) -> bool {
-    batch_index_at(block_number) == BLOCKS_PER_BATCH - 1
-}
-
-/// Returns a boolean expressing if the block at a given block number (height) is a micro block.
-#[inline]
-pub fn is_micro_block_at(block_number: u32) -> bool {
-    batch_index_at(block_number) != BLOCKS_PER_BATCH - 1
-}
-
-/// Returns the block number of the first block of the given epoch (which is always a micro block).
-pub fn first_block_of(epoch: u32) -> u32 {
-    if epoch == 0 {
-        panic!("Called first_block_of for epoch 0");
+    #[inline]
+    pub fn blocks_per_batch() -> u32 {
+        GLOBAL_POLICY.get_or_init(Policy::default).blocks_per_batch
     }
-    (epoch - 1) * BLOCKS_PER_EPOCH + 1
-}
 
-/// Returns the block number of the first block of the given batch (which is always a micro block).
-pub fn first_block_of_batch(batch: u32) -> u32 {
-    if batch == 0 {
-        panic!("Called first_block_of_batch for batch 0");
+    #[inline]
+    pub fn blocks_per_epoch() -> u32 {
+        GLOBAL_POLICY
+            .get_or_init(Policy::default)
+            .get_blocks_per_epoch()
     }
-    (batch - 1) * BLOCKS_PER_BATCH + 1
+
+    #[inline]
+    pub fn tendermint_timeout_init() -> u64 {
+        GLOBAL_POLICY
+            .get_or_init(Policy::default)
+            .tendermint_timeout_init
+    }
+
+    #[inline]
+    pub fn tendermint_timeout_delta() -> u64 {
+        GLOBAL_POLICY
+            .get_or_init(Policy::default)
+            .tendermint_timeout_delta
+    }
+
+    /// Returns the epoch number at a given block number (height).
+    #[inline]
+    pub fn epoch_at(block_number: u32) -> u32 {
+        let blocks_per_epoch = Self::blocks_per_epoch();
+        (block_number + blocks_per_epoch - 1) / blocks_per_epoch
+    }
+
+    /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
+    /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
+    #[inline]
+    pub fn epoch_index_at(block_number: u32) -> u32 {
+        let blocks_per_epoch = Self::blocks_per_epoch();
+        (block_number + blocks_per_epoch - 1) % blocks_per_epoch
+    }
+
+    /// Returns the batch number at a given `block_number` (height)
+    #[inline]
+    pub fn batch_at(block_number: u32) -> u32 {
+        let blocks_per_batch = Self::blocks_per_batch();
+        (block_number + blocks_per_batch - 1) / blocks_per_batch
+    }
+
+    /// Returns the batch index at a given block number. The batch index is the number of a block relative
+    /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
+    #[inline]
+    pub fn batch_index_at(block_number: u32) -> u32 {
+        let blocks_per_batch = Self::blocks_per_batch();
+        (block_number + blocks_per_batch - 1) % blocks_per_batch
+    }
+
+    /// Returns the number (height) of the next election macro block after a given block number (height).
+    #[inline]
+    pub fn election_block_after(block_number: u32) -> u32 {
+        let blocks_per_epoch = Self::blocks_per_epoch();
+        (block_number / blocks_per_epoch + 1) * blocks_per_epoch
+    }
+
+    /// Returns the block number (height) of the preceding election macro block before a given block number (height).
+    /// If the given block number is an election macro block, it returns the election macro block before it.
+    #[inline]
+    pub fn election_block_before(block_number: u32) -> u32 {
+        if block_number == 0 {
+            panic!("Called macro_block_before with block_number 0");
+        }
+        let blocks_per_epoch = Self::blocks_per_epoch();
+        (block_number - 1) / blocks_per_epoch * blocks_per_epoch
+    }
+
+    /// Returns the block number (height) of the last election macro block at a given block number (height).
+    /// If the given block number is an election macro block, then it returns that block number.
+    #[inline]
+    pub fn last_election_block(block_number: u32) -> u32 {
+        let blocks_per_epoch = Self::blocks_per_epoch();
+        block_number / blocks_per_epoch * blocks_per_epoch
+    }
+
+    /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
+    #[inline]
+    pub fn is_election_block_at(block_number: u32) -> bool {
+        Self::epoch_index_at(block_number) == Self::blocks_per_epoch() - 1
+    }
+
+    /// Returns the block number (height) of the next macro block after a given block number (height).
+    #[inline]
+    pub fn macro_block_after(block_number: u32) -> u32 {
+        let blocks_per_batch = Self::blocks_per_batch();
+        (block_number / blocks_per_batch + 1) * blocks_per_batch
+    }
+
+    /// Returns the block number (height) of the preceding macro block before a given block number (height).
+    /// If the given block number is a macro block, it returns the macro block before it.
+    #[inline]
+    pub fn macro_block_before(block_number: u32) -> u32 {
+        if block_number == 0 {
+            panic!("Called macro_block_before with block_number 0");
+        }
+        let blocks_per_batch = Self::blocks_per_batch();
+        (block_number - 1) / blocks_per_batch * blocks_per_batch
+    }
+
+    /// Returns the block number (height) of the last macro block at a given block number (height).
+    /// If the given block number is a macro block, then it returns that block number.
+    #[inline]
+    pub fn last_macro_block(block_number: u32) -> u32 {
+        let blocks_per_batch = Self::blocks_per_batch();
+        block_number / blocks_per_batch * blocks_per_batch
+    }
+
+    /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
+    #[inline]
+    pub fn is_macro_block_at(block_number: u32) -> bool {
+        Self::batch_index_at(block_number) == Self::blocks_per_batch() - 1
+    }
+
+    /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
+    #[inline]
+    pub fn is_micro_block_at(block_number: u32) -> bool {
+        Self::batch_index_at(block_number) != Self::blocks_per_batch() - 1
+    }
+
+    /// Returns the block number of the first block of the given epoch (which is always a micro block).
+    pub fn first_block_of(epoch: u32) -> u32 {
+        if epoch == 0 {
+            panic!("Called first_block_of for epoch 0");
+        }
+        (epoch - 1) * Self::blocks_per_epoch() + 1
+    }
+
+    /// Returns the block number of the first block of the given batch (which is always a micro block).
+    pub fn first_block_of_batch(batch: u32) -> u32 {
+        if batch == 0 {
+            panic!("Called first_block_of_batch for batch 0");
+        }
+        (batch - 1) * Self::blocks_per_batch() + 1
+    }
+
+    /// Returns the block number of the election macro block of the given epoch (which is always the last block).
+    pub fn election_block_of(epoch: u32) -> u32 {
+        epoch * Self::blocks_per_epoch()
+    }
+
+    /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
+    /// is always the last block).
+    pub fn macro_block_of(batch: u32) -> u32 {
+        batch * Self::blocks_per_batch()
+    }
+
+    /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
+    /// of the epoch.
+    #[inline]
+    pub fn first_batch_of_epoch(block_number: u32) -> bool {
+        Self::epoch_index_at(block_number) < Self::blocks_per_batch()
+    }
+
+    /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
+    /// calculated using the following formula:
+    /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
+    /// Where e is the exponential function, t is the time in milliseconds since the genesis block and
+    /// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
+    pub fn supply_at(genesis_supply: u64, genesis_time: u64, current_time: u64) -> u64 {
+        assert!(current_time >= genesis_time);
+
+        let t = (current_time - genesis_time) as f64;
+
+        let exponent = -Policy::SUPPLY_DECAY * t;
+
+        let supply = genesis_supply
+            + (Policy::INITIAL_SUPPLY_VELOCITY / Policy::SUPPLY_DECAY * (1.0 - exponent.exp()))
+                as u64;
+
+        cmp::min(supply, Policy::TOTAL_SUPPLY)
+    }
+
+    #[inline]
+    pub fn get_or_init(policy: Policy) -> Policy {
+        *GLOBAL_POLICY.get_or_init(|| policy)
+    }
 }
 
-/// Returns the block number of the election macro block of the given epoch (which is always the last block).
-pub fn election_block_of(epoch: u32) -> u32 {
-    epoch * BLOCKS_PER_EPOCH
-}
-
-/// Returns the block number of the macro block (checkpoint or election) of the given batch (which
-/// is always the last block).
-pub fn macro_block_of(batch: u32) -> u32 {
-    batch * BLOCKS_PER_BATCH
-}
-
-/// Returns a boolean expressing if the batch at a given block number (height) is the first batch
-/// of the epoch.
-#[inline]
-pub fn first_batch_of_epoch(block_number: u32) -> bool {
-    epoch_index_at(block_number) < BLOCKS_PER_BATCH
-}
-
-/// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
-/// calculated using the following formula:
-/// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
-/// Where e is the exponential function, t is the time in milliseconds since the genesis block and
-/// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
-pub fn supply_at(genesis_supply: u64, genesis_time: u64, current_time: u64) -> u64 {
-    assert!(current_time >= genesis_time);
-
-    let t = (current_time - genesis_time) as f64;
-
-    let exponent = -SUPPLY_DECAY * t;
-
-    let supply =
-        genesis_supply + (INITIAL_SUPPLY_VELOCITY / SUPPLY_DECAY * (1.0 - exponent.exp())) as u64;
-
-    cmp::min(supply, TOTAL_SUPPLY)
+impl Default for Policy {
+    fn default() -> Self {
+        Policy {
+            blocks_per_batch: 60,
+            batches_per_epoch: 360,
+            tendermint_timeout_init: 1000,
+            tendermint_timeout_delta: 1000,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -244,129 +309,148 @@ mod tests {
     use super::*;
     use nimiq_test_log::test;
 
+    fn initialize_policy() {
+        let policy = Policy {
+            blocks_per_batch: 32,
+            batches_per_epoch: 4,
+            tendermint_timeout_init: 1000,
+            tendermint_timeout_delta: 1000,
+        };
+        let _ = Policy::get_or_init(policy);
+    }
+
     #[test]
     fn it_correctly_computes_epoch() {
-        assert_eq!(epoch_at(0), 0);
-        assert_eq!(epoch_at(1), 1);
-        assert_eq!(epoch_at(128), 1);
-        assert_eq!(epoch_at(129), 2);
+        initialize_policy();
+        assert_eq!(Policy::epoch_at(0), 0);
+        assert_eq!(Policy::epoch_at(1), 1);
+        assert_eq!(Policy::epoch_at(128), 1);
+        assert_eq!(Policy::epoch_at(129), 2);
     }
 
     #[test]
     fn it_correctly_computes_epoch_index() {
-        assert_eq!(epoch_index_at(1), 0);
-        assert_eq!(epoch_index_at(2), 1);
-        assert_eq!(epoch_index_at(128), 127);
-        assert_eq!(epoch_index_at(129), 0);
+        initialize_policy();
+        assert_eq!(Policy::epoch_index_at(1), 0);
+        assert_eq!(Policy::epoch_index_at(2), 1);
+        assert_eq!(Policy::epoch_index_at(128), 127);
+        assert_eq!(Policy::epoch_index_at(129), 0);
     }
 
     #[test]
     fn it_correctly_computes_batch() {
-        assert_eq!(batch_at(0), 0);
-        assert_eq!(batch_at(1), 1);
-        assert_eq!(batch_at(32), 1);
-        assert_eq!(batch_at(33), 2);
+        initialize_policy();
+        assert_eq!(Policy::batch_at(0), 0);
+        assert_eq!(Policy::batch_at(1), 1);
+        assert_eq!(Policy::batch_at(32), 1);
+        assert_eq!(Policy::batch_at(33), 2);
     }
 
     #[test]
     fn it_correctly_computes_batch_index() {
-        assert_eq!(batch_index_at(1), 0);
-        assert_eq!(batch_index_at(2), 1);
-        assert_eq!(batch_index_at(128), 31);
-        assert_eq!(batch_index_at(129), 0);
+        initialize_policy();
+        assert_eq!(Policy::batch_index_at(1), 0);
+        assert_eq!(Policy::batch_index_at(2), 1);
+        assert_eq!(Policy::batch_index_at(128), 31);
+        assert_eq!(Policy::batch_index_at(129), 0);
     }
 
     #[test]
     fn it_correctly_computes_block_positions() {
-        assert_eq!(is_macro_block_at(0), true);
-        assert_eq!(!is_micro_block_at(0), true);
-        assert_eq!(is_election_block_at(0), true);
+        initialize_policy();
+        assert_eq!(Policy::is_macro_block_at(0), true);
+        assert_eq!(!Policy::is_micro_block_at(0), true);
+        assert_eq!(Policy::is_election_block_at(0), true);
 
-        assert_eq!(is_macro_block_at(1), false);
-        assert_eq!(!is_micro_block_at(1), false);
-        assert_eq!(is_election_block_at(1), false);
+        assert_eq!(Policy::is_macro_block_at(1), false);
+        assert_eq!(!Policy::is_micro_block_at(1), false);
+        assert_eq!(Policy::is_election_block_at(1), false);
 
-        assert_eq!(is_macro_block_at(2), false);
-        assert_eq!(!is_micro_block_at(2), false);
-        assert_eq!(is_election_block_at(2), false);
+        assert_eq!(Policy::is_macro_block_at(2), false);
+        assert_eq!(!Policy::is_micro_block_at(2), false);
+        assert_eq!(Policy::is_election_block_at(2), false);
 
-        assert_eq!(is_macro_block_at(32), true);
-        assert_eq!(is_micro_block_at(32), false);
-        assert_eq!(is_election_block_at(32), false);
+        assert_eq!(Policy::is_macro_block_at(32), true);
+        assert_eq!(Policy::is_micro_block_at(32), false);
+        assert_eq!(Policy::is_election_block_at(32), false);
 
-        assert_eq!(is_macro_block_at(127), false);
-        assert_eq!(!is_micro_block_at(127), false);
-        assert_eq!(is_election_block_at(127), false);
+        assert_eq!(Policy::is_macro_block_at(127), false);
+        assert_eq!(!Policy::is_micro_block_at(127), false);
+        assert_eq!(Policy::is_election_block_at(127), false);
 
-        assert_eq!(is_macro_block_at(128), true);
-        assert_eq!(!is_micro_block_at(128), true);
-        assert_eq!(is_election_block_at(128), true);
+        assert_eq!(Policy::is_macro_block_at(128), true);
+        assert_eq!(!Policy::is_micro_block_at(128), true);
+        assert_eq!(Policy::is_election_block_at(128), true);
 
-        assert_eq!(is_macro_block_at(129), false);
-        assert_eq!(!is_micro_block_at(129), false);
-        assert_eq!(is_election_block_at(129), false);
+        assert_eq!(Policy::is_macro_block_at(129), false);
+        assert_eq!(!Policy::is_micro_block_at(129), false);
+        assert_eq!(Policy::is_election_block_at(129), false);
 
-        assert_eq!(is_macro_block_at(160), true);
-        assert_eq!(is_micro_block_at(160), false);
-        assert_eq!(is_election_block_at(160), false);
+        assert_eq!(Policy::is_macro_block_at(160), true);
+        assert_eq!(Policy::is_micro_block_at(160), false);
+        assert_eq!(Policy::is_election_block_at(160), false);
     }
 
     #[test]
     fn it_correctly_computes_macro_numbers() {
-        assert_eq!(macro_block_after(0), 32);
-        assert_eq!(macro_block_after(1), 32);
-        assert_eq!(macro_block_after(127), 128);
-        assert_eq!(macro_block_after(128), 160);
-        assert_eq!(macro_block_after(129), 160);
+        initialize_policy();
+        assert_eq!(Policy::macro_block_after(0), 32);
+        assert_eq!(Policy::macro_block_after(1), 32);
+        assert_eq!(Policy::macro_block_after(127), 128);
+        assert_eq!(Policy::macro_block_after(128), 160);
+        assert_eq!(Policy::macro_block_after(129), 160);
 
-        assert_eq!(macro_block_before(1), 0);
-        assert_eq!(macro_block_before(2), 0);
-        assert_eq!(macro_block_before(127), 96);
-        assert_eq!(macro_block_before(128), 96);
-        assert_eq!(macro_block_before(129), 128);
-        assert_eq!(macro_block_before(130), 128);
+        assert_eq!(Policy::macro_block_before(1), 0);
+        assert_eq!(Policy::macro_block_before(2), 0);
+        assert_eq!(Policy::macro_block_before(127), 96);
+        assert_eq!(Policy::macro_block_before(128), 96);
+        assert_eq!(Policy::macro_block_before(129), 128);
+        assert_eq!(Policy::macro_block_before(130), 128);
     }
 
     #[test]
     fn it_correctly_computes_election_numbers() {
-        assert_eq!(election_block_after(0), 128);
-        assert_eq!(election_block_after(1), 128);
-        assert_eq!(election_block_after(127), 128);
-        assert_eq!(election_block_after(128), 256);
-        assert_eq!(election_block_after(129), 256);
+        initialize_policy();
+        assert_eq!(Policy::election_block_after(0), 128);
+        assert_eq!(Policy::election_block_after(1), 128);
+        assert_eq!(Policy::election_block_after(127), 128);
+        assert_eq!(Policy::election_block_after(128), 256);
+        assert_eq!(Policy::election_block_after(129), 256);
 
-        assert_eq!(election_block_before(1), 0);
-        assert_eq!(election_block_before(2), 0);
-        assert_eq!(election_block_before(127), 0);
-        assert_eq!(election_block_before(128), 0);
-        assert_eq!(election_block_before(129), 128);
-        assert_eq!(election_block_before(130), 128);
+        assert_eq!(Policy::election_block_before(1), 0);
+        assert_eq!(Policy::election_block_before(2), 0);
+        assert_eq!(Policy::election_block_before(127), 0);
+        assert_eq!(Policy::election_block_before(128), 0);
+        assert_eq!(Policy::election_block_before(129), 128);
+        assert_eq!(Policy::election_block_before(130), 128);
 
-        assert_eq!(last_election_block(0), 0);
-        assert_eq!(last_election_block(1), 0);
-        assert_eq!(last_election_block(127), 0);
-        assert_eq!(last_election_block(128), 128);
-        assert_eq!(last_election_block(129), 128);
+        assert_eq!(Policy::last_election_block(0), 0);
+        assert_eq!(Policy::last_election_block(1), 0);
+        assert_eq!(Policy::last_election_block(127), 0);
+        assert_eq!(Policy::last_election_block(128), 128);
+        assert_eq!(Policy::last_election_block(129), 128);
     }
 
     #[test]
     fn it_correctly_comutes_first_ofs() {
-        assert_eq!(first_block_of(1), 1);
-        assert_eq!(first_block_of(2), 129);
+        initialize_policy();
+        assert_eq!(Policy::first_block_of(1), 1);
+        assert_eq!(Policy::first_block_of(2), 129);
 
-        assert_eq!(first_block_of_batch(1), 1);
-        assert_eq!(first_block_of_batch(2), 33);
-        assert_eq!(first_block_of_batch(3), 65);
-        assert_eq!(first_block_of_batch(4), 97);
-        assert_eq!(first_block_of_batch(5), 129);
+        assert_eq!(Policy::first_block_of_batch(1), 1);
+        assert_eq!(Policy::first_block_of_batch(2), 33);
+        assert_eq!(Policy::first_block_of_batch(3), 65);
+        assert_eq!(Policy::first_block_of_batch(4), 97);
+        assert_eq!(Policy::first_block_of_batch(5), 129);
     }
 
     #[test]
     fn it_correctly_computes_first_batch_of_epoch() {
-        assert_eq!(first_batch_of_epoch(1), true);
-        assert_eq!(first_batch_of_epoch(32), true);
-        assert_eq!(first_batch_of_epoch(33), false);
-        assert_eq!(first_batch_of_epoch(128), false);
-        assert_eq!(first_batch_of_epoch(129), true);
+        initialize_policy();
+        assert_eq!(Policy::first_batch_of_epoch(1), true);
+        assert_eq!(Policy::first_batch_of_epoch(32), true);
+        assert_eq!(Policy::first_batch_of_epoch(33), false);
+        assert_eq!(Policy::first_batch_of_epoch(128), false);
+        assert_eq!(Policy::first_batch_of_epoch(129), true);
     }
 }

--- a/primitives/src/slots.rs
+++ b/primitives/src/slots.rs
@@ -27,7 +27,7 @@ use nimiq_bls::lazy::LazyPublicKey as LazyBlsPublicKey;
 use nimiq_bls::PublicKey as BlsPublicKey;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
 
-use crate::policy::SLOTS;
+use crate::policy::Policy;
 
 /// A validator that owns some slots.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -109,7 +109,7 @@ impl Validators {
 
     /// Calculates the slot band of the validator that owns the given slot.
     pub fn get_band_from_slot(&self, slot: u16) -> u16 {
-        assert!(slot < SLOTS);
+        assert!(slot < Policy::SLOTS);
 
         let mut pivot = self.num_validators() / 2;
         let mut last_pivot = 0usize;

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -5,7 +5,7 @@ use nimiq_bls::{CompressedPublicKey as BlsPublicKey, CompressedSignature as BlsS
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 use crate::SignatureProof;
 use crate::{Transaction, TransactionError};
@@ -142,7 +142,7 @@ impl IncomingStakingTransactionData {
                 ..
             } => {
                 // Validators must be created with exactly the validator deposit amount.
-                if transaction.value != Coin::from_u64_unchecked(policy::VALIDATOR_DEPOSIT) {
+                if transaction.value != Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT) {
                     error!("Validator stake value different from VALIDATOR_DEPOSIT. The offending transaction is the following:\n{:?}", transaction);
                     return Err(TransactionError::InvalidValue);
                 }

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -20,7 +20,7 @@ use nimiq_keys::{PublicKey, Signature};
 use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_utils::merkle::{Blake2bMerklePath, Blake2bMerkleProof};
 
 use crate::account::AccountTransactionVerification;
@@ -334,7 +334,7 @@ impl Transaction {
             return Ok(());
         }
 
-        if self.recipient == policy::STAKING_CONTRACT_ADDRESS
+        if self.recipient == Policy::STAKING_CONTRACT_ADDRESS
             && self.recipient_type != AccountType::Staking
         {
             return Err(TransactionError::InvalidForRecipient);
@@ -342,7 +342,7 @@ impl Transaction {
 
         // Should not be necessary as the sender would have to sign the transaction
         // and the private key for the staking contract is unknown
-        if self.sender == policy::STAKING_CONTRACT_ADDRESS
+        if self.sender == Policy::STAKING_CONTRACT_ADDRESS
             && self.sender_type != AccountType::Staking
         {
             return Err(TransactionError::InvalidForSender);
@@ -364,7 +364,7 @@ impl Transaction {
         // Check that value + fee doesn't overflow.
         match self.value.checked_add(self.fee) {
             Some(coin) => {
-                if coin > Coin::from_u64_unchecked(policy::TOTAL_SUPPLY) {
+                if coin > Coin::from_u64_unchecked(Policy::TOTAL_SUPPLY) {
                     return Err(TransactionError::Overflow);
                 }
             }
@@ -387,11 +387,11 @@ impl Transaction {
     }
 
     pub fn is_valid_at(&self, block_height: u32) -> bool {
-        let window = policy::TRANSACTION_VALIDITY_WINDOW;
+        let window = Policy::TRANSACTION_VALIDITY_WINDOW;
         block_height
             >= self
                 .validity_start_height
-                .saturating_sub(policy::BLOCKS_PER_BATCH)
+                .saturating_sub(Policy::blocks_per_batch())
             && block_height < self.validity_start_height + window
     }
 

--- a/primitives/transaction/tests/staking_contract.rs
+++ b/primitives/transaction/tests/staking_contract.rs
@@ -9,7 +9,7 @@ use nimiq_keys::{Address, KeyPair, PrivateKey, PublicKey};
 use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::{STAKING_CONTRACT_ADDRESS, VALIDATOR_DEPOSIT};
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_transaction::account::staking_contract::{
     IncomingStakingTransactionData, OutgoingStakingTransactionProof,
@@ -81,7 +81,7 @@ fn create_validator() {
             signal_data: None,
             proof: SignatureProof::default(),
         },
-        VALIDATOR_DEPOSIT,
+        Policy::VALIDATOR_DEPOSIT,
         &cold_keypair,
         None,
     );
@@ -101,14 +101,14 @@ fn create_validator() {
     assert_eq!(AccountType::verify_incoming_transaction(&tx), Ok(()));
 
     // Deposit too small or too big.
-    tx.value = Coin::from_u64_unchecked(VALIDATOR_DEPOSIT - 100);
+    tx.value = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT - 100);
 
     assert_eq!(
         AccountType::verify_incoming_transaction(&tx),
         Err(TransactionError::InvalidValue)
     );
 
-    tx.value = Coin::from_u64_unchecked(VALIDATOR_DEPOSIT + 100);
+    tx.value = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT + 100);
 
     assert_eq!(
         AccountType::verify_incoming_transaction(&tx),
@@ -128,7 +128,7 @@ fn create_validator() {
             signal_data: None,
             proof: SignatureProof::default(),
         },
-        VALIDATOR_DEPOSIT,
+        Policy::VALIDATOR_DEPOSIT,
         &cold_keypair,
         None,
     );
@@ -152,7 +152,7 @@ fn create_validator() {
             signal_data: None,
             proof: SignatureProof::default(),
         },
-        VALIDATOR_DEPOSIT,
+        Policy::VALIDATOR_DEPOSIT,
         &cold_keypair,
         Some(other_pair.public),
     );
@@ -499,7 +499,7 @@ fn create_staker() {
             delegation: None,
             proof: SignatureProof::default(),
         },
-        VALIDATOR_DEPOSIT,
+        Policy::VALIDATOR_DEPOSIT,
         &keypair,
         Some(other_pair.public),
     );
@@ -598,7 +598,7 @@ fn update_staker() {
 #[test]
 fn delete_validator() {
     // Test serialization and deserialization.
-    let tx = make_delete_validator_tx(VALIDATOR_DEPOSIT - 100, false);
+    let tx = make_delete_validator_tx(Policy::VALIDATOR_DEPOSIT - 100, false);
 
     let tx_hex = "010000d6d530da000000000000602dbca99b0000000000038c551fabc6e6e00c609c3f0313257ad7e835643c00000000003b9ac99c00000000000000640000000104000062007451b039e2f3fcafc3be7c6bd9e01fbc072c956a2b95a335cfb3cd3702335b5300f59b9c7c01cd154de300f0106650b7f3a7d79af892ddb69c96f4010e9f5fe78160a371e8d801da9f55e079687474601898857d02168f160d47041dade476280a";
     let tx_size = 167;
@@ -616,16 +616,16 @@ fn delete_validator() {
 
     // This transaction is no longer statically checked for the validator deposit, so the only case where the verification
     // would fail, is by sending a wrong signature
-    let tx = make_delete_validator_tx(VALIDATOR_DEPOSIT - 200, false);
+    let tx = make_delete_validator_tx(Policy::VALIDATOR_DEPOSIT - 200, false);
 
     assert_eq!(AccountType::verify_outgoing_transaction(&tx), Ok(()));
 
-    let tx = make_delete_validator_tx(VALIDATOR_DEPOSIT, false);
+    let tx = make_delete_validator_tx(Policy::VALIDATOR_DEPOSIT, false);
 
     assert_eq!(AccountType::verify_outgoing_transaction(&tx), Ok(()));
 
     // Wrong signature.
-    let tx = make_delete_validator_tx(VALIDATOR_DEPOSIT - 100, true);
+    let tx = make_delete_validator_tx(Policy::VALIDATOR_DEPOSIT - 100, true);
 
     assert_eq!(
         AccountType::verify_outgoing_transaction(&tx),
@@ -668,7 +668,7 @@ fn make_incoming_tx(data: IncomingStakingTransactionData, value: u64) -> Transac
         | IncomingStakingTransactionData::Stake { .. } => Transaction::new_extended(
             Address::from_any_str(STAKER_ADDRESS).unwrap(),
             AccountType::Basic,
-            STAKING_CONTRACT_ADDRESS,
+            Policy::STAKING_CONTRACT_ADDRESS,
             AccountType::Staking,
             value.try_into().unwrap(),
             100.try_into().unwrap(),
@@ -679,7 +679,7 @@ fn make_incoming_tx(data: IncomingStakingTransactionData, value: u64) -> Transac
         _ => Transaction::new_signalling(
             Address::from_any_str(STAKER_ADDRESS).unwrap(),
             AccountType::Basic,
-            STAKING_CONTRACT_ADDRESS,
+            Policy::STAKING_CONTRACT_ADDRESS,
             AccountType::Staking,
             value.try_into().unwrap(),
             100.try_into().unwrap(),
@@ -726,7 +726,7 @@ fn make_signed_incoming_tx(
 
 fn make_delete_validator_tx(value: u64, wrong_sig: bool) -> Transaction {
     let mut tx = Transaction::new_extended(
-        STAKING_CONTRACT_ADDRESS,
+        Policy::STAKING_CONTRACT_ADDRESS,
         AccountType::Staking,
         Address::from_any_str(STAKER_ADDRESS).unwrap(),
         AccountType::Basic,
@@ -764,7 +764,7 @@ fn make_delete_validator_tx(value: u64, wrong_sig: bool) -> Transaction {
 
 fn make_unstake_tx(wrong_sig: bool) -> Transaction {
     let mut tx = Transaction::new_extended(
-        STAKING_CONTRACT_ADDRESS,
+        Policy::STAKING_CONTRACT_ADDRESS,
         AccountType::Staking,
         Address::from_any_str(STAKER_ADDRESS).unwrap(),
         AccountType::Basic,

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -19,7 +19,7 @@ use nimiq_collections::BitSet;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::{Address, PublicKey};
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 use nimiq_transaction::account::htlc_contract::AnyHash;
 use nimiq_transaction::account::htlc_contract::HashAlgorithm as HTLCContractHashAlgorithm;
@@ -215,8 +215,8 @@ impl Block {
         let block_number = block.block_number();
         let timestamp = block.timestamp();
         let size = block.serialized_size() as u32;
-        let batch = policy::batch_at(block_number);
-        let epoch = policy::epoch_at(block_number);
+        let batch = Policy::batch_at(block_number);
+        let epoch = Policy::epoch_at(block_number);
 
         match block {
             nimiq_block::Block::Macro(macro_block) => {
@@ -269,7 +269,7 @@ impl Block {
                     history_hash: macro_block.header.history_root,
                     transactions,
                     additional_fields: BlockAdditionalFields::Macro {
-                        is_election_block: policy::is_election_block_at(block_number),
+                        is_election_block: Policy::is_election_block_at(block_number),
                         parent_election_hash: macro_block.header.parent_election_hash,
                         slots,
                         lost_reward_set,

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -8,7 +8,7 @@ use nimiq_account::{BlockLog as BBlockLog, StakingContract, TransactionLog};
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_rpc_interface::types::{
     is_of_log_type_and_related_to_addresses, BlockLog, BlockNumberOrHash, BlockchainState,
     ParkedSet, RPCData, RPCResult, Validator,
@@ -103,12 +103,12 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     /// Returns the batch number for the current head.
     async fn get_batch_number(&mut self) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::batch_at(self.blockchain.read().block_number()).into())
+        Ok(Policy::batch_at(self.blockchain.read().block_number()).into())
     }
 
     /// Returns the epoch number for the current head.
     async fn get_epoch_number(&mut self) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::epoch_at(self.blockchain.read().block_number()).into())
+        Ok(Policy::epoch_at(self.blockchain.read().block_number()).into())
     }
 
     /// Tries to fetch a block given its hash. It has an option to include the transactions in the
@@ -313,8 +313,8 @@ impl BlockchainInterface for BlockchainDispatcher {
         let blockchain = self.blockchain.read();
 
         // Calculate the numbers for the micro blocks in the batch.
-        let first_block = policy::first_block_of_batch(batch_number);
-        let last_block = policy::macro_block_of(batch_number);
+        let first_block = Policy::first_block_of_batch(batch_number);
+        let last_block = Policy::macro_block_of(batch_number);
 
         // Search all micro blocks of the batch to find the transactions.
         let mut transactions = vec![];
@@ -351,7 +351,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     ) -> RPCResult<Vec<Inherent>, (), Self::Error> {
         let blockchain = self.blockchain.read();
 
-        let macro_block_number = policy::macro_block_of(batch_number);
+        let macro_block_number = Policy::macro_block_of(batch_number);
 
         // Check the batch's macro block to see if the batch includes slashes.
         let macro_block = blockchain
@@ -364,7 +364,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
         if !macro_body.lost_reward_set.is_empty() {
             // Search all micro blocks of the batch to find the slash inherents.
-            let first_micro_block = policy::first_block_of_batch(batch_number);
+            let first_micro_block = Policy::first_block_of_batch(batch_number);
             let last_micro_block = macro_block_number - 1;
 
             for i in first_micro_block..=last_micro_block {

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_rpc_interface::policy::PolicyInterface;
 use nimiq_rpc_interface::types::{PolicyConstants, RPCResult};
 
@@ -16,41 +16,41 @@ impl PolicyInterface for PolicyDispatcher {
     /// Returns a bundle of policy constants
     async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error> {
         Ok(PolicyConstants {
-            staking_contract_address: policy::STAKING_CONTRACT_ADDRESS.to_string(),
-            coinbase_address: policy::COINBASE_ADDRESS.to_string(),
-            transaction_validity_window: policy::TRANSACTION_VALIDITY_WINDOW,
-            max_size_micro_body: policy::MAX_SIZE_MICRO_BODY,
-            version: policy::VERSION,
-            slots: policy::SLOTS,
-            blocks_per_batch: policy::BLOCKS_PER_BATCH,
-            batches_per_epoch: policy::BATCHES_PER_EPOCH,
-            blocks_per_epoch: policy::BLOCKS_PER_EPOCH,
-            validator_deposit: policy::VALIDATOR_DEPOSIT,
-            total_supply: policy::TOTAL_SUPPLY,
+            staking_contract_address: Policy::STAKING_CONTRACT_ADDRESS.to_string(),
+            coinbase_address: Policy::COINBASE_ADDRESS.to_string(),
+            transaction_validity_window: Policy::TRANSACTION_VALIDITY_WINDOW,
+            max_size_micro_body: Policy::MAX_SIZE_MICRO_BODY,
+            version: Policy::VERSION,
+            slots: Policy::SLOTS,
+            blocks_per_batch: Policy::blocks_per_batch(),
+            batches_per_epoch: Policy::batches_per_epoch(),
+            blocks_per_epoch: Policy::blocks_per_epoch(),
+            validator_deposit: Policy::VALIDATOR_DEPOSIT,
+            total_supply: Policy::TOTAL_SUPPLY,
         }
         .into())
     }
 
     /// Returns the epoch number at a given block number (height).
     async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::epoch_at(block_number).into())
+        Ok(Policy::epoch_at(block_number).into())
     }
 
     /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
     /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
     async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::epoch_index_at(block_number).into())
+        Ok(Policy::epoch_index_at(block_number).into())
     }
 
     /// Returns the batch number at a given `block_number` (height)
     async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::batch_at(block_number).into())
+        Ok(Policy::batch_at(block_number).into())
     }
 
     /// Returns the batch index at a given block number. The batch index is the number of a block relative
     /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
     async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::batch_index_at(block_number).into())
+        Ok(Policy::batch_index_at(block_number).into())
     }
 
     /// Returns the number (height) of the next election macro block after a given block number (height).
@@ -58,7 +58,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::election_block_after(block_number).into())
+        Ok(Policy::election_block_after(block_number).into())
     }
 
     /// Returns the number block (height) of the preceding election macro block before a given block number (height).
@@ -71,7 +71,7 @@ impl PolicyInterface for PolicyDispatcher {
             return Err(Error::BlockNumberNotZero);
         }
 
-        Ok(policy::election_block_before(block_number).into())
+        Ok(Policy::election_block_before(block_number).into())
     }
 
     /// Returns the block number (height) of the last election macro block at a given block number (height).
@@ -80,7 +80,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::last_election_block(block_number).into())
+        Ok(Policy::last_election_block(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
@@ -88,7 +88,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error> {
-        Ok(policy::is_election_block_at(block_number).into())
+        Ok(Policy::is_election_block_at(block_number).into())
     }
 
     /// Returns the block number (height) of the next macro block after a given block number (height).
@@ -96,7 +96,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::macro_block_after(block_number).into())
+        Ok(Policy::macro_block_after(block_number).into())
     }
 
     /// Returns the block number (height) of the preceding macro block before a given block number (height).
@@ -109,13 +109,13 @@ impl PolicyInterface for PolicyDispatcher {
             return Err(Error::BlockNumberNotZero);
         }
 
-        Ok(policy::macro_block_before(block_number).into())
+        Ok(Policy::macro_block_before(block_number).into())
     }
 
     /// Returns block the number (height) of the last macro block at a given block number (height).
     /// If the given block number is a macro block, then it returns that block number.
     async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::last_macro_block(block_number).into())
+        Ok(Policy::last_macro_block(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
@@ -123,7 +123,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error> {
-        Ok(policy::is_macro_block_at(block_number).into())
+        Ok(Policy::is_macro_block_at(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
@@ -131,7 +131,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error> {
-        Ok(policy::is_micro_block_at(block_number).into())
+        Ok(Policy::is_micro_block_at(block_number).into())
     }
 
     /// Returns the block number of the first block of the given epoch (which is always a micro block).
@@ -140,7 +140,7 @@ impl PolicyInterface for PolicyDispatcher {
             return Err(Error::EpochNumberNotZero);
         }
 
-        Ok(policy::first_block_of(epoch).into())
+        Ok(Policy::first_block_of(epoch).into())
     }
 
     /// Returns the block number of the first block of the given batch (which is always a micro block).
@@ -149,18 +149,18 @@ impl PolicyInterface for PolicyDispatcher {
             return Err(Error::BatchNumberNotZero);
         }
 
-        Ok(policy::first_block_of_batch(batch).into())
+        Ok(Policy::first_block_of_batch(batch).into())
     }
 
     /// Returns the block number of the election macro block of the given epoch (which is always the last block).
     async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::election_block_of(epoch).into())
+        Ok(Policy::election_block_of(epoch).into())
     }
 
     /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
     /// is always the last block).
     async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
-        Ok(policy::macro_block_of(batch).into())
+        Ok(Policy::macro_block_of(batch).into())
     }
 
     /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
@@ -169,7 +169,7 @@ impl PolicyInterface for PolicyDispatcher {
         &mut self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error> {
-        Ok(policy::first_batch_of_epoch(block_number).into())
+        Ok(Policy::first_batch_of_epoch(block_number).into())
     }
 
     /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
@@ -183,6 +183,6 @@ impl PolicyInterface for PolicyDispatcher {
         genesis_time: u64,
         current_time: u64,
     ) -> RPCResult<u64, (), Self::Error> {
-        Ok(policy::supply_at(genesis_supply, genesis_time, current_time).into())
+        Ok(Policy::supply_at(genesis_supply, genesis_time, current_time).into())
     }
 }

--- a/tendermint/src/utils.rs
+++ b/tendermint/src/utils.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use beserial::{Deserialize, Serialize};
 use nimiq_block::TendermintStep;
-use nimiq_primitives::policy::TWO_F_PLUS_ONE;
+use nimiq_primitives::policy::Policy;
 use std::collections::BTreeMap;
 use thiserror::Error;
 
@@ -134,7 +134,9 @@ pub(crate) fn aggregation_to_vote<ProposalHashTy: ProposalHashTrait, ProofTy: Pr
     proposal_hash: &Option<ProposalHashTy>,
     agg: BTreeMap<Option<ProposalHashTy>, (ProofTy, u16)>,
 ) -> VoteResult<ProofTy> {
-    if proposal_hash.is_some() && agg.get(proposal_hash).map_or(0, |x| x.1) >= TWO_F_PLUS_ONE {
+    if proposal_hash.is_some()
+        && agg.get(proposal_hash).map_or(0, |x| x.1) >= Policy::TWO_F_PLUS_ONE
+    {
         log::debug!(
             "Current proposal {:?} has {} votes: {:#?}",
             &proposal_hash,
@@ -144,7 +146,7 @@ pub(crate) fn aggregation_to_vote<ProposalHashTy: ProposalHashTrait, ProofTy: Pr
         // If we received 2f+1 votes for the current (assuming that it isn't None), then we
         // must return Block.
         VoteResult::Block(agg.get(proposal_hash).cloned().unwrap().0)
-    } else if agg.get(&None).map_or(0, |x| x.1) >= TWO_F_PLUS_ONE {
+    } else if agg.get(&None).map_or(0, |x| x.1) >= Policy::TWO_F_PLUS_ONE {
         // is f+1 sufficient here?
         log::debug!(
             "Nil has {} votes: {:#?}",
@@ -181,5 +183,5 @@ pub(crate) fn has_2f1_votes<ProposalHashTy: ProposalHashTrait, ProofTy: ProofTra
         &prop_opt,
         agg.get(&prop_opt).map_or(0, |x| x.1),
     );
-    agg.get(&prop_opt).map_or(0, |x| x.1) >= TWO_F_PLUS_ONE
+    agg.get(&prop_opt).map_or(0, |x| x.1) >= Policy::TWO_F_PLUS_ONE
 }

--- a/tendermint/tests/mod.rs
+++ b/tendermint/tests/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use beserial::{Deserialize, Serialize};
 use futures::{future, future::BoxFuture, FutureExt, StreamExt};
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
-use nimiq_primitives::policy::{SLOTS, TWO_F_PLUS_ONE};
+use nimiq_primitives::policy::Policy;
 use nimiq_tendermint::*;
 use nimiq_test_log::test;
 use std::collections::BTreeMap;
@@ -323,28 +323,28 @@ async fn it_can_reenter_from_state() {
             (false, TestProposal(0, 5), None), // irrelevant the node should propose (1,3)
         ],
         agg_prevote_rounds: vec![
-            (false, 0, 0, SLOTS),
-            (true, 0, 0, SLOTS),
-            (false, 0, 0, SLOTS),
-            (false, 0, SLOTS, 0),
-            (false, 0, SLOTS, 0),
-            (false, 0, SLOTS, 0),
+            (false, 0, 0, Policy::SLOTS),
+            (true, 0, 0, Policy::SLOTS),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, Policy::SLOTS, 0),
+            (false, 0, Policy::SLOTS, 0),
+            (false, 0, Policy::SLOTS, 0),
         ],
         agg_precommit_rounds: vec![
-            (false, 0, 0, SLOTS),
-            (false, 0, 0, SLOTS),
-            (true, 0, 0, SLOTS),
-            (false, 0, 0, SLOTS),
-            (false, 0, 0, SLOTS),
-            (false, 0, SLOTS, 0),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, 0, Policy::SLOTS),
+            (true, 0, 0, Policy::SLOTS),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, Policy::SLOTS, 0),
         ],
         get_agg_rounds: vec![
-            (false, 0, 0, SLOTS),
-            (false, 0, 0, SLOTS),
-            (false, 0, SLOTS, 0),
-            (false, 0, SLOTS, 0),
-            (false, 0, 0, SLOTS),
-            (false, 0, 0, SLOTS),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, Policy::SLOTS, 0),
+            (false, 0, Policy::SLOTS, 0),
+            (false, 0, 0, Policy::SLOTS),
+            (false, 0, 0, Policy::SLOTS),
         ],
     };
 
@@ -426,9 +426,9 @@ async fn it_does_not_unlock() {
             (false, TestProposal(0, 0), None),
             (true, TestProposal(1, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0), (false, 0, SLOTS, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, SLOTS), (false, 0, 0, SLOTS)],
-        get_agg_rounds: vec![(false, SLOTS, 0, 0), (false, 0, SLOTS, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0), (false, 0, Policy::SLOTS, 0)],
+        agg_precommit_rounds: vec![(false, 0, 0, Policy::SLOTS), (false, 0, 0, Policy::SLOTS)],
+        get_agg_rounds: vec![(false, Policy::SLOTS, 0, 0), (false, 0, Policy::SLOTS, 0)],
     };
 
     if let Ok(mut tendermint) = Tendermint::new(val, None) {
@@ -496,8 +496,8 @@ async fn everything_works() {
     let proposer = TestValidator {
         proposer_round: 0,
         proposal_rounds: vec![(false, TestProposal(0, 0), None)],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -509,8 +509,8 @@ async fn everything_works() {
     let validator = TestValidator {
         proposer_round: 99,
         proposal_rounds: vec![(false, TestProposal(0, 0), None)],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -528,8 +528,8 @@ async fn no_proposal() {
             (true, TestProposal(0, 0), None),
             (false, TestProposal(0, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, 0, 0, SLOTS), (false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, SLOTS), (false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, 0, 0, Policy::SLOTS), (false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, 0, 0, Policy::SLOTS), (false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -550,8 +550,8 @@ async fn all_timeouts() {
             (true, TestProposal(0, 0), None),
             (false, TestProposal(0, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, 0, 0, 0), (false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, 0, 0, 0), (false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -569,8 +569,11 @@ async fn not_enough_prevotes() {
             (false, TestProposal(0, 0), None),
             (false, TestProposal(0, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, TWO_F_PLUS_ONE - 1, 0, 0), (false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, SLOTS), (false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![
+            (false, Policy::TWO_F_PLUS_ONE - 1, 0, 0),
+            (false, Policy::SLOTS, 0, 0),
+        ],
+        agg_precommit_rounds: vec![(false, 0, 0, Policy::SLOTS), (false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -588,8 +591,11 @@ async fn not_enough_precommits() {
             (false, TestProposal(0, 0), None),
             (false, TestProposal(0, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0), (false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, TWO_F_PLUS_ONE - 1, 0, 0), (false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0), (false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![
+            (false, Policy::TWO_F_PLUS_ONE - 1, 0, 0),
+            (false, Policy::SLOTS, 0, 0),
+        ],
         get_agg_rounds: vec![],
     };
 
@@ -610,8 +616,8 @@ async fn locks_and_rebroadcasts() {
             // what it has stored.
             (false, TestProposal(0, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0), (false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0), (false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -630,8 +636,8 @@ async fn locks_and_unlocks() {
             (false, TestProposal(0, 0), None),
             (false, TestProposal(1, 1), None),
         ],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0), (false, 0, SLOTS, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, 0, SLOTS, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0), (false, 0, Policy::SLOTS, 0)],
+        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, 0, Policy::SLOTS, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -648,7 +654,7 @@ async fn forced_commit() {
         proposer_round: 99,
         proposal_rounds: vec![(false, TestProposal(0, 0), None)],
         agg_prevote_rounds: vec![(false, 0, 0, 0)],
-        agg_precommit_rounds: vec![(false, SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, Policy::SLOTS, 0, 0)],
         get_agg_rounds: vec![],
     };
 
@@ -668,9 +674,17 @@ async fn past_proposal() {
             (false, TestProposal(1, 1), None),
             (false, TestProposal(0, 2), Some(0)),
         ],
-        agg_prevote_rounds: vec![(false, 0, 0, 0), (false, 0, 0, SLOTS), (false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, 0, 0, 0), (false, 0, 0, SLOTS), (false, SLOTS, 0, 0)],
-        get_agg_rounds: vec![(false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![
+            (false, 0, 0, 0),
+            (false, 0, 0, Policy::SLOTS),
+            (false, Policy::SLOTS, 0, 0),
+        ],
+        agg_precommit_rounds: vec![
+            (false, 0, 0, 0),
+            (false, 0, 0, Policy::SLOTS),
+            (false, Policy::SLOTS, 0, 0),
+        ],
+        get_agg_rounds: vec![(false, Policy::SLOTS, 0, 0)],
     };
 
     assert!(tendermint_loop(validator, None, TestProposal(0, 2))
@@ -683,9 +697,9 @@ async fn it_can_assemble_block_from_state() {
     let val = TestValidator {
         proposer_round: 99,
         proposal_rounds: vec![(false, TestProposal(0, 0), None)],
-        agg_prevote_rounds: vec![(false, SLOTS, 0, 0)],
-        agg_precommit_rounds: vec![(false, SLOTS, 0, 0)],
-        get_agg_rounds: vec![(false, SLOTS, 0, 0)],
+        agg_prevote_rounds: vec![(false, Policy::SLOTS, 0, 0)],
+        agg_precommit_rounds: vec![(false, Policy::SLOTS, 0, 0)],
+        get_agg_rounds: vec![(false, Policy::SLOTS, 0, 0)],
     };
 
     // First, make the validator lock itself on a value but then drop the instance. Keep the state.

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 log = { package = "tracing", version = "0.1", features = ["log"] }
 nimiq-log = { path = "../log" }
+nimiq-primitives = { path = "../primitives", features = ["policy"] }
 nimiq-test-log-proc-macro = { path = "proc-macro" }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/test-log/src/lib.rs
+++ b/test-log/src/lib.rs
@@ -1,5 +1,6 @@
 use log::level_filters::LevelFilter;
 use nimiq_log::TargetsExt;
+use nimiq_primitives::policy::Policy;
 use parking_lot::Once;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt;
@@ -22,5 +23,14 @@ pub fn initialize() {
                     .with_env(),
             )
             .init();
+        // Run tests with different policy values:
+        // Shorter epochs and shorter batches
+        let policy = Policy {
+            blocks_per_batch: 32,
+            batches_per_epoch: 4,
+            tendermint_timeout_init: 1000,
+            tendermint_timeout_delta: 1000,
+        };
+        let _ = Policy::get_or_init(policy);
     });
 }

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -18,7 +18,7 @@ use nimiq_genesis::NetworkId;
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, PrivateKey as SchnorrPrivateKey};
 use nimiq_keys::{KeyPair, PrivateKey};
 use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_transaction::Transaction;
 use nimiq_transaction_builder::TransactionBuilder;
 
@@ -126,9 +126,9 @@ pub fn fill_micro_blocks_with_txns(
 ) {
     let init_height = blockchain.read().block_number();
     let key_pair = KeyPair::from(PrivateKey::from_str(UNIT_KEY).unwrap());
-    assert!(policy::is_macro_block_at(init_height));
+    assert!(Policy::is_macro_block_at(init_height));
 
-    let macro_block_number = init_height + policy::BLOCKS_PER_BATCH;
+    let macro_block_number = init_height + Policy::blocks_per_batch();
 
     for i in (init_height + 1)..macro_block_number {
         log::debug!(" Current Height: {}", i);
@@ -203,7 +203,7 @@ pub fn sign_macro_block(
 
     // Create signers Bitset.
     let mut signers = BitSet::new();
-    for i in 0..policy::TWO_F_PLUS_ONE {
+    for i in 0..Policy::TWO_F_PLUS_ONE {
         signers.insert(i as usize);
     }
 
@@ -211,7 +211,7 @@ pub fn sign_macro_block(
     let multisig = MultiSignature {
         signature: AggregateSignature::from_signatures(&vec![
             signed_precommit;
-            policy::TWO_F_PLUS_ONE as usize
+            Policy::TWO_F_PLUS_ONE as usize
         ]),
         signers,
     };
@@ -236,9 +236,9 @@ pub fn sign_skip_block_info(
         SignedSkipBlockInfo::from_message(skip_block_info.clone(), &voting_key_pair.secret_key, 0);
 
     let signature =
-        AggregateSignature::from_signatures(&[skip_block_info.signature.multiply(policy::SLOTS)]);
+        AggregateSignature::from_signatures(&[skip_block_info.signature.multiply(Policy::SLOTS)]);
     let mut signers = BitSet::new();
-    for i in 0..policy::SLOTS {
+    for i in 0..Policy::SLOTS {
         signers.insert(i as usize);
     }
 

--- a/test-utils/src/blockchain_with_rng.rs
+++ b/test-utils/src/blockchain_with_rng.rs
@@ -7,7 +7,7 @@ use rand::Rng;
 use nimiq_block::Block;
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, PushResult};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 
 use crate::blockchain::sign_macro_block;
 
@@ -87,9 +87,9 @@ pub fn fill_micro_blocks_with_rng<R: Rng + CryptoRng>(
 ) {
     let init_height = blockchain.read().block_number();
 
-    assert!(policy::is_macro_block_at(init_height));
+    assert!(Policy::is_macro_block_at(init_height));
 
-    let macro_block_number = init_height + policy::BLOCKS_PER_BATCH;
+    let macro_block_number = init_height + Policy::blocks_per_batch();
 
     for _ in (init_height + 1)..macro_block_number {
         push_micro_block_with_rng(producer, blockchain, rng);

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, KeyPair, PublicKey};
-use nimiq_primitives::policy::{STAKING_CONTRACT_ADDRESS, VALIDATOR_DEPOSIT};
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
 use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
 use nimiq_transaction::{SignatureProof, Transaction};
@@ -1082,7 +1082,7 @@ impl TransactionBuilder {
         match key_pair {
             None => {
                 builder
-                    .with_sender(STAKING_CONTRACT_ADDRESS)
+                    .with_sender(Policy::STAKING_CONTRACT_ADDRESS)
                     .with_sender_type(AccountType::Staking);
             }
             Some(key) => {
@@ -1140,7 +1140,7 @@ impl TransactionBuilder {
 
         let mut builder = Self::new();
         builder
-            .with_sender(STAKING_CONTRACT_ADDRESS)
+            .with_sender(Policy::STAKING_CONTRACT_ADDRESS)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient)
             .with_value(value)
@@ -1196,7 +1196,7 @@ impl TransactionBuilder {
         builder
             .with_sender(Address::from(key_pair))
             .with_recipient(recipient.generate().unwrap())
-            .with_value(Coin::from_u64_unchecked(VALIDATOR_DEPOSIT))
+            .with_value(Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT))
             .with_fee(fee)
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
@@ -1464,7 +1464,7 @@ impl TransactionBuilder {
 
         let mut builder = Self::new();
         builder
-            .with_sender(STAKING_CONTRACT_ADDRESS)
+            .with_sender(Policy::STAKING_CONTRACT_ADDRESS)
             .with_sender_type(AccountType::Staking)
             .with_recipient(recipient)
             .with_value(value)

--- a/transaction-builder/src/proof/mod.rs
+++ b/transaction-builder/src/proof/mod.rs
@@ -270,7 +270,7 @@ impl TransactionProofBuilder {
     /// use nimiq_primitives::networks::NetworkId;
     /// use nimiq_primitives::account::{AccountType};
     /// # use nimiq_utils::key_rng::SecureGenerate;
-    /// use nimiq_primitives::policy::STAKING_CONTRACT_ADDRESS;
+    /// use nimiq_primitives::policy::Policy;
     ///
     /// # let key_pair = KeyPair::generate_default_csprng();
     /// # let recipient_address = Address::from(&key_pair.public);
@@ -278,7 +278,7 @@ impl TransactionProofBuilder {
     /// let recipient = Recipient::new_basic(recipient_address);
     ///
     /// let mut tx_builder = TransactionBuilder::with_required(
-    ///     STAKING_CONTRACT_ADDRESS,
+    ///     Policy::STAKING_CONTRACT_ADDRESS,
     ///     recipient,
     ///     Coin::from_u64_unchecked(100),
     ///     1,

--- a/transaction-builder/src/recipient/mod.rs
+++ b/transaction-builder/src/recipient/mod.rs
@@ -1,7 +1,6 @@
 use beserial::Serialize;
 use nimiq_keys::Address;
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::policy::STAKING_CONTRACT_ADDRESS;
+use nimiq_primitives::{account::AccountType, policy::Policy};
 use nimiq_transaction::account::htlc_contract::CreationTransactionData as HtlcCreationData;
 use nimiq_transaction::account::staking_contract::IncomingStakingTransactionData;
 use nimiq_transaction::account::vesting_contract::CreationTransactionData as VestingCreationData;
@@ -208,7 +207,7 @@ impl Recipient {
     pub fn address(&self) -> Option<Address> {
         match self {
             Recipient::Basic { address, .. } => Some(address.clone()),
-            Recipient::Staking { .. } => Some(STAKING_CONTRACT_ADDRESS),
+            Recipient::Staking { .. } => Some(Policy::STAKING_CONTRACT_ADDRESS),
             _ => None,
         }
     }

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -7,7 +7,7 @@ use nimiq_keys::{Address, KeyPair, PrivateKey};
 use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::{STAKING_CONTRACT_ADDRESS, VALIDATOR_DEPOSIT};
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_transaction::account::staking_contract::{
     IncomingStakingTransactionData, OutgoingStakingTransactionProof,
@@ -168,7 +168,7 @@ fn it_can_create_validator_transactions() {
             signal_data: Some(Blake2bHash::default()),
             proof: Default::default(),
         },
-        VALIDATOR_DEPOSIT,
+        Policy::VALIDATOR_DEPOSIT,
         &key_pair,
     );
 
@@ -283,13 +283,13 @@ fn it_can_create_validator_transactions() {
     assert_eq!(tx, tx2);
 
     // Delete
-    let tx = make_delete_transaction(&key_pair, VALIDATOR_DEPOSIT - 100);
+    let tx = make_delete_transaction(&key_pair, Policy::VALIDATOR_DEPOSIT - 100);
 
     let tx2 = TransactionBuilder::new_delete_validator(
         address,
         &key_pair,
         100.try_into().unwrap(),
-        Coin::from_u64_unchecked(VALIDATOR_DEPOSIT - 100),
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT - 100),
         1,
         NetworkId::Dummy,
     )
@@ -305,7 +305,7 @@ fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -
         | IncomingStakingTransactionData::CreateValidator { .. } => Transaction::new_extended(
             Address::from_any_str(ADDRESS).unwrap(),
             AccountType::Basic,
-            STAKING_CONTRACT_ADDRESS,
+            Policy::STAKING_CONTRACT_ADDRESS,
             AccountType::Staking,
             value.try_into().unwrap(),
             100.try_into().unwrap(),
@@ -316,7 +316,7 @@ fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -
         _ => Transaction::new_signalling(
             Address::from_any_str(ADDRESS).unwrap(),
             AccountType::Basic,
-            STAKING_CONTRACT_ADDRESS,
+            Policy::STAKING_CONTRACT_ADDRESS,
             AccountType::Staking,
             value.try_into().unwrap(),
             100.try_into().unwrap(),
@@ -346,7 +346,7 @@ fn make_signed_incoming_transaction(
 
 fn make_unstake_transaction(key_pair: &KeyPair, value: u64) -> Transaction {
     let mut tx = Transaction::new_extended(
-        STAKING_CONTRACT_ADDRESS,
+        Policy::STAKING_CONTRACT_ADDRESS,
         AccountType::Staking,
         Address::from_any_str(ADDRESS).unwrap(),
         AccountType::Basic,
@@ -366,7 +366,7 @@ fn make_unstake_transaction(key_pair: &KeyPair, value: u64) -> Transaction {
 //TODO update this function with a more proper interface
 fn make_delete_transaction(key_pair: &KeyPair, value: u64) -> Transaction {
     let mut tx = Transaction::new_extended(
-        STAKING_CONTRACT_ADDRESS,
+        Policy::STAKING_CONTRACT_ADDRESS,
         AccountType::Staking,
         Address::from_any_str(ADDRESS).unwrap(),
         AccountType::Basic,
@@ -385,9 +385,9 @@ fn make_delete_transaction(key_pair: &KeyPair, value: u64) -> Transaction {
 
 fn make_self_transaction(data: IncomingStakingTransactionData, key_pair: &KeyPair) -> Transaction {
     let mut tx = Transaction::new_signalling(
-        STAKING_CONTRACT_ADDRESS,
+        Policy::STAKING_CONTRACT_ADDRESS,
         AccountType::Staking,
-        STAKING_CONTRACT_ADDRESS,
+        Policy::STAKING_CONTRACT_ADDRESS,
         AccountType::Staking,
         0.try_into().unwrap(),
         100.try_into().unwrap(),

--- a/validator/src/aggregation/registry.rs
+++ b/validator/src/aggregation/registry.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use nimiq_bls::PublicKey;
 use nimiq_collections::BitSet;
 use nimiq_handel::identity::{Identity, IdentityRegistry, WeightRegistry};
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 
 /// Implementation for Handel registry using a `Validators` list.
@@ -83,7 +83,7 @@ impl IdentityRegistry for ValidatorRegistry {
 
 impl WeightRegistry for ValidatorRegistry {
     fn weight(&self, id: usize) -> Option<usize> {
-        if (0..policy::SLOTS).contains(&(id as u16)) {
+        if (0..Policy::SLOTS).contains(&(id as u16)) {
             Some(1)
         } else {
             None

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -235,7 +235,7 @@ impl SkipBlockAggregation {
             let protocol = SkipBlockAggregationProtocol::new(
                 active_validators.clone(),
                 validator_id as usize,
-                policy::TWO_F_PLUS_ONE as usize,
+                policy::Policy::TWO_F_PLUS_ONE as usize,
                 message_hash,
             );
 
@@ -271,12 +271,12 @@ impl SkipBlockAggregation {
                             trace!(
                                 "New Skip Block Aggregate weight: {} / {} Signers: {:?}",
                                 aggregate_weight,
-                                policy::TWO_F_PLUS_ONE,
+                                policy::Policy::TWO_F_PLUS_ONE,
                                 &sb_msg.proof.contributors(),
                             );
 
                             // Check if the combined weight of the aggregation is at least 2f+1.
-                            if aggregate_weight >= policy::TWO_F_PLUS_ONE as usize {
+                            if aggregate_weight >= policy::Policy::TWO_F_PLUS_ONE as usize {
                                 // Create SkipBlockProof out of the aggregate
                                 let skip_block_proof = SkipBlockProof { sig: sb_msg.proof };
                                 trace!("Skip block completed, proof={:?}", &skip_block_proof);

--- a/validator/src/aggregation/tendermint/aggregations.rs
+++ b/validator/src/aggregation/tendermint/aggregations.rs
@@ -24,7 +24,7 @@ use nimiq_handel::{
     identity::WeightRegistry, update::LevelUpdate,
 };
 use nimiq_macros::store_waker;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_validator_network::ValidatorNetwork;
 
 use crate::aggregation::{
@@ -217,7 +217,7 @@ impl<N: ValidatorNetwork + 'static> Stream for TendermintAggregations<N> {
                         if let Some(weight) =
                             self.validator_registry.signers_weight(&future_contributors)
                         {
-                            if weight >= policy::F_PLUS_ONE as usize {
+                            if weight >= Policy::F_PLUS_ONE as usize {
                                 return Poll::Ready(Some(TendermintAggregationEvent::NewRound(
                                     message.tag.round_number,
                                 )));

--- a/validator/src/aggregation/tendermint/background_task.rs
+++ b/validator/src/aggregation/tendermint/background_task.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 use nimiq_block::TendermintStep;
 use nimiq_handel::contribution::AggregatableContribution;
 use nimiq_handel::identity::WeightRegistry;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_tendermint::AggregationResult;
 use nimiq_validator_network::ValidatorNetwork;
 
@@ -141,7 +141,7 @@ impl<N: ValidatorNetwork + 'static> BackgroundTask<N> {
         // better results but will, if nothing better is made available also return this aggregate.
         if current_aggregation.round == round
             && current_aggregation.step == step
-            && self.signature_weight(&contribution) >= policy::TWO_F_PLUS_ONE as usize
+            && self.signature_weight(&contribution) >= Policy::TWO_F_PLUS_ONE as usize
         {
             trace!(
                 "Completed round for {}-{:?}: {:?}",

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -8,7 +8,7 @@ use nimiq_block::{MultiSignature, TendermintIdentifier, TendermintStep, Tendermi
 use nimiq_bls::SecretKey;
 use nimiq_handel::{identity::WeightRegistry, update::LevelUpdateMessage};
 use nimiq_hash::Blake2sHash;
-use nimiq_primitives::{policy, slots::Validators};
+use nimiq_primitives::{policy::Policy, slots::Validators};
 use nimiq_tendermint::{AggregationResult, TendermintError};
 use nimiq_validator_network::ValidatorNetwork;
 
@@ -294,7 +294,7 @@ impl<N: ValidatorNetwork + 'static> HandelTendermintAdapter<N> {
 
                     // iterate all proposals present in this contribution
                     for (proposal, (_, weight)) in map.iter() {
-                        if *weight >= policy::TWO_F_PLUS_ONE {
+                        if *weight >= Policy::TWO_F_PLUS_ONE {
                             if step == TendermintStep::PreCommit {
                                 // PreCommit Aggreations are never requested again, so the aggregation can be canceled.
                                 self.event_sender
@@ -319,7 +319,7 @@ impl<N: ValidatorNetwork + 'static> HandelTendermintAdapter<N> {
                     }
 
                     // combined weight of all proposals excluding the one this node signed reached 2f+1
-                    if combined_weight >= policy::TWO_F_PLUS_ONE {
+                    if combined_weight >= Policy::TWO_F_PLUS_ONE {
                         if step == TendermintStep::PreCommit {
                             // PreCommit Aggreations are never requested again, so the aggregation can be canceled.
                             self.event_sender
@@ -336,7 +336,7 @@ impl<N: ValidatorNetwork + 'static> HandelTendermintAdapter<N> {
                     }
 
                     // none of the above but every signatory is present and thus no improvement can be made
-                    if total_weight == policy::SLOTS {
+                    if total_weight == Policy::SLOTS {
                         if step == TendermintStep::PreCommit {
                             // PreCommit Aggreations are never requested again, so the aggregation can be canceled.
                             self.event_sender

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -29,8 +29,7 @@ use nimiq_keys::{Address, KeyPair as SchnorrKeyPair};
 use nimiq_macros::store_waker;
 use nimiq_mempool::{config::MempoolConfig, mempool::Mempool, mempool_transactions::TxPriority};
 use nimiq_network_interface::network::{Network, PubsubId, Topic};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy;
+use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_tendermint::TendermintReturn;
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_utils::observer::NotifierStream;
@@ -142,7 +141,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
 {
     const MACRO_STATE_DB_NAME: &'static str = "ValidatorState";
     const MACRO_STATE_KEY: &'static str = "validatorState";
-    const PRODUCER_TIMEOUT: Duration = Duration::from_millis(policy::BLOCK_PRODUCER_TIMEOUT);
+    const PRODUCER_TIMEOUT: Duration = Duration::from_millis(Policy::BLOCK_PRODUCER_TIMEOUT);
     const EMPTY_BLOCK_DELAY: Duration = Duration::from_secs(1);
     const FORK_PROOFS_MAX_SIZE: usize = 1_000; // bytes
 
@@ -273,7 +272,8 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
             let staking_state = self.get_staking_state(&blockchain);
             if (staking_state == ValidatorStakingState::Parked
                 || staking_state == ValidatorStakingState::Inactive)
-                && blockchain.block_number() >= tx_validity_window_start + policy::BLOCKS_PER_EPOCH
+                && blockchain.block_number()
+                    >= tx_validity_window_start + Policy::blocks_per_epoch()
                 && !blockchain.tx_in_validity_window(tx_hash, *tx_validity_window_start, None)
             {
                 // If we are parked or inactive and no transaction has been seen in the expected validity window

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -10,7 +10,7 @@ use nimiq_block::Block;
 use nimiq_genesis::NetworkInfo;
 use nimiq_nano_primitives::state_commitment;
 use nimiq_network_interface::network::Network;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use parking_lot::lock_api::RwLockUpgradableReadGuard;
 use parking_lot::{RwLock, RwLockWriteGuard};
 
@@ -83,7 +83,8 @@ impl<N: Network> ZKProver<N> {
             blockchain_rg
                 .get_macro_blocks(
                     &zkp_state.read().latest_header_hash,
-                    (blockchain_election_height - current_state_height) / policy::BLOCKS_PER_EPOCH,
+                    (blockchain_election_height - current_state_height)
+                        / Policy::blocks_per_epoch(),
                     true,
                     Direction::Forward,
                     true,
@@ -116,10 +117,11 @@ impl<N: Network> ZKProver<N> {
                 let keys_path2 = keys_path.clone();
                 assert!(
                     zkp_state.latest_block_number
-                        >= block.block_number() - policy::BLOCKS_PER_EPOCH,
+                        >= block.block_number() - Policy::blocks_per_epoch(),
                     "The current state should never lag behind more than one epoch"
                 );
-                if zkp_state.latest_block_number == block.block_number() - policy::BLOCKS_PER_EPOCH
+                if zkp_state.latest_block_number
+                    == block.block_number() - Policy::blocks_per_epoch()
                 {
                     launch_generate_new_proof(
                         recv,

--- a/zkp-component/tests/proof_utils.rs
+++ b/zkp-component/tests/proof_utils.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use ark_groth16::Proof;
 use beserial::Deserialize;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_utils::blockchain_with_rng::produce_macro_blocks_with_rng;
 use nimiq_test_utils::zkp_test_data::{KEYS_PATH, ZKPROOF_SERIALIZED_IN_HEX};
 use nimiq_zkp_component::proof_utils::ProofStore;
@@ -63,7 +63,7 @@ async fn can_detect_invalid_proof_none_genesis_blocks() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 
@@ -91,7 +91,7 @@ async fn can_detect_invalid_proof_none_genesis_blocks() {
     );
 
     let zkp_proof = ZKProof {
-        block_number: block.block_number() + policy::BLOCKS_PER_EPOCH,
+        block_number: block.block_number() + Policy::blocks_per_epoch(),
         proof: Some(Proof::default()),
     };
 
@@ -110,7 +110,7 @@ async fn can_detect_valid_proof_none_genesis_blocks() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 
@@ -129,7 +129,7 @@ async fn can_store_and_load_zkp_state_from_db() {
 
     let proof_store = ProofStore::new(env);
     let new_proof = ZKProof {
-        block_number: policy::BLOCKS_PER_EPOCH,
+        block_number: Policy::blocks_per_epoch(),
         proof: Some(Proof::default()),
     };
 
@@ -141,7 +141,7 @@ async fn can_store_and_load_zkp_state_from_db() {
     );
 
     let new_proof = ZKProof {
-        block_number: policy::BLOCKS_PER_EPOCH,
+        block_number: Policy::blocks_per_epoch(),
         proof: Some(Proof::default()),
     };
 

--- a/zkp-component/tests/types.rs
+++ b/zkp-component/tests/types.rs
@@ -5,7 +5,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_block::MacroBlock;
 use nimiq_database::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_hash::Blake2bHash;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_utils::zkp_test_data::KEYS_PATH;
 use nimiq_zkp_component::types::{ProofInput, ZKPState, ZKProof};
 
@@ -52,7 +52,7 @@ fn it_serializes_and_deserializes_zkp_state() {
     let state = ZKPState {
         latest_pks: vec![Default::default(); 512],
         latest_header_hash: Blake2bHash::default(),
-        latest_block_number: policy::BLOCKS_PER_EPOCH,
+        latest_block_number: Policy::blocks_per_epoch(),
         latest_proof: Some(Proof::default()),
     };
     let serialized = Serialize::serialize_to_vec(&state);

--- a/zkp-component/tests/zkp_component.rs
+++ b/zkp-component/tests/zkp_component.rs
@@ -11,9 +11,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use nimiq_network_interface::network::Network;
-use nimiq_network_mock::MockHub;
-use nimiq_network_mock::MockNetwork;
-use nimiq_primitives::policy;
+use nimiq_network_mock::{MockHub, MockNetwork};
+use nimiq_primitives::policy::Policy;
 use nimiq_zkp_component::proof_utils::ProofStore;
 use nimiq_zkp_component::types::ZKProofTopic;
 
@@ -82,7 +81,7 @@ async fn loads_valid_zkp_state_from_db() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 
@@ -104,7 +103,7 @@ async fn loads_valid_zkp_state_from_db() {
     let zkp_proxy = zkp_prover.proxy();
     assert_eq!(
         zkp_proxy.get_zkp_state().latest_block_number,
-        policy::BLOCKS_PER_EPOCH,
+        Policy::blocks_per_epoch(),
         "The load of the zkp state should have worked"
     );
 }
@@ -120,7 +119,7 @@ async fn does_not_load_invalid_zkp_state_from_db() {
 
     let proof_store = ProofStore::new(env);
     let new_proof = ZKProof {
-        block_number: policy::BLOCKS_PER_EPOCH,
+        block_number: Policy::blocks_per_epoch(),
         proof: None,
     };
 
@@ -178,7 +177,7 @@ async fn can_produce_two_consecutive_valid_zk_proofs() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 
@@ -194,7 +193,7 @@ async fn can_produce_two_consecutive_valid_zk_proofs() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 

--- a/zkp-component/tests/zkp_requests.rs
+++ b/zkp-component/tests/zkp_requests.rs
@@ -11,7 +11,7 @@ use nimiq_nano_zkp::NanoZKP;
 use nimiq_network_interface::network::Network;
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_log::test;
 use nimiq_test_utils::blockchain::{signing_key, voting_key};
 use nimiq_test_utils::blockchain_with_rng::produce_macro_blocks_with_rng;
@@ -98,13 +98,13 @@ async fn peers_reply_with_valid_proof() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain2,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain3,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 
@@ -173,13 +173,13 @@ async fn peers_reply_with_valid_proof_and_election_block() {
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain2,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
     produce_macro_blocks_with_rng(
         &producer,
         &blockchain3,
-        policy::BATCHES_PER_EPOCH as usize,
+        Policy::batches_per_epoch() as usize,
         &mut get_base_seed(),
     );
 


### PR DESCRIPTION
- Use `once_cell` to safely initialize global policy related
  parameters.
- Adjust policy constants:
  - `BLOCKS_PER_BATCH` to 60.
  - `BATCHES_PER_EPOCH` to 360.
 
Depends on #888.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.