### PR TITLE
[Done] Add missing property to RPC PolicyConstants

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -370,6 +370,7 @@ pub struct PolicyConstants {
     pub slots: u16,
     pub blocks_per_batch: u32,
     pub batches_per_epoch: u16,
+    pub blocks_per_epoch: u32,
     pub validator_deposit: u64,
     pub total_supply: u64,
 }

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -24,6 +24,7 @@ impl PolicyInterface for PolicyDispatcher {
             slots: policy::SLOTS,
             blocks_per_batch: policy::BLOCKS_PER_BATCH,
             batches_per_epoch: policy::BATCHES_PER_EPOCH,
+            blocks_per_epoch: policy::BLOCKS_PER_EPOCH,
             validator_deposit: policy::VALIDATOR_DEPOSIT,
             total_supply: policy::TOTAL_SUPPLY,
         })


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

During the initial creation of `PolicyConstants` struct I've missed the `policy::BLOCKS_PER_EPOCH` constant.