### PR TITLE
Fix typos and re-add clippy ignore

### DIFF
--- a/beserial/src/lib.rs
+++ b/beserial/src/lib.rs
@@ -198,6 +198,7 @@ impl Deserialize for bool {
 
 impl Serialize for bool {
     fn serialize<W: WriteBytesExt>(&self, writer: &mut W) -> Result<usize, SerializingError> {
+        #[allow(clippy::bool_to_int_with_if)]
         writer.write_u8(if *self { 1u8 } else { 0u8 })?;
         Ok(self.serialized_size())
     }

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -147,7 +147,7 @@ impl ExecutedTransaction {
         }
     }
 
-    pub fn succeed(&self) -> bool {
+    pub fn succeeded(&self) -> bool {
         match self {
             ExecutedTransaction::Ok(_) => true,
             ExecutedTransaction::Err(_) => false,

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -126,14 +126,14 @@ impl Default for SignatureProof {
 #[derive(Clone, Eq, Debug, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ExecutedTransaction {
-    /// A sucessfull executed transaction
+    /// A successful executed transaction
     Ok(Transaction),
     /// A failed transaction (only fees are deducted)
     Err(Transaction),
 }
 
 impl ExecutedTransaction {
-    //Obtains the underlaying transaction, regardless of execution result
+    /// Obtains the underlying transaction, regardless of execution result
     pub fn get_raw_transaction(&self) -> &Transaction {
         match self {
             ExecutedTransaction::Ok(txn) => txn,

--- a/zkp-component/src/proof_utils.rs
+++ b/zkp-component/src/proof_utils.rs
@@ -19,7 +19,7 @@ use tokio::{io::AsyncWriteExt, process::Command};
 use super::types::ZKPState;
 use crate::types::*;
 
-/// Fully validates the proof by verifying both the zk proof and the blocks existance on the blockchain.
+/// Fully validates the proof by verifying both the zk proof and the blocks existence on the blockchain.
 pub fn validate_proof(
     blockchain: &Arc<RwLock<Blockchain>>,
     proof: &ZKProof,
@@ -31,7 +31,7 @@ pub fn validate_proof(
         return true;
     }
 
-    // Fetches and verfies the election blocks for the proofs and then validates the proof
+    // Fetches and verifies the election blocks for the proofs and then validates the proof
     if let Ok((new_block, genesis_block, proof)) =
         get_proof_macro_blocks(blockchain, proof, election_block)
     {
@@ -114,7 +114,7 @@ pub(crate) fn validate_proof_get_new_state(
     Err(ZKPComponentError::InvalidProof)
 }
 
-/// Generates the zk proof and sends it through the channel provided. Upon failure, the error is sent trough the channel providded.
+/// Generates the zk proof and sends it through the channel provided. Upon failure, the error is sent trough the channel provided.
 pub fn generate_new_proof(
     block: MacroBlock,
     latest_pks: Vec<G2MNT6>,
@@ -224,7 +224,7 @@ async fn parse_proof_generation_output(
 #[derive(Debug)]
 pub struct ProofStore {
     pub env: Environment,
-    // A database of the curreent zkp state.
+    // A database of the current zkp state.
     zkp_db: Database,
 }
 

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -79,7 +79,7 @@ impl<N: Network> ZKPComponentProxy<N> {
 /// ZKP Component aggregates the logic of request new proofs from peers, gossiping with peers on the most recent proofs,
 /// pushing the received or generated zk proofs into state and storing them on the db.
 ///
-/// The ZKP Compoenet has:
+/// The ZKP Component has:
 ///
 /// - The blockchain
 /// - The network
@@ -301,7 +301,7 @@ impl<N: Network> Future for ZKPComponent<N> {
             }
         }
 
-        // Exhaustes all peer gossiped proofs and tries to push them.
+        // Exhausts all peer gossiped proofs and tries to push them.
         loop {
             match this.zk_proofs_stream.as_mut().poll_next(cx) {
                 Poll::Ready(Some(proof)) => {


### PR DESCRIPTION
- Re-add clippy ignore that was removed by mistake in `96a89f0`.
- Fix some typos in the `zkp-component` and primitive's `transaction` crates.
- Rename the `succeed` method of `ExecutedTransaction` to `succeeded` to be consistent with the naming of the `failed` method.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.