### PR TITLE
Do not cancel running aggregations. Restart aggregations on startup.

### DIFF
--- a/tendermint/src/outside_deps.rs
+++ b/tendermint/src/outside_deps.rs
@@ -87,6 +87,15 @@ pub trait TendermintOutsideDeps: Send + Unpin + Sized + 'static {
         proposal_hash: Option<Self::ProposalHashTy>,
     ) -> Result<(Self, AggregationResult<Self::ProposalHashTy, Self::ProofTy>), TendermintError>;
 
+    /// Rebroadcasts a vote and starts an aggregations, but does not wait for the result.
+    /// Used for restarting aggregations from state.
+    fn rebroadcast_and_aggregate(
+        &self,
+        round: u32,
+        step: Step,
+        proposal_hash: Option<Self::ProposalHashTy>,
+    );
+
     /// Returns the current aggregation for a given round and step. The returned aggregation might
     /// or not have 2f+1 votes, this function only returns all the votes that we have so far.
     /// It will fail if no aggregation was started for the given round and step.

--- a/tendermint/tests/mod.rs
+++ b/tendermint/tests/mod.rs
@@ -161,6 +161,14 @@ impl TendermintOutsideDeps for TestValidator {
         }
     }
 
+    fn rebroadcast_and_aggregate(
+        &self,
+        _round: u32,
+        _step: Step,
+        _proposal_hash: Option<Self::ProposalHashTy>,
+    ) {
+    }
+
     // Note that this function returns an AggregationResult, not VoteResult. AggregationResult can
     // only be an Aggregation (containing the raw votes) or a NewRound.
     async fn broadcast_and_aggregate(

--- a/validator/src/aggregation/tendermint/aggregations.rs
+++ b/validator/src/aggregation/tendermint/aggregations.rs
@@ -163,11 +163,12 @@ impl<N: ValidatorNetwork> TendermintAggregations<N> {
         }
     }
 
-    pub fn cancel_aggregation(&self, round: u32, step: TendermintStep) {
-        if let Some(descriptor) = self.aggregation_descriptors.get(&(round, step)) {
-            trace!("cancelling aggregation for {}-{:?}", &round, &step);
-            descriptor.is_running.store(false, Ordering::Relaxed);
-        }
+    pub fn cancel_aggregation(&self, _round: u32, _step: TendermintStep) {
+        // For now do not cancel any aggregations
+        // if let Some(descriptor) = self.aggregation_descriptors.get(&(round, step)) {
+        //     trace!("cancelling aggregation for {}-{:?}", &round, &step);
+        //     descriptor.is_running.store(false, Ordering::Relaxed);
+        // }
     }
 }
 

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -433,6 +433,16 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
             .map(|result| (self, result))
     }
 
+    fn rebroadcast_and_aggregate(
+        &self,
+        round: u32,
+        step: Step,
+        proposal_hash: Option<Self::ProposalHashTy>,
+    ) {
+        self.aggregation_adapter
+            .rebroadcast_and_aggregate(round, step, proposal_hash)
+    }
+
     /// Returns the vote aggregation for a given round and step. It simply calls the aggregation
     /// adapter, which does all the work.
     async fn get_aggregation(


### PR DESCRIPTION
A validator once restarted during macro block production will remember its past votes, but it will not start those aggregations to let other validators know about them. This PR fixes that by introducing an init() function to tendermint, which will restart all aggregations prior to the one in the current state if existent. The one in the current state will, (and has been) started automatically.

Furthermore pre commit aggregations were canceled up until this PR once they reach a clear result. That can in rare cases lead to a stalling situation. There is a threshold once reached where these aggregations could be terminated, but for the sake of a timely fix, in this PR aggregations are no longer terminated at all.