### PR TITLE
history_sync: Use macro block terminated chunks

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -128,7 +128,7 @@ impl BlockProducer {
         // Store the extended transactions into the history tree and calculate the history root.
         let mut txn = blockchain.write_transaction();
 
-        let history_root = blockchain
+        let (history_root, _) = blockchain
             .history_store
             .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
             .expect("Failed to compute history root during block production.");
@@ -280,7 +280,8 @@ impl BlockProducer {
         header.history_root = blockchain
             .history_store
             .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
-            .expect("Failed to compute history root during block production.");
+            .expect("Failed to compute history root during block production.")
+            .0;
 
         txn.abort();
 

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -87,6 +87,7 @@ pub fn next_micro_block(
             .history_store
             .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
             .expect("Failed to compute history root during block production.")
+            .0
     });
 
     txn.abort();
@@ -175,6 +176,7 @@ pub fn next_skip_block(
             .history_store
             .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
             .expect("Failed to compute history root during block production.")
+            .0
     });
 
     txn.abort();
@@ -271,7 +273,8 @@ fn next_macro_block_proposal(
     header.history_root = blockchain
         .history_store
         .add_to_history(&mut txn, policy::epoch_at(block_number), &ext_txs)
-        .expect("Failed to compute history root during block production.");
+        .expect("Failed to compute history root during block production.")
+        .0;
 
     txn.abort();
 

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -113,15 +113,20 @@ impl Blockchain {
             false, // Can't check seed since we don't have the previous block info to get the proposer's signing key
             false,
             NextBlock::HistoryChunkMacro,
+            &this.election_head_hash(),
         ) {
             warn!(%block, reason = "bad header", "Rejecting block");
             return Err(e);
         }
 
         // Check the justification. Signing key is not necessary since it isn't needed for macro blocks
-        if let Err(e) =
-            Blockchain::verify_block_justification(&*this, &block, &PublicKey::default(), true)
-        {
+        if let Err(e) = Blockchain::verify_block_justification(
+            &*this,
+            &block,
+            &PublicKey::default(),
+            true,
+            &this.current_validators().unwrap(),
+        ) {
             warn!(%block, reason = "bad justification", "Rejecting block");
             return Err(e);
         }

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -96,6 +96,7 @@ impl Blockchain {
             !trusted,
             block.is_skip(),
             NextBlock::Subsequent,
+            &this.election_head_hash(),
         ) {
             warn!(%block, reason = "bad header", "Rejecting block");
             return Err(e);
@@ -107,6 +108,7 @@ impl Blockchain {
             &block,
             &proposer_slot.validator.signing_key,
             !trusted,
+            &this.current_validators().unwrap(),
         ) {
             warn!(%block, reason = "bad justification", "Rejecting block");
             return Err(e);

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -13,8 +13,8 @@ use crate::blockchain_state::BlockchainState;
 use crate::chain_info::ChainInfo;
 use crate::chain_store::MAX_EPOCHS_STORED;
 use crate::{
-    AbstractBlockchain, Blockchain, BlockchainEvent, ChainOrdering, ForkEvent, PushError,
-    PushResult,
+    AbstractBlockchain, Blockchain, BlockchainEvent, ChainOrdering, ForkEvent, NextBlock,
+    PushError, PushResult,
 };
 
 /// Implements methods to push blocks into the chain. This is used when the node has already synced
@@ -95,6 +95,7 @@ impl Blockchain {
             Some(&read_txn),
             !trusted,
             block.is_skip(),
+            NextBlock::Subsequent,
         ) {
             warn!(%block, reason = "bad header", "Rejecting block");
             return Err(e);

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -283,6 +283,7 @@ impl Blockchain {
         };
 
         chain_info.on_main_chain = true;
+        chain_info.set_cumulative_ext_tx_size(&prev_info, block_log.total_tx_size());
         prev_info.main_chain_successor = Some(chain_info.head.hash());
 
         this.chain_store

--- a/blockchain/src/chain_store.rs
+++ b/blockchain/src/chain_store.rs
@@ -40,7 +40,9 @@ impl ChainStore {
         let block_db = env.open_database(Self::BLOCK_DB_NAME.to_string());
         let height_idx = env.open_database_with_flags(
             Self::HEIGHT_IDX_NAME.to_string(),
-            DatabaseFlags::DUPLICATE_KEYS | DatabaseFlags::DUP_FIXED_SIZE_VALUES,
+            DatabaseFlags::DUPLICATE_KEYS
+                | DatabaseFlags::DUP_FIXED_SIZE_VALUES
+                | DatabaseFlags::UINT_KEYS,
         );
         let receipt_db = env
             .open_database_with_flags(Self::RECEIPT_DB_NAME.to_string(), DatabaseFlags::UINT_KEYS);

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -87,3 +87,12 @@ pub enum Direction {
     Forward,
     Backward,
 }
+
+//// Next Block type used for sequence/order checks of blocks
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum NextBlock {
+    /// Block is the next macro block that terminates a history chunk
+    HistoryChunkMacro,
+    /// Block is the next block in the chain (block number + 1)
+    Subsequent,
+}

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -86,24 +86,32 @@ impl RequestCommon for RequestBatchSet {
     const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_BATCH_SET;
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BatchSet {
+    pub macro_block: Option<MacroBlock>,
+    pub history_len: u32,
+}
+
 /// This message contains a macro block and the number of extended transactions (transitions)
 /// within this epoch.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct BatchSetInfo {
-    pub block: Option<MacroBlock>,
-    pub history_len: u32,
+    pub election_macro_block: Option<MacroBlock>,
+    #[beserial(len_type(u16, limit = 128))]
+    pub batch_sets: Vec<BatchSet>,
+    pub total_history_len: u64,
 }
 
 impl Debug for BatchSetInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchSetInfo");
-        if let Some(block) = &self.block {
+        if let Some(block) = &self.election_macro_block {
             debug_struct
-                .field("epoch_number", &block.epoch_number())
-                .field("block_number", &block.block_number())
-                .field("is_election_block", &block.is_election_block());
+                .field("election_epoch_number", &block.epoch_number())
+                .field("election_block_number", &block.block_number());
         }
-        debug_struct.field("history_len", &self.history_len);
+        debug_struct.field("total_history_len", &self.total_history_len);
+        debug_struct.field("batch_sets_len", &self.batch_sets.len());
         debug_struct.finish()
     }
 }

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -333,9 +333,9 @@ async fn sync_ingredients() {
     let epoch = SyncCluster::request_epoch(Arc::clone(&net2), peer_id, epochs[0].clone())
         .await
         .expect("Should yield epoch");
-    let block1 = epoch.block.expect("Should have block");
+    let block1 = epoch.election_macro_block.expect("Should have block");
 
-    assert_eq!(epoch.history_len, 3);
+    assert_eq!(epoch.total_history_len, 3);
     assert_eq!(
         block1.hash(),
         consensus1.blockchain.read().election_head_hash()
@@ -384,9 +384,15 @@ async fn sync_ingredients() {
     let epoch = SyncCluster::request_epoch(Arc::clone(&net2), peer_id, checkpoint.hash)
         .await
         .expect("Should yield epoch");
-    let block2 = epoch.block.expect("Should have block");
+    let block2 = epoch
+        .batch_sets
+        .last()
+        .expect("Should have a batch set")
+        .macro_block
+        .clone()
+        .expect("Should have block");
 
-    assert_eq!(epoch.history_len, 1);
+    assert_eq!(epoch.total_history_len, 1);
     assert_eq!(
         block2.hash(),
         consensus1.blockchain.read().macro_head_hash()

--- a/nano-blockchain/src/push.rs
+++ b/nano-blockchain/src/push.rs
@@ -54,6 +54,7 @@ impl NanoBlockchain {
             true,
             block.is_skip(),
             NextBlock::Subsequent,
+            &self.election_head_hash(),
         )?;
 
         // If this is an election block, check the body.
@@ -70,7 +71,13 @@ impl NanoBlockchain {
         }
 
         // Check the justification.
-        Blockchain::verify_block_justification(self, &block, &slot_owner.signing_key, true)?;
+        Blockchain::verify_block_justification(
+            self,
+            &block,
+            &slot_owner.signing_key,
+            true,
+            &self.current_validators().unwrap(),
+        )?;
 
         // Create the chaininfo for the new block.
         let chain_info = ChainInfo::from_block(block, &prev_info);

--- a/nano-blockchain/src/push.rs
+++ b/nano-blockchain/src/push.rs
@@ -1,6 +1,6 @@
 use nimiq_block::{Block, BlockError, BlockType, MacroHeader};
 use nimiq_blockchain::{
-    AbstractBlockchain, Blockchain, ChainInfo, ChainOrdering, PushError, PushResult,
+    AbstractBlockchain, Blockchain, ChainInfo, ChainOrdering, NextBlock, PushError, PushResult,
 };
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_primitives::policy;
@@ -53,6 +53,7 @@ impl NanoBlockchain {
             None,
             true,
             block.is_skip(),
+            NextBlock::Subsequent,
         )?;
 
         // If this is an election block, check the body.

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -273,6 +273,7 @@ pub enum BlockLog {
         block_number: u32,
         timestamp: u64,
         tx_logs: Vec<TransactionLog>,
+        total_tx_size: u64,
     },
 
     RevertedBlock {
@@ -280,6 +281,7 @@ pub enum BlockLog {
         block_hash: Blake2bHash,
         block_number: u32,
         tx_logs: Vec<TransactionLog>,
+        total_tx_size: u64,
     },
 }
 
@@ -288,6 +290,13 @@ impl BlockLog {
         match self {
             BlockLog::AppliedBlock { .. } => false,
             BlockLog::RevertedBlock { .. } => true,
+        }
+    }
+
+    pub fn total_tx_size(&self) -> u64 {
+        match self {
+            BlockLog::AppliedBlock { total_tx_size, .. } => *total_tx_size,
+            BlockLog::RevertedBlock { total_tx_size, .. } => *total_tx_size,
         }
     }
 }

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -93,6 +93,10 @@ pub const SUPPLY_DECAY: f64 = 4.692821935e-13;
 /// The maximum size of the BLS public key cache.
 pub const BLS_CACHE_MAX_CAPACITY: usize = 1000;
 
+/// Maximum size of history chunks
+/// 25 MB
+pub const HISTORY_CHUNKS_MAX_SIZE: u64 = 25 * 1024 * 1024;
+
 /// Returns the epoch number at a given block number (height).
 #[inline]
 pub fn epoch_at(block_number: u32) -> u32 {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -799,6 +799,7 @@ impl RPCData<BlockLog, BlockchainState> {
                 block_number,
                 timestamp,
                 tx_logs,
+                total_tx_size: _,
             } => Self::new(
                 BlockLog::AppliedBlock {
                     inherent_logs,
@@ -815,6 +816,7 @@ impl RPCData<BlockLog, BlockchainState> {
                 block_hash,
                 block_number,
                 tx_logs,
+                total_tx_size: _,
             } => Self::new(
                 BlockLog::RevertedBlock {
                     inherent_logs,

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -693,6 +693,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                             block_number,
                             timestamp,
                             tx_logs,
+                            total_tx_size: _,
                         } => {
                             // Collects the inherents that are related to any of the addresses specified and of any of the log types provided.
                             inherent_logs.retain(|log| {
@@ -739,6 +740,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                             block_hash,
                             block_number,
                             tx_logs,
+                            total_tx_size: _,
                         } => {
                             // Filters the inherents and tx_logs the same way as the AppliedBlock
                             inherent_logs.retain(|log| {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -13,7 +13,7 @@ use nimiq_block::{
     SignedTendermintProposal, TendermintProof, TendermintProposal,
 };
 use nimiq_block_production::BlockProducer;
-use nimiq_blockchain::{AbstractBlockchain, Blockchain};
+use nimiq_blockchain::{AbstractBlockchain, Blockchain, NextBlock};
 use nimiq_bls::PublicKey;
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
 use nimiq_network_interface::network::MsgAcceptance;
@@ -347,6 +347,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
                 None,
                 true,
                 false,
+                NextBlock::Subsequent,
             )
             .is_err()
             {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -348,6 +348,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
                 true,
                 false,
                 NextBlock::Subsequent,
+                &blockchain.election_head_hash(),
             )
             .is_err()
             {


### PR DESCRIPTION
- Use macro block terminated chunks to push history.
  For this, the accumulated size of extended transactions is used to
  keep an account of it and signal which checkpoint macro blocks must
  be kept.
  History sync will request such intermediate checkpoints (if they
  exist) along with the corresponding history instead of requesting
  a full epoch to then push it to the blockchain.
  This resolves #896.
- Fix chain store height index database flags since it uses integers as
  keys and in order to properly use the `prev` and `next` DB cursor
  functions the DB must know that the keys are integers.
- Add optimization for getting the number of final transactions from
   the history store. This adds a new function
   `get_number_final_epoch_transactions` that allows to quickly get them
   instead of needing to call `get_final_epoch_transactions(..).len()`.
   The latter is very expensive when having long epochs.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.