### PR TITLE
Fix incorrect size computation in mempool

### DIFF
--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -571,11 +571,13 @@ impl Mempool {
 
             // Calculate size. If we can't fit the transaction in the block, then we stop here.
             // TODO: We can optimize this. There might be a smaller transaction that still fits.
-            size += tx.serialized_size();
+            let next_size = size + tx.serialized_size();
 
-            if size > max_bytes {
+            if next_size > max_bytes {
                 break;
             }
+
+            size = next_size;
 
             // Remove the transaction from the mempool.
             mempool_state_upgraded.remove(&tx_hash, EvictionReason::BlockBuilding);
@@ -634,11 +636,13 @@ impl Mempool {
 
             // Calculate size. If we can't fit the transaction in the block, then we stop here.
             // TODO: We can optimize this. There might be a smaller transaction that still fits.
-            size += tx.serialized_size();
+            let next_size = size + tx.serialized_size();
 
-            if size > max_bytes {
+            if next_size > max_bytes {
                 break;
             }
+
+            size = next_size;
 
             // Remove the transaction from the mempool.
             mempool_state_upgraded.remove(&tx_hash, EvictionReason::BlockBuilding);

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -247,7 +247,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             .mempool
             .get_control_transactions_for_block(block_available_bytes);
 
-        block_available_bytes -= txn_size;
+        block_available_bytes = block_available_bytes.saturating_sub(txn_size);
 
         let (mut regular_transactions, _) = self
             .mempool


### PR DESCRIPTION
Fixed an incorrect size calculation when returning transactions from the mempool
This can cause underflow issues
Fixes #1035

