### PR TITLE
light-blockchain: Check block bodies for macro blocks

### DIFF
--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -48,6 +48,18 @@ impl LightBlockchain {
             .get_slot_owner_at(block.block_number(), offset, None)
             .expect("Failed to find slot owner!");
 
+        // We expect full blocks (with body) for macro blocks and no body for micro blocks.
+        if block.is_macro() {
+            block
+                .body()
+                .ok_or(PushError::InvalidBlock(BlockError::MissingBody))?;
+        } else {
+            assert!(
+                block.body().is_none(),
+                "Light blockchain expects micro blocks without body"
+            )
+        }
+
         // Perform block intrinsic checks.
         block.verify(false)?;
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -568,15 +568,11 @@ impl<TNetwork: Network, TValidatorNetwork: ValidatorNetwork>
                 "Failed to publish block"
             );
         }
-        // Empty body before publishing to the block header topic
+        // Empty body for Micro blocks before publishing to the block header topic
+        // Macro blocks must be always sent with body
         match block {
             Block::Micro(ref mut micro_block) => micro_block.body = None,
-            Block::Macro(ref mut macro_block) => {
-                // Macro blocks must be always sent with body
-                if !macro_block.is_election_block() {
-                    macro_block.body = None
-                }
-            }
+            Block::Macro(_) => {}
         }
         if let Err(e) = network.publish::<BlockHeaderTopic>(block.clone()).await {
             warn!(


### PR DESCRIPTION
- Check that macro blocks (not only election blocks) have a valid body for `LightBlockchain`.
- Change the block verification in `LightBlockchain`'s `sync` methods to use the new block verification functions.
- Change the `validator` code to publish block bodies also for checkpoint macro blocks.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.