### PR TITLE
For every RPC method apply correct `Error` type

### DIFF
--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -98,17 +98,17 @@ impl BlockchainInterface for BlockchainDispatcher {
     type Error = Error;
 
     /// Returns the block number for the current head.
-    async fn get_block_number(&mut self) -> Result<u32, Error> {
+    async fn get_block_number(&mut self) -> Result<u32, Self::Error> {
         Ok(self.blockchain.read().block_number())
     }
 
     /// Returns the batch number for the current head.
-    async fn get_batch_number(&mut self) -> Result<u32, Error> {
+    async fn get_batch_number(&mut self) -> Result<u32, Self::Error> {
         Ok(policy::batch_at(self.blockchain.read().block_number()))
     }
 
     /// Returns the epoch number for the current head.
-    async fn get_epoch_number(&mut self) -> Result<u32, Error> {
+    async fn get_epoch_number(&mut self) -> Result<u32, Self::Error> {
         Ok(policy::epoch_at(self.blockchain.read().block_number()))
     }
 
@@ -118,7 +118,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         hash: Blake2bHash,
         include_transactions: Option<bool>,
-    ) -> Result<Block, Error> {
+    ) -> Result<Block, Self::Error> {
         let blockchain = self.blockchain.read();
 
         get_block_by_hash(blockchain.deref(), &hash, include_transactions)
@@ -131,7 +131,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         block_number: u32,
         include_transactions: Option<bool>,
-    ) -> Result<Block, Error> {
+    ) -> Result<Block, Self::Error> {
         let blockchain = self.blockchain.read();
 
         let block = blockchain
@@ -150,7 +150,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     async fn get_latest_block(
         &mut self,
         include_transactions: Option<bool>,
-    ) -> Result<Block, Error> {
+    ) -> Result<Block, Self::Error> {
         let blockchain = self.blockchain.read();
         let block = blockchain.head();
 
@@ -168,7 +168,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         block_number: u32,
         view_number_opt: Option<u32>,
-    ) -> Result<Slot, Error> {
+    ) -> Result<Slot, Self::Error> {
         let blockchain = self.blockchain.read();
 
         let view_number = if let Some(view_number) = view_number_opt {
@@ -185,7 +185,10 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     /// Tries to fetch a transaction (including reward transactions) given its hash.
-    async fn get_transaction_by_hash(&mut self, hash: Blake2bHash) -> Result<Transaction, Error> {
+    async fn get_transaction_by_hash(
+        &mut self,
+        hash: Blake2bHash,
+    ) -> Result<Transaction, Self::Error> {
         let blockchain = self.blockchain.read();
 
         // Get all the extended transactions that correspond to this hash.
@@ -223,7 +226,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     async fn get_transactions_by_block_number(
         &mut self,
         block_number: u32,
-    ) -> Result<Vec<Transaction>, Error> {
+    ) -> Result<Vec<Transaction>, Self::Error> {
         let blockchain = self.blockchain.read();
 
         // Get all the extended transactions that correspond to this block.
@@ -330,7 +333,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     async fn get_inherents_by_batch_number(
         &mut self,
         batch_number: u32,
-    ) -> Result<Vec<Inherent>, Error> {
+    ) -> Result<Vec<Inherent>, Self::Error> {
         let blockchain = self.blockchain.read();
 
         let macro_block_number = policy::macro_block_of(batch_number);
@@ -389,7 +392,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         address: Address,
         max: Option<u16>,
-    ) -> Result<Vec<Blake2bHash>, Error> {
+    ) -> Result<Vec<Blake2bHash>, Self::Error> {
         Ok(self
             .blockchain
             .read()
@@ -405,7 +408,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         address: Address,
         max: Option<u16>,
-    ) -> Result<Vec<Transaction>, Error> {
+    ) -> Result<Vec<Transaction>, Self::Error> {
         let blockchain = self.blockchain.read();
 
         // Get the transaction hashes for this address.
@@ -450,7 +453,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     /// Tries to fetch the account at the given address.
-    async fn get_account_by_address(&mut self, address: Address) -> Result<Account, Error> {
+    async fn get_account_by_address(&mut self, address: Address) -> Result<Account, Self::Error> {
         let result = self.blockchain.read().get_account(&address);
 
         match result {
@@ -460,7 +463,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     /// Returns a map of the currently active validator's addresses and balances.
-    async fn get_active_validators(&mut self) -> Result<HashMap<Address, Coin>, Error> {
+    async fn get_active_validators(&mut self) -> Result<HashMap<Address, Coin>, Self::Error> {
         let staking_contract = self.blockchain.read().get_staking_contract();
 
         let mut active_validators = HashMap::new();
@@ -524,7 +527,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         address: Address,
         include_stakers: Option<bool>,
-    ) -> Result<BlockchainState<Validator>, Error> {
+    ) -> Result<BlockchainState<Validator>, Self::Error> {
         let blockchain = self.blockchain.read();
 
         get_validator_by_address(blockchain.deref(), &address, include_stakers)
@@ -534,7 +537,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     async fn get_staker_by_address(
         &mut self,
         address: Address,
-    ) -> Result<BlockchainState<Staker>, Error> {
+    ) -> Result<BlockchainState<Staker>, Self::Error> {
         let blockchain = self.blockchain.read();
 
         let accounts_tree = &blockchain.state().accounts.tree;
@@ -559,7 +562,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     async fn subscribe_for_head_block(
         &mut self,
         include_transactions: Option<bool>,
-    ) -> Result<BoxStream<'static, Block>, Error> {
+    ) -> Result<BoxStream<'static, Block>, Self::Error> {
         let blockchain = Arc::clone(&self.blockchain);
         let stream = self.subscribe_for_head_block_hash().await?;
 
@@ -579,7 +582,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     #[stream]
     async fn subscribe_for_head_block_hash(
         &mut self,
-    ) -> Result<BoxStream<'static, Blake2bHash>, Error> {
+    ) -> Result<BoxStream<'static, Blake2bHash>, Self::Error> {
         let stream = self.blockchain.write().notifier.as_stream();
         Ok(stream
             .map(|event| match event {
@@ -598,7 +601,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     async fn subscribe_for_validator_election_by_address(
         &mut self,
         address: Address,
-    ) -> Result<BoxStream<'static, BlockchainState<Validator>>, Error> {
+    ) -> Result<BoxStream<'static, BlockchainState<Validator>>, Self::Error> {
         let blockchain = Arc::clone(&self.blockchain);
         let stream = self.blockchain.write().notifier.as_stream();
 

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -77,13 +77,16 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     /// Given a serialized transaction, it will return the corresponding transaction struct.
-    async fn get_raw_transaction_info(&mut self, raw_tx: String) -> Result<RPCTransaction, Error> {
+    async fn get_raw_transaction_info(
+        &mut self,
+        raw_tx: String,
+    ) -> Result<RPCTransaction, Self::Error> {
         let transaction: Transaction = Deserialize::deserialize_from_vec(&hex::decode(&raw_tx)?)?;
         Ok(RPCTransaction::from_transaction(transaction))
     }
 
     /// Sends the given serialized transaction to the network.
-    async fn send_raw_transaction(&mut self, raw_tx: String) -> Result<Blake2bHash, Error> {
+    async fn send_raw_transaction(&mut self, raw_tx: String) -> Result<Blake2bHash, Self::Error> {
         let tx: Transaction = Deserialize::deserialize_from_vec(&hex::decode(&raw_tx)?)?;
         let txid = tx.hash::<Blake2bHash>();
 
@@ -101,7 +104,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let transaction = TransactionBuilder::new_basic(
             &self.get_wallet_keypair(&wallet)?,
             recipient,
@@ -122,7 +125,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_basic_transaction(wallet, recipient, value, fee, validity_start_height)
             .await?;
@@ -589,7 +592,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let transaction = TransactionBuilder::new_stake(
             &self.get_wallet_keypair(&sender_wallet)?,
             staker_address,
@@ -611,7 +614,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_stake_transaction(
                 sender_wallet,
@@ -634,7 +637,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         new_delegation: Option<Address>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let sender_key = match sender_wallet {
             None => None,
             Some(address) => Some(self.get_wallet_keypair(&address)?),
@@ -662,7 +665,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         new_delegation: Option<Address>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_update_transaction(
                 sender_wallet,
@@ -684,7 +687,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let transaction = TransactionBuilder::new_unstake(
             &self.get_wallet_keypair(&staker_wallet)?,
             recipient,
@@ -706,7 +709,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_unstake_transaction(staker_wallet, recipient, value, fee, validity_start_height)
             .await?;
@@ -729,7 +732,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signal_data: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let voting_secret_key =
             BlsSecretKey::deserialize_from_vec(&hex::decode(voting_secret_key).unwrap()).unwrap();
         let hot_keypair = BlsKeyPair::from(voting_secret_key);
@@ -781,7 +784,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signal_data: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_new_validator_transaction(
                 sender_wallet,
@@ -814,7 +817,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         new_signal_data: Option<String>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let new_voting_keypair = match new_voting_secret_key {
             Some(key) => {
                 let new_secret_key =
@@ -884,7 +887,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         new_signal_data: Option<String>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_update_validator_transaction(
                 sender_wallet,
@@ -909,7 +912,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let secret_key =
             PrivateKey::deserialize_from_vec(&hex::decode(signing_secret_key).unwrap()).unwrap();
         let signing_key_pair = KeyPair::from(secret_key);
@@ -935,7 +938,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_inactivate_validator_transaction(
                 sender_wallet,
@@ -957,7 +960,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let secret_key =
             PrivateKey::deserialize_from_vec(&hex::decode(signing_secret_key).unwrap()).unwrap();
         let signing_key_pair = KeyPair::from(secret_key);
@@ -983,7 +986,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_reactivate_validator_transaction(
                 sender_wallet,
@@ -1005,7 +1008,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let secret_key =
             PrivateKey::deserialize_from_vec(&hex::decode(signing_secret_key).unwrap()).unwrap();
         let signing_key_pair = KeyPair::from(secret_key);
@@ -1031,7 +1034,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_unpark_validator_transaction(
                 sender_wallet,
@@ -1052,7 +1055,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         recipient: Address,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Error> {
+    ) -> Result<String, Self::Error> {
         let transaction = TransactionBuilder::new_delete_validator(
             recipient,
             &self.get_wallet_keypair(&validator_wallet)?,
@@ -1072,7 +1075,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         recipient: Address,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Error> {
+    ) -> Result<Blake2bHash, Self::Error> {
         let raw_tx = self
             .create_delete_validator_transaction(
                 validator_wallet,

--- a/rpc-server/src/dispatchers/mempool.rs
+++ b/rpc-server/src/dispatchers/mempool.rs
@@ -62,7 +62,7 @@ impl MempoolInterface for MempoolDispatcher {
     async fn mempool_content(
         &mut self,
         include_transactions: bool,
-    ) -> Result<Vec<HashOrTx>, Error> {
+    ) -> Result<Vec<HashOrTx>, Self::Error> {
         return match include_transactions {
             true => Ok(self
                 .mempool
@@ -79,7 +79,7 @@ impl MempoolInterface for MempoolDispatcher {
         };
     }
 
-    async fn mempool(&mut self) -> Result<MempoolInfo, Error> {
+    async fn mempool(&mut self) -> Result<MempoolInfo, Self::Error> {
         Ok(MempoolInfo::from_txs(self.mempool.get_transactions()))
     }
 

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -42,7 +42,7 @@ impl WalletInterface for WalletDispatcher {
         &mut self,
         key_data: String,
         passphrase: Option<String>,
-    ) -> Result<Address, Error> {
+    ) -> Result<Address, Self::Error> {
         let passphrase = passphrase.unwrap_or_default();
 
         let private_key: PrivateKey = Deserialize::deserialize_from_vec(&hex::decode(&key_data)?)?;
@@ -60,22 +60,25 @@ impl WalletInterface for WalletDispatcher {
         Ok(address)
     }
 
-    async fn is_account_imported(&mut self, address: Address) -> Result<bool, Error> {
+    async fn is_account_imported(&mut self, address: Address) -> Result<bool, Self::Error> {
         let is_imported = self.wallet_store.get(&address, None).is_some();
 
         Ok(is_imported)
     }
 
-    async fn list_accounts(&mut self) -> Result<Vec<Address>, Error> {
+    async fn list_accounts(&mut self) -> Result<Vec<Address>, Self::Error> {
         Ok(self.wallet_store.list(None))
     }
 
-    async fn lock_account(&mut self, address: Address) -> Result<(), Error> {
+    async fn lock_account(&mut self, address: Address) -> Result<(), Self::Error> {
         self.unlocked_wallets.write().remove(&address);
         Ok(())
     }
 
-    async fn create_account(&mut self, passphrase: Option<String>) -> Result<ReturnAccount, Error> {
+    async fn create_account(
+        &mut self,
+        passphrase: Option<String>,
+    ) -> Result<ReturnAccount, Self::Error> {
         let passphrase = passphrase.unwrap_or_default();
         let account = WalletAccount::generate();
         let address = account.address.clone();
@@ -101,7 +104,7 @@ impl WalletInterface for WalletDispatcher {
         address: Address,
         passphrase: Option<String>,
         _duration: Option<u64>,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, Self::Error> {
         let passphrase = passphrase.unwrap_or_default();
         let account = self
             .wallet_store
@@ -117,7 +120,7 @@ impl WalletInterface for WalletDispatcher {
         Ok(true)
     }
 
-    async fn is_account_unlocked(&mut self, address: Address) -> Result<bool, Error> {
+    async fn is_account_unlocked(&mut self, address: Address) -> Result<bool, Self::Error> {
         let unlocked_wallets = self.unlocked_wallets.read();
         let is_unlocked = unlocked_wallets.get(&address).is_some();
 
@@ -130,7 +133,7 @@ impl WalletInterface for WalletDispatcher {
         address: Address,
         passphrase: Option<String>,
         is_hex: bool,
-    ) -> Result<ReturnSignature, Error> {
+    ) -> Result<ReturnSignature, Self::Error> {
         let message = message_from_maybe_hex(message, is_hex)?;
 
         let passphrase = passphrase.unwrap_or_default();
@@ -167,7 +170,7 @@ impl WalletInterface for WalletDispatcher {
         public_key: PublicKey,
         signature: Signature,
         is_hex: bool,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, Self::Error> {
         let message = message_from_maybe_hex(message, is_hex)?;
         Ok(WalletAccount::verify_message(
             &public_key,


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Noticed by nibhar, not every RPC method has the correct `Error` type in the `Result` enum. This PR tackles that. 
