### PR TITLE
Fix some clippy warnings

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -49,7 +49,7 @@ impl Blockchain {
         // Check that the extra data does not exceed the permitted size.
         // This is also checked during deserialization.
         // Skip blocks should not have extra data
-        if header.extra_data().len() > 32 || (skip_block && header.extra_data().len() != 0) {
+        if header.extra_data().len() > 32 || (skip_block && !header.extra_data().is_empty()) {
             warn!(
                 header = %header,
                 reason = "too much extra data",

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -368,7 +368,7 @@ impl PeerContactInfo {
     }
 
     /// Returns an iterator over the multi-addresses of this contact.
-    pub fn addresses<'a>(&'a self) -> impl Iterator<Item = &Multiaddr> + 'a {
+    pub fn addresses(&self) -> impl Iterator<Item = &Multiaddr> {
         self.contact.inner.addresses.iter()
     }
 
@@ -467,8 +467,8 @@ impl PeerContactBook {
         self.peer_contacts.get(peer_id).map(Arc::clone)
     }
 
-    pub fn query<'a>(
-        &'a self,
+    pub fn query(
+        &self,
         protocols: Protocols,
         services: Services,
     ) -> impl Iterator<Item = Arc<PeerContactInfo>> + '_ {

--- a/primitives/mmr/src/mmr/mod.rs
+++ b/primitives/mmr/src/mmr/mod.rs
@@ -419,13 +419,13 @@ impl<H: Merge + Clone + PartialEq, S: Store<H>> MerkleMountainRange<H, S> {
     {
         let h = elem.hash(1);
 
-        for i in 0..self.num_leaves() {
-            if h.eq(&self.get_leaf(i)?) {
-                return Some(i);
+        (0..self.num_leaves()).find(|&i| {
+            if let Some(leaf) = self.get_leaf(i) {
+                h.eq(&leaf)
+            } else {
+                false
             }
-        }
-
-        None
+        })
     }
 }
 

--- a/validator/src/aggregation/tendermint/tendermint.rs
+++ b/validator/src/aggregation/tendermint/tendermint.rs
@@ -116,7 +116,7 @@ impl<N: ValidatorNetwork + 'static> HandelTendermintAdapter<N> {
 
         // Construct the vote so it can be hashed and signed
         let vote = TendermintVote {
-            proposal_hash: proposal_hash.clone(),
+            proposal_hash,
             id: id.clone(),
         };
 


### PR DESCRIPTION
Fix some clippy warnings related to:
- A redundant clone in the `validator` crate.
- Unnecessary lifetime specifiers in the `network-libp2p` crate.
- Manual implementation of `find` in the `mmr` primitives crate.
- Length comparison to 0 instead of using `is_empty` in the `blockchain` crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.