### PR TITLE
Create a new HistoryAdoptedEvent

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -389,6 +389,10 @@ impl Blockchain {
             "Accepted epoch",
         );
 
+        // Notify the mempool about a new history adopted
+        this.notifier
+            .notify(BlockchainEvent::HistoryAdopted(block_hash.clone()));
+
         if is_election_block {
             this.notifier
                 .notify(BlockchainEvent::EpochFinalized(block_hash));

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -14,6 +14,7 @@ pub enum ForkEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockchainEvent {
     Extended(Blake2bHash),
+    HistoryAdopted(Blake2bHash),
     Rebranched(Vec<(Blake2bHash, Block)>, Vec<(Blake2bHash, Block)>),
     Finalized(Blake2bHash),
     EpochFinalized(Blake2bHash),
@@ -23,6 +24,7 @@ impl BlockchainEvent {
     pub fn get_newest_hash(&self) -> Blake2bHash {
         match self {
             Self::Extended(h) => h,
+            Self::HistoryAdopted(h) => h,
             Self::Rebranched(_, new_chain) => {
                 if let Some((h, _)) = new_chain.last() {
                     h

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -590,6 +590,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         Ok(stream
             .map(|event| match event {
                 BlockchainEvent::Extended(hash) => hash,
+                BlockchainEvent::HistoryAdopted(hash) => hash,
                 BlockchainEvent::Finalized(hash) => hash,
                 BlockchainEvent::EpochFinalized(hash) => hash,
                 BlockchainEvent::Rebranched(_, new_branch) => {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -427,6 +427,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
     fn on_blockchain_event(&mut self, event: BlockchainEvent) {
         match event {
             BlockchainEvent::Extended(ref hash) => self.on_blockchain_extended(hash),
+            BlockchainEvent::HistoryAdopted(ref hash) => self.on_blockchain_history_adopted(hash),
             BlockchainEvent::Finalized(ref hash) => self.on_blockchain_extended(hash),
             BlockchainEvent::EpochFinalized(ref hash) => {
                 self.on_blockchain_extended(hash);
@@ -436,6 +437,11 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                 self.on_blockchain_rebranched(old_chain, new_chain)
             }
         }
+    }
+
+    fn on_blockchain_history_adopted(&mut self, _: &Blake2bHash) {
+        self.mempool.mempool_clean_up();
+        debug!("Performed a mempool clean up because new history was adopted");
     }
 
     fn on_blockchain_extended(&mut self, hash: &Blake2bHash) {


### PR DESCRIPTION
Created a new event that is used to notify the mempool when a new history was adopted, in order to prune transactions from the mempool that are already included in the blockchain. Fixes issue #1036

