### PR TITLE
Add possibility to request proofs from individual peers

### DIFF
--- a/zkp-component/src/proof_utils.rs
+++ b/zkp-component/src/proof_utils.rs
@@ -46,7 +46,7 @@ pub(crate) fn get_proof_macro_blocks(
     blockchain: &BlockchainProxy,
     proof: &ZKProof,
     election_block: Option<MacroBlock>,
-) -> Result<(MacroBlock, MacroBlock, Proof<MNT6_753>), ZKPComponentError> {
+) -> Result<(MacroBlock, MacroBlock, Proof<MNT6_753>), Error> {
     let block_number = proof.block_number;
     let proof = proof.proof.clone().ok_or(NanoZKPError::EmptyProof)?;
 
@@ -57,10 +57,10 @@ pub(crate) fn get_proof_macro_blocks(
         let new_block = blockchain
             .read()
             .get_block_at(block_number, true, None)
-            .ok_or(ZKPComponentError::InvalidBlock)?;
+            .ok_or(Error::InvalidBlock)?;
 
         if !new_block.is_election() {
-            return Err(ZKPComponentError::InvalidBlock);
+            return Err(Error::InvalidBlock);
         }
         new_block.unwrap_macro()
     };
@@ -78,17 +78,17 @@ pub(crate) fn validate_proof_get_new_state(
     new_block: &MacroBlock,
     genesis_block: MacroBlock,
     keys_path: &Path,
-) -> Result<ZKPState, ZKPComponentError> {
+) -> Result<ZKPState, Error> {
     let genesis_pks: Vec<G2MNT6> = genesis_block
         .get_validators()
-        .ok_or(ZKPComponentError::InvalidBlock)?
+        .ok_or(Error::InvalidBlock)?
         .voting_keys()
         .into_iter()
         .map(|pub_key| pub_key.public_key)
         .collect();
     let new_pks: Vec<G2MNT6> = new_block
         .get_validators()
-        .ok_or(ZKPComponentError::InvalidBlock)?
+        .ok_or(Error::InvalidBlock)?
         .voting_keys()
         .into_iter()
         .map(|pub_key| pub_key.public_key)
@@ -111,7 +111,7 @@ pub(crate) fn validate_proof_get_new_state(
             latest_proof: Some(proof),
         });
     }
-    Err(ZKPComponentError::InvalidProof)
+    Err(Error::InvalidProof)
 }
 
 /// Generates the zk proof and sends it through the channel provided. Upon failure, the error is sent trough the channel provided.

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -318,8 +318,8 @@ impl<N: Network> Future for ZKPComponent<N> {
             }
 
             // Return verification result if channel exists.
-            if let Some(rx) = requests_item.response_channel {
-                let _ = rx.send(result.map(ZKPRequestEvent::Proof));
+            if let Some(tx) = requests_item.response_channel {
+                let _ = tx.send(result.map(ZKPRequestEvent::Proof));
             }
         }
 

--- a/zkp-component/src/zkp_requests.rs
+++ b/zkp-component/src/zkp_requests.rs
@@ -5,12 +5,21 @@ use std::task::{Context, Poll};
 use futures::future::BoxFuture;
 use futures::{FutureExt, Stream, StreamExt};
 
+use nimiq_network_interface::request::RequestError;
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+
 use nimiq_block::MacroBlock;
 use nimiq_network_interface::network::Network;
-use nimiq_network_interface::request::RequestError;
 
 use crate::types::*;
 use futures::stream::FuturesUnordered;
+
+pub struct ZKPRequestsItem<N: Network> {
+    pub peer_id: N::PeerId,
+    pub proof: ZKProof,
+    pub election_block: Option<MacroBlock>,
+    pub response_channel: Option<Sender<Result<ZKPRequestEvent<N>, Error>>>,
+}
 
 /// This component handles the requests to a given set of peers.
 ///
@@ -19,22 +28,25 @@ use futures::stream::FuturesUnordered;
 /// - The list of futures of replies from peers
 ///
 /// Polling this gives the next zkp response we received from our peers.
