### PR TITLE
zkp-component: Remove unnecessary mempool dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,7 +3734,6 @@ dependencies = [
  "nimiq-keys",
  "nimiq-log",
  "nimiq-macros",
- "nimiq-mempool",
  "nimiq-nano-primitives",
  "nimiq-nano-zkp",
  "nimiq-network-interface",

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -47,7 +47,6 @@ nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-log = { path = "../log", optional = true }
 nimiq-macros = { path = "../macros" }
-nimiq-mempool = { path = "../mempool" }
 nimiq-nano-primitives = { path = "../nano-primitives" }
 nimiq-nano-zkp = { path = "../nano-zkp"}
 nimiq-network-interface = { path = "../network-interface" }


### PR DESCRIPTION
Remove unnecessary `mempool` dependency from the `zkp-component` crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.