### PR TITLE
Return `Result` for calculating `pk_tree_root`

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -305,7 +305,9 @@ impl BlockProducer {
         };
 
         // Calculate the pk_tree_root.
-        let pk_tree_root = validators.as_ref().map(MacroBlock::pk_tree_root);
+        let pk_tree_root = validators
+            .as_ref()
+            .and_then(|validators| MacroBlock::pk_tree_root(validators).ok());
 
         // Create the body for the macro block.
         let body = MacroBody {

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -288,7 +288,9 @@ fn next_macro_block_proposal(
         None
     };
 
-    let pk_tree_root = validators.as_ref().map(MacroBlock::pk_tree_root);
+    let pk_tree_root = validators
+        .as_ref()
+        .and_then(|validators| MacroBlock::pk_tree_root(validators).ok());
 
     let body = MacroBody {
         validators,

--- a/primitives/block/examples/pk_tree.rs
+++ b/primitives/block/examples/pk_tree.rs
@@ -28,6 +28,6 @@ fn main() {
 
     for i in 0..50 {
         println!("{}", i);
-        MacroBlock::pk_tree_root(&validators);
+        MacroBlock::pk_tree_root(&validators).expect("PK tree root building failed");
     }
 }

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -166,7 +166,9 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintOutsideDeps
             } else {
                 None
             };
-            let pk_tree_root = validators.as_ref().map(MacroBlock::pk_tree_root);
+            let pk_tree_root = validators
+                .as_ref()
+                .and_then(|validators| MacroBlock::pk_tree_root(validators).ok());
 
             // Assemble the MacroBody
             Some(MacroBody {


### PR DESCRIPTION
Change the `MacroBlock` `pk_tree_root` function to return a `Result` and do additional checks on the provided `Validators`. This is to avoid hitting assertions when calling `pk_tree_construct` since the function assumes that the correct number of public keys are passed as arguments.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.