-pub struct ZKPRequests<TNetwork: Network + 'static> {
-    network: Arc<TNetwork>,
+///
+/// We offer the option to receive back the verification result via a one-shot channel.
+pub struct ZKPRequests<N: Network + 'static> {
+    network: Arc<N>,
     zkp_request_results: FuturesUnordered<
         BoxFuture<
             'static,
             (
-                TNetwork::PeerId,
+                N::PeerId,
                 bool,
+                Option<Sender<Result<ZKPRequestEvent<N>, Error>>>,
                 Result<(Option<ZKProof>, Option<MacroBlock>), RequestError>,
             ),
         >,
     >,
 }
 
-impl<TNetwork: Network + 'static> ZKPRequests<TNetwork> {
-    pub fn new(network: Arc<TNetwork>) -> Self {
+impl<N: Network + 'static> ZKPRequests<N> {
+    pub fn new(network: Arc<N>) -> Self {
         ZKPRequests {
             network,
             zkp_request_results: FuturesUnordered::new(),
@@ -46,61 +58,99 @@ impl<TNetwork: Network + 'static> ZKPRequests<TNetwork> {
         self.zkp_request_results.is_empty()
     }
 
-    /// Created the futures to requests zkps to all specified peers.
+    /// Creates the futures to request zkps from all specified peers.
     pub fn request_zkps(
         &mut self,
-        peers: Vec<TNetwork::PeerId>,
+        peers: Vec<N::PeerId>,
         block_number: u32,
         request_election_block: bool,
     ) {
         for peer_id in peers {
-            let network = Arc::clone(&self.network);
-            self.zkp_request_results.push(
-                async move {
-                    (
-                        peer_id,
-                        request_election_block,
-                        network
-                            .request::<RequestZKP>(
-                                RequestZKP {
-                                    block_number,
-                                    request_election_block,
-                                },
-                                peer_id,
-                            )
-                            .await,
-                    )
-                }
-                .boxed(),
-            );
+            self.push_request(peer_id, block_number, request_election_block, None);
         }
+    }
+
+    /// Requests a ZKP from a single peer and return future with verification result.
+    pub fn request_zkp(
+        &mut self,
+        peer_id: N::PeerId,
+        block_number: u32,
+        request_election_block: bool,
+    ) -> Receiver<Result<ZKPRequestEvent<N>, Error>> {
+        let (tx, rx) = channel();
+        self.push_request(peer_id, block_number, request_election_block, Some(tx));
+
+        rx
+    }
+
+    fn push_request(
+        &mut self,
+        peer_id: N::PeerId,
+        block_number: u32,
+        request_election_block: bool,
+        response_channel: Option<Sender<Result<ZKPRequestEvent<N>, Error>>>,
+    ) {
+        let network = Arc::clone(&self.network);
+        self.zkp_request_results.push(
+            async move {
+                (
+                    peer_id,
+                    request_election_block,
+                    response_channel,
+                    network
+                        .request::<RequestZKP>(
+                            RequestZKP {
+                                block_number,
+                                request_election_block,
+                            },
+                            peer_id,
+                        )
+                        .await,
+                )
+            }
+            .boxed(),
+        );
     }
 }
 
-impl<TNetwork: Network + 'static> Stream for ZKPRequests<TNetwork> {
-    type Item = (TNetwork::PeerId, ZKProof, Option<MacroBlock>);
+impl<N: Network + 'static> Stream for ZKPRequests<N> {
+    type Item = ZKPRequestsItem<N>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // We poll the zkp requests and return the proof.
         while let Poll::Ready(result) = self.zkp_request_results.poll_next_unpin(cx) {
             match result {
-                Some((peer_id, request_election_block, result)) => match result {
+                Some((peer_id, request_election_block, response_channel, result)) => match result {
                     Ok((Some(proof), mut election_block)) => {
                         // Check that the response is in-line with whether we asked for the election block or not.
                         if request_election_block {
                             if election_block.is_none() {
+                                if let Some(rx) = response_channel {
+                                    let _ = rx.send(Err(Error::InvalidBlock));
+                                }
                                 continue;
                             }
                         } else {
                             election_block = None;
                         }
-                        return Poll::Ready(Some((peer_id, proof, election_block)));
+                        return Poll::Ready(Some(ZKPRequestsItem {
+                            peer_id,
+                            proof,
+                            election_block,
+                            response_channel,
+                        }));
                     }
                     Ok((None, _)) => {
                         // This happens when the peer does not have a more recent proof than us.
+                        if let Some(rx) = response_channel {
+                            let _ = rx.send(Ok(ZKPRequestEvent::OutdatedProof));
+                        }
                     }
-                    Err(_) => {
+                    Err(e) => {
                         log::trace!("Failed zkp request");
+                        if let Some(rx) = response_channel {
+                            let _ = rx.send(Err(Error::Request(e)));
+                        }
                     }
                 },
                 None => return Poll::Ready(None),

--- a/zkp-component/src/zkp_requests.rs
+++ b/zkp-component/src/zkp_requests.rs
@@ -125,8 +125,8 @@ impl<N: Network + 'static> Stream for ZKPRequests<N> {
                         // Check that the response is in-line with whether we asked for the election block or not.
                         if request_election_block {
                             if election_block.is_none() {
-                                if let Some(rx) = response_channel {
-                                    let _ = rx.send(Err(Error::InvalidBlock));
+                                if let Some(tx) = response_channel {
+                                    let _ = tx.send(Err(Error::InvalidBlock));
                                 }
                                 continue;
                             }
@@ -142,14 +142,14 @@ impl<N: Network + 'static> Stream for ZKPRequests<N> {
                     }
                     Ok((None, _)) => {
                         // This happens when the peer does not have a more recent proof than us.
-                        if let Some(rx) = response_channel {
-                            let _ = rx.send(Ok(ZKPRequestEvent::OutdatedProof));
+                        if let Some(tx) = response_channel {
+                            let _ = tx.send(Ok(ZKPRequestEvent::OutdatedProof));
                         }
                     }
                     Err(e) => {
                         log::trace!("Failed zkp request");
-                        if let Some(rx) = response_channel {
-                            let _ = rx.send(Err(Error::Request(e)));
+                        if let Some(tx) = response_channel {
+                            let _ = tx.send(Err(Error::Request(e)));
                         }
                     }
                 },

--- a/zkp-component/tests/zkp_requests.rs
+++ b/zkp-component/tests/zkp_requests.rs
@@ -150,13 +150,13 @@ async fn peers_reply_with_valid_proof() {
     for _ in 0..2 {
         let proof_data = zkp_requests.next().await.unwrap();
         assert!(
-            proof_data.2.is_none(),
+            proof_data.election_block.is_none(),
             "Peers should not send an election block"
         );
         assert!(
             validate_proof(
                 &BlockchainProxy::from(&blockchain2),
-                &proof_data.1,
+                &proof_data.proof,
                 None,
                 Path::new(KEYS_PATH)
             ),
@@ -230,14 +230,14 @@ async fn peers_reply_with_valid_proof_and_election_block() {
     for _ in 0..2 {
         let proof_data = zkp_requests.next().await.unwrap();
         assert!(
-            proof_data.2.is_some(),
+            proof_data.election_block.is_some(),
             "Peers should send an election block"
         );
         assert!(
             validate_proof(
                 &BlockchainProxy::from(&blockchain2),
-                &proof_data.1,
-                proof_data.2,
+                &proof_data.proof,
+                proof_data.election_block,
                 Path::new(KEYS_PATH)
             ),
             "Peer should sent a new proof valid proof"


### PR DESCRIPTION
## What's in this pull request?
This PR adds new functionality to the ZKP component proxy to request a ZKP from a single individual.
The function returns a future that can be awaited to receive the ZKP and its verification result.

The requested ZKP still goes through all regular checks in the ZKP component and is stored there if up-to-date and valid.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

