### PR TITLE
Introducing the RPC result with metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,6 +3220,7 @@ dependencies = [
  "nimiq-primitives",
  "nimiq-transaction",
  "nimiq-vrf",
+ "parking_lot 0.12.0",
  "serde",
  "serde_json",
  "serde_with",

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -266,31 +266,19 @@ impl TransactionLog {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-// Renaming affects only the struct names and thus their tag, the "type" field.
-#[cfg_attr(
-    feature = "serde-derive",
-    serde(rename_all = "kebab-case", tag = "type")
-)]
 pub enum BlockLog {
-    #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
     AppliedBlock {
-        #[cfg_attr(feature = "serde-derive", serde(rename = "inherents"))]
         inherent_logs: Vec<Log>,
         block_hash: Blake2bHash,
         block_number: u32,
         timestamp: u64,
-        #[cfg_attr(feature = "serde-derive", serde(rename = "transactions"))]
         tx_logs: Vec<TransactionLog>,
     },
 
-    #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
     RevertedBlock {
-        #[cfg_attr(feature = "serde-derive", serde(rename = "inherents"))]
         inherent_logs: Vec<Log>,
         block_hash: Blake2bHash,
         block_number: u32,
-        #[cfg_attr(feature = "serde-derive", serde(rename = "transactions"))]
         tx_logs: Vec<TransactionLog>,
     },
 }

