### PR TITLE
Removing the path of the main process from the prover process command.

### DIFF
--- a/zkp-component/src/proof_gen_utils.rs
+++ b/zkp-component/src/proof_gen_utils.rs
@@ -80,7 +80,7 @@ pub async fn launch_generate_new_proof(
 
     let mut child = Command::new(path)
         .arg("--prove")
-        .args(env::args())
+        .args(env::args().skip(1))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;


### PR DESCRIPTION
## What's in this pull request?
Fixes the broken pipe error when launching the zk proof generation process. We must skip the first argument of the args array. This way the binary path of the main process is not passed on to the prover process.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.