### PR TITLE
Add light client binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nimiq-light-client"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "nimiq-lib",
+ "tokio",
+ "tokio-metrics",
+ "tracing",
+]
+
+[[package]]
 name = "nimiq-log"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,7 @@ dependencies = [
  "nimiq-jsonrpc-core",
  "nimiq-jsonrpc-server",
  "nimiq-keys",
+ "nimiq-light-blockchain",
  "nimiq-log",
  "nimiq-mempool",
  "nimiq-metrics-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "keys",
   "lib",
   "light-blockchain",
+  "light-client",
   "log",
   "macros",
   "mempool",

--- a/consensus/src/sync/live/block_live_sync.rs
+++ b/consensus/src/sync/live/block_live_sync.rs
@@ -146,7 +146,9 @@ impl<N: Network, TReq: RequestComponent<N>> BlockLiveSync<N, TReq> {
                                 BlockchainProxy::Full(blockchain) => {
                                     Blockchain::push(blockchain.upgradable_read(), block)
                                 }
-                                BlockchainProxy::Light(_) => todo!(),
+                                BlockchainProxy::Light(blockchain) => {
+                                    LightBlockchain::push(blockchain.upgradable_read(), block)
+                                }
                             }
                         })
                         .await

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -108,11 +108,16 @@ impl<N: Network> SyncerProxy<N> {
                     false,
                 );
 
+                let block_queue_config = BlockQueueConfig {
+                    include_body: false,
+                    ..Default::default()
+                };
+
                 let block_queue = BlockQueue::new(
                     Arc::clone(&network),
                     blockchain_proxy.clone(),
                     request_component,
-                    BlockQueueConfig::default(),
+                    block_queue_config,
                 )
                 .await;
 

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::{Stream, StreamExt};
+use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 use parking_lot::Mutex;
 
 use nimiq_block::Block;
@@ -21,10 +22,13 @@ use crate::sync::{
     syncer::{LiveSyncPushEvent, Syncer},
 };
 
+use super::light::LightMacroSync;
+
 macro_rules! gen_syncer_match {
     ($self: ident, $f: ident $(, $arg:expr )*) => {
         match $self {
             SyncerProxy::History(syncer) => syncer.$f($( $arg ),*),
+            SyncerProxy::Light(syncer) => syncer.$f($( $arg ),*),
         }
     };
 }
