### PR TITLE
Fix several clippy warnings

### DIFF
--- a/beserial/src/lib.rs
+++ b/beserial/src/lib.rs
@@ -198,6 +198,7 @@ impl Deserialize for bool {
 
 impl Serialize for bool {
     fn serialize<W: WriteBytesExt>(&self, writer: &mut W) -> Result<usize, SerializingError> {
+        #[allow(clippy::bool_to_int_with_if)]
         writer.write_u8(if *self { 1u8 } else { 0u8 })?;
         Ok(self.serialized_size())
     }

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -142,7 +142,7 @@ impl Address {
     }
 
     pub fn to_hex(&self) -> String {
-        hex::encode(&self.0)
+        hex::encode(self.0)
     }
 
     pub fn from_hex(s: &str) -> Result<Self, AddressParseError> {

--- a/keys/src/multisig.rs
+++ b/keys/src/multisig.rs
@@ -109,7 +109,7 @@ impl CommitmentPair {
         // Decompress the 32 byte cryptographically secure random data to 64 byte.
         let mut h: sha2::Sha512 = sha2::Sha512::default();
 
-        h.update(&randomness);
+        h.update(randomness);
         let scalar = Scalar::from_hash::<sha2::Sha512>(h);
         if scalar == Scalar::zero() || scalar == Scalar::one() {
             return Err(InvalidScalarError);

--- a/lib/src/extras/signal_handling.rs
+++ b/lib/src/extras/signal_handling.rs
@@ -2,7 +2,7 @@ use signal_hook::{consts::SIGINT, iterator::Signals};
 use tokio::time::{sleep, Duration};
 
 pub fn initialize_signal_handler() {
-    let signals = Signals::new(&[SIGINT]);
+    let signals = Signals::new([SIGINT]);
 
     if let Ok(mut signals) = signals {
         tokio::spawn(async move {

--- a/nano-zkp/src/gadgets/mnt4/macro_block.rs
+++ b/nano-zkp/src/gadgets/mnt4/macro_block.rs
@@ -183,7 +183,7 @@ impl MacroBlockGadget {
         cs: ConstraintSystemRef<MNT4Fr>,
     ) -> Result<Boolean<MNT4Fr>, SynthesisError> {
         // Get the minimum number of signers.
-        let min_signers = FqVar::new_constant(cs, &Fq::from(TWO_F_PLUS_ONE as u64))?;
+        let min_signers = FqVar::new_constant(cs, Fq::from(TWO_F_PLUS_ONE as u64))?;
 
         // Initialize the running sum.
         let mut num_signers = FqVar::zero();

--- a/peer-address/src/address/peer_address.rs
+++ b/peer-address/src/address/peer_address.rs
@@ -153,7 +153,7 @@ impl PeerAddress {
             return None;
         }
 
-        let public_key: String = ::hex::encode(&self.public_key.as_bytes());
+        let public_key: String = ::hex::encode(self.public_key.as_bytes());
         match self.ty {
             PeerAddressType::Ws(ref host, ref port) => {
                 Some(format!("ws://{}:{}/{}", host, port, public_key))
@@ -231,7 +231,7 @@ impl Eq for PeerAddress {}
 
 impl Hash for PeerAddress {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let peer_id: String = ::hex::encode(&self.peer_id.0);
+        let peer_id: String = ::hex::encode(self.peer_id.0);
         let peer_id_uri = match self.ty {
             PeerAddressType::Dumb => format!("dumb:///{}", peer_id),
             PeerAddressType::Ws(_, _) => format!("ws:///{}", peer_id),

--- a/tools/src/bls/main.rs
+++ b/tools/src/bls/main.rs
@@ -17,5 +17,5 @@ fn main() {
     println!();
     println!("# Proof Of Knowledge:");
     println!();
-    println!("{}", hex::encode(&secret_key.sign(&public_key).compress()));
+    println!("{}", hex::encode(secret_key.sign(&public_key).compress()));
 }

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -81,7 +81,7 @@ fn run_app() -> Result<(), Error> {
     let tx = if matches.get_flag("tx_from_stdin") {
         let mut line = String::new();
         stdin().read_line(&mut line)?;
-        Transaction::deserialize_from_vec(&hex::decode(&line.trim_end())?)?
+        Transaction::deserialize_from_vec(&hex::decode(line.trim_end())?)?
     } else {
         let from_address = Address::from_user_friendly_address(
             matches

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -52,7 +52,7 @@ impl VrfEntropy {
 impl std::fmt::Debug for VrfEntropy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VrfEntropy")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }
@@ -229,14 +229,14 @@ impl Default for VrfSeed {
 impl fmt::Debug for VrfSeed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VrfSeed")
-            .field(&hex::encode(&self.signature))
+            .field(&hex::encode(self.signature))
             .finish()
     }
 }
 
 impl fmt::Display for VrfSeed {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{}", hex::encode(&self.signature))
+        write!(f, "{}", hex::encode(self.signature))
     }
 }
 


### PR DESCRIPTION
Fix several clippy warnings in the `keys`, `lib`, `nano-zpk`, `peer-address`, `tools` and `vrf` crates.
Warnings were related to needless borrows.
Also ignore the clippy warning for converting a boolean to `int` using `if` in the `beserial` crate since the solution doesn't make the code clearer.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.