### PR TITLE
Fix network discovery bug

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -114,7 +114,7 @@ pub fn generate_service_flags(sync_mode: SyncMode) -> (Services, Services) {
         // Services required by full nodes
         crate::config::config::SyncMode::Full => Services::FULL_BLOCKS | Services::ACCOUNTS_CHUNKS,
         // Services required by light nodes
-        crate::config::config::SyncMode::Light => Services::CHAIN_PROOF | Services::ACCOUNTS_PROOF,
+        crate::config::config::SyncMode::Light => Services::ACCOUNTS_PROOF,
     };
     (provided_services, required_services)
 }
@@ -167,13 +167,8 @@ impl ClientInner {
             identity_keypair.public().to_peer_id().to_base58()
         );
 
-        let (mut provided_services, required_services) =
+        let (provided_services, required_services) =
             generate_service_flags(config.consensus.sync_mode);
-
-        // TODO: This flag should be used internally to, apart from announcing the service, properly control the mechanism
-        if config.zkp_propagation {
-            provided_services |= Services::CHAIN_PROOF;
-        }
 
         // Generate my peer contact from identity keypair and my provided services
         let mut peer_contact = PeerContact::new(

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -760,7 +760,6 @@ impl ClientConfigBuilder {
             self.zkp = Some(ZKPConfig {
                 prover_active: zkp_settings.prover_active,
                 setup_keys_path,
-                zkp_propagation: zkp_settings.zkp_propagation,
             });
         }
 
@@ -881,9 +880,6 @@ pub struct ZKPConfig {
 
     /// ZKP prover path for verifying and proving keys.
     pub setup_keys_path: PathBuf,
-
-    /// Flag for enabling the propagation of ZK proofs
-    pub zkp_propagation: bool,
 }
 
 impl Default for ZKPConfig {
@@ -891,7 +887,6 @@ impl Default for ZKPConfig {
         ZKPConfig {
             prover_active: false,
             setup_keys_path: PathBuf::from(".zkp"),
-            zkp_propagation: false,
         }
     }
 }

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -471,6 +471,4 @@ pub struct ZKPSettings {
     pub prover_active: bool,
     #[serde(default)]
     pub setup_keys_path: Option<String>,
-    #[serde(default)]
-    pub zkp_propagation: bool,
 }

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -475,9 +475,11 @@ impl ConnectionHandler for DiscoveryHandler {
                                         self.config.required_services,
                                     );
 
-                                    // Insert the initial set of peer contacts into the peer contact book.
-                                    // TODO: This doesn't actually filter and just assumes the peer already filtered.
-                                    peer_contact_book.insert_all(peer_contacts);
+                                    // Insert the peer's contacts (filtered) into my contact book
+                                    peer_contact_book.insert_all_filtered(
+                                        peer_contacts,
+                                        self.config.required_services,
+                                    );
 
                                     // Store peer contact in handler
                                     self._peer_contact = Some(peer_contact.clone());

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -32,10 +32,6 @@ bitflags! {
         ///
         const HISTORY = 1 << 1;
 
-        /// The node provides the ZKP for the latest election block
-        ///
-        const CHAIN_PROOF = 1 << 2;
-
         /// The node provides inclusion and exclusion proofs for accounts that are necessary to verify active accounts as
         /// well as accounts in all transactions it provided from its mempool.
         ///

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -186,7 +186,7 @@ pub struct Network {
     ///  we store a some value with the peer contact itself
     /// Otherwise,
     ///  we just store a None value
-    connected_peers: Arc<RwLock<HashMap<PeerId, Option<PeerContact>>>>,
+    connected_peers: Arc<RwLock<HashMap<PeerId, PeerContact>>>,
     /// Stream used to send event messages
     events_tx: broadcast::Sender<NetworkEvent<PeerId>>,
     /// Stream used to send action messages
@@ -330,7 +330,7 @@ impl Network {
         events_tx: broadcast::Sender<NetworkEvent<PeerId>>,
         mut action_rx: mpsc::Receiver<NetworkAction>,
         mut validate_rx: mpsc::UnboundedReceiver<ValidateMessage<PeerId>>,
-        connected_peers: Arc<RwLock<HashMap<PeerId, Option<PeerContact>>>>,
+        connected_peers: Arc<RwLock<HashMap<PeerId, PeerContact>>>,
         peer_request_limits: Arc<Mutex<HashMap<PeerId, HashMap<u16, RateLimit>>>>,
         rate_limits_pending_deletion: Arc<Mutex<VecDeque<((PeerId, u16), TokioInstant)>>>,
         #[cfg(feature = "metrics")] metrics: Arc<NetworkMetrics>,
@@ -388,7 +388,7 @@ impl Network {
         events_tx: &broadcast::Sender<NetworkEvent<PeerId>>,
         swarm: &mut NimiqSwarm,
         state: &mut TaskState,
-        connected_peers: &RwLock<HashMap<PeerId, Option<PeerContact>>>,
+        connected_peers: &RwLock<HashMap<PeerId, PeerContact>>,
         peer_request_limits: Arc<Mutex<HashMap<PeerId, HashMap<u16, RateLimit>>>>,
         rate_limits_pending_deletion: Arc<Mutex<VecDeque<((PeerId, u16), TokioInstant)>>>,
         #[cfg(feature = "metrics")] metrics: &Arc<NetworkMetrics>,
@@ -1540,7 +1540,7 @@ impl NetworkInterface for Network {
     }
 
     fn peer_provides_required_services(&self, peer_id: PeerId) -> bool {
-        if let Some(Some(contact)) = self.connected_peers.read().get(&peer_id) {
+        if let Some(contact) = self.connected_peers.read().get(&peer_id) {
             contact.services.contains(self.required_services)
         } else {
             // If we dont know the peer we return false

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -153,10 +153,7 @@ pub async fn test_exchanging_peers() {
     let mut node2_peer_contacts = vec![
         random_peer_contact(13, Services::FULL_BLOCKS),
         random_peer_contact(14, Services::FULL_BLOCKS | Services::HISTORY),
-        random_peer_contact(
-            15,
-            Services::FULL_BLOCKS | Services::CHAIN_PROOF | Services::ACCOUNTS_PROOF,
-        ),
+        random_peer_contact(15, Services::FULL_BLOCKS | Services::ACCOUNTS_PROOF),
     ];
 
     // insert peers into node's contact books


### PR DESCRIPTION
- Peers were addded being added to the contact book regardless of the services flags
- Removed no longer needed ChainProof service flag, since all nodes distribute ZKP proofs
