### PR TITLE
Fix several clippy warnings

### DIFF
--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -29,7 +29,7 @@ impl BitSet {
     }
 
     pub fn with_capacity(nbits: usize) -> Self {
-        let nblocks = (nbits >> 6) + if nbits.trailing_zeros() >= 6 { 0 } else { 1 };
+        let nblocks = (nbits >> 6) + usize::from(nbits.trailing_zeros() < 6);
         Self {
             store: Vec::with_capacity(nblocks),
             count: 0,

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -122,7 +122,7 @@ impl ClientInner {
     async fn from_config(config: ClientConfig) -> Result<Client, Error> {
         // Get network info (i.e. which specific blockchain we're on)
         if !config.network_id.is_albatross() {
-            return Err(Error::config_error(&format!(
+            return Err(Error::config_error(format!(
                 "{} is not compatible with Albatross",
                 config.network_id
             )));

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -303,7 +303,7 @@ impl StorageConfig {
                     })?
                     .to_string();
                 MdbxEnvironment::new_with_max_readers(
-                    &db_path,
+                    db_path,
                     db_config.size,
                     db_config.max_dbs,
                     db_config.max_readers,

--- a/nano-zkp/src/nano_zkp/setup.rs
+++ b/nano-zkp/src/nano_zkp/setup.rs
@@ -64,8 +64,8 @@ impl NanoZKP {
         let proving_keys = path.join("proving_keys");
 
         for i in 0..5 {
-            if !verifying_keys.join(&format!("pk_tree_{}.bin", i)).exists()
-                || (prover_active && !proving_keys.join(&format!("pk_tree_{}.bin", i)).exists())
+            if !verifying_keys.join(format!("pk_tree_{}.bin", i)).exists()
+                || (prover_active && !proving_keys.join(format!("pk_tree_{}.bin", i)).exists())
             {
                 return false;
             }

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -439,7 +439,7 @@ mod serde_public_key {
     {
         let hex_encoded: String = Deserialize::deserialize(deserializer)?;
 
-        let raw = hex::decode(&hex_encoded).map_err(D::Error::custom)?;
+        let raw = hex::decode(hex_encoded).map_err(D::Error::custom)?;
 
         beserial::Deserialize::deserialize_from_vec(&raw).map_err(D::Error::custom)
     }

--- a/primitives/trie/src/key_nibbles.rs
+++ b/primitives/trie/src/key_nibbles.rs
@@ -326,7 +326,7 @@ impl Serialize for KeyNibbles {
     fn serialize<W: WriteBytesExt>(&self, writer: &mut W) -> Result<usize, SerializingError> {
         let mut size = 2;
         writer.write_u8(self.length)?;
-        writer.write_u8(self.bytes_length as u8)?;
+        writer.write_u8(self.bytes_length)?;
         size += writer.write(&self.bytes[..self.bytes_length as usize])?;
         Ok(size)
     }

--- a/primitives/trie/src/trie_node.rs
+++ b/primitives/trie/src/trie_node.rs
@@ -268,7 +268,7 @@ impl<A: Serialize + Deserialize + Clone> Serialize for TrieNode<A> {
             TrieNode::BranchNode { ref children, .. } => {
                 let child_count: u8 = children
                     .iter()
-                    .fold(0, |acc, child| acc + if child.is_none() { 0 } else { 1 });
+                    .fold(0, |acc, child| acc + u8::from(!child.is_none()));
                 Serialize::serialize(&child_count, writer)?;
 
                 for child in children.iter().flatten() {

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -64,7 +64,7 @@ impl ConsensusDispatcher {
 }
 
 fn transaction_to_hex_string(transaction: &Transaction) -> String {
-    hex::encode(&transaction.serialize_to_vec())
+    hex::encode(transaction.serialize_to_vec())
 }
 
 #[nimiq_jsonrpc_derive::service(rename_all = "camelCase")]
@@ -82,7 +82,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         &mut self,
         raw_tx: String,
     ) -> RPCResult<RPCTransaction, (), Self::Error> {
-        let transaction: Transaction = Deserialize::deserialize_from_vec(&hex::decode(&raw_tx)?)?;
+        let transaction: Transaction = Deserialize::deserialize_from_vec(&hex::decode(raw_tx)?)?;
         Ok(RPCTransaction::from_transaction(transaction).into())
     }
 
@@ -544,7 +544,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             self.get_network_id(),
         )?;
 
-        Ok(hex::encode(&sig.serialize_to_vec()).into())
+        Ok(hex::encode(sig.serialize_to_vec()).into())
     }
 
     /// Returns a serialized `new_staker` transaction. You need to provide the address of a basic

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -46,7 +46,7 @@ impl WalletInterface for WalletDispatcher {
     ) -> RPCResult<Address, (), Self::Error> {
         let passphrase = passphrase.unwrap_or_default();
 
-        let private_key: PrivateKey = Deserialize::deserialize_from_vec(&hex::decode(&key_data)?)?;
+        let private_key: PrivateKey = Deserialize::deserialize_from_vec(&hex::decode(key_data)?)?;
 
         let wallet_account = WalletAccount::from(KeyPair::from(private_key));
 

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -118,7 +118,7 @@ fn run_app() -> Result<(), Error> {
         let key_pair: KeyPair = PrivateKey::deserialize_from_vec(&raw_secret_key)?.into();
         let signature = key_pair.sign(tx.serialize_content().as_slice());
         let raw_signature = signature.serialize_to_vec();
-        println!("{}", hex::encode(&raw_signature));
+        println!("{}", hex::encode(raw_signature));
         Ok(())
     } else {
         Err(AppError::SecretKey.into())

--- a/utils/src/tagged_signing.rs
+++ b/utils/src/tagged_signing.rs
@@ -309,7 +309,7 @@ mod serde_tagged_signature {
         {
             let hex_encoded: String = Deserialize::deserialize(deserializer)?;
 
-            let data = hex::decode(&hex_encoded).map_err(D::Error::custom)?;
+            let data = hex::decode(hex_encoded).map_err(D::Error::custom)?;
 
             Ok(TaggedSignature::from_bytes(data))
         }


### PR DESCRIPTION
Fix several clippy warnings related to:
- Boolean to `int` conversion using `if`.
- Borrowed expression implements the required traits.
- Unnecessary castings.

In the following crates:
- `collections`
- `lib`
- `nano-zkp`
- `network-libp2p`
- `trie` primitives
- `rpc-server`
- `tools`
- `utils`

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.