### PR TITLE
Fixes bug in trie chunk

### DIFF
--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -474,6 +474,10 @@ impl<A: Serialize + Deserialize + Clone> MerkleRadixTrie<A> {
     ) -> Vec<TrieNode<A>> {
         let mut chunk = Vec::new();
 
+        if size == 0_usize {
+            return chunk;
+        }
+
         let mut stack = vec![self
             .get_root(txn)
             .expect("The Merkle Radix Trie didn't have a root node!")];


### PR DESCRIPTION
Fixes #1030
If a validator does not have any staker we return an empty list of stakers
The underlying issue was a problem in the get_trie_chunk when the size is 0

