### PR TITLE
RPC Client default port

### DIFF
--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -103,7 +103,7 @@ async fn run_app(opt: Opt) -> Result<(), Error> {
     let url = opt
         .url
         .as_deref()
-        .unwrap_or("ws://127.0.0.1:8649/ws")
+        .unwrap_or("ws://127.0.0.1:8648/ws")
         .parse()?;
 
     let credentials = match (&opt.username, &opt.password) {


### PR DESCRIPTION
Sets the default port for the RPC client to the one thats default in the server.   
I assume the wrong one accidentally got commited after local testing.
