### PR TITLE
Cud4m/remove log rotation and fix log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,16 +1745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
-name = "file-rotate"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff9cc595c02801d7e61675928f8c4698cab40b68b837884936a6b24fcf711e1"
-dependencies = [
- "chrono",
- "flate2",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,7 +3839,6 @@ dependencies = [
  "console-subscriber",
  "derive_builder 0.12.0",
  "directories",
- "file-rotate",
  "hex",
  "log-panics",
  "nimiq-block",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "4.1", features = ["derive"] }
 console-subscriber = { version = "0.1", features = ["parking_lot"], optional = true }
 derive_builder = "0.12"
 directories = "4.0"
-file-rotate = { version = "0.7", optional = true }
 hex = "0.4"
 # human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
 log = { package = "tracing", version = "0.1", features = ["log"] }
@@ -83,7 +82,7 @@ deadlock = ["parking_lot/deadlock_detection"]
 default = ["full-consensus"]
 full-consensus = ["database-storage", "nimiq-blockchain", "nimiq-consensus/full"]
 launcher = []
-logging = ["file-rotate", "nimiq-log", "serde_json", "tokio", "tracing-subscriber"]
+logging = ["nimiq-log", "serde_json", "tokio", "tracing-subscriber"]
 loki = ["logging", "tracing-loki"]
 metrics-server = ["nimiq-metrics-server", "nimiq-network-libp2p/metrics", "nimiq-validator/metrics"]
 panic = ["log-panics"]

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -188,20 +188,6 @@ level = "debug"
 # Default: None
 #tokio_console_bind_address = "127.0.0.1:6669"
 
-# Specify a rotating log file containing a trace log
-# [log.rotating_trace_log]
-
-# Set the path to the folder containing the log files
-# Default: "~/.nimiq/logs"
-# path = none
-
-# Size of each log file
-# Default: 50_000_000 (50 MB)
-# size = 50_000_000
-
-# Count of additional log files. The total log files count will be file_count + 2.
-# Default: 3
-# file_count = 2
 
 # Loki target
 # [log.loki]

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::read_to_string;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 
 use log::level_filters::LevelFilter;
@@ -289,27 +289,6 @@ pub struct LokiConfig {
     pub extra_fields: HashMap<String, String>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RotatingLogFileConfig {
-    #[serde(default)]
-    pub path: PathBuf,
-    #[serde(default)]
-    pub size: usize,
-    #[serde(default)]
-    pub file_count: usize,
-}
-
-impl Default for RotatingLogFileConfig {
-    fn default() -> Self {
-        Self {
-            path: paths::home().join("logs"),
-            size: 50_000_000, // 50 MB
-            file_count: 3,
-        }
-    }
-}
-
 const fn default_true() -> bool {
     true
 }
@@ -332,8 +311,6 @@ pub struct LogSettings {
     #[serde(default)]
     pub loki: Option<LokiConfig>,
     #[serde(default)]
-    pub rotating_trace_log: Option<RotatingLogFileConfig>,
-    #[serde(default)]
     pub tokio_console_bind_address: Option<String>,
 }
 
@@ -352,7 +329,6 @@ impl Default for LogSettings {
             statistics: 10,
             file: None,
             loki: None,
-            rotating_trace_log: None,
             tokio_console_bind_address: None,
         }
     }


### PR DESCRIPTION
## Pull request checklist

- [x] I have resolved any merge conflicts.

#### This fixes #1224.

## What's in this pull request?
- Removed rotation logs, as it didn't work properly, caused conflicts and was not really useful.
- Now if a file log is added to client.toml config file: 
   ** When the log file doesn't exist, it's created  (instead of falling with an I/O Error ).
   **If the file exist, new logs will be added at the end of the existing file.

