### PR TITLE
Fix crate compilation for different features

### DIFF
--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -34,6 +34,7 @@ nimiq-utils = { path = "../utils", features = ["key-rng"] }
 nimiq-test-log = { path = "../test-log" }
 
 [features]
+cache = ["lazy"]
 default = ["beserial", "lazy"]
 lazy = ["parking_lot"]
 serde-derive = ["serde", "beserial"]

--- a/bls/src/lib.rs
+++ b/bls/src/lib.rs
@@ -28,4 +28,5 @@ pub mod rand_gen;
 pub type SigHash = Blake2sHash;
 
 // A simple cache implementation for the (un)compressed keys.
+#[cfg(feature = "cache")]
 pub mod cache;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -47,7 +47,7 @@ beserial = { path = "../beserial" }
 nimiq-block = { path = "../primitives/block" }
 nimiq-blockchain = { path = "../blockchain" }
 nimiq-blockchain-proxy = { path = "../blockchain-proxy" }
-nimiq-bls = { path = "../bls", optional = true }
+nimiq-bls = { path = "../bls" }
 nimiq-consensus = { path = "../consensus" }
 nimiq-database = { path = "../database" }
 nimiq-genesis = { path = "../genesis" }
@@ -81,5 +81,5 @@ logging = ["console-subscriber", "nimiq-log", "serde_json", "tokio", "tracing-lo
 metrics-server = ["nimiq-validator/metrics"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
-validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-bls", "nimiq-rpc-server"]
+validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-rpc-server"]
 wallet = ["nimiq-wallet"]

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rpc-server")]
+#[cfg(any(feature = "rpc-server", feature = "metrics-server"))]
 use std::net::IpAddr;
 #[cfg(feature = "metrics-server")]
 use std::net::SocketAddr;

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -28,7 +28,10 @@ pub enum Log {
         from: Address,
         to: Address,
         amount: Coin,
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "serde-derive",
+            serde(skip_serializing_if = "Option::is_none")
+        )]
         data: Option<Vec<u8>>,
     },
 

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -27,7 +27,7 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 beserial = { path = "../../beserial", features = ["derive"] }
-nimiq-bls = { path = "../../bls", features = ["beserial"]}
+nimiq-bls = { path = "../../bls", features = ["beserial", "cache"]}
 nimiq-collections = { path = "../../collections" }
 nimiq-database = { path = "../../database" }
 nimiq-handel = { path = "../../handel" }


### PR DESCRIPTION
Fix crate compilation for different features:
- `bls` with no features.
- `lib` with `metrics-server` feature and without features.
- `account` primitives with no features.

Also move the `PedersenGenerator` implementation of `beserial`'s (de)serialization to the serialization file within the `bls` crate and introduce a `cache` feature to handle properly the `lazy` feature dependency in the cache code.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.