### PR TITLE
CI: Move away from deprecated commands/procedures

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: llvm-cov
-        args: --no-run --lcov --output-path coverage.lcov
+        args: report --lcov --output-path coverage.lcov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Retrieve initial timestamp
       id: initial_ts
       run: |
-         echo "::set-output name=INITIAL_TS::$(date +%s%N | cut -b1-13)"
+         echo "INITIAL_TS=$(date +%s%N | cut -b1-13)" >> $GITHUB_OUTPUT
     - name: Execute the test
       run: |
           bash scripts/devnet/devnet.sh --run-environment ci ${{ matrix.devnet_args }}
@@ -90,22 +90,22 @@ jobs:
       if: always()
       run: |
           if [ -f temp-state/RESULT.TXT ]; then
-            echo "::set-output name=FAIL_REASON::$(cat temp-state/RESULT.TXT)"
+            echo "FAIL_REASON=$(cat temp-state/RESULT.TXT)" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=FAIL_REASON::other"
+            echo "FAIL_REASON=other" >> $GITHUB_OUTPUT
           fi
       id: reason
     - name: Retrieve final timestamp and Run ID
       if: always()
       id: final_ts_run_id
       run: |
-         echo "::set-output name=FINAL_TS::$(date +%s%N | cut -b1-13)"
-         echo "::set-output name=RUN_ID::$(cat temp-logs/*/conf/run_id.info)"
+         echo "FINAL_TS=$(date +%s%N | cut -b1-13)" >> $GITHUB_OUTPUT
+         echo "RUN_ID=$(cat temp-logs/*/conf/run_id.info)" >> $GITHUB_OUTPUT
     - name: Build Grafana dashboard link
       if: always()
       id: grafana_url
       run: |
-         echo "::set-output name=GRAFANA_URL::http://localhost:3001/d/YbjdvlU7z/nimiq-test?orgId=1&var-env=ci&var-run_id=${{steps.final_ts_run_id.outputs.RUN_ID}}&from=${{steps.initial_ts.outputs.INITIAL_TS}}&to=${{steps.final_ts_run_id.outputs.FINAL_TS}}"
+         echo "GRAFANA_URL=http://localhost:3001/d/YbjdvlU7z/nimiq-test?orgId=1&var-env=ci&var-run_id=${{steps.final_ts_run_id.outputs.RUN_ID}}&from=${{steps.initial_ts.outputs.INITIAL_TS}}&to=${{steps.final_ts_run_id.outputs.FINAL_TS}}" >> $GITHUB_OUTPUT
     - name: Report potential deadlocks to slack
       if: always() && contains(steps.reason.outputs.FAIL_REASON, 'DEADLOCK')
       uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Retrieve initial timestamp
       id: initial_ts
       run: |
-         echo "::set-output name=INITIAL_TS::$(date +%s%N | cut -b1-13)"
+         echo "INITIAL_TS=$(date +%s%N | cut -b1-13)" >> $GITHUB_OUTPUT
     - name: Execute the test
       run: |          
           bash scripts/devnet/devnet.sh --run-environment ci ${{ matrix.devnet_args }}
@@ -86,22 +86,22 @@ jobs:
       if: always()
       run: |
           if [ -f temp-state/RESULT.TXT ]; then
-            echo "::set-output name=FAIL_REASON::$(cat temp-state/RESULT.TXT)"
+            echo "FAIL_REASON=$(cat temp-state/RESULT.TXT)" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=FAIL_REASON::other"
+            echo "FAIL_REASON=other" >> $GITHUB_OUTPUT
           fi
       id: reason
     - name: Retrieve final timestamp and Run ID
       if: always()
       id: final_ts_run_id
       run: |
