### PR TITLE
Improve handling of key generation

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -91,8 +91,17 @@ impl ClientInner {
 
         // For the albatross dev net, we need to generate/download the test keys
         // for the zero-knowledge proofs.
-        if config.network_id == NetworkId::DevAlbatross {
-            log::info!("Setting up zero-knowledge proof keys for devnet.");
+        if config.network_id == NetworkId::DevAlbatross
+            && !NanoZKP::all_files_created(&config.zkp.setup_keys_path, config.zkp.prover_active)
+        {
+            // If the prover node is disabled, we do not generate keys
+            // but inform the user of having set a wrong location for the verifying keys.
+            if !config.zkp.prover_active {
+                log::error!("Missing ZKP verification keys. Make sure to set the correct `setup_keys_path` inside the config.");
+                return Err(Error::config_error("Missing ZKP verification keys"));
+            }
+
+            log::info!("Setting up zero-knowledge prover keys for devnet.");
             log::info!("This task only needs to be run once and might take about an hour.");
             let seed = [
                 1, 0, 52, 0, 0, 0, 0, 0, 1, 0, 10, 0, 22, 32, 0, 0, 2, 0, 55, 49, 0, 11, 0, 0, 3,

--- a/nano-zkp/src/nano_zkp/setup.rs
+++ b/nano-zkp/src/nano_zkp/setup.rs
@@ -59,7 +59,7 @@ impl NanoZKP {
         Ok(())
     }
 
-    fn all_files_created(path: &Path, prover_active: bool) -> bool {
+    pub fn all_files_created(path: &Path, prover_active: bool) -> bool {
         let verifying_keys = path.join("verifying_keys");
         let proving_keys = path.join("proving_keys");
 

--- a/zkp-component/src/proof_utils.rs
+++ b/zkp-component/src/proof_utils.rs
@@ -158,6 +158,8 @@ pub fn generate_new_proof(
     Err(ZKProofGenerationError::InvalidBlock)
 }
 
+/// Starts the prover in a new child process.
+/// Warning: The child process will continue to run if the parent process crashes.
 pub async fn launch_generate_new_proof(
     mut recv: BroadcastReceiver<()>,
     proof_input: ProofInput,


### PR DESCRIPTION
Don't generate keys for non-prover nodes and return configuration error instead.
Add warning about child process.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.