### PR TITLE
Refactor block verification

### DIFF
--- a/blockchain/src/abstract_blockchain.rs
+++ b/blockchain/src/abstract_blockchain.rs
@@ -59,12 +59,7 @@ pub trait AbstractBlockchain {
     }
 
     /// Returns the block type of the next block.
-    fn get_next_block_type(&self, last_number: Option<u32>) -> BlockType {
-        let last_block_number = match last_number {
-            None => self.block_number(),
-            Some(n) => n,
-        };
-
+    fn get_next_block_type(last_block_number: u32) -> BlockType {
         if Policy::is_macro_block_at(last_block_number + 1) {
             BlockType::Macro
         } else {

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -1,312 +1,85 @@
-use nimiq_block::{
-    Block, BlockError, MacroBlock, MacroBody, MicroJustification, SkipBlockInfo, TendermintProof,
-};
-use nimiq_database::{ReadTransaction, Transaction as DBtx};
+use nimiq_block::{Block, BlockError, MacroBlock, MacroBody};
+use nimiq_database::Transaction as DBTransaction;
 use nimiq_hash::{Blake2bHash, Hash};
-use nimiq_primitives::slots::Validator;
-use nimiq_primitives::{policy::Policy, slots::Validators};
-use nimiq_vrf::VrfSeed;
 
 use crate::blockchain_state::BlockchainState;
-use crate::{AbstractBlockchain, BlockSuccessor, Blockchain, PushError};
+use crate::{AbstractBlockchain, Blockchain, PushError};
 
 /// Implements methods to verify the validity of blocks.
 impl Blockchain {
     /// Verifies a block for the current blockchain state.
     /// This method does a full verification on the block except for the block state checks.
     /// See `verify_block_state` for these type of checks.
-    // Note: This is an associated method because we need to use it on the light-blockchain. There
-    //       might be a better way to do this though.
-    pub fn verify_block_for_current_state<B: AbstractBlockchain>(
-        blockchain: &B,
-        read_txn: &ReadTransaction,
+    pub fn verify_block(
+        &self,
+        txn: &DBTransaction,
         block: &Block,
         trusted: bool,
     ) -> Result<(), PushError> {
-        // Do block intrinsic checks
+        // We expect full blocks (with body) here.
+        block
+            .body()
+            .ok_or(PushError::InvalidBlock(BlockError::MissingBody))?;
+
+        // Perform block intrinsic checks.
         block.verify(!trusted)?;
 
-        // Check block for predecessor block
-        let prev_info = blockchain
-            .get_chain_info(block.parent_hash(), false, Some(read_txn))
+        // Fetch predecessor block. Fail if it doesn't exist.
+        let predecessor = self
+            .get_chain_info(block.parent_hash(), false, Some(txn))
+            .map(|info| info.head)
             .ok_or(PushError::Orphan)?;
-        let predecessor = prev_info.head;
-        Self::verify_block_for_predecessor(
-            block,
-            &predecessor,
-            BlockSuccessor::Subsequent(blockchain.election_head_hash()),
-        )?;
 
-        // Check block for slot and validators
-        // Get the intended block proposer.
-        let offset = if let Block::Macro(macro_block) = &block {
-            macro_block.round()
-        } else {
-            // Skip and micro block offset is block number
-            block.block_number()
-        };
+        // Verify that the block is a valid immediate successor to its predecessor.
+        block.verify_immediate_successor(&predecessor)?;
 
-        // In trusted don't do slot related checks since they are mostly signature verifications and are slow.
+        // If the block is a macro block, check that it is a valid successor to the current
+        // election block.
+        if block.is_macro() {
+            block.verify_macro_successor(&self.election_head())?;
+        }
+
+        // In trusted don't do slot related checks since they are mostly signature verifications
+        // that can be slow.
         if !trusted {
-            let (proposer_slot, _) = blockchain
-                .get_slot_owner_at(block.block_number(), offset, Some(read_txn))
+            // Check block for slot and validators
+            // Get the intended block proposer.
+            let offset = if let Block::Macro(macro_block) = &block {
+                macro_block.round()
+            } else {
+                // Skip and micro block offset is block number
+                block.block_number()
+            };
+
+            let (proposer_slot, _) = self
+                .get_slot_owner_at(block.block_number(), offset, Some(txn))
                 .ok_or_else(|| {
                     warn!(%block, reason = "failed to determine block proposer", "Rejecting block");
                     PushError::Orphan
                 })?;
 
-            Self::verify_block_for_slot(
-                block,
-                predecessor.seed(),
-                Some(&proposer_slot),
-                &blockchain.current_validators().unwrap(),
-            )?;
+            // Verify that the block is valid for the given proposer.
+            block.verify_proposer(&proposer_slot.signing_key, predecessor.seed())?;
+
+            // Verify that the block is valid for the current validators.
+            block.verify_validators(&self.current_validators().unwrap())?;
+
+            // Verify that the transactions in the block are valid.
+            self.verify_transactions(block)?;
         }
 
         Ok(())
     }
 
-    /// Verifies a block given its predecessor.
-    /// This only performs verifications where the predecessor is needed.
-    /// Check Block.verify() or verify_block_for_slot for further checks.
-    pub fn verify_block_for_predecessor(
-        block: &Block,
-        predecessor: &Block,
-        sequence_type: BlockSuccessor,
-    ) -> Result<(), PushError> {
-        let header = block.header();
-
-        // Check that the current block timestamp is equal or greater than the timestamp of the
-        // previous block.
-        if header.timestamp() < predecessor.timestamp() {
-            warn!(
-                header = %header,
-                obtained_timestamp = header.timestamp(),
-                parent_timestamp   = predecessor.timestamp(),
-                reason = "Block timestamp precedes predecessor timestamp",
-                "Rejecting block"
-            );
-            return Err(PushError::InvalidSuccessor);
-        }
-
-        // Check that skip blocks has the expected timestamp and that the VRF seed is carried over
-        if block.is_skip() {
-            if header.timestamp() != predecessor.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT {
-                warn!(
-                    header = %header,
-                    obtained_timestamp = header.timestamp(),
-                    expected_timestamp   = predecessor.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT,
-                    reason = "Unexpected timestamp for a skip block",
-                    "Rejecting block"
-                );
-                return Err(PushError::InvalidBlock(
-                    BlockError::InvalidSkipBlockTimestamp,
-                ));
-            }
-            // In skip blocks the VRF seed must be carried over (because a new VRF seed requires a new leader)
-            if header.seed() != predecessor.seed() {
-                warn!(header = %header,
-                    reason = "Invalid seed",
-                    "Rejecting skip block");
-                return Err(PushError::InvalidBlock(BlockError::InvalidSeed));
-            }
-        }
-
-        match sequence_type {
-            BlockSuccessor::Subsequent(ref exp_parent_election_hash) => {
-                // Check that blocks are actually subsequent
-                if *block.parent_hash() != predecessor.hash() {
-                    warn!(
-                        header = %header,
-                        reason = "Wrong parent hash",
-                        parent_hash = %block.parent_hash(),
-                        expected_parent_hash = %predecessor.hash(),
-                        "Rejecting block",
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                }
-
-                // Check that the block is a valid successor of its predecessor.
-                let next_block_type = Self::get_next_block_type(predecessor.block_number());
-                if header.ty() != next_block_type {
-                    warn!(
-                        header = %header,
-                        reason = "Wrong block type",
-                        "Rejecting block obtained_type={:?} expected_type={:?}", header.ty(), next_block_type
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                }
-
-                // Check the block number.
-                if !block.is_immediate_successor_of(predecessor) {
-                    warn!(
-                        header = %header,
-                        obtained_block_number = block.block_number(),
-                        expected_block_number = predecessor.block_number() + 1,
-                        reason = "Wrong block number",
-                        "Rejecting block"
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                }
-
-                // Check if the parent election hash matches the expected election head hash
-                if block.is_macro() {
-                    let parent_election_hash = header.parent_election_hash().unwrap();
-                    if parent_election_hash != exp_parent_election_hash {
-                        warn!(
-                            header = %header,
-                            parent_election_hash = %parent_election_hash,
-                            expected_hash = %exp_parent_election_hash,
-                            reason = "Wrong parent election hash",
-                            "Rejecting block"
-                        );
-                        return Err(PushError::InvalidSuccessor);
-                    }
-                }
-            }
-            BlockSuccessor::Macro => {
-                // Check that blocks are macro block successors
-                if block.is_election()
-                    && predecessor.is_election()
-                    && !block.is_election_successor_of(predecessor)
-                {
-                    warn!(
-                        header = %header,
-                        predecessor = %predecessor,
-                        reason = "Election blocks are not macro block successors",
-                        "Rejecting block"
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                } else if !block.is_macro_successor_of(predecessor) {
-                    warn!(
-                        header = %header,
-                        predecessor = %predecessor,
-                        reason = "Blocks are not macro block successors",
-                        "Rejecting block"
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                }
-                // Check the block number is a non decreasing block number
-                if header.block_number() <= predecessor.block_number() {
-                    warn!(
-                        header = %header,
-                        obtained_block_number = header.block_number(),
-                        checked_block_number = predecessor.block_number(),
-                        reason = "Decreasing block number",
-                        "Rejecting block"
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                }
-
-                // The expected parent election hash depends on the predecessor:
-                // - Predecessor is an election macro block: this block must have its hash as
-                //   parent election hash
-                // - Predecessor is a checkpoint macro block: this block must have the same
-                //   parent election hash
-                let predecessor_hash = predecessor.hash();
-                let exp_parent_election_hash = if predecessor.is_election() {
-                    &predecessor_hash
-                } else {
-                    predecessor.parent_election_hash().unwrap()
-                };
-                // Check that the blocks have the same parent election hash
-                // Check if the parent election hash matches the current election head hash
-                let parent_election_hash = block.parent_election_hash().unwrap();
-                if parent_election_hash != exp_parent_election_hash {
-                    warn!(
-                        header = %header,
-                        parent_election_hash = %parent_election_hash,
-                        blockchain_election_hash = %predecessor.parent_election_hash().unwrap(),
-                        reason = "Wrong parent election hash",
-                        "Rejecting block"
-                    );
-                    return Err(PushError::InvalidSuccessor);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Verifies a block given the slot.
-    /// This only performs verifications where the slot or the set of current validators are needed.
-    /// Check Block.verify() or verify_block_for_predecessor for further checks.
-    /// Notes: Passing `None` to `proposer` skips the VRF seed and the MicroJustification verification.
-    pub fn verify_block_for_slot(
-        block: &Block,
-        prev_seed: &VrfSeed,
-        proposer: Option<&Validator>,
-        validators: &Validators,
-    ) -> Result<(), PushError> {
-        // Check if the seed was signed by the intended producer.
-        if let Some(validator) = proposer {
-            // Skip block seeds are carried from the previous block and this is checked in
-            // `verify_block_for_predecessor`.
-            if !block.is_skip() {
-                if let Err(e) = block.seed().verify(prev_seed, &validator.signing_key) {
-                    warn!(header = %block.header(),
-                  reason = "Invalid seed",
-                  "Rejecting block vrf_error={:?}", e);
-                    return Err(PushError::InvalidBlock(BlockError::InvalidSeed));
+    fn verify_transactions(&self, block: &Block) -> Result<(), BlockError> {
+        if let Some(transactions) = block.transactions() {
+            for transaction in transactions {
+                if !self.tx_verification_cache.is_known(&transaction.hash()) {
+                    transaction.get_raw_transaction().verify(self.network_id)?;
                 }
             }
         }
 
-        // Verify the block justification
-        match block {
-            Block::Micro(micro_block) => {
-                // Checks if the justification exists. If yes, unwrap it.
-                let justification = micro_block
-                    .justification
-                    .as_ref()
-                    .ok_or(PushError::InvalidBlock(BlockError::NoJustification))?;
-
-                // Verify the signature on the justification.
-                match justification {
-                    MicroJustification::Micro(justification) => {
-                        if let Some(validator) = proposer {
-                            let hash = block.hash();
-                            let signing_key = validator.signing_key;
-                            if !signing_key.verify(justification, hash.as_slice()) {
-                                warn!(
-                                    %block,
-                                    %signing_key,
-                                    reason = "Invalid signature for slot owner",
-                                    "Rejecting block"
-                                );
-                                return Err(PushError::InvalidBlock(
-                                    BlockError::InvalidJustification,
-                                ));
-                            }
-                        }
-                    }
-                    MicroJustification::Skip(justification) => {
-                        let skip_block_info = SkipBlockInfo {
-                            block_number: micro_block.header.block_number,
-                            vrf_entropy: micro_block.header.seed.entropy(),
-                        };
-
-                        if !justification.verify(&skip_block_info, validators) {
-                            warn!(
-                                    %block,
-                                    reason = "Bad skip block proof",
-                                    "Rejecting block");
-                            return Err(PushError::InvalidBlock(BlockError::InvalidSkipBlockProof));
-                        }
-                    }
-                }
-            }
-            Block::Macro(macro_block) => {
-                // Verify the Tendermint proof.
-                if !TendermintProof::verify(macro_block, validators) {
-                    warn!(
-                        %block,
-                        reason = "Macro block with bad justification",
-                        "Rejecting block"
-                    );
-                    return Err(PushError::InvalidBlock(BlockError::InvalidJustification));
-                }
-            }
-        }
         Ok(())
     }
 
@@ -325,7 +98,7 @@ impl Blockchain {
         &self,
         state: &BlockchainState,
         block: &Block,
-        txn_opt: Option<&DBtx>,
+        txn_opt: Option<&DBTransaction>,
     ) -> Result<Option<MacroBody>, PushError> {
         let accounts = &state.accounts;
 

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -87,13 +87,3 @@ pub enum Direction {
     Forward,
     Backward,
 }
-
-//// Next Block type used for sequence/order checks of blocks
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum BlockSuccessor {
-    /// Block is the next macro block
-    Macro,
-    /// Block is the next block in the chain (block number + 1)
-    /// It must carry the expected election hash for the block
-    Subsequent(Blake2bHash),
-}

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -89,10 +89,11 @@ pub enum Direction {
 }
 
 //// Next Block type used for sequence/order checks of blocks
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum NextBlock {
-    /// Block is the next macro block that terminates a history chunk
-    HistoryChunkMacro,
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum BlockSuccessor {
+    /// Block is the next macro block
+    Macro,
     /// Block is the next block in the chain (block number + 1)
-    Subsequent,
+    /// It must carry the expected election hash for the block
+    Subsequent(Blake2bHash),
 }

--- a/blockchain/src/history/extended_transaction.rs
+++ b/blockchain/src/history/extended_transaction.rs
@@ -129,10 +129,10 @@ impl ExtendedTransaction {
     /// their transaction hash.
     pub fn tx_hash(&self) -> Blake2bHash {
         match &self.data {
-            ExtTxData::Basic(tx) => tx.get_hash(),
+            ExtTxData::Basic(tx) => tx.hash(),
             ExtTxData::Inherent(v) => {
                 if v.ty == InherentType::Reward {
-                    self.clone().into_transaction().unwrap().get_hash()
+                    self.clone().into_transaction().unwrap().hash()
                 } else {
                     v.hash()
                 }

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -265,7 +265,7 @@ fn it_validates_block_number() {
             block_number_offset: 1,
             ..Default::default()
         },
-        Err(PushError::InvalidSuccessor),
+        Err(InvalidBlock(BlockError::InvalidBlockNumber)),
     );
 }
 
@@ -276,7 +276,7 @@ fn it_validates_block_time() {
             timestamp_offset: -2,
             ..Default::default()
         },
-        Err(PushError::InvalidSuccessor),
+        Err(InvalidBlock(BlockError::InvalidTimestamp)),
     );
 }
 
@@ -287,7 +287,7 @@ fn it_validates_body_hash() {
             body_hash: Some(Blake2bHash::default()),
             ..Default::default()
         },
-        Err(PushError::InvalidBlock(BlockError::BodyHashMismatch)),
+        Err(InvalidBlock(BlockError::BodyHashMismatch)),
     );
 
     expect_push_micro_block(
@@ -349,7 +349,9 @@ fn it_validates_parent_election_hash() {
             parent_election_hash: Some(Blake2bHash::default()),
             ..Default::default()
         },
-        Err(PushError::InvalidSuccessor),
+        Err(PushError::InvalidBlock(
+            BlockError::InvalidParentElectionHash,
+        )),
     );
 }
 

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -25,24 +25,35 @@ mod tendermint;
 /// Enum containing a variety of block error types.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum BlockError {
+    #[error("Invalid block type for this block number")]
+    InvalidBlockType,
     #[error("Unsupported version")]
     UnsupportedVersion,
+    #[error("Invalid block number")]
+    InvalidBlockNumber,
+    #[error("Invalid timestamp")]
+    InvalidTimestamp,
+    #[error("Invalid parent hash")]
+    InvalidParentHash,
+    #[error("Invalid parent election hash")]
+    InvalidParentElectionHash,
+    #[error("Contains an invalid seed")]
+    InvalidSeed,
     #[error("Extra data too large")]
     ExtraDataTooLarge,
-    #[error("Block is from the future")]
-    FromTheFuture,
-    #[error("Block size exceeded")]
-    SizeExceeded,
 
     #[error("Body hash mismatch")]
     BodyHashMismatch,
     #[error("Accounts hash mismatch")]
     AccountsHashMismatch,
+    #[error("Invalid history root")]
+    InvalidHistoryRoot,
+
+    #[error("Block size exceeded")]
+    SizeExceeded,
 
     #[error("Missing justification")]
-    NoJustification,
-    #[error("Missing skip block proof")]
-    NoSkipBlockProof,
+    MissingJustification,
     #[error("Missing body")]
     MissingBody,
 
@@ -62,27 +73,16 @@ pub enum BlockError {
     #[error("Transactions execution result mismatch")]
     TransactionExecutionMismatch,
 
-    #[error("Duplicate receipt in block")]
-    DuplicateReceipt,
-    #[error("Invalid receipt in block")]
-    InvalidReceipt,
-    #[error("Receipts incorrectly ordered")]
-    ReceiptsNotOrdered,
-
     #[error("Justification is invalid")]
     InvalidJustification,
     #[error("Skip block proof is invalid")]
     InvalidSkipBlockProof,
-    #[error("Contains an invalid seed")]
-    InvalidSeed,
-    #[error("Invalid history root")]
-    InvalidHistoryRoot,
+
     #[error("Incorrect validators")]
     InvalidValidators,
     #[error("Incorrect PK Tree root")]
     InvalidPkTreeRoot,
-    #[error("Invalid skip block timestamp")]
-    InvalidSkipBlockTimestamp,
+
     #[error("Skip block contains a non empty body")]
     InvalidSkipBlockBody,
 }

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -1,12 +1,16 @@
+use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::{fmt, io};
 
+use crate::{BlockError, SkipBlockInfo};
 use beserial::{Deserialize, Serialize};
 use nimiq_database::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_keys::Signature;
+use nimiq_keys::{PublicKey, Signature};
 use nimiq_primitives::policy::Policy;
+use nimiq_primitives::slots::Validators;
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_transaction::Transaction;
 use nimiq_vrf::VrfSeed;
@@ -28,74 +32,13 @@ pub struct MicroBlock {
     pub body: Option<MicroBody>,
 }
 
-/// Enumeration representing the justification for a Micro block
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
-#[repr(u8)]
-pub enum MicroJustification {
-    /// Regular micro block justification which is the signature of the block producer
-    Micro(Signature),
-    /// Skip block justification which is the aggregated signature of the validator's
-    /// signatures for a skip block.
-    Skip(SkipBlockProof),
-}
-
-/// The struct representing the header of a Micro block.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializeContent)]
-pub struct MicroHeader {
-    /// The version number of the block. Changing this always results in a hard fork.
-    pub version: u16,
-    /// The number of the block.
-    pub block_number: u32,
-    /// The timestamp of the block. It follows the Unix time and has millisecond precision.
-    pub timestamp: u64,
-    /// The hash of the header of the immediately preceding block (either micro or macro).
-    pub parent_hash: Blake2bHash,
-    /// The seed of the block. This is the BLS signature of the seed of the immediately preceding
-    /// block (either micro or macro) using the validator key of the block producer.
-    pub seed: VrfSeed,
-    /// The extra data of the block. It is simply 32 raw bytes. No planned use.
-    #[beserial(len_type(u8, limit = 32))]
-    pub extra_data: Vec<u8>,
-    /// The root of the Merkle tree of the blockchain state. It just acts as a commitment to the
-    /// state.
-    pub state_root: Blake2bHash,
-    /// The root of the Merkle tree of the body. It just acts as a commitment to the
-    /// body.
-    pub body_root: Blake2bHash,
-    /// A Merkle root over all of the transactions that happened in the current epoch.
-    pub history_root: Blake2bHash,
-}
-
-/// The struct representing the body of a Micro block.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, SerializeContent)]
-pub struct MicroBody {
-    /// A vector containing the fork proofs for this block. It might be empty.
-    #[beserial(len_type(u16))]
-    pub fork_proofs: Vec<ForkProof>,
-    /// A vector containing the transactions for this block. It might be empty.
-    #[beserial(len_type(u16))]
-    pub transactions: Vec<ExecutedTransaction>,
-}
-
-impl MicroBody {
-    pub fn get_raw_transactions(&self) -> Vec<Transaction> {
-        // Extract the transactions from the block
-        self.transactions
-            .iter()
-            .map(|txn| txn.get_raw_transaction().clone())
-            .collect()
-    }
-}
-
 impl MicroBlock {
     /// Returns the hash of the block header.
     pub fn hash(&self) -> Blake2bHash {
         self.header.hash()
     }
 
-    /// Returns wether the micro block is a skip block
+    /// Returns whether the micro block is a skip block
     pub fn is_skip_block(&self) -> bool {
         if let Some(justification) = &self.justification {
             return matches!(justification, MicroJustification::Skip(_));
@@ -103,22 +46,65 @@ impl MicroBlock {
         false
     }
 
-    // Returns the available size, in bytes, in a micro block body for transactions.
+    /// Returns the available size, in bytes, in a micro block body for transactions.
     pub fn get_available_bytes(num_fork_proofs: usize) -> usize {
         Policy::MAX_SIZE_MICRO_BODY
             - (/*fork_proofs vector length*/2 + num_fork_proofs * ForkProof::SIZE
             + /*transactions vector length*/ 2)
     }
-}
 
-impl MicroHeader {
-    /// Returns the size, in bytes, of a Micro block header. This represents the maximum possible
-    /// size since we assume that the extra_data field is completely filled.
-    pub const MAX_SIZE: usize =
-        /*version*/
-        2 + /*block_number*/ 4 + /*timestamp*/ 8 + /*parent_hash*/ 32
-        + /*seed*/ VrfSeed::SIZE + /*extra_data*/ 32 + /*state_root*/ 32
-        + /*body_root*/ 32 + /*history_root*/ 32;
+    pub(crate) fn verify_proposer(&self, signing_key: &PublicKey) -> Result<(), BlockError> {
+        let justification = self
+            .justification
+            .as_ref()
+            .ok_or(BlockError::MissingJustification)?;
+
+        match justification {
+            MicroJustification::Micro(signature) => {
+                let hash = self.hash();
+                if !signing_key.verify(signature, hash.as_slice()) {
+                    warn!(
+                        block = %self,
+                        %signing_key,
+                        reason = "Invalid signature for proposer",
+                        "Rejecting block"
+                    );
+                    return Err(BlockError::InvalidJustification);
+                }
+            }
+            MicroJustification::Skip(_) => {}
+        };
+
+        Ok(())
+    }
+
+    pub(crate) fn verify_validators(&self, validators: &Validators) -> Result<(), BlockError> {
+        let justification = self
+            .justification
+            .as_ref()
+            .ok_or(BlockError::MissingJustification)?;
+
+        match justification {
+            MicroJustification::Skip(proof) => {
+                let skip_block = SkipBlockInfo {
+                    block_number: self.header.block_number,
+                    vrf_entropy: self.header.seed.entropy(),
+                };
+
+                if !proof.verify(&skip_block, validators) {
+                    debug!(
+                        block = %self,
+                        reason = "Bad skip block proof",
+                        "Rejecting block"
+                    );
+                    return Err(BlockError::InvalidSkipBlockProof);
+                }
+            }
+            MicroJustification::Micro(_) => {}
+        }
+
+        Ok(())
+    }
 }
 
 impl IntoDatabaseValue for MicroBlock {
@@ -147,6 +133,64 @@ impl fmt::Display for MicroBlock {
     }
 }
 
+/// Enumeration representing the justification for a Micro block
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
+#[repr(u8)]
+pub enum MicroJustification {
+    /// Regular micro block justification which is the signature of the block producer
+    Micro(Signature),
+    /// Skip block justification which is the aggregated signature of the validator's
+    /// signatures for a skip block.
+    Skip(SkipBlockProof),
+}
+
+impl MicroJustification {
+    pub fn unwrap_micro(self) -> Signature {
+        match self {
+            MicroJustification::Micro(signature) => signature,
+            MicroJustification::Skip(_) => unreachable!(),
+        }
+    }
+}
+/// The struct representing the header of a Micro block.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializeContent)]
+pub struct MicroHeader {
+    /// The version number of the block. Changing this always results in a hard fork.
+    pub version: u16,
+    /// The number of the block.
+    pub block_number: u32,
+    /// The timestamp of the block. It follows the Unix time and has millisecond precision.
+    pub timestamp: u64,
+    /// The hash of the header of the immediately preceding block (either micro or macro).
+    pub parent_hash: Blake2bHash,
+    /// The seed of the block. This is the BLS signature of the seed of the immediately preceding
+    /// block (either micro or macro) using the validator key of the block producer.
+    pub seed: VrfSeed,
+    /// The extra data of the block. It is simply 32 raw bytes. No planned use.
+    #[beserial(len_type(u8, limit = 32))]
+    pub extra_data: Vec<u8>,
+    /// The root of the Merkle tree of the blockchain state. It just acts as a commitment to the
+    /// state.
+    pub state_root: Blake2bHash,
+    /// The root of the Merkle tree of the body. It just acts as a commitment to the
+    /// body.
+    pub body_root: Blake2bHash,
+    /// A Merkle root over all of the transactions that happened in the current epoch.
+    pub history_root: Blake2bHash,
+}
+
+impl MicroHeader {
+    /// Returns the size, in bytes, of a Micro block header. This represents the maximum possible
+    /// size since we assume that the extra_data field is completely filled.
+    pub const MAX_SIZE: usize =
+        /*version*/
+        2 + /*block_number*/ 4 + /*timestamp*/ 8 + /*parent_hash*/ 32
+            + /*seed*/ VrfSeed::SIZE + /*extra_data*/ 32 + /*state_root*/ 32
+            + /*body_root*/ 32 + /*history_root*/ 32;
+}
+
 impl Hash for MicroHeader {}
 
 impl fmt::Display for MicroHeader {
@@ -157,6 +201,91 @@ impl fmt::Display for MicroHeader {
             self.block_number,
             self.hash::<Blake2bHash>().to_short_str(),
         )
+    }
+}
+
+/// The struct representing the body of a Micro block.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, SerializeContent)]
+pub struct MicroBody {
+    /// A vector containing the fork proofs for this block. It might be empty.
+    #[beserial(len_type(u16))]
+    pub fork_proofs: Vec<ForkProof>,
+    /// A vector containing the transactions for this block. It might be empty.
+    #[beserial(len_type(u16))]
+    pub transactions: Vec<ExecutedTransaction>,
+}
+
+impl MicroBody {
+    pub fn get_raw_transactions(&self) -> Vec<Transaction> {
+        // Extract the transactions from the block
+        self.transactions
+            .iter()
+            .map(|txn| txn.get_raw_transaction().clone())
+            .collect()
+    }
+
+    pub(crate) fn verify(&self, is_skip: bool, block_number: u32) -> Result<(), BlockError> {
+        // Check that the maximum body size is not exceeded.
+        let body_size = self.serialized_size();
+        if body_size > Policy::MAX_SIZE_MICRO_BODY {
+            debug!(
+                body_size = body_size,
+                max_size = Policy::MAX_SIZE_MICRO_BODY,
+                reason = "Body size exceeds maximum size",
+                "Invalid block"
+            );
+            return Err(BlockError::SizeExceeded);
+        }
+
+        // Check that the body is empty for skip blocks.
+        if is_skip && (!self.fork_proofs.is_empty() || !self.transactions.is_empty()) {
+            debug!(
+                num_transactions = self.transactions.len(),
+                num_fork_proofs = self.fork_proofs.len(),
+                reason = "Skip block has a non empty body",
+                "Invalid block"
+            );
+            return Err(BlockError::InvalidSkipBlockBody);
+        }
+
+        // Ensure that fork proofs are ordered, unique and within their reporting window.
+        let mut previous_proof: Option<&ForkProof> = None;
+        for proof in &self.fork_proofs {
+            // Check reporting window.
+            if !proof.is_valid_at(block_number) {
+                return Err(BlockError::InvalidForkProof);
+            }
+
+            // Check proof ordering and uniqueness.
+            if let Some(previous) = previous_proof {
+                match previous.cmp(proof) {
+                    Ordering::Equal => {
+                        return Err(BlockError::DuplicateForkProof);
+                    }
+                    Ordering::Greater => {
+                        return Err(BlockError::ForkProofsNotOrdered);
+                    }
+                    _ => {}
+                }
+            }
+            previous_proof = Some(proof);
+        }
+
+        // Ensure transactions are unique and within their validity window.
+        let mut uniq = HashSet::new();
+        for tx in &self.get_raw_transactions() {
+            // Check validity window.
+            if !tx.is_valid_at(block_number) {
+                return Err(BlockError::ExpiredTransaction);
+            }
+
+            // Check uniqueness.
+            if !uniq.insert(tx.hash::<Blake2bHash>()) {
+                return Err(BlockError::DuplicateTransaction);
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -1,0 +1,445 @@
+use nimiq_block::{
+    Block, BlockError, BlockHeader, ForkProof, MacroBlock, MacroBody, MacroHeader, MicroBlock,
+    MicroBody, MicroHeader, MicroJustification, MultiSignature, SkipBlockProof,
+};
+use nimiq_bls::AggregateSignature;
+use nimiq_collections::BitSet;
+use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_keys::{KeyPair, Signature};
+use nimiq_primitives::{networks::NetworkId, policy::Policy, slots::Validators};
+use nimiq_test_log::test;
+use nimiq_test_utils::blockchain::generate_transactions;
+use nimiq_transaction::ExecutedTransaction;
+use nimiq_vrf::VrfSeed;
+
+#[test]
+fn test_verify_header_version() {
+    let mut micro_header = MicroHeader {
+        version: Policy::VERSION - 1,
+        block_number: 1,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: [].to_vec(),
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+    let header = BlockHeader::Micro(micro_header.clone());
+
+    // Check version at header level
+    assert_eq!(header.verify(false), Err(BlockError::UnsupportedVersion));
+
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: None,
+        body: None,
+    });
+
+    // Error should remain at block level
+    assert_eq!(block.verify(false), Err(BlockError::UnsupportedVersion));
+
+    // Fix the version and check that it passes
+    micro_header.version = Policy::VERSION;
+    let header = BlockHeader::Micro(micro_header);
+    assert_eq!(header.verify(false), Ok(()));
+}
+
+#[test]
+fn test_verify_header_extra_data() {
+    let mut micro_header = MicroHeader {
+        version: Policy::VERSION,
+        block_number: 1,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![0; 33],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+    let header = BlockHeader::Micro(micro_header.clone());
+
+    // Check extra data field at header level
+    assert_eq!(header.verify(false), Err(BlockError::ExtraDataTooLarge));
+    // Error should remain for a skip block
+    assert_eq!(header.verify(true), Err(BlockError::ExtraDataTooLarge));
+
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: None,
+        body: None,
+    });
+
+    // Error should remain at block level
+    assert_eq!(block.verify(false), Err(BlockError::ExtraDataTooLarge));
+
+    // Fix the extra data field and check that it passes
+    micro_header.extra_data = vec![0; 32];
+    let header = BlockHeader::Micro(micro_header.clone());
+    assert_eq!(header.verify(false), Ok(()));
+    // Error should remain for a skip block
+    assert_eq!(header.verify(true), Err(BlockError::ExtraDataTooLarge));
+
+    // Fix the extra data field for a skip block and check that it passes
+    micro_header.extra_data = [].to_vec();
+    let header = BlockHeader::Micro(micro_header);
+    assert_eq!(header.verify(true), Ok(()));
+}
+
+#[test]
+fn test_verify_body_root() {
+    let mut micro_header = MicroHeader {
+        version: Policy::VERSION,
+        block_number: 1,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![0; 30],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+
+    let micro_justification = MicroJustification::Micro(Signature::default());
+
+    // Build a block without body
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: None,
+    });
+
+    assert_eq!(block.verify(false), Err(BlockError::MissingBody));
+
+    let micro_body = MicroBody {
+        fork_proofs: [].to_vec(),
+        transactions: [].to_vec(),
+    };
+
+    // Build a block with body
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    // The body root check must fail
+    assert_eq!(block.verify(false), Err(BlockError::BodyHashMismatch));
+
+    // Fix the body root and check that it passes
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification),
+        body: Some(micro_body),
+    });
+
+    assert_eq!(block.verify(false), Ok(()));
+}
+
+#[test]
+fn test_verify_skip_block() {
+    let mut micro_header = MicroHeader {
+        version: Policy::VERSION,
+        block_number: 1,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+
+    let micro_justification = MicroJustification::Skip(SkipBlockProof {
+        sig: MultiSignature {
+            signature: AggregateSignature::new(),
+            signers: BitSet::default(),
+        },
+    });
+
+    let transactions: Vec<ExecutedTransaction> =
+        generate_transactions(&KeyPair::default(), 1, NetworkId::UnitAlbatross, 1, 0)
+            .iter()
+            .map(|tx| ExecutedTransaction::Ok(tx.clone()))
+            .collect();
+
+    let mut micro_body = MicroBody {
+        fork_proofs: [].to_vec(),
+        transactions: transactions,
+    };
+
+    // Build a block with body
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    // The skip block body should fail
+    assert_eq!(block.verify(false), Err(BlockError::InvalidSkipBlockBody));
+
+    // Fix the body with empty transactions and check that it passes
+    micro_body.transactions = vec![];
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification),
+        body: Some(micro_body),
+    });
+
+    assert_eq!(block.verify(false), Ok(()));
+}
+
+#[test]
+fn test_verify_micro_block_body_txns() {
+    let mut micro_header = MicroHeader {
+        version: Policy::VERSION,
+        block_number: 1,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+
+    let micro_justification = MicroJustification::Micro(Signature::default());
+
+    let txns: Vec<ExecutedTransaction> =
+        generate_transactions(&KeyPair::default(), 1, NetworkId::UnitAlbatross, 5, 0)
+            .iter()
+            .map(|tx| ExecutedTransaction::Ok(tx.clone()))
+            .collect();
+
+    // Lets have a duplicate transaction
+    let mut txns_dup = txns.clone();
+    txns_dup.push(txns.first().unwrap().clone());
+
+    let mut micro_body = MicroBody {
+        fork_proofs: [].to_vec(),
+        transactions: txns_dup.clone(),
+    };
+
+    // Build a block with body with a duplicate transaction
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    // The body check should fail
+    assert_eq!(block.verify(false), Err(BlockError::DuplicateTransaction));
+
+    // Fix the body with empty transactions and check that it passes
+    txns_dup.pop();
+    micro_body.transactions = txns_dup;
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body),
+    });
+
+    assert_eq!(block.verify(false), Ok(()));
+
+    // Now modify the validity start height
+    let txns: Vec<ExecutedTransaction> = generate_transactions(
+        &KeyPair::default(),
+        Policy::blocks_per_epoch(),
+        NetworkId::UnitAlbatross,
+        5,
+        0,
+    )
+    .iter()
+    .map(|tx| ExecutedTransaction::Ok(tx.clone()))
+    .collect();
+
+    let micro_body = MicroBody {
+        fork_proofs: [].to_vec(),
+        transactions: txns.clone(),
+    };
+
+    // Build a block with body with the expired transactions
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification),
+        body: Some(micro_body.clone()),
+    });
+
+    // The body check should fail
+    assert_eq!(block.verify(false), Err(BlockError::ExpiredTransaction));
+}
+
+#[test]
+fn test_verify_micro_block_body_fork_proofs() {
+    let mut micro_header = MicroHeader {
+        version: Policy::VERSION,
+        block_number: 1,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+
+    let mut micro_header_1 = micro_header.clone();
+    micro_header_1.block_number += 1;
+
+    let mut micro_header_2 = micro_header_1.clone();
+    micro_header_2.block_number += 1;
+
+    let fork_proof_1 = ForkProof {
+        header1: micro_header.clone(),
+        header2: micro_header_1.clone(),
+        justification1: Signature::default(),
+        justification2: Signature::default(),
+        prev_vrf_seed: VrfSeed::default(),
+    };
+
+    let mut fork_proof_2 = fork_proof_1.clone();
+    fork_proof_2.header2 = micro_header_2;
+
+    let mut fork_proof_3 = fork_proof_2.clone();
+    fork_proof_3.header1 = micro_header_1;
+
+    let micro_justification = MicroJustification::Micro(Signature::default());
+
+    let mut fork_proofs = vec![fork_proof_1, fork_proof_2, fork_proof_3];
+    let micro_body = MicroBody {
+        fork_proofs: fork_proofs.clone(),
+        transactions: [].to_vec(),
+    };
+
+    // Build a block with body with a the unsorted fork proofs
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    // The body check should fail
+    assert_eq!(block.verify(false), Err(BlockError::ForkProofsNotOrdered));
+
+    // Sort fork proofs and re-build block
+    fork_proofs.sort();
+    let micro_body = MicroBody {
+        fork_proofs: fork_proofs.clone(),
+        transactions: [].to_vec(),
+    };
+
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    assert_eq!(block.verify(false), Ok(()));
+
+    // Lets have a duplicate fork proof
+    fork_proofs.push(fork_proofs.last().unwrap().clone());
+    let micro_body = MicroBody {
+        fork_proofs: fork_proofs.clone(),
+        transactions: [].to_vec(),
+    };
+
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    assert_eq!(block.verify(false), Err(BlockError::DuplicateForkProof));
+
+    // Now modify the block height of the first header of the first fork proof
+    let mut fork_proof = fork_proofs.pop().unwrap();
+    fork_proof.header1.block_number = Policy::blocks_per_epoch();
+    fork_proofs.push(fork_proof);
+    fork_proofs.sort();
+
+    let micro_body = MicroBody {
+        fork_proofs: fork_proofs.clone(),
+        transactions: [].to_vec(),
+    };
+
+    micro_header.body_root = micro_body.hash();
+    let block = Block::Micro(MicroBlock {
+        header: micro_header.clone(),
+        justification: Some(micro_justification.clone()),
+        body: Some(micro_body.clone()),
+    });
+
+    // The first fork proof should no longer be valid
+    assert_eq!(block.verify(false), Err(BlockError::InvalidForkProof));
+}
+
+#[test]
+fn test_verify_election_macro_body() {
+    let mut macro_header = MacroHeader {
+        version: Policy::VERSION,
+        block_number: Policy::blocks_per_epoch(),
+        round: 0,
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        parent_election_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![0; 30],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+    };
+
+    let mut macro_body = MacroBody {
+        validators: None,
+        pk_tree_root: None,
+        lost_reward_set: BitSet::default(),
+        disabled_set: BitSet::default(),
+    };
+    macro_header.body_root = macro_body.hash();
+
+    // Build an election macro block
+    let block = Block::Macro(MacroBlock {
+        header: macro_header.clone(),
+        justification: None,
+        body: Some(macro_body.clone()),
+    });
+
+    // The validators check should fail
+    assert_eq!(block.verify(false), Err(BlockError::InvalidValidators));
+
+    // Fix the validators set
+    macro_body.validators = Some(Validators::new(vec![]));
+    macro_header.body_root = macro_body.hash();
+    let block = Block::Macro(MacroBlock {
+        header: macro_header.clone(),
+        justification: None,
+        body: Some(macro_body.clone()),
+    });
+    // The PK tree root check should fail
+    assert_eq!(block.verify(false), Err(BlockError::InvalidPkTreeRoot));
+
+    // Fix the PK tree root set
+    macro_body.pk_tree_root = Some(vec![]);
+    macro_header.body_root = macro_body.hash();
+    let block = Block::Macro(MacroBlock {
+        header: macro_header.clone(),
+        justification: None,
+        body: Some(macro_body.clone()),
+    });
+
+    // Verification would fail since validators are empty
+    assert_eq!(block.verify(true), Err(BlockError::InvalidValidators));
+
+    // Skipping the verification of the PK tree root should make the verify function to pass
+    assert_eq!(block.verify(false), Ok(()));
+}

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -103,15 +103,6 @@ fn test_verify_body_root() {
 
     let micro_justification = MicroJustification::Micro(Signature::default());
 
-    // Build a block without body
-    let block = Block::Micro(MicroBlock {
-        header: micro_header.clone(),
-        justification: Some(micro_justification.clone()),
-        body: None,
-    });
-
-    assert_eq!(block.verify(false), Err(BlockError::MissingBody));
-
     let micro_body = MicroBody {
         fork_proofs: [].to_vec(),
         transactions: [].to_vec(),

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -154,7 +154,7 @@ impl ExecutedTransaction {
         }
     }
 
-    pub fn get_hash(&self) -> Blake2bHash {
+    pub fn hash(&self) -> Blake2bHash {
         match self {
             ExecutedTransaction::Ok(txn) => txn.hash(),
             ExecutedTransaction::Err(txn) => txn.hash(),

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -358,7 +358,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         self.macro_producer = None;
         self.micro_producer = None;
 
-        match Blockchain::get_next_block_type(head.block_number()) {
+        match BlockType::of(next_block_number) {
             BlockType::Macro => {
                 let active_validators = blockchain.current_validators().unwrap();
                 let proposal_stream = self.proposal_receiver.clone().boxed();

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -358,7 +358,7 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
         self.macro_producer = None;
         self.micro_producer = None;
 
-        match blockchain.get_next_block_type(None) {
+        match Blockchain::get_next_block_type(head.block_number()) {
             BlockType::Macro => {
                 let active_validators = blockchain.current_validators().unwrap();
                 let proposal_stream = self.proposal_receiver.clone().boxed();


### PR DESCRIPTION
- Refactor block verification functions in `blockchain` such that
  they can be split by its small verification functions that only
  receive as argument the required information.
- Add tests at the primitives `block` crate to stimulate the block
  verification functionality.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.