### PR TITLE
blockchain-proxy: Remove the `Blockchain` variant for wasm

### DIFF
--- a/blockchain-proxy/Cargo.toml
+++ b/blockchain-proxy/Cargo.toml
@@ -20,10 +20,12 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 futures = { package = "futures-util", version = "0.3" }
 
 nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
 nimiq-light-blockchain = { path = "../light-blockchain" }
 nimiq-database = { path = "../database" }
 nimiq-genesis = { path = "../genesis" }
 nimiq-hash = { path = "../hash" }
 nimiq-primitives = { path = "../primitives" }
 nimiq-transaction = { path = "../primitives/transaction" }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+nimiq-blockchain = { path = "../blockchain" }

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -54,7 +54,10 @@ impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
             })
             .collect();
 
+        #[cfg(not(target_family = "wasm"))]
         let include_micro_bodies = matches!(blockchain, BlockchainProxy::Full(_));
+        #[cfg(target_family = "wasm")]
+        let include_micro_bodies = false;
 
         HeadRequests {
             peers,

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -134,6 +134,7 @@ impl<N: Network> Consensus<N> {
         let stream = network.receive_requests::<RequestHead>();
         tokio::spawn(request_handler(network, stream, blockchain));
         match blockchain {
+            #[cfg(not(target_family = "wasm"))]
             BlockchainProxy::Full(blockchain) => {
                 let stream = network.receive_requests::<RequestBatchSet>();
                 tokio::spawn(request_handler(network, stream, blockchain));

--- a/consensus/src/sync/live/block_live_sync.rs
+++ b/consensus/src/sync/live/block_live_sync.rs
@@ -149,6 +149,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockLiveSync<N, TReq> {
                             // Update validator keys from BLS public key cache.
                             block.update_validator_keys(&mut bls_cache1.lock());
                             match blockchain1 {
+                                #[cfg(not(target_family = "wasm"))]
                                 BlockchainProxy::Full(blockchain) => {
                                     Blockchain::push(blockchain.upgradable_read(), block)
                                 }
@@ -215,6 +216,7 @@ impl<N: Network, TReq: RequestComponent<N>> BlockLiveSync<N, TReq> {
                                 // Update validator keys from BLS public key cache.
                                 block.update_validator_keys(&mut bls_cache2.lock());
                                 match blockchain2 {
+                                    #[cfg(not(target_family = "wasm"))]
                                     BlockchainProxy::Full(blockchain) => {
                                         Blockchain::push(blockchain.upgradable_read(), block)
                                     }

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -43,6 +43,7 @@ pub enum SyncerProxy<N: Network> {
 }
 
 impl<N: Network> SyncerProxy<N> {
+    #[cfg(not(target_family = "wasm"))]
     /// Creates a new instance of a `SyncerProxy` for the `History` variant
     pub async fn new_history(
         blockchain_proxy: BlockchainProxy,


### PR DESCRIPTION
- Remove the `Blockchain` enum variant when compiling the crate for wasm.
- Change `consensus` to also not use this enum variant when it is compiled for wasm.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.