@@ -34,6 +38,8 @@ macro_rules! gen_syncer_match {
 pub enum SyncerProxy<N: Network> {
     /// History Syncer, uses history macro sync for macro sync and block live sync.
     History(Syncer<N, HistoryMacroSync<N>, BlockLiveSync<N, BlockRequestComponent<N>>>),
+    /// Light Syncer, uses light macro sync for macro sync and block live sync.
+    Light(Syncer<N, LightMacroSync<N>, BlockLiveSync<N, BlockRequestComponent<N>>>),
 }
 
 impl<N: Network> SyncerProxy<N> {
@@ -81,6 +87,55 @@ impl<N: Network> SyncerProxy<N> {
         }
     }
 
+    /// Creates a new instance of a `SyncerProxy` for the `Light` variant
+    pub async fn new_light(
+        blockchain_proxy: BlockchainProxy,
+        network: Arc<N>,
+        bls_cache: Arc<Mutex<PublicKeyCache>>,
+        zkp_component_proxy: Arc<ZKPComponentProxy<N>>,
+        network_event_rx: SubscribeEvents<N::PeerId>,
+    ) -> Self {
+        assert!(
+            matches!(blockchain_proxy, BlockchainProxy::Light(_)),
+            "Light Syncer can only be created for a light blockchain"
+        );
+
+        match blockchain_proxy {
+            BlockchainProxy::Light(ref blockchain) => {
+                let request_component = BlockRequestComponent::new(
+                    network.subscribe_events(),
+                    Arc::clone(&network),
+                    false,
+                );
+
+                let block_queue = BlockQueue::new(
+                    Arc::clone(&network),
+                    blockchain_proxy.clone(),
+                    request_component,
+                    BlockQueueConfig::default(),
+                )
+                .await;
+
+                let live_sync = BlockLiveSync::new(
+                    blockchain_proxy.clone(),
+                    Arc::clone(&network),
+                    block_queue,
+                    bls_cache,
+                );
+
+                let macro_sync = LightMacroSync::new(
+                    Arc::clone(blockchain),
+                    network,
+                    network_event_rx,
+                    zkp_component_proxy,
+                );
+
+                Self::Light(Syncer::new(live_sync, macro_sync))
+            }
+            BlockchainProxy::Full(_) => unreachable!(),
+        }
+    }
+
     /// Pushes a block for the live sync method
     pub fn push_block(&mut self, block: Block, peer_id: N::PeerId, pubsub_id: Option<N::PubsubId>) {
         gen_syncer_match!(self, push_block, block, peer_id, pubsub_id)
@@ -108,6 +163,7 @@ impl<N: Network> Stream for SyncerProxy<N> {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         match self.project() {
             SyncerProxyProj::History(syncer) => syncer.poll_next_unpin(cx),
+            SyncerProxyProj::Light(syncer) => syncer.poll_next_unpin(cx),
         }
     }
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -54,6 +54,7 @@ nimiq-genesis = { path = "../genesis" }
 nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git" }
 nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git" }
 nimiq-keys = { path = "../keys" }
+nimiq-light-blockchain = { path = "../light-blockchain" }
 nimiq-log = { path = "../log", optional = true }
 nimiq-mempool = { path = "../mempool" }
 nimiq-metrics-server = { path = "../metrics-server" }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "nimiq-light-client"
+version = "0.1.0"
+authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+edition = "2021"
+description = "Nimiq's Rust light client"
+homepage = "https://nimiq.com"
+repository = "https://github.com/nimiq/core-rs-albatross"
+license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["nimiq", "cryptocurrency", "blockchain"]
+exclude = ["db", "peer_key.dat"]
+
+[badges]
+travis-ci = { repository = "nimiq/core-rs", branch = "master" }
+is-it-maintained-issue-resolution = { repository = "nimiq/core-rs" }
+is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
+maintenance = { status = "experimental" }
+
+[dependencies]
+futures = { package = "futures-util", version = "0.3" }
+log = { package = "tracing", version = "0.1", features = ["log"] }
+tokio = { version = "1.22", features = ["rt-multi-thread", "time", "tracing"] }
+tokio-metrics = "0.1"
+
+[dependencies.nimiq]
+package = "nimiq-lib"
+path = "../lib"
+version = "0.1"
+features = [
+    "rpc-server",
+    "deadlock",
+    "logging",
+    "metrics-server",
+    "signal-handling",
+    "wallet",
+    "panic",
+]

--- a/light-client/nimiq-client.service
+++ b/light-client/nimiq-client.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Nimiq's Rust light client
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=exec
+ExecStartPre=$(which nimiq-light-client)
+ExecStart=$(which nimiq-light-client)
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/light-client/src/main.rs
+++ b/light-client/src/main.rs
@@ -1,0 +1,154 @@
+use std::time::Duration;
+
+use log::info;
+
+pub use nimiq::{
+    client::{Client, Consensus},
+    config::command_line::CommandLine,
+    config::config::ClientConfig,
+    config::config_file::{ConfigFile, SyncMode},
+    error::Error,
+    extras::{
+        deadlock::initialize_deadlock_detection,
+        logging::{initialize_logging, log_error_cause_chain},
+        metrics_server::NimiqTaskMonitor,
+        panic::initialize_panic_reporting,
+        signal_handling::initialize_signal_handler,
+    },
+};
+
+async fn main_inner() -> Result<(), Error> {
+    // Initialize deadlock detection
+    initialize_deadlock_detection();
+
+    // Parse command line.
+    let command_line = CommandLine::parse();
+    log::trace!("Command line: {:#?}", command_line);
+
+    // Parse config file - this will obey the `--config` command line option.
+    let config_file = ConfigFile::find(Some(&command_line))?;
+    log::trace!("Config file: {:#?}", config_file);
+
+    if config_file.consensus.sync_mode != SyncMode::Light {
+        return Err(Error::config_error(
+            "Only light sync mode is supported in this client",
+        ));
+    }
+
+    // Initialize logging with config values.
+    initialize_logging(Some(&command_line), Some(&config_file.log))?;
+
+    // Initialize panic hook.
+    initialize_panic_reporting();
+
+    // Initialize signal handler
+    initialize_signal_handler();
+
+    // Create config builder and apply command line and config file.
+    // You usually want the command line to override config settings, so the order is important.
+    let mut builder = ClientConfig::builder();
+    builder.config_file(&config_file)?;
+    builder.command_line(&command_line)?;
+
+    // Finalize config.
+    let config = builder.build()?;
+    log::debug!("Final configuration: {:#?}", config);
+
+    // Clone config for RPC and metrics server
+    let rpc_config = config.rpc_server.clone();
+    let metrics_config = config.metrics_server.clone();
+    let metrics_enabled = metrics_config.is_some();
+
+    // Create client from config.
+    log::info!("Initializing light client");
+    let mut client: Client = Client::from_config(config).await?;
+    log::info!("Light client initialized");
+
+    // Initialize RPC server
+    if let Some(rpc_config) = rpc_config {
+        use nimiq::extras::rpc_server::initialize_rpc_server;
+        let rpc_server = initialize_rpc_server(&client, rpc_config, client.wallet_store())
+            .expect("Failed to initialize RPC server");
+        tokio::spawn(async move { rpc_server.run().await });
+    }
+
+    // Vector for task monitors (Tokio task metrics)
+    let mut nimiq_task_metric = vec![];
+
+    // Start consensus.
+    let consensus = client.take_consensus().unwrap();
+
+    log::info!("Spawning consensus");
+    if metrics_enabled {
+        let con_metrics_monitor = tokio_metrics::TaskMonitor::new();
+        let instr_con = con_metrics_monitor.instrument(consensus);
+        tokio::spawn(instr_con);
+        nimiq_task_metric.push(NimiqTaskMonitor {
+            name: "consensus".to_string(),
+            monitor: con_metrics_monitor,
+        });
+    } else {
+        tokio::spawn(consensus);
+    }
+    let consensus = client.consensus_proxy();
+
+    let zkp_component = client.take_zkp_component().unwrap();
+    tokio::spawn(zkp_component); //ITODO get metrics on this? ask JD
+
+    // Start metrics server
+    if let Some(metrics_config) = metrics_config {
+        nimiq::extras::metrics_server::start_metrics_server(
+            metrics_config.addr,
+            client.blockchain(),
+            None,
+            client.consensus_proxy(),
+            client.network(),
+            &nimiq_task_metric,
+        )
+    }
+
+    // Create the "monitor" future which never completes to keep the client alive.
+    // This closure is executed after the client has been initialized.
+    // TODO Get rid of this. Make the Client a future/stream instead.
+    let mut statistics_interval = config_file.log.statistics;
+    let mut show_statistics = true;
+    if statistics_interval == 0 {
+        statistics_interval = 10;
+        show_statistics = false;
+    }
+
+    // Run periodically
+    let mut interval = tokio::time::interval(Duration::from_secs(statistics_interval));
+
+    loop {
+        interval.tick().await;
+
+        if show_statistics {
+            match client.network().network_info().await {
+                Ok(network_info) => {
+                    let head = client.blockchain_head().clone();
+
+                    info!(
+                        block_number = head.block_number(),
+                        num_peers = network_info.num_peers(),
+                        status = consensus.is_established(),
+                        "Consensus status: {:?} - Head: #{}- {}",
+                        consensus.is_established(),
+                        head.block_number(),
+                        head.hash(),
+                    )
+                }
+                Err(err) => {
+                    log::error!("Error retrieving NetworkInfo: {:?}", err);
+                }
+            };
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = main_inner().await {
+        log_error_cause_chain(&e);
+    }
+}


### PR DESCRIPTION
- Add `Light` variant for `SyncerProxy` using light macro sync for macro sync and block live sync.
- Add support for a light client by properly instantiating the required objects when initializing the client.
- Add a `light-client` binary supporting only the `Light` variant of `SyncMode` and removing unneeded components from the regular client.
- Change the `put_chain_info` method of the `ChainStore` to not empty out macro bodies.
  Macro bodies are needed to get the set of validators and the disabled slots for blocks in the subsequent epoch/batch.
- Fix missing implementation for `LightBlockchain` in `BlockLiveSync`.
- Fix configuration for `BlockLiveSync` when using the `Light` variant of the `SyncerProxy`.

Depends on #1140.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
