### PR TITLE
Add some features to `lib` and `network-libp2p` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,8 +1469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3218,6 +3220,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "futures-util",
+ "getrandom 0.2.6",
  "hex",
  "ip_network",
  "libp2p",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,13 +28,15 @@ package = "nimiq-lib"
 path = "../lib"
 version = "0.1"
 features = [
-    "validator",
-    "rpc-server",
     "deadlock",
+    "dns-tcp",
     "logging",
     "metrics-server",
-    "signal-handling",
-    "wallet",
     "panic",
+    "rpc-server",
+    "signal-handling",
+    "tokio-console",
+    "validator",
+    "wallet",
     "zkp-prover",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4"
 # human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
 log = { package = "tracing", version = "0.1", features = ["log"] }
 log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git", features = ["deadlock_detection"] }
+parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = "0.8"
 rand_chacha = "0.3.1"
 serde = "1.0"
@@ -59,7 +59,7 @@ nimiq-log = { path = "../log", optional = true }
 nimiq-mempool = { path = "../mempool" }
 nimiq-metrics-server = { path = "../metrics-server" }
 nimiq-nano-zkp = { path = "../nano-zkp", features = ["prover"] }
-nimiq-network-libp2p = { path = "../network-libp2p", features = ["metrics"] }
+nimiq-network-libp2p = { path = "../network-libp2p" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-primitives = { path = "../primitives", features = ["networks"] }
 nimiq-rpc-server = { path = "../rpc-server", optional = true }
@@ -73,14 +73,16 @@ nimiq-zkp-component = { path = "../zkp-component" }
 nimiq-test-log = { path = "../test-log" }
 
 [features]
-deadlock = []
+deadlock = ["parking_lot/deadlock_detection"]
 default = []
+dns-tcp = ["nimiq-network-libp2p/dns-tcp"]
 launcher = []
 signal-handling = ["signal-hook", "tokio"]
-logging = ["console-subscriber", "nimiq-log", "serde_json", "tokio", "tracing-loki", "tracing-subscriber"]
-metrics-server = ["nimiq-validator/metrics"]
+logging = ["nimiq-log", "serde_json", "tokio", "tracing-loki", "tracing-subscriber"]
+metrics-server = ["nimiq-validator/metrics", "nimiq-network-libp2p/metrics"]
 panic = ["log-panics"]
 rpc-server = ["validator", "nimiq-rpc-server", "nimiq-wallet"]
+tokio-console = ["console-subscriber", "logging", "tokio"]
 validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-rpc-server"]
 wallet = ["nimiq-wallet"]
 zkp-prover = ["nimiq-zkp-component/prover"]

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs::{self, File};
 use std::io;
-#[cfg(tokio_unstable)]
+#[cfg(all(tokio_unstable, feature = "tokio-console"))]
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
@@ -183,7 +183,7 @@ pub fn initialize_logging(
         (None, None)
     };
 
-    #[cfg(tokio_unstable)]
+    #[cfg(all(tokio_unstable, feature = "tokio-console"))]
     fn initialize_tokio_console<S>(bind_address: &str) -> Option<Box<dyn Layer<S> + Send + Sync>>
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
@@ -198,7 +198,7 @@ pub fn initialize_logging(
                 .spawn(),
         ))
     }
-    #[cfg(not(tokio_unstable))]
+    #[cfg(not(all(tokio_unstable, feature = "tokio-console")))]
     fn initialize_tokio_console<S>(bind_address: &str) -> Option<Box<dyn Layer<S> + Send + Sync>>
     where
         S: Subscriber + for<'a> LookupSpan<'a>,

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -28,11 +28,11 @@ package = "nimiq-lib"
 path = "../lib"
 version = "0.1"
 features = [
-    "rpc-server",
     "deadlock",
     "logging",
     "metrics-server",
+    "panic",
+    "rpc-server",
     "signal-handling",
     "wallet",
-    "panic",
 ]

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -26,14 +26,12 @@ futures = { package = "futures-util", version = "0.3" }
 hex = "0.4"
 ip_network = "0.4"
 libp2p = { version = "0.46", default-features = false, features = [
-    "dns-tokio",
     "gossipsub",
     "identify",
     "kad",
     "noise",
     "ping",
     "request-response",
-    "tcp-tokio",
     "websocket",
     "yamux",
 ] }
@@ -70,5 +68,10 @@ nimiq-test-log = { path = "../test-log" }
 
 [features]
 default = ["peer-contact-book-persistence"]
+dns-tcp = ["libp2p/dns-tokio", "libp2p/tcp-tokio"]
 metrics = ["prometheus-client"]
 peer-contact-book-persistence = ["serde"]
+
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+getrandom = { version = "0.2.3", features = ["js"] }


### PR DESCRIPTION
Add the following features to the `network-libp2p` crate:
- `dns-tcp`: Feature that enables `tokio-dns` and `tokio-tcp` features of `libp2p`. These two features depend on `tokio` and don't compile for wasm. Also change the code to not use these transports when these features are not enabled.
- Include the `js` feature of `getrandom` when the build target is wasm.

And the following features to the `lib` crate:
- `tokio-console`: To enable the Tokio console and pull the `console-subscribe` crate that doesn't compile for wasm.
- `dns-tcp`: Feature to set the `network-libp2p`'s `dns-tcp` feature.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.