### PR TITLE
Expose protocol policy through RPC server

### DIFF
--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -54,6 +54,7 @@ pub fn initialize_rpc_server(
     if let Some(mempool) = client.mempool() {
         dispatcher.add(MempoolDispatcher::new(mempool));
     }
+    dispatcher.add(PolicyDispatcher::new());
     if let Some(validator_proxy) = client.validator_proxy() {
         dispatcher.add(ValidatorDispatcher::new(validator_proxy));
     }

--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -54,7 +54,7 @@ pub fn initialize_rpc_server(
     if let Some(mempool) = client.mempool() {
         dispatcher.add(MempoolDispatcher::new(mempool));
     }
-    dispatcher.add(PolicyDispatcher::new());
+    dispatcher.add(PolicyDispatcher {});
     if let Some(validator_proxy) = client.validator_proxy() {
         dispatcher.add(ValidatorDispatcher::new(validator_proxy));
     }

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -94,7 +94,7 @@ pub fn epoch_at(block_number: u32) -> u32 {
 }
 
 /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
-/// to the the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
+/// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
 #[inline]
 pub fn epoch_index_at(block_number: u32) -> u32 {
     (block_number + BLOCKS_PER_EPOCH - 1) % BLOCKS_PER_EPOCH
@@ -107,7 +107,7 @@ pub fn batch_at(block_number: u32) -> u32 {
 }
 
 /// Returns the batch index at a given block number. The batch index is the number of a block relative
-/// to the the batch it is in. For example, the first block of any batch always has an batch index of 0.
+/// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
 #[inline]
 pub fn batch_index_at(block_number: u32) -> u32 {
     (block_number + BLOCKS_PER_BATCH - 1) % BLOCKS_PER_BATCH
@@ -119,8 +119,8 @@ pub fn election_block_after(block_number: u32) -> u32 {
     (block_number / BLOCKS_PER_EPOCH + 1) * BLOCKS_PER_EPOCH
 }
 
-/// Returns the number (height) of the preceding election macro block before a given block number (height).
-/// If the given block number is an  election macro block, it returns the election macro block before it.
+/// Returns the block number (height) of the preceding election macro block before a given block number (height).
+/// If the given block number is an election macro block, it returns the election macro block before it.
 #[inline]
 pub fn election_block_before(block_number: u32) -> u32 {
     if block_number == 0 {
@@ -129,7 +129,7 @@ pub fn election_block_before(block_number: u32) -> u32 {
     (block_number - 1) / BLOCKS_PER_EPOCH * BLOCKS_PER_EPOCH
 }
 
-/// Returns the number (height) of the last election macro block at a given block number (height).
+/// Returns the block number (height) of the last election macro block at a given block number (height).
 /// If the given block number is an election macro block, then it returns that block number.
 #[inline]
 pub fn last_election_block(block_number: u32) -> u32 {
@@ -142,13 +142,13 @@ pub fn is_election_block_at(block_number: u32) -> bool {
     epoch_index_at(block_number) == BLOCKS_PER_EPOCH - 1
 }
 
-/// Returns the number (height) of the next macro block after a given block number (height).
+/// Returns the block number (height) of the next macro block after a given block number (height).
 #[inline]
 pub fn macro_block_after(block_number: u32) -> u32 {
     (block_number / BLOCKS_PER_BATCH + 1) * BLOCKS_PER_BATCH
 }
 
-/// Returns the number (height) of the preceding macro block before a given block number (height).
+/// Returns the block number (height) of the preceding macro block before a given block number (height).
 /// If the given block number is a macro block, it returns the macro block before it.
 #[inline]
 pub fn macro_block_before(block_number: u32) -> u32 {
@@ -158,7 +158,7 @@ pub fn macro_block_before(block_number: u32) -> u32 {
     (block_number - 1) / BLOCKS_PER_BATCH * BLOCKS_PER_BATCH
 }
 
-/// Returns the number (height) of the last macro block at a given block number (height).
+/// Returns the block number (height) of the last macro block at a given block number (height).
 /// If the given block number is a macro block, then it returns that block number.
 #[inline]
 pub fn last_macro_block(block_number: u32) -> u32 {
@@ -185,7 +185,7 @@ pub fn first_block_of(epoch: u32) -> u32 {
     (epoch - 1) * BLOCKS_PER_EPOCH + 1
 }
 
-///  Returns the block number of the first block of the given batch (which is always a micro block).
+/// Returns the block number of the first block of the given batch (which is always a micro block).
 pub fn first_block_of_batch(batch: u32) -> u32 {
     if batch == 0 {
         panic!("Called first_block_of_batch for batch 0");

--- a/rpc-interface/src/lib.rs
+++ b/rpc-interface/src/lib.rs
@@ -3,6 +3,7 @@ pub mod consensus;
 pub mod error;
 pub mod mempool;
 pub mod network;
+pub mod policy;
 mod serde_helpers;
 pub mod types;
 pub mod validator;

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -1,0 +1,54 @@
+use async_trait::async_trait;
+
+use crate::types::PolicyConstants;
+
+#[nimiq_jsonrpc_derive::proxy(name = "PolicyProxy", rename_all = "camelCase")]
+#[async_trait]
+pub trait PolicyInterface {
+    type Error;
+
+    async fn get_policy_constants(&mut self) -> Result<PolicyConstants, Self::Error>;
+
+    async fn get_epoch_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_epoch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_batch_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_batch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_election_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_election_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_last_election_block(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_is_election_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+
+    async fn get_macro_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_macro_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_last_macro_block(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+
+    async fn get_is_macro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+
+    async fn get_is_micro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+
+    async fn get_first_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error>;
+
+    async fn get_first_block_of_batch(&mut self, batch: u32) -> Result<u32, Self::Error>;
+
+    async fn get_election_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error>;
+
+    async fn get_macro_block_of(&mut self, batch: u32) -> Result<u32, Self::Error>;
+
+    async fn get_first_batch_of_epoch(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+
+    async fn get_supply_at(
+        &mut self,
+        genesis_supply: u64,
+        genesis_time: u64,
+        current_time: u64,
+    ) -> Result<u64, Self::Error>;
+}

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -362,6 +362,21 @@ impl From<nimiq_block::MicroJustification> for MicroJustification {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PolicyConstants {
+    pub staking_contract_address: String,
+    pub coinbase_address: String,
+    pub transaction_validity_window: u32,
+    pub max_size_micro_body: usize,
+    pub version: u16,
+    pub slots: u16,
+    pub blocks_per_batch: u32,
+    pub batches_per_epoch: u16,
+    pub validator_deposit: u64,
+    pub total_supply: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Slot {
     pub slot_number: u16,
     pub validator: Address,

--- a/rpc-server/src/dispatchers/mod.rs
+++ b/rpc-server/src/dispatchers/mod.rs
@@ -2,6 +2,7 @@ pub use blockchain::BlockchainDispatcher;
 pub use consensus::ConsensusDispatcher;
 pub use mempool::MempoolDispatcher;
 pub use network::NetworkDispatcher;
+pub use policy::PolicyDispatcher;
 pub use validator::ValidatorDispatcher;
 pub use wallet::WalletDispatcher;
 
@@ -9,5 +10,6 @@ mod blockchain;
 mod consensus;
 mod mempool;
 mod network;
+mod policy;
 mod validator;
 mod wallet;

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -8,12 +8,6 @@ use crate::error::Error;
 
 pub struct PolicyDispatcher {}
 
-impl PolicyDispatcher {
-    pub fn new() -> Self {
-        PolicyDispatcher {}
-    }
-}
-
 #[nimiq_jsonrpc_derive::service(rename_all = "camelCase")]
 #[async_trait]
 impl PolicyInterface for PolicyDispatcher {

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -35,7 +35,7 @@ impl PolicyInterface for PolicyDispatcher {
     }
 
     /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
-    /// to the the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
+    /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
     async fn get_epoch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         Ok(policy::epoch_index_at(block_number))
     }
@@ -46,7 +46,7 @@ impl PolicyInterface for PolicyDispatcher {
     }
 
     /// Returns the batch index at a given block number. The batch index is the number of a block relative
-    /// to the the batch it is in. For example, the first block of any batch always has an batch index of 0.
+    /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
     async fn get_batch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         Ok(policy::batch_index_at(block_number))
     }
@@ -56,8 +56,8 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(policy::election_block_after(block_number))
     }
 
-    /// Returns the number (height) of the preceding election macro block before a given block number (height).
-    /// If the given block number is an  election macro block, it returns the election macro block before it.
+    /// Returns the number block (height) of the preceding election macro block before a given block number (height).
+    /// If the given block number is an election macro block, it returns the election macro block before it.
     async fn get_election_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         if block_number == 0 {
             return Err(Error::BlockNumberNotZero);
@@ -66,7 +66,7 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(policy::election_block_before(block_number))
     }
 
-    /// Returns the number (height) of the last election macro block at a given block number (height).
+    /// Returns the block number (height) of the last election macro block at a given block number (height).
     /// If the given block number is an election macro block, then it returns that block number.
     async fn get_last_election_block(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         Ok(policy::last_election_block(block_number))
@@ -77,12 +77,12 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(policy::is_election_block_at(block_number))
     }
 
-    /// Returns the number (height) of the next macro block after a given block number (height).
+    /// Returns the block number (height) of the next macro block after a given block number (height).
     async fn get_macro_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         Ok(policy::macro_block_after(block_number))
     }
 
-    /// Returns the number (height) of the preceding macro block before a given block number (height).
+    /// Returns the block number (height) of the preceding macro block before a given block number (height).
     /// If the given block number is a macro block, it returns the macro block before it.
     async fn get_macro_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         if block_number == 0 {
@@ -92,7 +92,7 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(policy::macro_block_before(block_number))
     }
 
-    /// Returns the number (height) of the last macro block at a given block number (height).
+    /// Returns block the number (height) of the last macro block at a given block number (height).
     /// If the given block number is a macro block, then it returns that block number.
     async fn get_last_macro_block(&mut self, block_number: u32) -> Result<u32, Self::Error> {
         Ok(policy::last_macro_block(block_number))
@@ -117,7 +117,7 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(policy::first_block_of(epoch))
     }
 
-    ///  Returns the block number of the first block of the given batch (which is always a micro block).
+    /// Returns the block number of the first block of the given batch (which is always a micro block).
     async fn get_first_block_of_batch(&mut self, batch: u32) -> Result<u32, Self::Error> {
         if batch == 0 {
             return Err(Error::BatchNumberNotZero);

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -1,0 +1,169 @@
+use async_trait::async_trait;
+
+use nimiq_primitives::policy;
+use nimiq_rpc_interface::policy::PolicyInterface;
+use nimiq_rpc_interface::types::PolicyConstants;
+
+use crate::error::Error;
+
+pub struct PolicyDispatcher {}
+
+impl PolicyDispatcher {
+    pub fn new() -> Self {
+        PolicyDispatcher {}
+    }
+}
+
+#[nimiq_jsonrpc_derive::service(rename_all = "camelCase")]
+#[async_trait]
+impl PolicyInterface for PolicyDispatcher {
+    type Error = Error;
+
+    /// Returns a bundle of policy constants
+    async fn get_policy_constants(&mut self) -> Result<PolicyConstants, Self::Error> {
+        Ok(PolicyConstants {
+            staking_contract_address: policy::STAKING_CONTRACT_ADDRESS.to_string(),
+            coinbase_address: policy::COINBASE_ADDRESS.to_string(),
+            transaction_validity_window: policy::TRANSACTION_VALIDITY_WINDOW,
+            max_size_micro_body: policy::MAX_SIZE_MICRO_BODY,
+            version: policy::VERSION,
+            slots: policy::SLOTS,
+            blocks_per_batch: policy::BLOCKS_PER_BATCH,
+            batches_per_epoch: policy::BATCHES_PER_EPOCH,
+            validator_deposit: policy::VALIDATOR_DEPOSIT,
+            total_supply: policy::TOTAL_SUPPLY,
+        })
+    }
+
+    /// Returns the epoch number at a given block number (height).
+    async fn get_epoch_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::epoch_at(block_number))
+    }
+
+    /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
+    /// to the the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
+    async fn get_epoch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::epoch_index_at(block_number))
+    }
+
+    /// Returns the batch number at a given `block_number` (height)
+    async fn get_batch_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::batch_at(block_number))
+    }
+
+    /// Returns the batch index at a given block number. The batch index is the number of a block relative
+    /// to the the batch it is in. For example, the first block of any batch always has an batch index of 0.
+    async fn get_batch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::batch_index_at(block_number))
+    }
+
+    /// Returns the number (height) of the next election macro block after a given block number (height).
+    async fn get_election_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::election_block_after(block_number))
+    }
+
+    /// Returns the number (height) of the preceding election macro block before a given block number (height).
+    /// If the given block number is an  election macro block, it returns the election macro block before it.
+    async fn get_election_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        if block_number == 0 {
+            return Err(Error::BlockNumberNotZero);
+        }
+
+        Ok(policy::election_block_before(block_number))
+    }
+
+    /// Returns the number (height) of the last election macro block at a given block number (height).
+    /// If the given block number is an election macro block, then it returns that block number.
+    async fn get_last_election_block(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::last_election_block(block_number))
+    }
+
+    /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
+    async fn get_is_election_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error> {
+        Ok(policy::is_election_block_at(block_number))
+    }
+
+    /// Returns the number (height) of the next macro block after a given block number (height).
+    async fn get_macro_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::macro_block_after(block_number))
+    }
+
+    /// Returns the number (height) of the preceding macro block before a given block number (height).
+    /// If the given block number is a macro block, it returns the macro block before it.
+    async fn get_macro_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        if block_number == 0 {
+            return Err(Error::BlockNumberNotZero);
+        }
+
+        Ok(policy::macro_block_before(block_number))
+    }
+
+    /// Returns the number (height) of the last macro block at a given block number (height).
+    /// If the given block number is a macro block, then it returns that block number.
+    async fn get_last_macro_block(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+        Ok(policy::last_macro_block(block_number))
+    }
+
+    /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
+    async fn get_is_macro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error> {
+        Ok(policy::is_macro_block_at(block_number))
+    }
+
+    /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
+    async fn get_is_micro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error> {
+        Ok(policy::is_micro_block_at(block_number))
+    }
+
+    /// Returns the block number of the first block of the given epoch (which is always a micro block).
+    async fn get_first_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error> {
+        if epoch == 0 {
+            return Err(Error::EpochNumberNotZero);
+        }
+
+        Ok(policy::first_block_of(epoch))
+    }
+
+    ///  Returns the block number of the first block of the given batch (which is always a micro block).
+    async fn get_first_block_of_batch(&mut self, batch: u32) -> Result<u32, Self::Error> {
+        if batch == 0 {
+            return Err(Error::BatchNumberNotZero);
+        }
+
+        Ok(policy::first_block_of_batch(batch))
+    }
+
+    /// Returns the block number of the election macro block of the given epoch (which is always the last block).
+    async fn get_election_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error> {
+        Ok(policy::election_block_of(epoch))
+    }
+
+    /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
+    /// is always the last block).
+    async fn get_macro_block_of(&mut self, batch: u32) -> Result<u32, Self::Error> {
+        Ok(policy::macro_block_of(batch))
+    }
+
+    /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
+    /// of the epoch.
+    async fn get_first_batch_of_epoch(&mut self, block_number: u32) -> Result<bool, Self::Error> {
+        Ok(policy::first_batch_of_epoch(block_number))
+    }
+
+    /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
+    /// calculated using the following formula:
+    /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
+    /// Where e is the exponential function, t is the time in milliseconds since the genesis block and
+    /// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
+    async fn get_supply_at(
+        &mut self,
+        genesis_supply: u64,
+        genesis_time: u64,
+        current_time: u64,
+    ) -> Result<u64, Self::Error> {
+        Ok(policy::supply_at(
+            genesis_supply,
+            genesis_time,
+            current_time,
+        ))
+    }
+}

--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -20,6 +20,15 @@ pub enum Error {
     #[error("Block not found: {0}")]
     BlockNotFound(BlockNumberOrHash),
 
+    #[error("Block number is not allowed to be 0")]
+    BlockNumberNotZero,
+
+    #[error("Epoch number is not allowed to be 0")]
+    EpochNumberNotZero,
+
+    #[error("Batch number is not allowed to be 0")]
+    BatchNumberNotZero,
+
     #[error("Unexpected macro block: {0}")]
     UnexpectedMacroBlock(BlockNumberOrHash),
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## Expose policy constants and methods through the RPC interface

At the moment it isn't possible to retrieve information about the policy constants or make use of batch/epoch formulas defined in the protocol policy through RPC. This results that you have to re-implement this logic/constants yourself.

This PR exposes almost everything that's defined in `primitives/src/policy.rs`. So once something in the policy changes and the nodes updates to the latest version, the policy info fetched through the RPC server will be up to date automatically.

An important precaution to prevent Denial of Service attacks on nodes has been taken with `get_election_block_before`, `get_macro_block_before`, `get_first_block_of` and `get_first_block_of_batch`. Those methods have extra checks because their implementation contain `panic!()`s.