-         echo "::set-output name=FINAL_TS::$(date +%s%N | cut -b1-13)"
-         echo "::set-output name=RUN_ID::$(cat temp-logs/*/conf/run_id.info)"
+         echo "FINAL_TS=$(date +%s%N | cut -b1-13)" >> $GITHUB_OUTPUT
+         echo "RUN_ID=$(cat temp-logs/*/conf/run_id.info)" >> $GITHUB_OUTPUT
     - name: Build Grafana dashboard link
       if: always()
       id: grafana_url
       run: |
-         echo "::set-output name=GRAFANA_URL::http://localhost:3001/d/YbjdvlU7z/nimiq-test?orgId=1&var-env=ci&var-run_id=${{steps.final_ts_run_id.outputs.RUN_ID}}&from=${{steps.initial_ts.outputs.INITIAL_TS}}&to=${{steps.final_ts_run_id.outputs.FINAL_TS}}"
+         echo "GRAFANA_URL=http://localhost:3001/d/YbjdvlU7z/nimiq-test?orgId=1&var-env=ci&var-run_id=${{steps.final_ts_run_id.outputs.RUN_ID}}&from=${{steps.initial_ts.outputs.INITIAL_TS}}&to=${{steps.final_ts_run_id.outputs.FINAL_TS}}" >> $GITHUB_OUTPUT
     - name: Report potential deadlocks to slack
       if: always() && contains(steps.reason.outputs.FAIL_REASON, 'DEADLOCK')
       uses: ravsamhq/notify-slack-action@v2

--- a/scripts/devnet/devnet.sh
+++ b/scripts/devnet/devnet.sh
@@ -55,7 +55,7 @@ function cleanup_exit() {
         echo "...FAILED..."
         exit 1
     fi
-    echo "SUCCESS" >> temp-state/RESULT.TXT
+    echo -n "SUCCESS" >> temp-state/RESULT.TXT
     exit 0
 }
 
@@ -68,7 +68,7 @@ function check_failures() {
         if grep -rin " panic " $logsdir/*.log
         then
             echo "   !!!   PANIC   !!!"
-            echo "PANIC" >> temp-state/RESULT.TXT
+            echo -n "PANIC" >> temp-state/RESULT.TXT
             fail=true
             break
         fi
@@ -88,21 +88,21 @@ function report_warnings() {
     if grep -rin "lock held for a long time" $logsdir/*.log
     then
         echo "   !!!   LONG LOCK HOLD TIME   !!!"
-        echo "LONG_LOCK_HOLD_TIME" >> temp-state/RESULT.TXT
+        echo -n "LONG_LOCK_HOLD_TIME" >> temp-state/RESULT.TXT
     fi
 
     # Search for slow lock acquisitions
     if grep -rin "slow.*took" $logsdir/*.log
     then
         echo "   !!!   SLOW LOCK ACQUISITION   !!!"
-        echo "SLOW_LOCK_ACQUISITION" >> temp-state/RESULT.TXT
+        echo -n "SLOW_LOCK_ACQUISITION" >> temp-state/RESULT.TXT
     fi
 
     # Search for deadlocks
     if grep -wrin "deadlock" $logsdir/*.log
     then
         echo "   !!!   POTENTIAL DEADLOCK DETECTED  !!!"
-        echo "DEADLOCK" >> temp-state/RESULT.TXT
+        echo -n "DEADLOCK" >> temp-state/RESULT.TXT
     fi
 }
 
@@ -433,7 +433,7 @@ do
 
     if [ $new_block_number -eq $old_block_number ] ; then
         echo "   !!!   BLOCKS ARE NOT BEING PRODUCED AFTER $sleep_time SECONDS   !!!"
-        echo "CHAIN-STALL" >> temp-state/RESULT.TXT
+        echo -n "CHAIN-STALL" >> temp-state/RESULT.TXT
         fail=true
         break
     fi


### PR DESCRIPTION
- Remove usage of deprecated `set-output` and move to use `GITHUB_OUTPUT` environment files as documented [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
- Use `cargo llvm-cov report` instead of the deprecated `cargo llvm-cov --no-run`.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.