### PR TITLE
Reintroduce error when trying to query the staking contract as an account

### DIFF
--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -454,7 +454,12 @@ impl BlockchainInterface for BlockchainDispatcher {
         let result = self.blockchain.read().get_account(&address);
 
         match result {
-            Some(account) => Ok(Account::from_account(address, account)),
+            Some(account) => match account {
+                nimiq_account::Account::Staking(_) => {
+                    Err(Error::GetAccountUnsupportedStakingContract)
+                }
+                _ => Ok(Account::from_account(address, account)),
+            },
             None => Ok(Account::empty(address)),
         }
     }

--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -64,6 +64,9 @@ pub enum Error {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("getAccountByAddress does not support querying the staking contract")]
+    GetAccountUnsupportedStakingContract,
 }
 
 impl From<Error> for nimiq_jsonrpc_core::RpcError {


### PR DESCRIPTION
The check and error was removed in commit ff8eaa4ce3c02c3602923119c38ba20e67393d1c.

Fixes #947.
