### PR TITLE
Properly use the `round` when verifying VRF seed

### DIFF
--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -323,11 +323,11 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
 
             // In case the proposal has a valid round, the original proposer signed the VRF Seed,
             // so the original slot owners key must be retrieved for header verification.
-            let vrf_key = if let Some(valid_round) = valid_round {
+            let vrf_key = if valid_round.is_some() {
                 let proposer_slot = blockchain
                     .get_proposer_at(
                         self.block_height,
-                        valid_round,
+                        header.round,
                         self.prev_seed.entropy(),
                         None,
                     )


### PR DESCRIPTION
Properly use the `round` field inside the macro block header from the proposal for verifying the VRF seed.

This fixes #1055.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.