### PR TITLE
Fix a double-lock bug in mempool

### DIFF
--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -296,7 +296,19 @@ impl Mempool {
         let blockchain = self.blockchain.read();
         let mut mempool_state = self.state.write();
 
-        let transactions = self.get_transactions();
+        let transactions: Vec<Transaction> = mempool_state
+            .control_transactions
+            .transactions
+            .values()
+            .cloned()
+            .chain(
+                mempool_state
+                    .regular_transactions
+                    .transactions
+                    .values()
+                    .cloned(),
+            )
+            .collect();
 
         for transaction in &transactions {
             let tx_hash: Blake2bHash = transaction.hash();


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes #___.

## What's in this pull request?

Fix a double-lock bug in Mempool::mempool_clean_up

The first lock is on L297

https://github.com/nimiq/core-rs-albatross/blob/700a79d2e538f10fe6cec9751aacbb82432f4e54/mempool/src/mempool.rs#L294-L307

Then it calls get_transactions() on L299, where the second lock is on L767

https://github.com/nimiq/core-rs-albatross/blob/700a79d2e538f10fe6cec9751aacbb82432f4e54/mempool/src/mempool.rs#L766-L776

The fix is to reuse the `mempool_state`.
