### PR TITLE
Changes to enable light-client wasm compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,7 +3405,6 @@ version = "0.1.0"
 dependencies = [
  "beserial",
  "futures-util",
- "nimiq-account",
  "nimiq-block",
  "nimiq-database-value",
  "nimiq-hash",
@@ -3504,7 +3503,6 @@ dependencies = [
  "nimiq-keys",
  "nimiq-light-blockchain",
  "nimiq-macros",
- "nimiq-mempool",
  "nimiq-nano-primitives",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
@@ -4338,6 +4336,7 @@ dependencies = [
  "nimiq-hash",
  "nimiq-keys",
  "nimiq-macros",
+ "nimiq-network-interface",
  "nimiq-primitives",
  "nimiq-test-log",
  "nimiq-utils",

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -22,7 +22,6 @@ parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 thiserror = "1.0"
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-account = { path = "../primitives/account" }
 nimiq-block = { path = "../primitives/block" }
 nimiq-database-value = { path = "../database/database-value" }
 nimiq-hash = { path = "../hash" }

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -1,6 +1,5 @@
 use thiserror::Error;
 
-use nimiq_account::AccountError;
 use nimiq_block::{Block, BlockError, ForkProof};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::networks::NetworkId;
@@ -84,8 +83,8 @@ pub enum PushError {
     InvalidPredecessor,
     #[error("Duplicate transaction")]
     DuplicateTransaction,
-    #[error("Account error: {0}")]
-    AccountsError(#[from] AccountError),
+    #[error("Account error")]
+    AccountsError,
     #[error("Invalid fork")]
     InvalidFork,
     #[error("Blockchain error: {0}")]

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -37,7 +37,9 @@ impl Blockchain {
 
                 // Check if the receipts contain an error.
                 if let Err(e) = batch_info {
-                    return Err(PushError::AccountsError(e));
+                    // TODO: This is due to a dependency between blockchain and accounts that is not wasm friendly
+                    log::error!("Received accounts error while committing accounts: {}", e);
+                    return Err(PushError::AccountsError);
                 }
 
                 // Macro blocks are final and receipts for the previous batch are no longer necessary
@@ -99,7 +101,9 @@ impl Blockchain {
                     Ok(batch_info) => batch_info,
                     Err(e) => {
                         // Check if the receipts contain an error.
-                        return Err(PushError::AccountsError(e));
+                        // TODO: This is due to a dependency between blockchain and accounts that is not wasm friendly
+                        log::error!("Received accounts error while committing accounts: {}", e);
+                        return Err(PushError::AccountsError);
                     }
                 };
 

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -229,7 +229,12 @@ impl Blockchain {
                 txn.abort();
                 #[cfg(feature = "metrics")]
                 this.metrics.note_invalid_block();
-                return Err(PushError::AccountsError(e));
+                // TODO: This is due to a dependency between blockchain and accounts that is not wasm friendly
+                log::error!(
+                    "Received accounts error while extending history sync: {}",
+                    e,
+                );
+                return Err(PushError::AccountsError);
             }
         }
         this.state.accounts.finalize_batch(&mut txn);

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -38,7 +38,6 @@ nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-light-blockchain = { path = "../light-blockchain" }
 nimiq-macros = { path = "../macros" }
-nimiq-mempool = { path = "../mempool" }
 nimiq-nano-primitives = { path = "../nano-primitives" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -5,10 +5,9 @@ use tokio::sync::broadcast::Sender as BroadcastSender;
 use tokio_stream::wrappers::BroadcastStream;
 
 use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_mempool::mempool::{ControlTransactionTopic, TransactionTopic};
 use nimiq_network_interface::network::Network;
 use nimiq_primitives::account::AccountType;
-use nimiq_transaction::Transaction;
+use nimiq_transaction::{ControlTransactionTopic, Transaction, TransactionTopic};
 
 use crate::ConsensusEvent;
 

--- a/consensus/src/sync/live/block_live_sync.rs
+++ b/consensus/src/sync/live/block_live_sync.rs
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use pin_project::pin_project;
 use tokio::task::spawn_blocking;
 
-use nimiq_block::Block;
+use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
 #[cfg(feature = "full")]
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{PushError, PushResult};
@@ -20,7 +20,7 @@ use nimiq_network_interface::network::{MsgAcceptance, Network};
 
 use crate::sync::{
     live::{
-        block_queue::{BlockHeaderTopic, BlockQueue, BlockTopic, QueuedBlock},
+        block_queue::{BlockQueue, QueuedBlock},
         request_component::RequestComponent,
     },
     syncer::{LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},

--- a/consensus/src/sync/live/block_queue.rs
+++ b/consensus/src/sync/live/block_queue.rs
@@ -8,36 +8,14 @@ use std::{
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 
-use nimiq_block::Block;
+use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
 use nimiq_blockchain_interface::{AbstractBlockchain, Direction};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;
-use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId, Topic};
+use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
 use nimiq_primitives::policy::Policy;
 
 use crate::sync::live::request_component::{RequestComponent, RequestComponentEvent};
-
-#[derive(Clone, Debug, Default)]
-pub struct BlockTopic;
-
-impl Topic for BlockTopic {
-    type Item = Block;
-
-    const BUFFER_SIZE: usize = 16;
-    const NAME: &'static str = "blocks";
-    const VALIDATE: bool = true;
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct BlockHeaderTopic;
-
-impl Topic for BlockHeaderTopic {
-    type Item = Block;
-
-    const BUFFER_SIZE: usize = 16;
-    const NAME: &'static str = "block-headers";
-    const VALIDATE: bool = true;
-}
 
 pub type BlockStream<N> = BoxStream<'static, (Block, <N as Network>::PubsubId)>;
 

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -18,7 +18,7 @@ use nimiq_primitives::coin::Coin;
 use nimiq_transaction::account::staking_contract::{
     IncomingStakingTransactionData, OutgoingStakingTransactionProof,
 };
-use nimiq_transaction::Transaction;
+use nimiq_transaction::{ControlTransactionTopic, Transaction, TransactionTopic};
 
 use crate::config::MempoolConfig;
 use crate::executor::MempoolExecutor;
@@ -28,30 +28,6 @@ use crate::mempool_metrics::MempoolMetrics;
 use crate::mempool_state::{EvictionReason, MempoolState};
 use crate::mempool_transactions::TxPriority;
 use crate::verify::{verify_tx, VerifyErr};
-
-/// Transaction topic for the Mempool to request transactions from the network
-#[derive(Clone, Debug, Default)]
-pub struct TransactionTopic;
-
-impl Topic for TransactionTopic {
-    type Item = Transaction;
-
-    const BUFFER_SIZE: usize = 1024;
-    const NAME: &'static str = "transactions";
-    const VALIDATE: bool = true;
-}
-
-/// Control Transaction topic for the Mempool to request transactions from the network
-#[derive(Clone, Debug, Default)]
-pub struct ControlTransactionTopic;
-
-impl Topic for ControlTransactionTopic {
-    type Item = Transaction;
-
-    const BUFFER_SIZE: usize = 1024;
-    const NAME: &'static str = "Controltransactions";
-    const VALIDATE: bool = true;
-}
 
 /// Struct defining the Mempool
 pub struct Mempool {

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -9,6 +9,7 @@ use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_keys::PublicKey;
+use nimiq_network_interface::network::Topic;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
@@ -18,6 +19,29 @@ use nimiq_vrf::VrfSeed;
 use crate::macro_block::{MacroBlock, MacroHeader};
 use crate::micro_block::{MicroBlock, MicroHeader};
 use crate::{BlockError, MacroBody, MicroBody, MicroJustification, TendermintProof};
+
+/// These network topics are used to subscribe and request Blocks and Block Headers respectively
+#[derive(Clone, Debug, Default)]
+pub struct BlockTopic;
+
+impl Topic for BlockTopic {
+    type Item = Block;
+
+    const BUFFER_SIZE: usize = 16;
+    const NAME: &'static str = "blocks";
+    const VALIDATE: bool = true;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BlockHeaderTopic;
+
+impl Topic for BlockHeaderTopic {
+    type Item = Block;
+
+    const BUFFER_SIZE: usize = 16;
+    const NAME: &'static str = "block-headers";
+    const VALIDATE: bool = true;
+}
 
 /// Defines the type of the block, either Micro or Macro (which includes both checkpoint and
 /// election blocks).

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -5,6 +5,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
+use nimiq_network_interface::network::Topic;
 use nimiq_primitives::policy::Policy;
 use nimiq_primitives::slots::Validators;
 
@@ -13,6 +14,17 @@ use crate::signed::{
     PREFIX_TENDERMINT_PROPOSAL,
 };
 use crate::{MacroBlock, MacroHeader, MultiSignature};
+
+/// This topic is used to obtain tendermint proposals through the network
+pub struct ProposalTopic;
+
+impl Topic for ProposalTopic {
+    type Item = SignedTendermintProposal;
+
+    const BUFFER_SIZE: usize = 8;
+    const NAME: &'static str = "tendermint-proposal";
+    const VALIDATE: bool = true;
+}
 
 /// The proposal message sent by the Tendermint leader.
 #[derive(Clone, Debug, Serialize, Deserialize, SerializeContent, PartialEq, Eq)]

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -24,6 +24,7 @@ nimiq-bls = { path = "../../bls", features = ["serde-derive"] }
 nimiq-hash = { path = "../../hash", features = ["serde-derive"] }
 nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
 nimiq-macros = { path = "../../macros" }
+nimiq-network-interface = { path = "../../network-interface" }
 nimiq-primitives = { path = "..", features = ["account", "coin", "networks", "policy", "serde-derive"] }
 nimiq-utils = { path = "../../utils", features = ["merkle"] }
 

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -17,6 +17,7 @@ use beserial::{
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_keys::Address;
 use nimiq_keys::{PublicKey, Signature};
+use nimiq_network_interface::network::Topic;
 use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::networks::NetworkId;
@@ -27,6 +28,29 @@ use crate::account::AccountTransactionVerification;
 
 pub mod account;
 
+/// Transaction topic for the Mempool to request transactions from the network
+#[derive(Clone, Debug, Default)]
+pub struct TransactionTopic;
+
+impl Topic for TransactionTopic {
+    type Item = Transaction;
+
+    const BUFFER_SIZE: usize = 1024;
+    const NAME: &'static str = "transactions";
+    const VALIDATE: bool = true;
+}
+
+/// Control Transaction topic for the Mempool to request control transactions from the network
+#[derive(Clone, Debug, Default)]
+pub struct ControlTransactionTopic;
+
+impl Topic for ControlTransactionTopic {
+    type Item = Transaction;
+
+    const BUFFER_SIZE: usize = 1024;
+    const NAME: &'static str = "Controltransactions";
+    const VALIDATE: bool = true;
+}
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TransactionsProof {
     #[beserial(len_type(u16))]

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -7,8 +7,8 @@ use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
 use parking_lot::RwLock;
 
 use nimiq_block::{
-    Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SignedTendermintProposal,
-    TendermintProof, TendermintProposal,
+    Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, ProposalTopic,
+    SignedTendermintProposal, TendermintProof, TendermintProposal,
 };
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
@@ -26,7 +26,6 @@ use nimiq_validator_network::ValidatorNetwork;
 use nimiq_vrf::VrfSeed;
 
 use crate::aggregation::tendermint::HandelTendermintAdapter;
-use crate::validator::ProposalTopic;
 
 /// The struct that interfaces with the Tendermint crate. It only has to implement the
 /// TendermintOutsideDeps trait in order to do this.

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -19,12 +19,11 @@ use crate::micro::{ProduceMicroBlock, ProduceMicroBlockEvent};
 use crate::r#macro::{PersistedMacroState, ProduceMacroBlock};
 use crate::slash::ForkProofPool;
 use nimiq_account::StakingContract;
-use nimiq_block::{Block, BlockType, SignedTendermintProposal};
+use nimiq_block::{Block, BlockHeaderTopic, BlockTopic, BlockType, ProposalTopic};
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, ForkEvent, PushResult};
 use nimiq_bls::KeyPair as BlsKeyPair;
-use nimiq_consensus::sync::live::block_queue::{BlockHeaderTopic, BlockTopic};
 use nimiq_consensus::{Consensus, ConsensusEvent, ConsensusProxy};
 use nimiq_database::{Database, Environment, ReadTransaction, WriteTransaction};
 use nimiq_hash::{Blake2bHash, Hash};
@@ -36,16 +35,6 @@ use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_tendermint::TendermintReturn;
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_validator_network::ValidatorNetwork;
-
-pub struct ProposalTopic;
-
-impl Topic for ProposalTopic {
-    type Item = SignedTendermintProposal;
-
-    const BUFFER_SIZE: usize = 8;
-    const NAME: &'static str = "tendermint-proposal";
-    const VALIDATE: bool = true;
-}
 
 #[derive(PartialEq)]
 enum ValidatorStakingState {


### PR DESCRIPTION
- Moved around the different network Topics to their respective crates
- Consensus no longer depends upon mempool
- Remove a dependency of account from blockchain interface

The idea of these changes is to allow the light client to compile by:
* Not requiring accounts (which depends upon the db)
* Not requiring  mempool (which is not needed for the light client)

