### PR TITLE
Modify light blockchain to receieve 'this' lock

### DIFF
--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -39,7 +39,7 @@ impl AbstractBlockchain for LightBlockchain {
     }
 
     fn contains(&self, hash: &Blake2bHash, include_forks: bool) -> bool {
-        match self.chain_store.read().unwrap().get_chain_info(hash) {
+        match self.chain_store.get_chain_info(hash) {
             Some(chain_info) => include_forks || chain_info.on_main_chain,
             None => false,
         }
@@ -52,8 +52,6 @@ impl AbstractBlockchain for LightBlockchain {
         _txn_option: Option<&Transaction>,
     ) -> Option<Block> {
         self.chain_store
-            .read()
-            .unwrap()
             .get_chain_info_at(height)
             .map(|chain_info| chain_info.head)
     }
@@ -65,8 +63,6 @@ impl AbstractBlockchain for LightBlockchain {
         _txn_option: Option<&Transaction>,
     ) -> Option<Block> {
         self.chain_store
-            .read()
-            .unwrap()
             .get_chain_info(hash)
             .map(|chain_info| chain_info.head.clone())
     }
@@ -77,11 +73,7 @@ impl AbstractBlockchain for LightBlockchain {
         _include_body: bool,
         _txn_option: Option<&Transaction>,
     ) -> Option<ChainInfo> {
-        self.chain_store
-            .read()
-            .unwrap()
-            .get_chain_info(hash)
-            .cloned()
+        self.chain_store.get_chain_info(hash).cloned()
     }
 
     fn get_slot_owner_at(

--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::ChainInfo;
@@ -27,7 +27,7 @@ pub struct LightBlockchain {
     // The genesis block.
     pub genesis_block: Block,
     // The chain store is a database containing all of the chain infos in the current batch.
-    pub chain_store: RwLock<ChainStore>,
+    pub chain_store: ChainStore,
 }
 
 /// Implements methods to start a Blockchain.
@@ -57,7 +57,7 @@ impl LightBlockchain {
             election_head: genesis_block.clone().unwrap_macro(),
             current_validators: genesis_block.validators(),
             genesis_block,
-            chain_store: RwLock::new(chain_store),
+            chain_store,
         }
     }
 }


### PR DESCRIPTION
Previously the light blockchain was receiving a mut reference to self, changed this to the same use model that is used in the regular blockchain where a RwLock of 'this' is used.

