### PR TITLE
Fix problem in light sync

### DIFF
--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -87,13 +87,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                         }
                     }
                 }
-                OutdatedProof { block_height } => {
-                    if block_height < self.blockchain.read().block_number() {
-                        // The peer is behind us, so we emit it
-                        return Poll::Ready(Some(MacroSyncReturn::Outdated(peer_id)));
-                    }
-
-                    // If the peer has the same ZKP level as us, then we request epoch ids from this peer
+                OutdatedProof { block_height: _ } => {
+                    // We need to request epoch ids from this peer to know if it is outdated or not
                     let future = Self::request_epoch_ids(
                         Arc::clone(&self.blockchain),
                         Arc::clone(&self.network),

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -159,13 +159,11 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Stream for Syncer<N, M
         while let Poll::Ready(result) = self.macro_sync.poll_next_unpin(cx) {
             match result {
                 Some(MacroSyncReturn::Good(peer_id)) => {
+                    debug!(%peer_id, "Macro sync returned good peer");
                     self.move_peer_into_live_sync(peer_id);
                 }
                 Some(MacroSyncReturn::Outdated(peer_id)) => {
-                    debug!(
-                        "History sync returned outdated peer {:?}. Waiting.",
-                        peer_id
-                    );
+                    debug!(%peer_id,"Macro sync returned outdated peer. Waiting.");
                     self.outdated_timeouts.insert(peer_id, Instant::now());
                     self.outdated_peers.insert(peer_id);
                 }


### PR DESCRIPTION
The only way to know if a peer is outdated is to request the epoch ids from that peer, because it could be the case that there is no prover node and a peer will always give us an outdated proof.
Fixed some misleading logs

