### PR TITLE
Fix some typos

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -440,7 +440,7 @@ fn it_can_revert_failed_transactions() {
 
     transactions.push(tx_valid.clone());
 
-    //We will send a second create staker transaction, this sould fail, as the same staker cannot be created twice
+    // We will send a second create staker transaction, this should fail, as the same staker cannot be created twice
     let tx_failed = TransactionBuilder::new_create_staker(
         &key_pair,
         &key_pair,

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -238,7 +238,7 @@ impl Accounts {
                         create_logs.push(TransactionLog::new(transaction.hash(), info.logs));
                     }
 
-                    // Store the sucessful executed transaction
+                    // Store the successfully executed transaction
                     executed_txns.push(ExecutedTransaction::Ok(transaction.clone()));
                 }
                 Err(account_err) => {
@@ -357,7 +357,7 @@ impl Accounts {
                             )
                             .unwrap_or_else(|_| {
                                 log::error!(
-                                    " Failed to revert a succesfull incoming transaction: {:?}",
+                                    " Failed to revert a successful incoming transaction: {:?}",
                                     txn
                                 );
                                 panic!();
@@ -387,7 +387,7 @@ impl Accounts {
                         )
                         .unwrap_or_else(|_| {
                             log::error!(
-                                " Failed to revert a succesfull outgoing transaction: {:?}",
+                                " Failed to revert a successful outgoing transaction: {:?}",
                                 txn
                             );
                             panic!();
@@ -690,7 +690,7 @@ impl Accounts {
         )
     }
 
-    /// Merges the log transactions from senders, receiptients and create_contracts and returns batch_info containing the merged tx_logs.
+    /// Merges the log transactions from senders, recipients and create_contracts and returns batch_info containing the merged tx_logs.
     /// This means that the batch_info inherent_logs and receipts are preserved and returned by this method.
     /// The batch_info provided as argument is expected to have its tx_logs vec empty, otherwise its content will get overwritten.
     fn check_merge_tx_logs(
@@ -699,7 +699,7 @@ impl Accounts {
         mut recipients_logs: Vec<TransactionLog>,
         mut create_logs: Vec<TransactionLog>,
     ) -> BatchInfo {
-        // The senders has all transaction log entries. We iterate over it and append the remaing logs to the respective tx_log of sender_logs.
+        // The senders has all transaction log entries. We iterate over it and append the remaining logs to the respective tx_log of sender_logs.
         let mut tx_logs_recipients = recipients_logs.iter_mut().peekable();
         let mut tx_logs_create = create_logs.iter_mut().peekable();
 
@@ -721,7 +721,7 @@ impl Accounts {
             }
         }
 
-        // All receipient and create tx_logs should have a matching tx_log from the senders.
+        // All recipients and create tx_logs should have a matching tx_log from the senders.
         // Therefore, all tx_logs of these two vecs are now expected to be processed and appended senders_logs tx_logs.
         assert_eq!(None, tx_logs_recipients.peek(), "recipients tx_logs were not fully processed. Possible cause is a ordering difference compared to senders_logs tx_logs");
         assert_eq!(None, tx_logs_create.peek(), "create tx_logs were not fully processed. Possible cause is a ordering difference compared to senders_logs tx_logs");

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -117,7 +117,7 @@ impl<N: Network> ZKProver<N> {
                 assert!(
                     zkp_state.latest_block_number
                         >= block.block_number() - policy::BLOCKS_PER_EPOCH,
-                    "The current state should never lag behiind more than one epoch"
+                    "The current state should never lag behind more than one epoch"
                 );
                 if zkp_state.latest_block_number == block.block_number() - policy::BLOCKS_PER_EPOCH
                 {

--- a/zkp-component/tests/proof_utils.rs
+++ b/zkp-component/tests/proof_utils.rs
@@ -137,7 +137,7 @@ async fn can_store_and_load_zkp_state_from_db() {
     assert_eq!(
         proof_store.get_zkp().unwrap(),
         new_proof,
-        "Load from db was not succesfull"
+        "Load from db was not successful"
     );
 
     let new_proof = ZKProof {
@@ -149,6 +149,6 @@ async fn can_store_and_load_zkp_state_from_db() {
     assert_eq!(
         proof_store.get_zkp().unwrap(),
         new_proof,
-        "Load from db was not succesfull"
+        "Load from db was not successful"
     );
 }


### PR DESCRIPTION
Fix some typos in the `block-production`, `primitives` and `zkp-component` crates.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.