### PR TITLE
Rename and fix `LowViewChangeDelay` test

### DIFF
--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -17,7 +17,7 @@ jobs:
         - FourValidatorsReconnectSpammer
         - MacroBlockProduction
         - Validators90sDown
-        - LowViewChangeDelay
+        - LowBlockProducerTimeout
         - FiveValidatorsWithSpammer
 
         include:
@@ -34,8 +34,8 @@ jobs:
           devnet_args: -k 0 -s 150 -R -b 2
         - test: Validators90sDown
           devnet_args: -s 500 -t 90 -R
-        - test: LowViewChangeDelay
-          pre: "sed -i 's/VIEW_CHANGE_DELAY: Duration = Duration::from_secs(10);/VIEW_CHANGE_DELAY: Duration = Duration::from_secs(2);/g' validator/src/validator.rs"
+        - test: LowBlockProducerTimeout
+          pre: "sed -i 's/BLOCK_PRODUCER_TIMEOUT: u64 = 4 * 1000;/BLOCK_PRODUCER_TIMEOUT: u64 = 2 * 1000;/g' primitives/src/policy.rs"
           devnet_args: -k 0 -s 150 -R
         - test: FiveValidatorsWithSpammer
           devnet_args: --validators 5 -R -s 500 -k 0

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -17,7 +17,7 @@ jobs:
         - FourValidatorsReconnectSpammer
         - MacroBlockProduction
         - Validators90sDown
-        - LowViewChangeDelay
+        - LowBlockProducerTimeout
 
         include:
         - test: FourValidatorsReconnect
@@ -33,8 +33,8 @@ jobs:
           devnet_args: -k 0 -s 15 -u 100
         - test: Validators90sDown
           devnet_args: -s 50 -t 90 -u 100
-        - test: LowViewChangeDelay
-          pre: "sed -i 's/VIEW_CHANGE_DELAY: Duration = Duration::from_secs(10);/VIEW_CHANGE_DELAY: Duration = Duration::from_secs(2);/g' validator/src/validator.rs"
+        - test: LowBlockProducerTimeout
+          pre: "sed -i 's/BLOCK_PRODUCER_TIMEOUT: u64 = 4 * 1000;/BLOCK_PRODUCER_TIMEOUT: u64 = 2 * 1000;/g' primitives/src/policy.rs"
           devnet_args: -k 0 -s 15 -u 100
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Rename `LowViewChangeDelay` test to `LowBlockProducerTimeout` since the concept of view change no longer exists.
Also change the regular expression of the job to correctly modify the wanted constant which is `BLOCK_PRODUCER_TIMEOUT`.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.