### PR TITLE
consensus: Change requests to always request macro bodies

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -1,14 +1,14 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use nimiq_blockchain_proxy::BlockchainProxy;
+use tokio::sync::broadcast::Sender as BroadcastSender;
+use tokio_stream::wrappers::BroadcastStream;
 
+use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_mempool::mempool::{ControlTransactionTopic, TransactionTopic};
 use nimiq_network_interface::network::Network;
 use nimiq_primitives::account::AccountType;
 use nimiq_transaction::Transaction;
-use tokio::sync::broadcast::Sender as BroadcastSender;
-use tokio_stream::wrappers::BroadcastStream;
 
 use crate::ConsensusEvent;
 

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -174,8 +174,44 @@ impl Handle<ResponseBlocks, BlockchainProxy> for RequestMissingBlocks {
         let mut blocks = Vec::new();
         let mut block_hash = self.target_hash.clone();
         while !locators.contains(&block_hash) {
-            let block = blockchain.get_block(&block_hash, self.include_body, None);
+            let block = blockchain.get_block(&block_hash, false, None);
             if let Ok(block) = block {
+                let block = match block {
+                    // Macro bodies are always needed
+                    Block::Macro(_) => match blockchain.get_block(&block_hash, true, None) {
+                        Ok(block) => block,
+                        Err(error) => {
+                            debug!(
+                                %error,
+                                blocks_found = blocks.len(),
+                                block_hash = %block_hash,
+                                "ResponseBlocks - Failed to get macro block",
+                            );
+                            return ResponseBlocks { blocks: None };
+                        }
+                    },
+                    // Micro bodies are requested based on `include_micro_bodies`
+                    Block::Micro(_) => {
+                        if self.include_micro_bodies {
+                            match blockchain.get_block(&block_hash, true, None) {
+                                Ok(block) => block,
+                                Err(error) => {
+                                    debug!(
+                                        %error,
+                                        include_body = self.include_micro_bodies,
+                                        blocks_found = blocks.len(),
+                                        block_hash = %block_hash,
+                                        "ResponseBlocks - Failed to get micro block",
+                                    );
+                                    return ResponseBlocks { blocks: None };
+                                }
+                            }
+                        } else {
+                            // Micro bodies are not requested, so we can return the already block obtained
+                            block
+                        }
+                    }
+                };
                 let is_macro = block.is_macro();
 
                 block_hash = block.parent_hash().clone();
@@ -188,9 +224,9 @@ impl Handle<ResponseBlocks, BlockchainProxy> for RequestMissingBlocks {
                 // This can only happen if the target hash is unknown or after the chain was pruned.
                 // TODO Return the blocks we found instead of failing here?
                 debug!(
-                    "ResponseBlocks - unknown target block/predecessor {} ({} blocks found)",
-                    block_hash,
-                    blocks.len(),
+                    blocks_found = blocks.len(),
+                    unknown_block_hash = %block_hash,
+                    "ResponseBlocks - unknown target block/predecessor",
                 );
                 return ResponseBlocks { blocks: None };
             }

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -140,7 +140,7 @@ pub struct HistoryChunk {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestBlock {
     pub hash: Blake2bHash,
-    pub include_body: bool,
+    pub include_micro_bodies: bool,
 }
 
 impl RequestCommon for RequestBlock {

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -177,7 +177,7 @@ impl Debug for ResponseBlocks {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestMissingBlocks {
     pub target_hash: Blake2bHash,
-    pub include_body: bool,
+    pub include_micro_bodies: bool,
     #[beserial(len_type(u16, limit = 128))]
     pub locators: Vec<Blake2bHash>,
 }

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -5,11 +5,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use thiserror::Error;
-
 use futures::{FutureExt, Stream, StreamExt};
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
+use thiserror::Error;
 
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::{
@@ -21,8 +20,10 @@ use nimiq_network_interface::{network::Network, request::RequestError};
 use nimiq_primitives::{policy::Policy, slots::Validators};
 use nimiq_utils::math::CeilingDiv;
 
-use crate::messages::{BatchSetInfo, HistoryChunk, RequestBatchSet, RequestHistoryChunk};
-use crate::sync::sync_queue::{SyncQueue, SyncQueuePeer};
+use crate::{
+    messages::{BatchSetInfo, HistoryChunk, RequestBatchSet, RequestHistoryChunk},
+    sync::sync_queue::{SyncQueue, SyncQueuePeer},
+};
 
 /// Error enumeration for history sync request
 #[derive(Clone, Debug, Error, Eq, PartialEq)]

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -1,9 +1,9 @@
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
-use parking_lot::RwLock;
-
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::task::Waker;
+
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
+use parking_lot::RwLock;
 
 use nimiq_block::Block;
 use nimiq_hash::Blake2bHash;

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -1,7 +1,7 @@
+use std::sync::Arc;
+
 use futures::FutureExt;
 use parking_lot::RwLock;
-
-use std::sync::Arc;
 
 use nimiq_block::Block;
 use nimiq_blockchain::AbstractBlockchain;
@@ -21,10 +21,10 @@ use nimiq_zkp_component::{
 };
 
 use crate::messages::{MacroChain, RequestBlock, RequestMacroChain};
-use crate::sync::light::sync::EpochIds;
-use crate::sync::light::LightMacroSync;
-
-use super::sync::PeerMacroRequests;
+use crate::sync::light::{
+    sync::{EpochIds, PeerMacroRequests},
+    LightMacroSync,
+};
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
     pub(crate) async fn request_zkps(
@@ -208,7 +208,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             self.block_headers.push(
                 async move {
                     (
-                        Self::request_block(network, peer_id, block_hash).await,
+                        Self::request_macro_block(network, peer_id, block_hash).await,
                         peer_id,
                     )
                 }
@@ -225,7 +225,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             self.block_headers.push(
                 async move {
                     (
-                        Self::request_block(network, peer_id, block_hash).await,
+                        Self::request_macro_block(network, peer_id, block_hash).await,
                         peer_id,
                     )
                 }
@@ -238,7 +238,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         None
     }
 
-    pub async fn request_block(
+    pub async fn request_macro_block(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,
         hash: Blake2bHash,
@@ -248,7 +248,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             .request::<RequestBlock>(
                 RequestBlock {
                     hash,
-                    include_body: true,
+                    include_micro_bodies: false,
                 },
                 peer_id,
             )

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -1,8 +1,8 @@
-use futures::{FutureExt, Stream, StreamExt};
-
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+
+use futures::{FutureExt, Stream, StreamExt};
 
 use nimiq_blockchain::AbstractBlockchain;
 use nimiq_light_blockchain::LightBlockchain;
@@ -10,9 +10,10 @@ use nimiq_macros::store_waker;
 use nimiq_network_interface::network::{Network, NetworkEvent};
 use nimiq_zkp_component::types::ZKPRequestEvent::{OutdatedProof, Proof};
 
-use crate::sync::syncer::{MacroSync, MacroSyncReturn};
-
-use super::LightMacroSync;
+use crate::sync::{
+    light::LightMacroSync,
+    syncer::{MacroSync, MacroSyncReturn},
+};
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
     // This function is the one that starts the LightMacroSync process,

--- a/consensus/src/sync/live/block_live_sync.rs
+++ b/consensus/src/sync/live/block_live_sync.rs
@@ -131,7 +131,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockLiveSync<N, TReq> {
             let blockchain1 = this.blockchain.clone();
             let bls_cache1 = Arc::clone(this.bls_cache);
             let network1 = Arc::clone(this.network);
-            let include_body = this.block_queue.includes_body();
+            let include_micro_bodies = this.block_queue.includes_micro_bodies();
 
             let is_head = matches!(queued_block, QueuedBlock::Head(..));
             match queued_block {
@@ -168,7 +168,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockLiveSync<N, TReq> {
                         };
 
                         if let Some(id) = pubsub_id {
-                            if include_body {
+                            if include_micro_bodies {
                                 network1.validate_message::<BlockTopic>(id, acceptance);
                             } else {
                                 network1.validate_message::<BlockHeaderTopic>(id, acceptance);

--- a/consensus/src/sync/live/block_live_sync.rs
+++ b/consensus/src/sync/live/block_live_sync.rs
@@ -1,8 +1,13 @@
-use crate::sync::live::block_queue::{BlockHeaderTopic, BlockQueue, BlockTopic, QueuedBlock};
-use crate::sync::live::request_component::RequestComponent;
-use crate::sync::syncer::{LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent};
-use futures::future::BoxFuture;
-use futures::{FutureExt, Stream, StreamExt};
+use std::collections::{HashSet, VecDeque};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
+use parking_lot::Mutex;
+use pin_project::pin_project;
+use tokio::task::spawn_blocking;
+
 use nimiq_block::Block;
 use nimiq_blockchain::{Blockchain, PushError, PushResult};
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -10,13 +15,14 @@ use nimiq_bls::cache::PublicKeyCache;
 use nimiq_hash::Blake2bHash;
 use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{MsgAcceptance, Network};
-use parking_lot::Mutex;
-use pin_project::pin_project;
-use std::collections::{HashSet, VecDeque};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{ready, Context, Poll};
-use tokio::task::spawn_blocking;
+
+use crate::sync::{
+    live::{
+        block_queue::{BlockHeaderTopic, BlockQueue, BlockTopic, QueuedBlock},
+        request_component::RequestComponent,
+    },
+    syncer::{LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
+};
 
 enum PushOpResult {
     Head(Result<PushResult, PushError>, Blake2bHash),

--- a/consensus/src/sync/live/block_queue.rs
+++ b/consensus/src/sync/live/block_queue.rs
@@ -8,7 +8,6 @@ use std::{
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 
-use crate::sync::live::request_component::RequestComponentEvent;
 use nimiq_block::Block;
 use nimiq_blockchain::{AbstractBlockchain, Direction};
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -16,7 +15,7 @@ use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId, Topic};
 use nimiq_primitives::policy::Policy;
 
-use super::request_component::RequestComponent;
+use crate::sync::live::request_component::{RequestComponent, RequestComponentEvent};
 
 #[derive(Clone, Debug, Default)]
 pub struct BlockTopic;

--- a/consensus/src/sync/live/block_queue.rs
+++ b/consensus/src/sync/live/block_queue.rs
@@ -55,8 +55,8 @@ pub struct BlockQueueConfig {
     /// How many blocks back into the past we tolerate without returning a peer as Outdated.
     pub tolerate_past_max: u32,
 
-    /// Flag to indicate if blocks should carry a body
-    pub include_body: bool,
+    /// Flag to indicate if micro blocks should carry a body
+    pub include_micro_bodies: bool,
 }
 
 impl Default for BlockQueueConfig {
@@ -65,7 +65,7 @@ impl Default for BlockQueueConfig {
             buffer_max: 4 * Policy::blocks_per_batch() as usize,
             window_ahead_max: 2 * Policy::blocks_per_batch(),
             tolerate_past_max: Policy::blocks_per_batch(),
-            include_body: true,
+            include_micro_bodies: true,
         }
     }
 }
@@ -348,7 +348,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockQueue<N, TReq> {
                     invalid_blocks.insert(hash.clone());
 
                     if let Some(id) = pubsub_id {
-                        if self.config.include_body {
+                        if self.config.include_micro_bodies {
                             self.network
                                 .validate_message::<BlockTopic>(id.clone(), MsgAcceptance::Reject);
                         } else {
@@ -378,7 +378,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockQueue<N, TReq> {
             for (_, pubsub_id) in blocks.values() {
                 // Inline `report_validation_result` here, because it solves the borrow issue:
                 if let Some(id) = pubsub_id {
-                    if self.config.include_body {
+                    if self.config.include_micro_bodies {
                         self.network
                             .validate_message::<BlockTopic>(id.clone(), MsgAcceptance::Ignore);
                     } else {
@@ -400,7 +400,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockQueue<N, TReq> {
         acceptance: MsgAcceptance,
     ) {
         if let Some(id) = pubsub_id {
-            if self.config.include_body {
+            if self.config.include_micro_bodies {
                 self.network.validate_message::<BlockTopic>(id, acceptance);
             } else {
                 self.network
@@ -449,7 +449,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockQueue<N, TReq> {
         request_component: TReq,
         config: BlockQueueConfig,
     ) -> Self {
-        let block_stream = if config.include_body {
+        let block_stream = if config.include_micro_bodies {
             network.subscribe::<BlockTopic>().await.unwrap().boxed()
         } else {
             network
@@ -509,8 +509,8 @@ impl<N: Network, TReq: RequestComponent<N>> BlockQueue<N, TReq> {
         self.request_component.num_peers()
     }
 
-    pub fn includes_body(&self) -> bool {
-        self.config.include_body
+    pub fn includes_micro_bodies(&self) -> bool {
+        self.config.include_micro_bodies
     }
 
     pub fn peers(&self) -> Vec<N::PeerId> {

--- a/consensus/src/sync/live/request_component.rs
+++ b/consensus/src/sync/live/request_component.rs
@@ -12,8 +12,7 @@ use nimiq_network_interface::{
     request::RequestError,
 };
 
-use crate::messages::RequestMissingBlocks;
-use crate::sync::sync_queue::SyncQueue;
+use crate::{messages::RequestMissingBlocks, sync::sync_queue::SyncQueue};
 
 pub trait RequestComponent<N: Network>:
     Stream<Item = RequestComponentEvent> + Unpin + Send

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -109,7 +109,7 @@ impl<N: Network> SyncerProxy<N> {
                 );
 
                 let block_queue_config = BlockQueueConfig {
-                    include_body: false,
+                    include_micro_bodies: false,
                     ..Default::default()
                 };
 

--- a/consensus/tests/syncer.rs
+++ b/consensus/tests/syncer.rs
@@ -727,7 +727,7 @@ async fn put_peer_back_into_sync_mode() {
             buffer_max: 10,
             window_ahead_max: 10,
             tolerate_past_max: 100,
-            include_body: true,
+            include_micro_bodies: true,
         },
     );
 


### PR DESCRIPTION
- Change `BlockLiveSync` to always request macro bodies. For this the `include_body` flag is changed to `include_micro_bodies`.
  This affects mainly `RequestMissingBlocks` and its handler since now the handler must detect the type of block being requested and include the body depending on the `include_micro_bodies` flag if the block is a micro block. If the block is a macro block then bodies are always returned.
- Change the `BlockRequest` to always send macro bodies. For that, the `include_micro_bodies` flag was added to the request and the handler only sends micro bodies when set but macro bodies are always sent.


## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.