### PR TITLE
Fixing zkp state command and typos on rpc crates

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -33,9 +33,8 @@ use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
 #[cfg(feature = "wallet")]
 use nimiq_wallet::WalletStore;
 
-use nimiq_zkp_component::zkp_component::{
-    ZKPComponent as AbstractZKPComponent, ZKPComponentProxy as AbstractZKPComponentProxy,
-};
+use nimiq_zkp_component::zkp_component::ZKPComponent as AbstractZKPComponent;
+use nimiq_zkp_component::zkp_component::ZKPComponentProxy as AbstractZKPComponentProxy;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 
@@ -77,7 +76,7 @@ pub(crate) struct ClientInner {
     #[cfg(feature = "validator")]
     validator: Option<ValidatorProxy>,
 
-    /// Wallet that stores keypairs for transaction signing
+    /// Wallet that stores key pairs for transaction signing
     #[cfg(feature = "wallet")]
     wallet_store: Arc<WalletStore>,
 

--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -61,6 +61,8 @@ pub fn initialize_rpc_server(
     }
     dispatcher.add(wallet_dispatcher);
 
+    dispatcher.add(ZKPComponentDispatcher::new(client.zkp_component()));
+
     Ok(Server::new(
         Config {
             bind_to: (config.bind_to.unwrap_or_else(default_bind), config.port).into(),

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -46,7 +46,7 @@ enum Command {
     #[clap(name = "tx", flatten)]
     Transaction(TransactionCommand),
 
-    /// Shows local mempool information and pushs tranactions to the mempool.
+    /// Shows local mempool information and push transactions to the mempool.
     #[clap(flatten)]
     Mempool(MempoolCommand),
 
@@ -55,13 +55,13 @@ enum Command {
     Network(NetworkCommand),
 
     /// Shows and modifies validator information.
-    /// Create, signs and send transactions reffering to the local validator.
+    /// Create, signs and send transactions referring to the local validator.
     #[clap(flatten)]
     Validator(ValidatorCommand),
 
     /// Shows the zkp information.
     #[clap(flatten)]
-    ZKPComponent(ZKProverCommand),
+    Zkp(ZKPComponentCommand),
 }
 
 impl Command {
@@ -74,7 +74,7 @@ impl Command {
             Command::Network(command) => command.handle_subcommand(client).await,
             Command::Mempool(command) => command.handle_subcommand(client).await,
             Command::Validator(command) => command.handle_subcommand(client).await,
-            Command::ZKPComponent(command) => command.handle_subcommand(client).await,
+            Command::Zkp(command) => command.handle_subcommand(client).await,
         }
     }
 }

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -116,6 +116,7 @@ pub enum BlockchainCommand {
     /// and that were disabled.
     SlashedSlots {
         /// To retrieve the previously slashed slots instead.
+        #[clap(short, long)]
         previous_slashed: bool,
     },
 

--- a/rpc-client/src/subcommands/mod.rs
+++ b/rpc-client/src/subcommands/mod.rs
@@ -6,7 +6,7 @@ pub use network_subcommands::NetworkCommand;
 pub use policy_subcommands::PolicyCommand;
 pub use transactions_subcommands::TransactionCommand;
 pub use validator_subcommands::ValidatorCommand;
-pub use zkp_component_subcommands::ZKProverCommand;
+pub use zkp_component_subcommands::ZKPComponentCommand;
 
 mod accounts_subcommands;
 mod blockchain_subcommands;

--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -202,16 +202,13 @@ impl HandleSubcommand for PolicyCommand {
             PolicyCommand::MacroBlockAfter { block_number } => {
                 println!(
                     "{:#?}",
-                    client.policy.get_election_block_after(block_number).await?
+                    client.policy.get_macro_block_after(block_number).await?
                 );
             }
             PolicyCommand::MacroBlockBefore { block_number } => {
                 println!(
                     "{:#?}",
-                    client
-                        .policy
-                        .get_election_block_before(block_number)
-                        .await?
+                    client.policy.get_macro_block_before(block_number).await?
                 );
             }
             PolicyCommand::LastMacroBlock { block_number } => {

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -34,9 +34,11 @@ pub enum ValidatorCommand {
     /// prior to this command.
     /// The sender_wallet must be unlocked prior to this command.
     /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
-    /// have a double Option. So we use the following work-around for the signal data:
-    ///  "" = Set the signal data field to None.
-    ///  "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
+    /// have a double Option. This becomes an issue when creating an update_validator transaction.
+    /// Instead we use the following work-around. We define the empty String to be None. So, in
+    /// this situation we have:
+    /// "" = None
+    /// "0x29a4b..." = Some(hash)
     CreateNewValidator {
         /// The fee will be payed from this address. This address must be already unlocked.
         #[clap(long)]
@@ -68,11 +70,11 @@ pub enum ValidatorCommand {
 
     /// Sends a transaction to the network to update this validator. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee and the sender wallet must be unlocked prior to this command.
-    ///  Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
     /// have a double Option. So we use the following work-around for the signal data:
-    ///  null = No change in the signal data field.
-    ///  "" = Change the signal data field to None.
-    ///  "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
+    /// null = No change in the signal data field.
+    /// "" = Change the signal data field to None.
+    /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     UpdateValidator {
         /// The fee will be payed from this address. This wallet must be already unlocked.
         #[clap(long)]
@@ -99,7 +101,7 @@ pub enum ValidatorCommand {
     },
 
     /// Sends a transaction to inactivate this validator. In order to avoid having the validator reactivated soon after
-    /// this transacation takes effect, use the command set-auto-reactivate-validator to make sure the automatic reactivation
+    /// this transaction takes effect, use the command set-auto-reactivate-validator to make sure the automatic reactivation
     /// configuration is turned off.
     /// The sender wallet must be unlocked prior to this command.
     InactivateValidator {
@@ -170,7 +172,7 @@ impl HandleSubcommand for ValidatorCommand {
                     .validator
                     .set_automatic_reactivation(automatic_reactivate)
                     .await?;
-                println!("Auto reacivate set to {}", automatic_reactivate);
+                println!("Auto reactivate set to {}", automatic_reactivate);
             }
 
             ValidatorCommand::CreateNewValidator {

--- a/rpc-client/src/subcommands/zkp_component_subcommands.rs
+++ b/rpc-client/src/subcommands/zkp_component_subcommands.rs
@@ -8,16 +8,16 @@ use crate::Client;
 use super::accounts_subcommands::HandleSubcommand;
 
 #[derive(Debug, Parser)]
-pub enum ZKProverCommand {
+pub enum ZKPComponentCommand {
     /// Returns the current zkp state.
-    ZKPState {},
+    ZkpState {},
 }
 
 #[async_trait]
-impl HandleSubcommand for ZKProverCommand {
+impl HandleSubcommand for ZKPComponentCommand {
     async fn handle_subcommand(self, mut client: Client) -> Result<(), Error> {
         match self {
-            ZKProverCommand::ZKPState {} => {
+            ZKPComponentCommand::ZkpState {} => {
                 println!("{:?}", client.zkp_component.get_zkp_state().await?);
             }
         }

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -905,7 +905,7 @@ pub fn is_of_log_type_and_related_to_addresses(
     addresses: &Vec<Address>,
     log_types: &Vec<LogType>,
 ) -> bool {
-    // If addresses are empty, it tries to find a matchinf log_type and early return. Otherwise, it will finish and return false.
+    // If addresses are empty, it tries to find a matching log_types and early return. Otherwise, it will finish and return false.
     if addresses.is_empty() {
         for log_type in log_types {
             if log_type.eq(&LogType::with_log(log)) {

--- a/rpc-interface/src/zkp_component.rs
+++ b/rpc-interface/src/zkp_component.rs
@@ -1,11 +1,10 @@
+use crate::types::{RPCResult, ZKPState};
 use async_trait::async_trait;
-
-use crate::types::ZKPState;
 
 #[nimiq_jsonrpc_derive::proxy(name = "ZKPComponentProxy", rename_all = "camelCase")]
 #[async_trait]
 pub trait ZKPComponentInterface {
     type Error;
 
-    async fn get_zkp_state(&mut self) -> Result<ZKPState, Self::Error>;
+    async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -640,7 +640,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         let stream = self.subscribe_for_head_block_hash().await?;
 
         // Uses the stream to receive hashes of blocks and then requests the actual block.
-        // If the block was reverted in between these steps, the stream won't emmit any event.
+        // If the block was reverted in between these steps, the stream won't emit any event.
         Ok(stream
             .filter_map(move |rpc_result| {
                 let blockchain_rg = blockchain.read();
@@ -655,7 +655,7 @@ impl BlockchainInterface for BlockchainDispatcher {
             .boxed())
     }
 
-    /// Subscribes to new block events (only retrieves the blockhash).
+    /// Subscribes to new block events (only retrieves the block hash).
     #[stream]
     async fn subscribe_for_head_block_hash(
         &mut self,
@@ -740,7 +740,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                                     )
                                 });
                                 // Since each TransactionLog has its own vec of logs, we iterate over each tx_logs and filter their logs,
-                                // if a tx_log has no logs after filtering, it will be filtered out completly.
+                                // if a tx_log has no logs after filtering, it will be filtered out completely.
                                 let tx_logs: Vec<TransactionLog> = tx_logs
                                     .into_iter()
                                     .filter_map(|mut tx_log| {
@@ -758,7 +758,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                                     .collect();
 
                                 // If this block has no transaction logs or inherent logs of interest, we return None. Otherwise, we return the filtered BlockLog.
-                                // This way the stream only emmits an event if a block has at least one log fulfilling the specified criteria.
+                                // This way the stream only emits an event if a block has at least one log fulfilling the specified criteria.
                                 if !inherent_logs.is_empty() || !tx_logs.is_empty() {
                                     Some(RPCData::new(
                                         BlockLog::AppliedBlock {

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -735,10 +735,10 @@ impl ConsensusInterface for ConsensusDispatcher {
 
     /// Returns a serialized `new_validator` transaction. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee and the validator deposit.
-    ///  Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
     /// have a double Option. So we use the following work-around for the signal data:
-    ///  "" = Set the signal data field to None.
-    ///  "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
+    /// "" = Set the signal data field to None.
+    /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn create_new_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -787,10 +787,10 @@ impl ConsensusInterface for ConsensusDispatcher {
 
     /// Sends a `new_validator` transaction to the network. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee and the validator deposit.
-    ///  Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
     /// have a double Option. So we use the following work-around for the signal data:
-    ///  "" = Set the signal data field to None.
-    ///  "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
+    /// "" = Set the signal data field to None.
+    /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn send_new_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -820,11 +820,11 @@ impl ConsensusInterface for ConsensusDispatcher {
 
     /// Returns a serialized `update_validator` transaction. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
-    ///  Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
     /// have a double Option. So we use the following work-around for the signal data:
-    ///  null = No change in the signal data field.
-    ///  "" = Change the signal data field to None.
-    ///  "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
+    /// null = No change in the signal data field.
+    /// "" = Change the signal data field to None.
+    /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn create_update_validator_transaction(
         &mut self,
         sender_wallet: Address,

--- a/rpc-server/src/dispatchers/zkp_component.rs
+++ b/rpc-server/src/dispatchers/zkp_component.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use nimiq_network_libp2p::Network;
+use nimiq_rpc_interface::types::RPCResult;
 use nimiq_rpc_interface::types::ZKPState;
 use nimiq_rpc_interface::zkp_component::ZKPComponentInterface;
 use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
@@ -23,9 +24,7 @@ impl ZKPComponentInterface for ZKPComponentDispatcher {
     type Error = Error;
 
     /// Returns the peer ID for our local peer.
-    async fn get_zkp_state(&mut self) -> Result<ZKPState, Self::Error> {
-        Ok(ZKPState::with_zkp_state(
-            &self.zkp_component.get_zkp_state(),
-        ))
+    async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error> {
+        Ok(ZKPState::with_zkp_state(&self.zkp_component.get_zkp_state()).into())
     }
 }


### PR DESCRIPTION
## What's in this pull request?
This fixes the rpc commands to get the zkp state and macro block before and before a block height. 
This also fixes some typos across the rpc related crates. 
The comments for the clap documentation of the create and update validator commands were also refined.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.