### PR TITLE
consensus: Add `SyncerProxy`

### DIFF
--- a/consensus/src/sync/mod.rs
+++ b/consensus/src/sync/mod.rs
@@ -2,3 +2,4 @@ pub mod history;
 pub mod live;
 mod sync_queue;
 pub mod syncer;
+pub mod syncer_proxy;

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -1,11 +1,13 @@
-use futures::{Stream, StreamExt};
-use nimiq_block::Block;
-use nimiq_hash::Blake2bHash;
-use nimiq_network_interface::network::Network;
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+
+use futures::{Stream, StreamExt};
+
+use nimiq_block::Block;
+use nimiq_hash::Blake2bHash;
+use nimiq_network_interface::network::Network;
 
 /// Trait that defines how a node synchronizes macro blocks
 /// The expected functionality is that there could be different methods of syncing but they
@@ -109,7 +111,6 @@ pub struct Syncer<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> {
     outdated_timeouts: HashMap<N::PeerId, Instant>,
 }
 
-//livesync and
 impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
     const CHECK_OUTDATED_TIMEOUT: Duration = Duration::from_secs(20);
 

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -1,0 +1,110 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::{Stream, StreamExt};
+use parking_lot::Mutex;
+
+use nimiq_block::Block;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_bls::cache::PublicKeyCache;
+use nimiq_network_interface::network::{Network, SubscribeEvents};
+use pin_project::pin_project;
+
+use crate::sync::{
+    history::HistoryMacroSync,
+    live::{
+        block_queue::{BlockQueue, BlockQueueConfig},
+        request_component::BlockRequestComponent,
+        BlockLiveSync,
+    },
+    syncer::{LiveSyncPushEvent, Syncer},
+};
+
+macro_rules! gen_syncer_match {
+    ($self: ident, $f: ident $(, $arg:expr )*) => {
+        match $self {
+            SyncerProxy::History(syncer) => syncer.$f($( $arg ),*),
+        }
+    };
+}
+
+#[pin_project(project = SyncerProxyProj)]
+/// The `SyncerProxy` is an abstraction over multiple types of `Syncer`s.
+pub enum SyncerProxy<N: Network> {
+    /// History Syncer, uses history macro sync for macro sync and block live sync.
+    History(Syncer<N, HistoryMacroSync<N>, BlockLiveSync<N, BlockRequestComponent<N>>>),
+}
+
+impl<N: Network> SyncerProxy<N> {
+    /// Creates a new instance of a `SyncerProxy` for the `History` variant
+    pub async fn new_history(
+        blockchain_proxy: BlockchainProxy,
+        network: Arc<N>,
+        bls_cache: Arc<Mutex<PublicKeyCache>>,
+        network_event_rx: SubscribeEvents<N::PeerId>,
+    ) -> Self {
+        assert!(
+            matches!(blockchain_proxy, BlockchainProxy::Full(_)),
+            "History Syncer can only be created for a full blockchain"
+        );
+
+        match blockchain_proxy {
+            BlockchainProxy::Full(ref blockchain) => {
+                let request_component =
+                    BlockRequestComponent::new(network.subscribe_events(), Arc::clone(&network));
+
+                let block_queue = BlockQueue::new(
+                    Arc::clone(&network),
+                    blockchain_proxy.clone(),
+                    request_component,
+                    BlockQueueConfig::default(),
+                )
+                .await;
+
+                let live_sync = BlockLiveSync::new(
+                    blockchain_proxy.clone(),
+                    Arc::clone(&network),
+                    block_queue,
+                    bls_cache,
+                );
+
+                let macro_sync =
+                    HistoryMacroSync::new(Arc::clone(blockchain), network, network_event_rx);
+
+                Self::History(Syncer::new(live_sync, macro_sync))
+            }
+            BlockchainProxy::Light(_) => unreachable!(),
+        }
+    }
+
+    /// Pushes a block for the live sync method
+    pub fn push_block(&mut self, block: Block, peer_id: N::PeerId, pubsub_id: Option<N::PubsubId>) {
+        gen_syncer_match!(self, push_block, block, peer_id, pubsub_id)
+    }
+
+    /// Returns the number of peers doing live synchronization
+    pub fn num_peers(&self) -> usize {
+        gen_syncer_match!(self, num_peers)
+    }
+
+    /// Returns the peers of peers doing live synchronization
+    pub fn peers(&self) -> Vec<N::PeerId> {
+        gen_syncer_match!(self, peers)
+    }
+
+    /// Returns the number of accepted block announcements seen
+    pub fn accepted_block_announcements(&self) -> usize {
+        gen_syncer_match!(self, accepted_block_announcements)
+    }
+}
+
+impl<N: Network> Stream for SyncerProxy<N> {
+    type Item = LiveSyncPushEvent;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        match self.project() {
+            SyncerProxyProj::History(syncer) => syncer.poll_next_unpin(cx),
+        }
+    }
+}


### PR DESCRIPTION
Add `SyncerProxy` as an `enum` of the different types of `Syncer`s. This `enum` is expected to have a variant for the different syncing methods that will be supported but for now only `History` was added along with a method to easily create this variant.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
