### PR TITLE
Update return result of getActiveValidators

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -1,12 +1,9 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 
 use nimiq_account::BlockLog;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_primitives::coin::Coin;
 
 use crate::types::{
     Account, Block, BlockchainState, Inherent, LogType, ParkedSet, SlashedSlots, Slot, Staker,
@@ -87,7 +84,7 @@ pub trait BlockchainInterface {
 
     async fn get_account_by_address(&mut self, address: Address) -> Result<Account, Self::Error>;
 
-    async fn get_active_validators(&mut self) -> Result<HashMap<Address, Coin>, Self::Error>;
+    async fn get_active_validators(&mut self) -> Result<Vec<Staker>, Self::Error>;
 
     async fn get_current_slashed_slots(&mut self) -> Result<SlashedSlots, Self::Error>;
 

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -84,7 +84,7 @@ pub trait BlockchainInterface {
 
     async fn get_account_by_address(&mut self, address: Address) -> Result<Account, Self::Error>;
 
-    async fn get_active_validators(&mut self) -> Result<Vec<Staker>, Self::Error>;
+    async fn get_active_validators(&mut self) -> Result<Vec<Validator>, Self::Error>;
 
     async fn get_current_slashed_slots(&mut self) -> Result<SlashedSlots, Self::Error>;
 

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -460,17 +460,16 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     /// Returns a map of the currently active validator's addresses and balances.
-    async fn get_active_validators(&mut self) -> Result<Vec<Staker>, Error> {
-        let staking_contract = self.blockchain.read().get_staking_contract();
+    async fn get_active_validators(&mut self) -> Result<Vec<Validator>, Self::Error> {
+        let blockchain = self.blockchain.read();
+        let staking_contract = blockchain.get_staking_contract();
 
         let mut active_validators = vec![];
 
-        for (address, balance) in staking_contract.active_validators {
-            active_validators.push(Staker {
-                address,
-                balance,
-                delegation: None,
-            });
+        for (address, _) in staking_contract.active_validators {
+            if let Ok(v) = get_validator_by_address(&blockchain, &address, None) {
+                active_validators.push(v.value);
+            }
         }
 
         Ok(active_validators)

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 use futures::{future, stream::BoxStream, StreamExt};
@@ -8,7 +8,7 @@ use nimiq_account::{BlockLog, StakingContract, TransactionLog};
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_primitives::{coin::Coin, policy};
+use nimiq_primitives::policy;
 use nimiq_rpc_interface::types::{
     is_of_log_type_and_related_to_addresses, BlockchainState, ParkedSet, Validator,
 };
@@ -460,13 +460,17 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     /// Returns a map of the currently active validator's addresses and balances.
-    async fn get_active_validators(&mut self) -> Result<HashMap<Address, Coin>, Error> {
+    async fn get_active_validators(&mut self) -> Result<Vec<Staker>, Error> {
         let staking_contract = self.blockchain.read().get_staking_contract();
 
-        let mut active_validators = HashMap::new();
+        let mut active_validators = vec![];
 
         for (address, balance) in staking_contract.active_validators {
-            active_validators.insert(address, balance);
+            active_validators.push(Staker {
+                address,
+                balance,
+                delegation: None,
+            });
         }
 
         Ok(active_validators)

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -49,7 +49,7 @@ fn get_block_by_hash(
         .ok_or_else(|| Error::BlockNotFound(hash.clone().into()))
 }
 
-/// Tries to fetch a validator information given its address. It has an option to include a map
+/// Tries to fetch a validator information given its address. It has an option to include a collection
 /// containing the addresses and stakes of all the stakers that are delegating to the validator.
 /// This function requeires the read lock acquisition prior to its execution
 fn get_validator_by_address(
@@ -459,7 +459,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns a map of the currently active validator's addresses and balances.
+    /// Returns a collection of the currently active validator's addresses and balances.
     async fn get_active_validators(&mut self) -> Result<Vec<Validator>, Self::Error> {
         let blockchain = self.blockchain.read();
         let staking_contract = blockchain.get_staking_contract();


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

Update the return type of `getActiveValidators` to align it with `getValidatorByAddress` after it changed in #939.

In this PR, the return type of `getActiveValidators` has now become `Result<Vec<Staker>, Self::Error>`. Officially we are not returning a list of `Staker`s but a list of `Validator`s, hence the RPC name, but this was the best solution without defining a new struct. Also `Validator` already has been defined as a RPC type. If you want this to become something else, I'm more than happy to apply feedback.