### PR TITLE
Fix history sync blockchain state mismatch issue

### DIFF
--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -403,7 +403,7 @@ impl<TNetwork: Network + 'static> Stream for SyncCluster<TNetwork> {
                         let block_hash = { pusher.read().block.hash() };
                         let future = async move {
                             debug!("Processing epoch #{} (no history items)", epoch_number);
-                            let pusher = pusher.read();
+                            let mut pusher = pusher.write();
                             if pusher.commit(blockchain.upgradable_read()).is_err() {
                                 return SyncClusterResult::Error;
                             }


### PR DESCRIPTION
Fix state mismatch after doing history sync.
The error was caused by history chunks that had transactions of
the same block number in different chunks.
Account's `commit_batch` requires all transactions of the same block
to be passed such that transactions can be applied in the expected
order: pre-inherents, senders, recipients and then post-inherents.

The solution implemented caches the last block transactions when
`add_history_chunk` is called and then merge them with the following
chunk if it happens to carry transactions of the same block. If
`commit` is called, it also checks for outstanding transactions in
the cache and applies them before doing the respective checks and
blockchain state updates.

This fixes #979.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.