### PR TITLE
Fix some clippy warnings

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -360,13 +360,8 @@ impl Blockchain {
                 for tx in &body.get_raw_transactions() {
                     // Ensure transactions are ordered and unique.
                     if let Some(previous) = previous_tx {
-                        match previous.cmp(tx) {
-                            Ordering::Equal => {
-                                return Err(PushError::InvalidBlock(
-                                    BlockError::DuplicateTransaction,
-                                ));
-                            }
-                            _ => (),
+                        if previous.cmp(tx) == Ordering::Equal {
+                            return Err(PushError::InvalidBlock(BlockError::DuplicateTransaction));
                         }
                     }
 

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -512,7 +512,7 @@ impl Accounts {
             {
                 match transaction {
                     ExecutedTransaction::Ok(transaction) => {
-                        Account::delete(&self.tree, txn, &transaction).unwrap();
+                        Account::delete(&self.tree, txn, transaction).unwrap();
 
                         contracts_logs.push(TransactionLog::new(
                             transaction.hash(),


### PR DESCRIPTION
Fix a couple of clippy warnings introduced by the failing txns changes in the `blockchain` and in the primitive `account` crates.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.