### PR TITLE
genesis: Add two features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,7 +3408,6 @@ dependencies = [
  "nimiq-account",
  "nimiq-block",
  "nimiq-database-value",
- "nimiq-genesis",
  "nimiq-hash",
  "nimiq-primitives",
  "nimiq-transaction",

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -25,7 +25,6 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 nimiq-account = { path = "../primitives/account" }
 nimiq-block = { path = "../primitives/block" }
 nimiq-database-value = { path = "../database/database-value" }
-nimiq-genesis = { path = "../genesis" }
 nimiq-hash = { path = "../hash" }
 nimiq-primitives = { path = "../primitives" }
 nimiq-transaction = { path = "../primitives/transaction" }

--- a/blockchain-proxy/Cargo.toml
+++ b/blockchain-proxy/Cargo.toml
@@ -24,7 +24,7 @@ nimiq-blockchain = { path = "../blockchain", optional = true }
 nimiq-blockchain-interface = { path = "../blockchain-interface" }
 nimiq-light-blockchain = { path = "../light-blockchain" }
 nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
+nimiq-genesis = { path = "../genesis", default-features = false }
 nimiq-hash = { path = "../hash" }
 nimiq-primitives = { path = "../primitives" }
 nimiq-transaction = { path = "../primitives/transaction" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -35,7 +35,6 @@ nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = fals
 nimiq-bls = { path = "../bls" }
 nimiq-blockchain = { path = "../blockchain", optional = true }
 nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
 nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-light-blockchain = { path = "../light-blockchain" }
@@ -58,6 +57,7 @@ hex = "0.4"
 
 nimiq-block-production = { path = "../block-production" }
 nimiq-bls = { path = "../bls" }
+nimiq-genesis = { path = "../genesis" }
 nimiq-genesis-builder = { path = "../genesis-builder" }
 nimiq-keys = { path = "../keys" }
 nimiq-network-mock = { path = "../network-mock" }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -24,18 +24,18 @@ lazy_static = "1.2"
 url = "2.3"
 
 beserial = { path = "../beserial", features = ["derive", "net"] }
-nimiq-account = { path = "../primitives/account" }
+nimiq-account = { path = "../primitives/account", optional = true }
 nimiq-block = { path = "../primitives/block" }
 nimiq-bls = { path = "../bls" }
-nimiq-database = { path = "../database" }
-nimiq-genesis-builder = { path = "../genesis-builder" }
+nimiq-database = { path = "../database", optional = true }
+nimiq-genesis-builder = { path = "../genesis-builder", optional = true }
 nimiq-hash = { path = "../hash" }
 nimiq-hash_derive = { path = "../hash/hash_derive" }
 nimiq-keys = { path = "../keys" }
 nimiq-macros = { path = "../macros" }
 nimiq-primitives = { path = "../primitives", features = ["coin", "networks"] }
 nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-trie = { path = "../primitives/trie" }
+nimiq-trie = { path = "../primitives/trie", optional = true }
 nimiq-utils = { path = "../utils", features = ["time"] }
 
 [build-dependencies]
@@ -46,3 +46,8 @@ nimiq-database = { path = "../database" }
 nimiq-genesis-builder = { path = "../genesis-builder" }
 nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
+
+[features]
+accounts = ["nimiq-account", "nimiq-trie"]
+default = ["accounts", "genesis-override"]
+genesis-override = ["accounts", "nimiq-database", "nimiq-genesis-builder"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -51,7 +51,7 @@ nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = fals
 nimiq-bls = { path = "../bls" }
 nimiq-consensus = { path = "../consensus", default-features = false }
 nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
+nimiq-genesis = { path = "../genesis", default-features = false }
 nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git", optional=true}
 nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git", optional=true}
 nimiq-keys = { path = "../keys" }

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -20,7 +20,7 @@ nimiq-block = { path = "../primitives/block" }
 nimiq-blockchain-interface = { path = "../blockchain-interface" }
 nimiq-collections = { path = "../collections" }
 nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
+nimiq-genesis = { path = "../genesis", default-features = false }
 nimiq-hash = { path = "../hash" }
 nimiq-nano-zkp = { path = "../nano-zkp" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -43,7 +43,7 @@ nimiq-blockchain-interface = { path = "../blockchain-interface" }
 nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
 nimiq-database = { path = "../database" }
 nimiq-database-value = { path = "../database/database-value" }
-nimiq-genesis = { path = "../genesis" }
+nimiq-genesis = { path = "../genesis", default-features = false }
 nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-log = { path = "../log", optional = true }


### PR DESCRIPTION
Add two features for the `genesis` crate:
- `accounts`
- `genesis-override`

This is to avoid pulling extra dependencies such as `nimiq-account` and `nimiq-database` that do not compile for `wasm`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
