### PR TITLE
primitives: Fix a clippy warning

### DIFF
--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -307,8 +307,7 @@ impl Policy {
         let t = delay as f64;
         let exponent = -Self::BLOCKS_DELAY_DECAY * t * t;
 
-        ((1.0 - Self::MINIMUM_REWARDS_PERCENTAGE) * exponent.exp()
-            + Self::MINIMUM_REWARDS_PERCENTAGE) as f64
+        (1.0 - Self::MINIMUM_REWARDS_PERCENTAGE) * exponent.exp() + Self::MINIMUM_REWARDS_PERCENTAGE
     }
 
     #[inline]


### PR DESCRIPTION
Fix a clippy warning related to an unnecessary cast in the `primitives` crate.

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.