### PR TITLE
Changed the DB sync mode to Durable

### DIFF
--- a/database/src/mdbx.rs
+++ b/database/src/mdbx.rs
@@ -57,7 +57,7 @@ impl MdbxEnvironment {
         let db_flags = libmdbx::EnvironmentFlags {
             no_rdahead: true,
             mode: libmdbx::Mode::ReadWrite {
-                sync_mode: libmdbx::SyncMode::UtterlyNoSync,
+                sync_mode: libmdbx::SyncMode::Durable,
             },
             ..Default::default()
         };


### PR DESCRIPTION
Changed the MDBX sync mode to Durable, which provides the following properties:
Atomicity, Consistency, Isolation and Durability.
This comes with a performance impact, that according to unittesting (which pushes full blocks),
it is ~10% slower than UtterlyNoSync debug mode
But it is 2x slower than UtterlyNoSync and similar to NoMetaSync in release mode.
A tradeoff needs to be made between database consistency and speed, which can be offset by the
desired block times during production
