### PR TITLE
Use `BlockchainProxy` for consensus handlers and move functions to `AbstractBlockchain`

### DIFF
--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -5,7 +5,7 @@ use parking_lot::{RwLock, RwLockReadGuard};
 
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::ChainInfo;
-use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent};
+use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent, Direction};
 use nimiq_database::Transaction;
 use nimiq_genesis::NetworkId;
 use nimiq_hash::Blake2bHash;
@@ -199,6 +199,28 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
             get_slot_owner_at,
             block_number,
             offset,
+            txn_option
+        )
+    }
+
+    fn get_macro_blocks(
+        &self,
+        start_block_hash: &Blake2bHash,
+        count: u32,
+        include_body: bool,
+        direction: Direction,
+        election_blocks_only: bool,
+        txn_option: Option<&Transaction>,
+    ) -> Option<Vec<Block>> {
+        gen_blockchain_match!(
+            self,
+            BlockchainReadProxy,
+            get_macro_blocks,
+            start_block_hash,
+            count,
+            include_body,
+            direction,
+            election_blocks_only,
             txn_option
         )
     }

--- a/blockchain/src/abstract_blockchain.rs
+++ b/blockchain/src/abstract_blockchain.rs
@@ -124,6 +124,19 @@ pub trait AbstractBlockchain {
         txn_option: Option<&Transaction>,
     ) -> Option<(Validator, u16)>;
 
+    /// Fetches a given number of macro blocks, starting at a specific block (by its hash).
+    /// It can fetch only election macro blocks if desired.
+    /// Returns None if given start_block_hash is not a macro block.
+    fn get_macro_blocks(
+        &self,
+        start_block_hash: &Blake2bHash,
+        count: u32,
+        include_body: bool,
+        direction: Direction,
+        election_blocks_only: bool,
+        txn_option: Option<&Transaction>,
+    ) -> Option<Vec<Block>>;
+
     /// Stream of Blockchain Events.
     fn notifier_as_stream(&self) -> BoxStream<'static, BlockchainEvent>;
 }
@@ -225,6 +238,25 @@ impl AbstractBlockchain for Blockchain {
     ) -> Vec<Block> {
         self.chain_store
             .get_blocks(start_block_hash, count, include_body, direction, txn_option)
+    }
+
+    fn get_macro_blocks(
+        &self,
+        start_block_hash: &Blake2bHash,
+        count: u32,
+        include_body: bool,
+        direction: Direction,
+        election_blocks_only: bool,
+        txn_option: Option<&Transaction>,
+    ) -> Option<Vec<Block>> {
+        self.chain_store.get_macro_blocks(
+            start_block_hash,
+            count,
+            include_body,
+            direction,
+            election_blocks_only,
+            txn_option,
+        )
     }
 
     fn notifier_as_stream(&self) -> BoxStream<'static, BlockchainEvent> {

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -32,27 +32,6 @@ impl Blockchain {
             .get_blocks(start_block_hash, count, include_body, direction, None)
     }
 
