### PR TITLE
light-blockchain: Use proper error when a block is not found

### DIFF
--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -26,7 +26,7 @@ impl ChainStore {
         let chain_info = self
             .chain_db
             .get(hash)
-            .ok_or(BlockchainError::BlockBodyNotFound)?;
+            .ok_or(BlockchainError::BlockNotFound)?;
         if include_body && chain_info.head.body().is_none() {
             return Err(BlockchainError::BlockBodyNotFound);
         }


### PR DESCRIPTION
Use a proper error when a block is not found getting chain information for `LightBlockchain`.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.