### PR TITLE
Do not care if there is no blockchain notifier listeners.

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -314,30 +314,17 @@ impl Blockchain {
             "Accepted epoch",
         );
 
-        // Notify the mempool about a new history adopted
-        if let Err(e) = this
+        // If there are no listeners we do not log errors
+        _ = this
             .notifier
-            .send(BlockchainEvent::HistoryAdopted(block_hash.clone()))
-        {
-            log::error!(
-                error = ?e,
-                "Error sending the History Adopted event to the events notifier",
-            );
-        }
+            .send(BlockchainEvent::HistoryAdopted(block_hash.clone()));
 
         if is_election_block {
-            if let Err(e) = this
+            _ = this
                 .notifier
-                .send(BlockchainEvent::EpochFinalized(block_hash))
-            {
-                log::error!(error = ?e,
-                    "Error sending the Epoch Finalized event to the events notifier",
-                );
-            }
-        } else if let Err(e) = this.notifier.send(BlockchainEvent::Finalized(block_hash)) {
-            log::error!(
-                error = ?e,"Error sending the Finalized event to the events notifier",
-            );
+                .send(BlockchainEvent::EpochFinalized(block_hash));
+        } else {
+            _ = this.notifier.send(BlockchainEvent::Finalized(block_hash));
         }
 
         // Return result.

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -259,25 +259,15 @@ impl Blockchain {
             "Accepted block",
         );
 
+        // We shouldn't log errors if there are no listeners
         if is_election_block {
-            if let Err(e) = this
+            _ = this
                 .notifier
-                .send(BlockchainEvent::EpochFinalized(block_hash))
-            {
-                log::error!(error = ?e,
-                    "Error sending the Epoch Finalized event to the events notifier",
-                );
-            }
+                .send(BlockchainEvent::EpochFinalized(block_hash));
         } else if is_macro_block {
-            if let Err(e) = this.notifier.send(BlockchainEvent::Finalized(block_hash)) {
-                log::error!(error = ?e,
-                    "Error sending the Finalized event to the events notifier",
-                );
-            }
-        } else if let Err(e) = this.notifier.send(BlockchainEvent::Extended(block_hash)) {
-            log::error!(error = ?e,
-                "Error sending the Extended event to the events notifier",
-            );
+            _ = this.notifier.send(BlockchainEvent::Finalized(block_hash));
+        } else {
+            _ = this.notifier.send(BlockchainEvent::Extended(block_hash));
         }
 
         // The log notifier is for informational purposes only, thus may have no listeners.
@@ -503,14 +493,11 @@ impl Blockchain {
         this.metrics
             .note_rebranch(&reverted_blocks, &adopted_blocks);
 
-        if let Err(e) = this
+        // We do not log errors if there are no listeners
+        _ = this
             .notifier
-            .send(BlockchainEvent::Rebranched(reverted_blocks, adopted_blocks))
-        {
-            log::error!(error = ?e,
-                "Error sending the Rebranched event to the events notifier"
-            );
-        }
+            .send(BlockchainEvent::Rebranched(reverted_blocks, adopted_blocks));
+
         send_vec(&this.log_notifier, block_logs);
 
         Ok(PushResult::Rebranched)


### PR DESCRIPTION
In some clients configuration, there is no mempool or no validator. In those cases, there are no listeners for the blockchain events which is fine, so we should generate those events without logging errors if there is nobody listening to those broadcast channels