-    /// Fetches a given number of macro blocks, starting at a specific block (by its hash).
-    /// It can fetch only election macro blocks if desired.
-    /// Returns None if given start_block_hash is not a macro block.
-    pub fn get_macro_blocks(
-        &self,
-        start_block_hash: &Blake2bHash,
-        count: u32,
-        include_body: bool,
-        direction: Direction,
-        election_blocks_only: bool,
-    ) -> Option<Vec<Block>> {
-        self.chain_store.get_macro_blocks(
-            start_block_hash,
-            count,
-            include_body,
-            direction,
-            election_blocks_only,
-            None,
-        )
-    }
-
     /// Returns the current staking contract.
     pub fn get_staking_contract(&self) -> StakingContract {
         let staking_contract_address = StakingContract::get_key_staking_contract();

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -87,7 +87,13 @@ impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
         hash: Blake2bHash,
     ) -> Result<Option<Block>, RequestError> {
         network
-            .request::<RequestBlock>(RequestBlock { hash }, peer_id)
+            .request::<RequestBlock>(
+                RequestBlock {
+                    hash,
+                    include_body: true,
+                },
+                peer_id,
+            )
             .await
     }
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -122,27 +122,26 @@ impl<N: Network> Consensus<N> {
     }
 
     fn init_network_request_receivers(network: &Arc<N>, blockchain: &BlockchainProxy) {
+        let stream = network.receive_requests::<RequestMacroChain>();
+        tokio::spawn(request_handler(network, stream, blockchain));
+
+        let stream = network.receive_requests::<RequestBlock>();
+        tokio::spawn(request_handler(network, stream, blockchain));
+
+        let stream = network.receive_requests::<RequestMissingBlocks>();
+        tokio::spawn(request_handler(network, stream, blockchain));
+
+        let stream = network.receive_requests::<RequestHead>();
+        tokio::spawn(request_handler(network, stream, blockchain));
         match blockchain {
             BlockchainProxy::Full(blockchain) => {
-                let stream = network.receive_requests::<RequestMacroChain>();
-                tokio::spawn(request_handler(network, stream, blockchain));
-
                 let stream = network.receive_requests::<RequestBatchSet>();
                 tokio::spawn(request_handler(network, stream, blockchain));
 
                 let stream = network.receive_requests::<RequestHistoryChunk>();
                 tokio::spawn(request_handler(network, stream, blockchain));
-
-                let stream = network.receive_requests::<RequestBlock>();
-                tokio::spawn(request_handler(network, stream, blockchain));
-
-                let stream = network.receive_requests::<RequestMissingBlocks>();
-                tokio::spawn(request_handler(network, stream, blockchain));
-
-                let stream = network.receive_requests::<RequestHead>();
-                tokio::spawn(request_handler(network, stream, blockchain));
             }
-            BlockchainProxy::Light(_) => todo!(),
+            BlockchainProxy::Light(_) => {}
         }
     }
 

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -43,6 +43,7 @@ impl Handle<MacroChain, Arc<RwLock<Blockchain>>> for RequestMacroChain {
                 false,
                 Direction::Forward,
                 true,
+                None,
             )
             .unwrap(); // We made sure that start_block_hash is on our chain.
         let epochs: Vec<_> = election_blocks.iter().map(|block| block.hash()).collect();

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -140,6 +140,7 @@ pub struct HistoryChunk {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestBlock {
     pub hash: Blake2bHash,
+    pub include_body: bool,
 }
 
 impl RequestCommon for RequestBlock {
@@ -176,6 +177,7 @@ impl Debug for ResponseBlocks {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestMissingBlocks {
     pub target_hash: Blake2bHash,
+    pub include_body: bool,
     #[beserial(len_type(u16, limit = 128))]
     pub locators: Vec<Blake2bHash>,
 }

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -245,6 +245,7 @@ mod tests {
     use parking_lot::RwLock;
 
     use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainConfig};
+    use nimiq_blockchain_proxy::BlockchainProxy;
     use nimiq_database::volatile::VolatileEnvironment;
     use nimiq_network_interface::network::Network;
     use nimiq_network_mock::{MockHub, MockNetwork};
@@ -317,7 +318,7 @@ mod tests {
         tokio::spawn(request_handler(
             network,
             network.receive_requests::<RequestMacroChain>(),
-            blockchain,
+            &BlockchainProxy::from(blockchain),
         ));
         tokio::spawn(request_handler(
             network,

--- a/consensus/src/sync/live/request_component.rs
+++ b/consensus/src/sync/live/request_component.rs
@@ -100,6 +100,7 @@ impl<TNetwork: Network + 'static> BlockRequestComponent<TNetwork> {
                 RequestMissingBlocks {
                     locators,
                     target_hash: target_block_hash,
+                    include_body: true,
                 },
                 peer_id,
             )

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -1,6 +1,6 @@
 use futures::stream::BoxStream;
 use nimiq_block::{Block, MacroBlock};
-use nimiq_blockchain::{AbstractBlockchain, BlockchainEvent, ChainInfo};
+use nimiq_blockchain::{AbstractBlockchain, BlockchainEvent, ChainInfo, Direction};
 use nimiq_database::Transaction;
 use nimiq_genesis::NetworkId;
 use nimiq_hash::Blake2bHash;
@@ -99,16 +99,36 @@ impl AbstractBlockchain for LightBlockchain {
 
     fn get_blocks(
         &self,
-        _start_block_hash: &Blake2bHash,
-        _count: u32,
+        start_block_hash: &Blake2bHash,
+        count: u32,
         include_body: bool,
-        _direction: nimiq_blockchain::Direction,
+        direction: nimiq_blockchain::Direction,
         _txn_option: Option<&Transaction>,
     ) -> Vec<Block> {
         // Light Blockchain can't return blocks with body
         if include_body {
             return vec![];
         }
-        todo!() // IPTODO
+        self.chain_store
+            .get_blocks(start_block_hash, count, direction)
+    }
+
+    /// Fetches a given number of macro blocks, starting at a specific block (by its hash).
+    /// It can fetch only election macro blocks if desired.
+    /// Returns None if given start_block_hash is not a macro block.
+    fn get_macro_blocks(
+        &self,
+        start_block_hash: &Blake2bHash,
+        count: u32,
+        include_body: bool,
+        direction: Direction,
+        election_blocks_only: bool,
+        _txn_option: Option<&Transaction>,
+    ) -> Option<Vec<Block>> {
+        if include_body {
+            return Some(vec![]);
+        }
+        self.chain_store
+            .get_macro_blocks(start_block_hash, count, direction, election_blocks_only)
     }
 }

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -48,9 +48,13 @@ impl AbstractBlockchain for LightBlockchain {
     fn get_block_at(
         &self,
         height: u32,
-        _include_body: bool,
+        include_body: bool,
         _txn_option: Option<&Transaction>,
     ) -> Option<Block> {
+        // Light Blockchain can't return blocks with body
+        if include_body {
+            return None;
+        }
         self.chain_store
             .get_chain_info_at(height)
             .map(|chain_info| chain_info.head)
@@ -59,9 +63,13 @@ impl AbstractBlockchain for LightBlockchain {
     fn get_block(
         &self,
         hash: &Blake2bHash,
-        _include_body: bool,
+        include_body: bool,
         _txn_option: Option<&Transaction>,
     ) -> Option<Block> {
+        // Light Blockchain can't return blocks with body
+        if include_body {
+            return None;
+        }
         self.chain_store
             .get_chain_info(hash)
             .map(|chain_info| chain_info.head.clone())
@@ -93,10 +101,14 @@ impl AbstractBlockchain for LightBlockchain {
         &self,
         _start_block_hash: &Blake2bHash,
         _count: u32,
-        _include_body: bool,
+        include_body: bool,
         _direction: nimiq_blockchain::Direction,
         _txn_option: Option<&Transaction>,
     ) -> Vec<Block> {
+        // Light Blockchain can't return blocks with body
+        if include_body {
+            return vec![];
+        }
         todo!() // IPTODO
     }
 }

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -89,6 +89,7 @@ impl<N: Network> ZKProver<N> {
                     true,
                     Direction::Forward,
                     true,
+                    None,
                 )
                 .expect("Fetching election blocks for zkp prover initialization failed")
                 .drain(..)


### PR DESCRIPTION
- Change some of the `consensus` request handlers to use `BlockchainProxy` instead of `Blockchain`. This applies to the following requests:
  - `RequestMacroChain`
  - `RequestBlock`
  - `RequestMissingBlocks`
  - `RequestHead`
- Move `get_macro_blocks` to `AbstractBlockchain` and add its implementation for `Blockchain`, `LightBlockchain` and `BlockchainProxy`.
  Also implement `get_blocks` for `LightBlockchain`.  
- Use the `include_nody` argument for functions of the `AbstractBlockchain` implementation for `LightBlockchain` and return no blocks when set to `true`.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.