--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -89,7 +89,7 @@ pub enum AccountCommand {
         #[clap(short, long)]
         public_key: PublicKey,
 
-        /// The signature returned upon signing the message. The r and s bystes should be all concatenated
+        /// The signature returned upon signing the message. The r and s bytes should be all concatenated
         /// into one continous input.
         #[clap(short, long)]
         signature: Signature,
@@ -111,7 +111,7 @@ impl HandleSubcommand for AccountCommand {
     async fn handle_subcommand(self, mut client: Client) -> Result<(), Error> {
         match self {
             AccountCommand::List { short } => {
-                let accounts = client.wallet.list_accounts().await?;
+                let accounts = client.wallet.list_accounts().await?.data;
                 for address in &accounts {
                     if short {
                         println!("{}", address.to_user_friendly_address());
@@ -129,23 +129,28 @@ impl HandleSubcommand for AccountCommand {
             }
             AccountCommand::Import { password, key_data } => {
                 let address = client.wallet.import_raw_key(key_data, password).await?;
-                println!("{}", address);
+                println!("{:#?}", address);
             }
             AccountCommand::IsImported { address } => {
-                println!("{}", client.wallet.is_account_imported(address).await?);
+                println!("{:#?}", client.wallet.is_account_imported(address).await?);
             }
-            AccountCommand::Lock { address } => client.wallet.lock_account(address).await?,
+            AccountCommand::Lock { address } => {
+                client.wallet.lock_account(address).await?;
+            }
             AccountCommand::Unlock {
                 address, password, ..
             } => {
                 // TODO: Duration
-                client
-                    .wallet
-                    .unlock_account(address, password, None)
-                    .await?;
+                println!(
+                    "{:#?}",
+                    client
+                        .wallet
+                        .unlock_account(address, password, None)
+                        .await?
+                );
             }
             AccountCommand::IsUnlocked { address } => {
-                println!("{}", client.wallet.is_account_unlocked(address).await?);
+                println!("{:#?}", client.wallet.is_account_unlocked(address).await?);
             }
             AccountCommand::Sign {
                 message,
@@ -153,7 +158,7 @@ impl HandleSubcommand for AccountCommand {
                 is_hex,
             } => {
                 println!(
-                    "{:?}",
+                    "{:#?}",
                     client.wallet.sign(message, address, None, is_hex).await?
                 );
             }
@@ -164,7 +169,7 @@ impl HandleSubcommand for AccountCommand {
                 is_hex,
             } => {
                 println!(
-                    "{:?}",
+                    "{:#?}",
                     client
                         .wallet
                         .verify_signature(message, public_key, signature, is_hex)

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -89,16 +89,16 @@ pub enum BlockchainCommand {
         just_hash: bool,
     },
 
-    /// Returns the information for the slot owner at the given block height and view number. The
-    /// view number is optional, it will default to getting the view number for the existing block
-    /// at the given height. We only have this information available for the last 2 batches at most.
+    /// Returns the information for the slot owner at the given block height and offset. The
+    /// offset is optional, it will default to the block number for micro blocks and to the round number for macro blocks.
+    /// We only have this information available for the last 2 batches at most.
     SlotAt {
         /// The block height to retrieve the slots information.
         block_number: u32,
 
-        /// The view number to retrieve at the block height specified.
+        /// The offset to retrieve at the block height specified.
         #[clap(short, long)]
-        view_number: Option<u32>,
+        offset: Option<u32>,
     },
 
     /// Returns information about the currently slashed slots or the previous batch. This includes slots that lost rewards
@@ -198,14 +198,11 @@ impl HandleSubcommand for BlockchainCommand {
             }
             BlockchainCommand::SlotAt {
                 block_number,
-                view_number,
+                offset,
             } => {
                 println!(
                     "{:#?}",
-                    client
-                        .blockchain
-                        .get_slot_at(block_number, view_number)
-                        .await?
+                    client.blockchain.get_slot_at(block_number, offset).await?
                 )
             }
             BlockchainCommand::Transaction { hash } => {
@@ -333,7 +330,7 @@ impl HandleSubcommand for BlockchainCommand {
                     let mut stream = client.blockchain.subscribe_for_head_block_hash().await?;
 
                     while let Some(block_hash) = stream.next().await {
-                        println!("{}", block_hash);
+                        println!("{:#?}", block_hash);
                     }
                 }
             }

--- a/rpc-client/src/subcommands/mempool_subcommands.rs
+++ b/rpc-client/src/subcommands/mempool_subcommands.rs
@@ -42,29 +42,29 @@ impl HandleSubcommand for MempoolCommand {
             } => {
                 if high_priority {
                     println!(
-                        "{}",
+                        "{:#?}",
                         client
                             .mempool
                             .push_high_priority_transaction(raw_tx)
                             .await?
                     );
                 } else {
-                    println!("{}", client.mempool.push_transaction(raw_tx).await?);
+                    println!("{:#?}", client.mempool.push_transaction(raw_tx).await?);
                 }
             }
             MempoolCommand::MempoolContent {
                 include_transactions,
             } => {
                 println!(
-                    "{:?}",
+                    "{:#?}",
                     client.mempool.mempool_content(include_transactions).await?
                 );
             }
             MempoolCommand::MempoolInfo {} => {
-                println!("{:?}", client.mempool.mempool().await?);
+                println!("{:#?}", client.mempool.mempool().await?);
             }
             MempoolCommand::MinFeePerByte {} => {
-                println!("{}", client.mempool.get_min_fee_per_byte().await?);
+                println!("{:#?}", client.mempool.get_min_fee_per_byte().await?);
             }
         }
         Ok(())

--- a/rpc-client/src/subcommands/network_subcommands.rs
+++ b/rpc-client/src/subcommands/network_subcommands.rs
@@ -25,13 +25,13 @@ impl HandleSubcommand for NetworkCommand {
     async fn handle_subcommand(self, mut client: Client) -> Result<(), Error> {
         match self {
             NetworkCommand::PeerId {} => {
-                println!("{}", client.network.get_peer_id().await?);
+                println!("{:#?}", client.network.get_peer_id().await?);
             }
             NetworkCommand::Peers { count } => {
                 if count {
-                    println!("{}", client.network.get_peer_count().await?);
+                    println!("{:#?}", client.network.get_peer_count().await?);
                 } else {
-                    println!("{:?}", client.network.get_peer_list().await?);
+                    println!("{:#?}", client.network.get_peer_list().await?);
                 }
             }
         }

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -340,7 +340,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -352,7 +352,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::NewStaker {
@@ -373,7 +373,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -386,7 +386,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::Stake {
@@ -405,7 +405,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -417,7 +417,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::UpdateStaker {
@@ -437,7 +437,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -449,7 +449,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::Unstake {
@@ -468,7 +468,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -480,7 +480,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -506,7 +506,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -521,7 +521,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::VestingRedeem {
@@ -542,7 +542,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -555,7 +555,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -585,7 +585,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -602,7 +602,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::RedeemRegularHTLC {
@@ -631,7 +631,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -648,7 +648,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::RedeemHTLCTimeout {
@@ -669,7 +669,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -682,7 +682,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::RedeemHTLCEarly {
@@ -706,7 +706,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -720,7 +720,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
             TransactionCommand::SignRedeemHTLCEarly {
@@ -742,7 +742,7 @@ impl HandleSubcommand for TransactionCommand {
                         validity_start_height,
                     )
                     .await?;
-                println!("{}", tx);
+                println!("{:#?}", tx);
             }
         }
         Ok(())

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -152,25 +152,25 @@ impl HandleSubcommand for ValidatorCommand {
     async fn handle_subcommand(self, mut client: Client) -> Result<(), Error> {
         match self {
             ValidatorCommand::ValidatorAddress {} => {
-                println!("{}", client.validator.get_address().await?);
+                println!("{:#?}", client.validator.get_address().await?);
             }
 
             ValidatorCommand::ValidatorSigningKey {} => {
-                println!("{}", client.validator.get_signing_key().await?);
+                println!("{:#?}", client.validator.get_signing_key().await?);
             }
 
             ValidatorCommand::ValidatorVotingKey {} => {
-                println!("{}", client.validator.get_voting_key().await?);
+                println!("{:#?}", client.validator.get_voting_key().await?);
             }
 
             ValidatorCommand::SetAutoReactivateValidator {
                 automatic_reactivate,
             } => {
-                let result = client
+                client
                     .validator
                     .set_automatic_reactivation(automatic_reactivate)
                     .await?;
-                println!("Auto reacivate set to {}", result);
+                println!("Auto reacivate set to {}", automatic_reactivate);
             }
 
             ValidatorCommand::CreateNewValidator {
@@ -196,7 +196,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -211,7 +211,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -223,7 +223,7 @@ impl HandleSubcommand for ValidatorCommand {
                 new_signal_data,
                 tx_commons,
             } => {
-                let validator_address = client.validator.get_address().await?;
+                let validator_address = client.validator.get_address().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
@@ -238,7 +238,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -253,7 +253,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -261,8 +261,8 @@ impl HandleSubcommand for ValidatorCommand {
                 sender_wallet,
                 tx_commons,
             } => {
-                let validator_address = client.validator.get_address().await?;
-                let key_data = client.validator.get_signing_key().await?;
+                let validator_address = client.validator.get_address().await?.data;
+                let key_data = client.validator.get_signing_key().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
@@ -274,7 +274,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -286,7 +286,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -294,8 +294,8 @@ impl HandleSubcommand for ValidatorCommand {
                 sender_wallet,
                 tx_commons,
             } => {
-                let validator_address = client.validator.get_address().await?;
-                let key_data = client.validator.get_signing_key().await?;
+                let validator_address = client.validator.get_address().await?.data;
+                let key_data = client.validator.get_signing_key().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
@@ -307,7 +307,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -319,7 +319,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -327,8 +327,8 @@ impl HandleSubcommand for ValidatorCommand {
                 sender_wallet,
                 tx_commons,
             } => {
-                let validator_address = client.validator.get_address().await?;
-                let key_data = client.validator.get_signing_key().await?;
+                let validator_address = client.validator.get_address().await?.data;
+                let key_data = client.validator.get_signing_key().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
@@ -340,7 +340,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -352,7 +352,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
 
@@ -360,7 +360,7 @@ impl HandleSubcommand for ValidatorCommand {
                 recipient_address,
                 tx_commons,
             } => {
-                let validator_address = client.validator.get_address().await?;
+                let validator_address = client.validator.get_address().await?.data;
                 if tx_commons.common_tx_fields.dry {
                     let tx = client
                         .consensus
@@ -372,7 +372,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", tx);
+                    println!("{:#?}", tx);
                 } else {
                     let txid = client
                         .consensus
@@ -384,7 +384,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{}", txid);
+                    println!("{:#?}", txid);
                 }
             }
         }

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -25,6 +25,7 @@ serde_with = "2.0"
 thiserror = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account", features = ["serde-derive"] }
 nimiq-block = { path = "../primitives/block", features = ["serde-derive"] }

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.0"
 thiserror = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-
+parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account", features = ["serde-derive"] }
 nimiq-block = { path = "../primitives/block", features = ["serde-derive"] }

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 
-use nimiq_account::BlockLog;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 
 use crate::types::{
-    Account, Block, BlockchainState, ExecutedTransaction, Inherent, LogType, ParkedSet,
+    Account, Block, BlockLog, ExecutedTransaction, Inherent, LogType, ParkedSet, RPCResult,
     SlashedSlots, Slot, Staker, Validator,
 };
 
@@ -42,7 +41,7 @@ pub trait BlockchainInterface {
         &mut self,
         block_number: u32,
         offset_opt: Option<u32>,
-    ) -> Result<Slot, Self::Error>;
+    ) -> Result<RPCResult<Slot>, Self::Error>;
 
     async fn get_transaction_by_hash(
         &mut self,
@@ -82,26 +81,29 @@ pub trait BlockchainInterface {
         max: Option<u16>,
     ) -> Result<Vec<ExecutedTransaction>, Self::Error>;
 
-    async fn get_account_by_address(&mut self, address: Address) -> Result<Account, Self::Error>;
+    async fn get_account_by_address(
+        &mut self,
+        address: Address,
+    ) -> Result<RPCResult<Account>, Self::Error>;
 
-    async fn get_active_validators(&mut self) -> Result<Vec<Validator>, Self::Error>;
+    async fn get_active_validators(&mut self) -> Result<RPCResult<Vec<Validator>>, Self::Error>;
 
-    async fn get_current_slashed_slots(&mut self) -> Result<SlashedSlots, Self::Error>;
+    async fn get_current_slashed_slots(&mut self) -> Result<RPCResult<SlashedSlots>, Self::Error>;
 
-    async fn get_previous_slashed_slots(&mut self) -> Result<SlashedSlots, Self::Error>;
+    async fn get_previous_slashed_slots(&mut self) -> Result<RPCResult<SlashedSlots>, Self::Error>;
 
-    async fn get_parked_validators(&mut self) -> Result<ParkedSet, Self::Error>;
+    async fn get_parked_validators(&mut self) -> Result<RPCResult<ParkedSet>, Self::Error>;
 
     async fn get_validator_by_address(
         &mut self,
         address: Address,
         include_stakers: Option<bool>,
-    ) -> Result<BlockchainState<Validator>, Self::Error>;
+    ) -> Result<RPCResult<Validator>, Self::Error>;
 
     async fn get_staker_by_address(
         &mut self,
         address: Address,
-    ) -> Result<BlockchainState<Staker>, Self::Error>;
+    ) -> Result<RPCResult<Staker>, Self::Error>;
 
     #[stream]
     async fn subscribe_for_head_block(
@@ -118,12 +120,12 @@ pub trait BlockchainInterface {
     async fn subscribe_for_validator_election_by_address(
         &mut self,
         address: Address,
-    ) -> Result<BoxStream<'static, BlockchainState<Validator>>, Self::Error>;
+    ) -> Result<BoxStream<'static, RPCResult<Validator>>, Self::Error>;
 
     #[stream]
     async fn subscribe_for_logs_by_addresses_and_types(
         &mut self,
         addresses: Vec<Address>,
         log_types: Vec<LogType>,
-    ) -> Result<BoxStream<'static, BlockLog>, Self::Error>;
+    ) -> Result<BoxStream<'static, RPCResult<BlockLog>>, Self::Error>;
 }

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -5,8 +5,8 @@ use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 
 use crate::types::{
-    Account, Block, BlockLog, ExecutedTransaction, Inherent, LogType, ParkedSet, RPCResult,
-    SlashedSlots, Slot, Staker, Validator,
+    Account, Block, BlockLog, BlockchainState, ExecutedTransaction, Inherent, LogType, ParkedSet,
+    RPCData, RPCResult, SlashedSlots, Slot, Staker, Validator,
 };
 
 #[nimiq_jsonrpc_derive::proxy(name = "BlockchainProxy", rename_all = "camelCase")]
@@ -14,118 +14,125 @@ use crate::types::{
 pub trait BlockchainInterface {
     type Error;
 
-    async fn get_block_number(&mut self) -> Result<u32, Self::Error>;
+    async fn get_block_number(&mut self) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_batch_number(&mut self) -> Result<u32, Self::Error>;
+    async fn get_batch_number(&mut self) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_epoch_number(&mut self) -> Result<u32, Self::Error>;
+    async fn get_epoch_number(&mut self) -> RPCResult<u32, (), Self::Error>;
 
     async fn get_block_by_hash(
         &mut self,
         hash: Blake2bHash,
         include_transactions: Option<bool>,
-    ) -> Result<Block, Self::Error>;
+    ) -> RPCResult<Block, (), Self::Error>;
 
     async fn get_block_by_number(
         &mut self,
         block_number: u32,
         include_transactions: Option<bool>,
-    ) -> Result<Block, Self::Error>;
+    ) -> RPCResult<Block, (), Self::Error>;
 
     async fn get_latest_block(
         &mut self,
         include_transactions: Option<bool>,
-    ) -> Result<Block, Self::Error>;
+    ) -> RPCResult<Block, (), Self::Error>;
 
     async fn get_slot_at(
         &mut self,
         block_number: u32,
         offset_opt: Option<u32>,
-    ) -> Result<RPCResult<Slot>, Self::Error>;
+    ) -> RPCResult<Slot, BlockchainState, Self::Error>;
 
     async fn get_transaction_by_hash(
         &mut self,
         hash: Blake2bHash,
-    ) -> Result<ExecutedTransaction, Self::Error>;
+    ) -> RPCResult<ExecutedTransaction, (), Self::Error>;
 
     async fn get_transactions_by_block_number(
         &mut self,
         block_number: u32,
-    ) -> Result<Vec<ExecutedTransaction>, Self::Error>;
+    ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     async fn get_inherents_by_block_number(
         &mut self,
         block_number: u32,
-    ) -> Result<Vec<Inherent>, Self::Error>;
+    ) -> RPCResult<Vec<Inherent>, (), Self::Error>;
 
     async fn get_transactions_by_batch_number(
         &mut self,
         batch_number: u32,
-    ) -> Result<Vec<ExecutedTransaction>, Self::Error>;
+    ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     async fn get_inherents_by_batch_number(
         &mut self,
         batch_number: u32,
-    ) -> Result<Vec<Inherent>, Self::Error>;
+    ) -> RPCResult<Vec<Inherent>, (), Self::Error>;
 
     // TODO: includes reward txs
     async fn get_transaction_hashes_by_address(
         &mut self,
         address: Address,
         max: Option<u16>,
-    ) -> Result<Vec<Blake2bHash>, Self::Error>;
+    ) -> RPCResult<Vec<Blake2bHash>, (), Self::Error>;
 
     async fn get_transactions_by_address(
         &mut self,
         address: Address,
         max: Option<u16>,
-    ) -> Result<Vec<ExecutedTransaction>, Self::Error>;
+    ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     async fn get_account_by_address(
         &mut self,
         address: Address,
-    ) -> Result<RPCResult<Account>, Self::Error>;
+    ) -> RPCResult<Account, BlockchainState, Self::Error>;
 
-    async fn get_active_validators(&mut self) -> Result<RPCResult<Vec<Validator>>, Self::Error>;
+    async fn get_active_validators(
+        &mut self,
+    ) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;
 
-    async fn get_current_slashed_slots(&mut self) -> Result<RPCResult<SlashedSlots>, Self::Error>;
+    async fn get_current_slashed_slots(
+        &mut self,
+    ) -> RPCResult<SlashedSlots, BlockchainState, Self::Error>;
 
-    async fn get_previous_slashed_slots(&mut self) -> Result<RPCResult<SlashedSlots>, Self::Error>;
+    async fn get_previous_slashed_slots(
+        &mut self,
+    ) -> RPCResult<SlashedSlots, BlockchainState, Self::Error>;
 
-    async fn get_parked_validators(&mut self) -> Result<RPCResult<ParkedSet>, Self::Error>;
+    async fn get_parked_validators(&mut self)
+        -> RPCResult<ParkedSet, BlockchainState, Self::Error>;
 
     async fn get_validator_by_address(
         &mut self,
         address: Address,
         include_stakers: Option<bool>,
-    ) -> Result<RPCResult<Validator>, Self::Error>;
+    ) -> RPCResult<Validator, BlockchainState, Self::Error>;
 
     async fn get_staker_by_address(
         &mut self,
         address: Address,
-    ) -> Result<RPCResult<Staker>, Self::Error>;
+    ) -> RPCResult<Staker, BlockchainState, Self::Error>;
 
     #[stream]
     async fn subscribe_for_head_block(
         &mut self,
         include_transactions: Option<bool>,
-    ) -> Result<BoxStream<'static, Block>, Self::Error>;
+    ) -> Result<BoxStream<'static, RPCData<Block, ()>>, Self::Error>;
 
     #[stream]
     async fn subscribe_for_head_block_hash(
         &mut self,
-    ) -> Result<BoxStream<'static, Blake2bHash>, Self::Error>;
+    ) -> Result<BoxStream<'static, RPCData<Blake2bHash, ()>>, Self::Error>;
 
     #[stream]
     async fn subscribe_for_validator_election_by_address(
         &mut self,
         address: Address,
-    ) -> Result<BoxStream<'static, RPCResult<Validator>>, Self::Error>;
+    ) -> Result<BoxStream<'static, RPCData<Validator, BlockchainState>>, Self::Error>;
 
     #[stream]
     async fn subscribe_for_logs_by_addresses_and_types(
         &mut self,
         addresses: Vec<Address>,
         log_types: Vec<LogType>,
-    ) -> Result<BoxStream<'static, RPCResult<BlockLog>>, Self::Error>;
+    ) -> Result<BoxStream<'static, RPCData<BlockLog, BlockchainState>>, Self::Error>;
 }

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
 
+use crate::types::{RPCResult, Transaction, ValidityStartHeight};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
-
-use crate::types::{Transaction, ValidityStartHeight};
 
 #[nimiq_jsonrpc_derive::proxy(name = "ConsensusProxy", rename_all = "camelCase")]
 #[async_trait]
@@ -14,14 +13,17 @@ pub trait ConsensusInterface {
 
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
-    async fn is_consensus_established(&mut self) -> Result<bool, Self::Error>;
+    async fn is_consensus_established(&mut self) -> RPCResult<bool, (), Self::Error>;
 
     async fn get_raw_transaction_info(
         &mut self,
         raw_tx: String,
-    ) -> Result<Transaction, Self::Error>;
+    ) -> RPCResult<Transaction, (), Self::Error>;
 
-    async fn send_raw_transaction(&mut self, raw_tx: String) -> Result<Blake2bHash, Self::Error>;
+    async fn send_raw_transaction(
+        &mut self,
+        raw_tx: String,
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_basic_transaction(
         &mut self,
@@ -30,7 +32,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_basic_transaction(
         &mut self,
@@ -39,7 +41,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_basic_transaction_with_data(
         &mut self,
@@ -49,7 +51,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_basic_transaction_with_data(
         &mut self,
@@ -59,7 +61,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_new_vesting_transaction(
         &mut self,
@@ -71,7 +73,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_new_vesting_transaction(
         &mut self,
@@ -83,7 +85,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_redeem_vesting_transaction(
         &mut self,
@@ -93,7 +95,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_redeem_vesting_transaction(
         &mut self,
@@ -103,7 +105,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_new_htlc_transaction(
         &mut self,
@@ -117,7 +119,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_new_htlc_transaction(
         &mut self,
@@ -131,7 +133,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_redeem_regular_htlc_transaction(
         &mut self,
@@ -145,7 +147,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_redeem_regular_htlc_transaction(
         &mut self,
@@ -159,7 +161,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_redeem_timeout_htlc_transaction(
         &mut self,
@@ -169,7 +171,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_redeem_timeout_htlc_transaction(
         &mut self,
@@ -179,7 +181,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_redeem_early_htlc_transaction(
         &mut self,
@@ -190,7 +192,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_redeem_early_htlc_transaction(
         &mut self,
@@ -201,7 +203,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn sign_redeem_early_htlc_transaction(
         &mut self,
@@ -211,7 +213,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn create_new_staker_transaction(
         &mut self,
@@ -221,7 +223,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_new_staker_transaction(
         &mut self,
@@ -231,7 +233,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_stake_transaction(
         &mut self,
@@ -240,7 +242,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_stake_transaction(
         &mut self,
@@ -249,7 +251,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_update_staker_transaction(
         &mut self,
@@ -258,7 +260,7 @@ pub trait ConsensusInterface {
         new_delegation: Option<Address>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_update_staker_transaction(
         &mut self,
@@ -267,7 +269,7 @@ pub trait ConsensusInterface {
         new_delegation: Option<Address>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_unstake_transaction(
         &mut self,
@@ -276,7 +278,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_unstake_transaction(
         &mut self,
@@ -285,7 +287,7 @@ pub trait ConsensusInterface {
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_new_validator_transaction(
         &mut self,
@@ -297,7 +299,7 @@ pub trait ConsensusInterface {
         signal_data: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_new_validator_transaction(
         &mut self,
@@ -309,7 +311,7 @@ pub trait ConsensusInterface {
         signal_data: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_update_validator_transaction(
         &mut self,
@@ -321,7 +323,7 @@ pub trait ConsensusInterface {
         new_signal_data: Option<String>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_update_validator_transaction(
         &mut self,
@@ -333,7 +335,7 @@ pub trait ConsensusInterface {
         new_signal_data: Option<String>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_inactivate_validator_transaction(
         &mut self,
@@ -342,7 +344,7 @@ pub trait ConsensusInterface {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_inactivate_validator_transaction(
         &mut self,
@@ -351,7 +353,7 @@ pub trait ConsensusInterface {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_reactivate_validator_transaction(
         &mut self,
@@ -360,7 +362,7 @@ pub trait ConsensusInterface {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_reactivate_validator_transaction(
         &mut self,
@@ -369,7 +371,7 @@ pub trait ConsensusInterface {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_unpark_validator_transaction(
         &mut self,
@@ -378,7 +380,7 @@ pub trait ConsensusInterface {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_unpark_validator_transaction(
         &mut self,
@@ -387,7 +389,7 @@ pub trait ConsensusInterface {
         signing_secret_key: String,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn create_delete_validator_transaction(
         &mut self,
@@ -396,7 +398,7 @@ pub trait ConsensusInterface {
         fee: Coin,
         value: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
+    ) -> RPCResult<String, (), Self::Error>;
 
     async fn send_delete_validator_transaction(
         &mut self,
@@ -405,5 +407,5 @@ pub trait ConsensusInterface {
         fee: Coin,
         value: Coin,
         validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 }

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -251,26 +251,6 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> Result<Blake2bHash, Self::Error>;
 
-    #[deprecated(note = "please use `create_update_staker_transaction` instead")]
-    async fn create_update_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        staker_wallet: Address,
-        new_delegation: Option<Address>,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error>;
-
-    #[deprecated(note = "please use `send_update_staker_transaction` instead")]
-    async fn send_update_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        staker_wallet: Address,
-        new_delegation: Option<Address>,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error>;
-
     async fn create_update_staker_transaction(
         &mut self,
         sender_wallet: Option<Address>,

--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -1,6 +1,5 @@
+use crate::types::{HashOrTx, MempoolInfo, RPCResult};
 use async_trait::async_trait;
-
-use crate::types::{HashOrTx, MempoolInfo};
 use nimiq_hash::Blake2bHash;
 
 #[nimiq_jsonrpc_derive::proxy(name = "MempoolProxy", rename_all = "camelCase")]
@@ -8,19 +7,20 @@ use nimiq_hash::Blake2bHash;
 pub trait MempoolInterface {
     type Error;
 
-    async fn push_transaction(&mut self, raw_tx: String) -> Result<Blake2bHash, Self::Error>;
+    async fn push_transaction(&mut self, raw_tx: String)
+        -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn push_high_priority_transaction(
         &mut self,
         raw_tx: String,
-    ) -> Result<Blake2bHash, Self::Error>;
+    ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     async fn mempool_content(
         &mut self,
         include_transactions: bool,
-    ) -> Result<Vec<HashOrTx>, Self::Error>;
+    ) -> RPCResult<Vec<HashOrTx>, (), Self::Error>;
 
-    async fn mempool(&mut self) -> Result<MempoolInfo, Self::Error>;
+    async fn mempool(&mut self) -> RPCResult<MempoolInfo, (), Self::Error>;
 
-    async fn get_min_fee_per_byte(&mut self) -> Result<f64, Self::Error>;
+    async fn get_min_fee_per_byte(&mut self) -> RPCResult<f64, (), Self::Error>;
 }

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -1,3 +1,4 @@
+use crate::types::RPCResult;
 use async_trait::async_trait;
 
 #[nimiq_jsonrpc_derive::proxy(name = "NetworkProxy", rename_all = "camelCase")]
@@ -5,9 +6,9 @@ use async_trait::async_trait;
 pub trait NetworkInterface {
     type Error;
 
-    async fn get_peer_id(&mut self) -> Result<String, Self::Error>;
+    async fn get_peer_id(&mut self) -> RPCResult<String, (), Self::Error>;
 
-    async fn get_peer_count(&mut self) -> Result<usize, Self::Error>;
+    async fn get_peer_count(&mut self) -> RPCResult<usize, (), Self::Error>;
 
-    async fn get_peer_list(&mut self) -> Result<Vec<String>, Self::Error>;
+    async fn get_peer_list(&mut self) -> RPCResult<Vec<String>, (), Self::Error>;
 }

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -1,54 +1,80 @@
 use async_trait::async_trait;
 
 use crate::types::PolicyConstants;
+use crate::types::RPCResult;
 
 #[nimiq_jsonrpc_derive::proxy(name = "PolicyProxy", rename_all = "camelCase")]
 #[async_trait]
 pub trait PolicyInterface {
     type Error;
 
-    async fn get_policy_constants(&mut self) -> Result<PolicyConstants, Self::Error>;
+    async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error>;
 
-    async fn get_epoch_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_epoch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_batch_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_batch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_election_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_election_block_after(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_election_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_election_block_before(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_last_election_block(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_last_election_block(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_is_election_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+    async fn get_is_election_block_at(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error>;
 
-    async fn get_macro_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_macro_block_after(&mut self, block_number: u32)
+        -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_macro_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_macro_block_before(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_last_macro_block(&mut self, block_number: u32) -> Result<u32, Self::Error>;
+    async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_is_macro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+    async fn get_is_macro_block_at(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error>;
 
-    async fn get_is_micro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+    async fn get_is_micro_block_at(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error>;
 
-    async fn get_first_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error>;
+    async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_first_block_of_batch(&mut self, batch: u32) -> Result<u32, Self::Error>;
+    async fn get_first_block_of_batch(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_election_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error>;
+    async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_macro_block_of(&mut self, batch: u32) -> Result<u32, Self::Error>;
+    async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_first_batch_of_epoch(&mut self, block_number: u32) -> Result<bool, Self::Error>;
+    async fn get_first_batch_of_epoch(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error>;
 
     async fn get_supply_at(
         &mut self,
         genesis_supply: u64,
         genesis_time: u64,
         current_time: u64,
-    ) -> Result<u64, Self::Error>;
+    ) -> RPCResult<u64, (), Self::Error>;
 }

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -1,5 +1,5 @@
+use crate::types::RPCResult;
 use async_trait::async_trait;
-
 use nimiq_keys::Address;
 
 #[nimiq_jsonrpc_derive::proxy(name = "ValidatorProxy", rename_all = "camelCase")]
@@ -7,14 +7,14 @@ use nimiq_keys::Address;
 pub trait ValidatorInterface {
     type Error;
 
-    async fn get_address(&mut self) -> Result<Address, Self::Error>;
+    async fn get_address(&mut self) -> RPCResult<Address, (), Self::Error>;
 
-    async fn get_signing_key(&mut self) -> Result<String, Self::Error>;
+    async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error>;
 
-    async fn get_voting_key(&mut self) -> Result<String, Self::Error>;
+    async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error>;
 
     async fn set_automatic_reactivation(
         &mut self,
         automatic_reactivate: bool,
-    ) -> Result<bool, Self::Error>;
+    ) -> RPCResult<(), (), Self::Error>;
 }

--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -1,5 +1,5 @@
+use crate::types::RPCResult;
 use async_trait::async_trait;
-
 use nimiq_keys::{Address, PrivateKey, PublicKey, Signature};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -26,31 +26,31 @@ pub trait WalletInterface {
         &mut self,
         key_data: String,
         passphrase: Option<String>,
-    ) -> Result<Address, Self::Error>;
+    ) -> RPCResult<Address, (), Self::Error>;
 
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
-    async fn is_account_imported(&mut self, address: Address) -> Result<bool, Self::Error>;
+    async fn is_account_imported(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
 
-    async fn list_accounts(&mut self) -> Result<Vec<Address>, Self::Error>;
+    async fn list_accounts(&mut self) -> RPCResult<Vec<Address>, (), Self::Error>;
 
-    async fn lock_account(&mut self, address: Address) -> Result<(), Self::Error>;
+    async fn lock_account(&mut self, address: Address) -> RPCResult<(), (), Self::Error>;
 
     async fn create_account(
         &mut self,
         passphrase: Option<String>,
-    ) -> Result<ReturnAccount, Self::Error>;
+    ) -> RPCResult<ReturnAccount, (), Self::Error>;
 
     async fn unlock_account(
         &mut self,
         address: Address,
         passphrase: Option<String>,
         duration: Option<u64>,
-    ) -> Result<bool, Self::Error>;
+    ) -> RPCResult<bool, (), Self::Error>;
 
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
-    async fn is_account_unlocked(&mut self, address: Address) -> Result<bool, Self::Error>;
+    async fn is_account_unlocked(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
 
     async fn sign(
         &mut self,
@@ -58,7 +58,7 @@ pub trait WalletInterface {
         address: Address,
         passphrase: Option<String>,
         is_hex: bool,
-    ) -> Result<ReturnSignature, Self::Error>;
+    ) -> RPCResult<ReturnSignature, (), Self::Error>;
 
     async fn verify_signature(
         &mut self,
@@ -66,5 +66,5 @@ pub trait WalletInterface {
         public_key: PublicKey,
         signature: Signature,
         is_hex: bool,
-    ) -> Result<bool, Self::Error>;
+    ) -> RPCResult<bool, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -630,57 +630,6 @@ impl ConsensusInterface for ConsensusDispatcher {
     /// Returns a serialized `update_staker` transaction. You can pay the transaction fee from a basic
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
-    async fn create_update_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        staker_wallet: Address,
-        new_delegation: Option<Address>,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<String, Self::Error> {
-        let sender_key = match sender_wallet {
-            None => None,
-            Some(address) => Some(self.get_wallet_keypair(&address)?),
-        };
-
-        let transaction = TransactionBuilder::new_update_staker(
-            sender_key.as_ref(),
-            &self.get_wallet_keypair(&staker_wallet)?,
-            new_delegation,
-            fee,
-            self.validity_start_height(validity_start_height),
-            self.get_network_id(),
-        )?;
-
-        Ok(transaction_to_hex_string(&transaction))
-    }
-
-    /// Sends a `update_staker` transaction to the network. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
-    async fn send_update_transaction(
-        &mut self,
-        sender_wallet: Option<Address>,
-        staker_wallet: Address,
-        new_delegation: Option<Address>,
-        fee: Coin,
-        validity_start_height: ValidityStartHeight,
-    ) -> Result<Blake2bHash, Self::Error> {
-        let raw_tx = self
-            .create_update_transaction(
-                sender_wallet,
-                staker_wallet,
-                new_delegation,
-                fee,
-                validity_start_height,
-            )
-            .await?;
-        self.send_raw_transaction(raw_tx).await
-    }
-
-    /// Returns a serialized `update_staker` transaction. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn create_update_staker_transaction(
         &mut self,
         sender_wallet: Option<Address>,

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use nimiq_network_interface::network::Network as InterfaceNetwork;
 use nimiq_network_libp2p::Network;
 use nimiq_rpc_interface::network::NetworkInterface;
+use nimiq_rpc_interface::types::RPCResult;
 
 use crate::error::Error;
 
@@ -24,22 +25,23 @@ impl NetworkInterface for NetworkDispatcher {
     type Error = Error;
 
     /// Returns the peer ID for our local peer.
-    async fn get_peer_id(&mut self) -> Result<String, Self::Error> {
-        Ok(self.network.local_peer_id().to_string())
+    async fn get_peer_id(&mut self) -> RPCResult<String, (), Self::Error> {
+        Ok(self.network.local_peer_id().to_string().into())
     }
 
     /// Returns the number of peers.
-    async fn get_peer_count(&mut self) -> Result<usize, Self::Error> {
-        Ok(self.network.get_peers().len())
+    async fn get_peer_count(&mut self) -> RPCResult<usize, (), Self::Error> {
+        Ok(self.network.get_peers().len().into())
     }
 
     /// Returns a list with the IDs of all our peers.
-    async fn get_peer_list(&mut self) -> Result<Vec<String>, Self::Error> {
+    async fn get_peer_list(&mut self) -> RPCResult<Vec<String>, (), Self::Error> {
         Ok(self
             .network
             .get_peers()
             .into_iter()
             .map(|peer_id| peer_id.to_string())
-            .collect())
+            .collect::<Vec<_>>()
+            .into())
     }
 }

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use nimiq_primitives::policy;
 use nimiq_rpc_interface::policy::PolicyInterface;
-use nimiq_rpc_interface::types::PolicyConstants;
+use nimiq_rpc_interface::types::{PolicyConstants, RPCResult};
 
 use crate::error::Error;
 
@@ -14,7 +14,7 @@ impl PolicyInterface for PolicyDispatcher {
     type Error = Error;
 
     /// Returns a bundle of policy constants
-    async fn get_policy_constants(&mut self) -> Result<PolicyConstants, Self::Error> {
+    async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error> {
         Ok(PolicyConstants {
             staking_contract_address: policy::STAKING_CONTRACT_ADDRESS.to_string(),
             coinbase_address: policy::COINBASE_ADDRESS.to_string(),
@@ -27,121 +27,149 @@ impl PolicyInterface for PolicyDispatcher {
             blocks_per_epoch: policy::BLOCKS_PER_EPOCH,
             validator_deposit: policy::VALIDATOR_DEPOSIT,
             total_supply: policy::TOTAL_SUPPLY,
-        })
+        }
+        .into())
     }
 
     /// Returns the epoch number at a given block number (height).
-    async fn get_epoch_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::epoch_at(block_number))
+    async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::epoch_at(block_number).into())
     }
 
     /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
     /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
-    async fn get_epoch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::epoch_index_at(block_number))
+    async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::epoch_index_at(block_number).into())
     }
 
     /// Returns the batch number at a given `block_number` (height)
-    async fn get_batch_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::batch_at(block_number))
+    async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::batch_at(block_number).into())
     }
 
     /// Returns the batch index at a given block number. The batch index is the number of a block relative
     /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
-    async fn get_batch_index_at(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::batch_index_at(block_number))
+    async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::batch_index_at(block_number).into())
     }
 
     /// Returns the number (height) of the next election macro block after a given block number (height).
-    async fn get_election_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::election_block_after(block_number))
+    async fn get_election_block_after(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::election_block_after(block_number).into())
     }
 
     /// Returns the number block (height) of the preceding election macro block before a given block number (height).
     /// If the given block number is an election macro block, it returns the election macro block before it.
-    async fn get_election_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+    async fn get_election_block_before(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error> {
         if block_number == 0 {
             return Err(Error::BlockNumberNotZero);
         }
 
-        Ok(policy::election_block_before(block_number))
+        Ok(policy::election_block_before(block_number).into())
     }
 
     /// Returns the block number (height) of the last election macro block at a given block number (height).
     /// If the given block number is an election macro block, then it returns that block number.
-    async fn get_last_election_block(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::last_election_block(block_number))
+    async fn get_last_election_block(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::last_election_block(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
-    async fn get_is_election_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error> {
-        Ok(policy::is_election_block_at(block_number))
+    async fn get_is_election_block_at(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error> {
+        Ok(policy::is_election_block_at(block_number).into())
     }
 
     /// Returns the block number (height) of the next macro block after a given block number (height).
-    async fn get_macro_block_after(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::macro_block_after(block_number))
+    async fn get_macro_block_after(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::macro_block_after(block_number).into())
     }
 
     /// Returns the block number (height) of the preceding macro block before a given block number (height).
     /// If the given block number is a macro block, it returns the macro block before it.
-    async fn get_macro_block_before(&mut self, block_number: u32) -> Result<u32, Self::Error> {
+    async fn get_macro_block_before(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error> {
         if block_number == 0 {
             return Err(Error::BlockNumberNotZero);
         }
 
-        Ok(policy::macro_block_before(block_number))
+        Ok(policy::macro_block_before(block_number).into())
     }
 
     /// Returns block the number (height) of the last macro block at a given block number (height).
     /// If the given block number is a macro block, then it returns that block number.
-    async fn get_last_macro_block(&mut self, block_number: u32) -> Result<u32, Self::Error> {
-        Ok(policy::last_macro_block(block_number))
+    async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::last_macro_block(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
-    async fn get_is_macro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error> {
-        Ok(policy::is_macro_block_at(block_number))
+    async fn get_is_macro_block_at(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error> {
+        Ok(policy::is_macro_block_at(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
-    async fn get_is_micro_block_at(&mut self, block_number: u32) -> Result<bool, Self::Error> {
-        Ok(policy::is_micro_block_at(block_number))
+    async fn get_is_micro_block_at(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error> {
+        Ok(policy::is_micro_block_at(block_number).into())
     }
 
     /// Returns the block number of the first block of the given epoch (which is always a micro block).
-    async fn get_first_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error> {
+    async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
         if epoch == 0 {
             return Err(Error::EpochNumberNotZero);
         }
 
-        Ok(policy::first_block_of(epoch))
+        Ok(policy::first_block_of(epoch).into())
     }
 
     /// Returns the block number of the first block of the given batch (which is always a micro block).
-    async fn get_first_block_of_batch(&mut self, batch: u32) -> Result<u32, Self::Error> {
+    async fn get_first_block_of_batch(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
         if batch == 0 {
             return Err(Error::BatchNumberNotZero);
         }
 
-        Ok(policy::first_block_of_batch(batch))
+        Ok(policy::first_block_of_batch(batch).into())
     }
 
     /// Returns the block number of the election macro block of the given epoch (which is always the last block).
-    async fn get_election_block_of(&mut self, epoch: u32) -> Result<u32, Self::Error> {
-        Ok(policy::election_block_of(epoch))
+    async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::election_block_of(epoch).into())
     }
 
     /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
     /// is always the last block).
-    async fn get_macro_block_of(&mut self, batch: u32) -> Result<u32, Self::Error> {
-        Ok(policy::macro_block_of(batch))
+    async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
+        Ok(policy::macro_block_of(batch).into())
     }
 
     /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
     /// of the epoch.
-    async fn get_first_batch_of_epoch(&mut self, block_number: u32) -> Result<bool, Self::Error> {
-        Ok(policy::first_batch_of_epoch(block_number))
+    async fn get_first_batch_of_epoch(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<bool, (), Self::Error> {
+        Ok(policy::first_batch_of_epoch(block_number).into())
     }
 
     /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
@@ -154,11 +182,7 @@ impl PolicyInterface for PolicyDispatcher {
         genesis_supply: u64,
         genesis_time: u64,
         current_time: u64,
-    ) -> Result<u64, Self::Error> {
-        Ok(policy::supply_at(
-            genesis_supply,
-            genesis_time,
-            current_time,
-        ))
+    ) -> RPCResult<u64, (), Self::Error> {
+        Ok(policy::supply_at(genesis_supply, genesis_time, current_time).into())
     }
 }

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use beserial::Serialize;
 
 use nimiq_keys::Address;
+use nimiq_rpc_interface::types::RPCResult;
 use nimiq_rpc_interface::validator::ValidatorInterface;
 use nimiq_validator::validator::ValidatorProxy;
 
@@ -25,38 +26,37 @@ impl ValidatorInterface for ValidatorDispatcher {
     type Error = Error;
 
     /// Returns our validator address.
-    async fn get_address(&mut self) -> Result<Address, Self::Error> {
-        Ok(self.validator.validator_address.read().clone())
+    async fn get_address(&mut self) -> RPCResult<Address, (), Self::Error> {
+        Ok(self.validator.validator_address.read().clone().into())
     }
 
     /// Returns our validator signing key.
-    async fn get_signing_key(&mut self) -> Result<String, Self::Error> {
-        Ok(hex::encode(
-            self.validator.signing_key.read().private.serialize_to_vec(),
-        ))
+    async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error> {
+        Ok(hex::encode(self.validator.signing_key.read().private.serialize_to_vec()).into())
     }
 
     /// Returns our validator voting key.
-    async fn get_voting_key(&mut self) -> Result<String, Self::Error> {
+    async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error> {
         Ok(hex::encode(
             self.validator
                 .voting_key
                 .read()
                 .secret_key
                 .serialize_to_vec(),
-        ))
+        )
+        .into())
     }
 
     /// Updates the configuration setting to automatically reactivate our validator.
     async fn set_automatic_reactivation(
         &mut self,
         automatic_reactivate: bool,
-    ) -> Result<bool, Self::Error> {
+    ) -> RPCResult<(), (), Self::Error> {
         self.validator
             .automatic_reactivate
             .store(automatic_reactivate, Ordering::Release);
 
         log::debug!("Automatic reactivation set to {}.", automatic_reactivate);
-        Ok(automatic_reactivate)
+        Ok(().into())
     }
 }


### PR DESCRIPTION
This pull request adds a new RPC return type to all RPC methods with the data and metadata fields. As of now, All methods except the ones mentioned below return empty metadata.

The metadata includes the block hash and block number for the following RPC functions:
- get_slot_at
- get_account_by_address
- get_active_validators
- get_current_slashed_slots
- get_previous_slashed_slots
- get_parked_validators
- get_validator_by_address
- get_staker_by_address
- subscribe_for_validator_election_by_address
- subscribe_for_logs_by_addresses_and_types

This pull request removes the deprecated functions:
- create_update_transaction
- send_update_transaction

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

#### This fixes #970.
