### PR TITLE
consensus: Add a parameter to `BlockLiveSync` to include block bodies

### DIFF
--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -51,8 +51,11 @@ impl<N: Network> SyncerProxy<N> {
 
         match blockchain_proxy {
             BlockchainProxy::Full(ref blockchain) => {
-                let request_component =
-                    BlockRequestComponent::new(network.subscribe_events(), Arc::clone(&network));
+                let request_component = BlockRequestComponent::new(
+                    network.subscribe_events(),
+                    Arc::clone(&network),
+                    true,
+                );
 
                 let block_queue = BlockQueue::new(
                     Arc::clone(&network),

--- a/consensus/tests/syncer.rs
+++ b/consensus/tests/syncer.rs
@@ -724,6 +724,7 @@ async fn put_peer_back_into_sync_mode() {
             buffer_max: 10,
             window_ahead_max: 10,
             tolerate_past_max: 100,
+            include_body: true,
         },
     );
 


### PR DESCRIPTION
Add a parameter to `BlockLiveSync` to include block bodies. Add a `BlockHeaderTopic` where only block headers and justifications are published.
Add parameters to `BlockQueue` and `RequestComponent` to use the `include_body` parameter and properly subscribe to the appropriate network topic (`BlockTopic` or `BlockHeaderTopic`).

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.