### PR TITLE
blockchain: Use `Result` as the return value

### DIFF
--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -366,7 +366,7 @@ pub fn next_macro_block(
 
     let validators =
         blockchain.get_validators_for_epoch(Policy::epoch_at(blockchain.block_number() + 1), None);
-    assert!(validators.is_some());
+    assert!(validators.is_ok());
 
     Block::Macro(finalize_macro_block(
         voting_key,

--- a/block-production/src/test_utils.rs
+++ b/block-production/src/test_utils.rs
@@ -91,7 +91,7 @@ impl TemporaryBlockProducer {
             // Get validator set and make sure it exists.
             let validators = blockchain
                 .get_validators_for_epoch(Policy::epoch_at(blockchain.block_number() + 1), None);
-            assert!(validators.is_some());
+            assert!(validators.is_ok());
 
             Block::Macro(TemporaryBlockProducer::finalize_macro_block(
                 TendermintProposal {

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -4,8 +4,8 @@ use futures::stream::BoxStream;
 use parking_lot::{RwLock, RwLockReadGuard};
 
 use nimiq_block::{Block, MacroBlock};
-use nimiq_blockchain::ChainInfo;
 use nimiq_blockchain::{AbstractBlockchain, Blockchain, BlockchainEvent, Direction};
+use nimiq_blockchain::{BlockchainError, ChainInfo};
 use nimiq_database::Transaction;
 use nimiq_genesis::NetworkId;
 use nimiq_hash::Blake2bHash;
@@ -124,7 +124,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         height: u32,
         include_body: bool,
         txn_option: Option<&Transaction>,
-    ) -> Option<Block> {
+    ) -> Result<Block, BlockchainError> {
         gen_blockchain_match!(
             self,
             BlockchainReadProxy,
@@ -140,7 +140,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         hash: &Blake2bHash,
         include_body: bool,
         txn_option: Option<&Transaction>,
-    ) -> Option<Block> {
+    ) -> Result<Block, BlockchainError> {
         gen_blockchain_match!(
             self,
             BlockchainReadProxy,
@@ -158,7 +158,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         include_body: bool,
         direction: nimiq_blockchain::Direction,
         txn_option: Option<&Transaction>,
-    ) -> Vec<Block> {
+    ) -> Result<Vec<Block>, BlockchainError> {
         gen_blockchain_match!(
             self,
             BlockchainReadProxy,
@@ -176,7 +176,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         hash: &Blake2bHash,
         include_body: bool,
         txn_option: Option<&Transaction>,
-    ) -> Option<ChainInfo> {
+    ) -> Result<ChainInfo, BlockchainError> {
         gen_blockchain_match!(
             self,
             BlockchainReadProxy,
@@ -192,7 +192,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         block_number: u32,
         offset: u32,
         txn_option: Option<&Transaction>,
-    ) -> Option<(Validator, u16)> {
+    ) -> Result<(Validator, u16), BlockchainError> {
         gen_blockchain_match!(
             self,
             BlockchainReadProxy,
@@ -211,7 +211,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         direction: Direction,
         election_blocks_only: bool,
         txn_option: Option<&Transaction>,
-    ) -> Option<Vec<Block>> {
+    ) -> Result<Vec<Block>, BlockchainError> {
         gen_blockchain_match!(
             self,
             BlockchainReadProxy,

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -51,7 +51,7 @@ impl Blockchain {
         if this
             .chain_store
             .get_chain_info(&macro_block.hash(), false, Some(&read_txn))
-            .is_some()
+            .is_ok()
         {
             return Ok(PushResult::Known);
         }

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -28,7 +28,7 @@ impl Blockchain {
         let predecessor = self
             .get_chain_info(block.parent_hash(), false, Some(txn))
             .map(|info| info.head)
-            .ok_or(PushError::Orphan)?;
+            .map_err(|_| PushError::Orphan)?;
 
         // Verify that the block is a valid immediate successor to its predecessor.
         block.verify_immediate_successor(&predecessor)?;
@@ -53,8 +53,8 @@ impl Blockchain {
 
             let (proposer_slot, _) = self
                 .get_slot_owner_at(block.block_number(), offset, Some(txn))
-                .ok_or_else(|| {
-                    warn!(%block, reason = "failed to determine block proposer", "Rejecting block");
+                .map_err(|error| {
+                    warn!(%error, %block, reason = "failed to determine block proposer", "Rejecting block");
                     PushError::Orphan
                 })?;
 

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -7,9 +7,9 @@ use nimiq_primitives::policy::Policy;
 #[cfg(feature = "metrics")]
 use std::sync::Arc;
 
-use crate::blockchain_state::BlockchainState;
 #[cfg(feature = "metrics")]
 use crate::chain_metrics::BlockchainMetrics;
+use crate::{blockchain_state::BlockchainState, BlockchainError};
 use crate::{AbstractBlockchain, Blockchain, Direction};
 use nimiq_trie::key_nibbles::KeyNibbles;
 
@@ -27,7 +27,7 @@ impl Blockchain {
         count: u32,
         include_body: bool,
         direction: Direction,
-    ) -> Vec<Block> {
+    ) -> Result<Vec<Block>, BlockchainError> {
         self.chain_store
             .get_blocks(start_block_hash, count, include_body, direction, None)
     }

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -49,6 +49,16 @@ pub enum BlockchainError {
     InconsistentState,
     #[error("No network for: {:?}", _0)]
     NoNetwork(NetworkId),
+    #[error("Block not found")]
+    BlockNotFound,
+    #[error("Block body not found")]
+    BlockBodyNotFound,
+    #[error("Block is not a macro block")]
+    BlockIsNotMacro,
+    #[error("No validators found")]
+    NoValidatorsFound,
+    #[error("Invalid epoch ID")]
+    InvalidEpoch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -107,12 +107,7 @@ impl<TNetwork: Network + 'static> Future for HeadRequests<TNetwork> {
             // If we got a result, check it and classify it as known block/unknown block.
             match result {
                 Ok(hash) => {
-                    if self
-                        .blockchain
-                        .read()
-                        .get_block(&hash, false, None)
-                        .is_some()
-                    {
+                    if self.blockchain.read().get_block(&hash, false, None).is_ok() {
                         self.num_known_blocks += 1;
                     } else {
                         // Request unknown blocks from peer that gave it to us.

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -286,7 +286,7 @@ mod tests {
                 .chain_store
                 .get_chain_info(&to.read().head_hash(), false, None);
         let mut block_hash = match chain_info {
-            Some(chain_info) if chain_info.on_main_chain => chain_info.main_chain_successor,
+            Ok(chain_info) if chain_info.on_main_chain => chain_info.main_chain_successor,
             _ => panic!("Chains have diverged"),
         };
 

--- a/consensus/tests/syncer.rs
+++ b/consensus/tests/syncer.rs
@@ -654,12 +654,15 @@ async fn request_missing_blocks_across_macro_block() {
         .read()
         .get_block(&target_block_hash, true, None)
         .unwrap();
-    let mut blocks = blockchain2.read().get_blocks(
-        &target_block_hash,
-        macro_head.block_number() - 2,
-        true,
-        Direction::Backward,
-    );
+    let mut blocks = blockchain2
+        .read()
+        .get_blocks(
+            &target_block_hash,
+            macro_head.block_number() - 2,
+            true,
+            Direction::Backward,
+        )
+        .unwrap();
     blocks.reverse();
     blocks.push(target_block);
     missing_blocks_request_tx.send(blocks).unwrap();

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -17,14 +17,14 @@ impl LightBlockchain {
         block: Block,
     ) -> Result<PushResult, PushError> {
         // Check if we already know this block.
-        if this.get_chain_info(&block.hash(), false, None).is_some() {
+        if this.get_chain_info(&block.hash(), false, None).is_ok() {
             return Ok(PushResult::Known);
         }
 
         // Check if we have this block's parent.
         let prev_info = this
             .get_chain_info(block.parent_hash(), false, None)
-            .ok_or(PushError::Orphan)?;
+            .map_err(|_| PushError::Orphan)?;
 
         // Calculate chain ordering.
         let chain_order = ChainOrdering::order_chains(this.deref(), &block, &prev_info, None);

--- a/light-blockchain/src/verify.rs
+++ b/light-blockchain/src/verify.rs
@@ -20,7 +20,7 @@ impl LightBlockchain {
         // Get the block.
         let block = self
             .get_block(&block_hash, false, None)
-            .ok_or(NanoError::MissingBlock)?;
+            .map_err(|_| NanoError::MissingBlock)?;
 
         // Verify the account proof.
         if !account_proof.verify(block.state_root()) {
@@ -40,7 +40,7 @@ impl LightBlockchain {
         // Get the block.
         let block = self
             .get_block(&block_hash, false, None)
-            .ok_or(NanoError::MissingBlock)?;
+            .map_err(|_| NanoError::MissingBlock)?;
 
         // Verify the History Tree proof.
         if !tx_proof

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -254,11 +254,11 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         );
 
         match proposer_slot {
-            Some(slot) => slot.band == self.validator_slot_band,
-            None => {
+            Ok(slot) => slot.band == self.validator_slot_band,
+            Err(error) => {
                 // The only scenario where this could potentially fail is if the macro block that
                 // precedes self.block_number is pruned while we're initializing ProduceMicroBlock.
-                warn!("Failed to find next proposer");
+                warn!(%error, "Failed to find next proposer");
                 false
             }
         }

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -277,7 +277,7 @@ async fn validator_can_catch_up() {
     // Wait for the new block producer to create a blockchainEvent (which is always an extended event for block 1) and keep the hash
     if let Some(BlockchainEvent::Extended(hash)) = events.next().await {
         // retrieve the block for height 1
-        if let Some(block) = blockchain.read().get_block_at(1, false, None) {
+        if let Ok(block) = blockchain.read().get_block_at(1, false, None) {
             // the hash needs to be the one the extended event returned.
             // (the chain itself i.e blockchain.header_hash() might have already progressed further)
             assert_eq!(block.header().hash(), hash);

--- a/zkp-component/src/proof_utils.rs
+++ b/zkp-component/src/proof_utils.rs
@@ -57,7 +57,7 @@ pub(crate) fn get_proof_macro_blocks(
         let new_block = blockchain
             .read()
             .get_block_at(block_number, true, None)
-            .ok_or(Error::InvalidBlock)?;
+            .map_err(|_| Error::InvalidBlock)?;
 
         if !new_block.is_election() {
             return Err(Error::InvalidBlock);

--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -541,6 +541,7 @@ impl Handle<RequestZKPResponse, Arc<ZKPStateEnvironment>> for RequestZKP {
             env.blockchain
                 .read()
                 .get_block_at(latest_block_number, true, None)
+                .ok()
                 .map(|block| block.unwrap_macro())
         } else {
             None

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -64,7 +64,7 @@ impl<N: Network> ZKProver<N> {
             let result = match event {
                 BlockchainEvent::EpochFinalized(hash) => {
                     let block = blockchain2.read().get_block(&hash, true, None);
-                    if let Some(Block::Macro(block)) = block {
+                    if let Ok(Block::Macro(block)) = block {
                         Some(block)
                     } else {
                         None


### PR DESCRIPTION
Use `Result` as the return value of some functions instead of just returning `Option`. This applies to the following functions of the `AbstractBlockchain` trait:
- get_block_at
- get_block
- get_blocks
- get_chain_info
- get_slot_owner_at
- get_macro_blocks

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.