### PR TITLE
Prune tokio features from several crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,7 +3280,6 @@ dependencies = [
  "serde",
  "strum_macros",
  "thiserror",
- "tokio",
  "tracing",
 ]
 

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }
 thiserror = "1.0"
-tokio = { version = "1.23", features = ["full"] }
+tokio = { version = "1.23", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -25,7 +25,7 @@ parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 pin-project = "1.0"
 rand = "0.8"
 thiserror = "1.0"
-tokio = { version = "1.23", features = ["full"] }
+tokio = { version = "1.23", features = ["rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 beserial = { path = "../beserial", features = ["derive"] }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -23,7 +23,7 @@ prometheus-client = { version = "0.18.1", optional = true}
 futures = { package = "futures-util", version = "0.3" }
 keyed_priority_queue = "0.4"
 linked-hash-map = "0.5.6"
-tokio = { version = "1.23", features = ["full", "tracing"] }
+tokio = { version = "1.23", features = ["rt", "sync", "tracing"] }
 tokio-metrics = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = "0.99"
 futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 thiserror = "1.0"
-tokio = { version = "1.23", features = ["macros", "rt", "tracing", "time", "test-util"] }
+tokio = { version = "1.23", features = ["rt"] }
 tokio-stream = { version = "0.1", features = ["default", "sync"] }
 
 beserial = { path = "../beserial", features = ["derive"] }

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -24,12 +24,9 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 thiserror = "1.0"
 tokio = { version = "1.23", features = [
-    "macros",
     "rt",
     "rt-multi-thread",
     "sync",
-    "time",
-    "tracing",
 ] }
 tokio-stream = "0.1"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,7 +29,6 @@ regex = { version = "1.7", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.24"
 thiserror = { version = "1.0.35", optional = true }
-tokio = { version = "1.23", features = ["rt", "time", "tracing"] }
 
 beserial = { path = "../beserial", features = ["derive"] }
 nimiq-bls = { path = "../bls", features = ["beserial"], optional = true }


### PR DESCRIPTION
Prune the required `tokio` features from several crates:
- `blockchain`
- `consensus`
- `mempool`
- `network-interface`
- `network-mock`
- `primitives` (completely removed from this crate)

This to avoid using `tokio` features that don't compile for wasm.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.