### PR TITLE
zkp-component: Use `blockchain` on the `prover` feature

### DIFF
--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = { version = "0.3", optional = true }
 
 beserial = { path = "../beserial", features = ["derive"] }
 nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
+nimiq-blockchain = { path = "../blockchain", optional = true }
 nimiq-blockchain-interface = { path = "../blockchain-interface" }
 nimiq-blockchain-proxy = { path = "../blockchain-proxy" }
 nimiq-database = { path = "../database" }
@@ -75,5 +75,5 @@ nimiq-test-utils = { path = "../test-utils" }
 tempfile = "3.3"
 
 [features]
-prover = ["nimiq-nano-zkp/prover", "tokio/io-util", "tokio/process"]
+prover = ["nimiq-blockchain", "nimiq-nano-zkp/prover", "tokio/io-util", "tokio/process"]
 test-prover = ["nimiq-log", "prover", "tracing-subscriber"]


### PR DESCRIPTION
Make the `blockchain` dependency optional and use it only when the `prover` feature is enabled.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.