### PR TITLE
Always return peer id on zkp requests

### DIFF
--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -64,9 +64,9 @@ impl<N: Network> Clone for ZKPEvent<N> {
 
 /// The ZKP event returned for individual requests by the ZKP requests component.
 #[derive(Debug)]
-pub enum ZKPRequestEvent<N: Network> {
+pub enum ZKPRequestEvent {
     /// A valid proof that has been pushed to the ZKP state.
-    Proof(ZKPEvent<N>),
+    Proof { proof: ZKProof, block: MacroBlock },
     /// The peer does not have a more recent proof.
     OutdatedProof,
 }
@@ -190,6 +190,15 @@ impl<N: Network> Clone for ProofSource<N> {
         match self {
             Self::PeerGenerated(peer_id) => Self::PeerGenerated(*peer_id),
             Self::SelfGenerated => Self::SelfGenerated,
+        }
+    }
+}
+
+impl<N: Network> ProofSource<N> {
+    pub fn unwrap_peer_id(&self) -> N::PeerId {
+        match self {
+            Self::PeerGenerated(peer_id) => *peer_id,
+            Self::SelfGenerated => panic!("Called unwrap_peer_id on a self generated proof source"),
         }
     }
 }

--- a/zkp-component/src/zkp_requests.rs
+++ b/zkp-component/src/zkp_requests.rs
@@ -18,7 +18,7 @@ pub struct ZKPRequestsItem<N: Network> {
     pub peer_id: N::PeerId,
     pub proof: ZKProof,
     pub election_block: Option<MacroBlock>,
-    pub response_channel: Option<Sender<Result<ZKPRequestEvent<N>, Error>>>,
+    pub response_channel: Option<Sender<Result<ZKPRequestEvent, Error>>>,
 }
 
 /// This component handles the requests to a given set of peers.
@@ -38,7 +38,7 @@ pub struct ZKPRequests<N: Network + 'static> {
             (
                 N::PeerId,
                 bool,
-                Option<Sender<Result<ZKPRequestEvent<N>, Error>>>,
+                Option<Sender<Result<ZKPRequestEvent, Error>>>,
                 Result<(Option<ZKProof>, Option<MacroBlock>), RequestError>,
             ),
         >,
@@ -76,7 +76,7 @@ impl<N: Network + 'static> ZKPRequests<N> {
         peer_id: N::PeerId,
         block_number: u32,
         request_election_block: bool,
-    ) -> Receiver<Result<ZKPRequestEvent<N>, Error>> {
+    ) -> Receiver<Result<ZKPRequestEvent, Error>> {
         let (tx, rx) = channel();
         self.push_request(peer_id, block_number, request_election_block, Some(tx));
 
@@ -88,7 +88,7 @@ impl<N: Network + 'static> ZKPRequests<N> {
         peer_id: N::PeerId,
         block_number: u32,
         request_election_block: bool,
-        response_channel: Option<Sender<Result<ZKPRequestEvent<N>, Error>>>,
+        response_channel: Option<Sender<Result<ZKPRequestEvent, Error>>>,
     ) {
         let network = Arc::clone(&self.network);
         self.zkp_request_results.push(


### PR DESCRIPTION
## What's in this pull request?

Added the peer id to the return type in all circumstances (errors and valid pushed proofs). Simplified the return type of the ZKP request to a single peer. 

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.