### PR TITLE
nimiq-lib: Make the database depedency optional

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-tokio = { version = "1.24", features = ["rt-multi-thread", "time", "tracing"] }
+tokio = { version = "1.24", features = ["macros", "rt-multi-thread", "time", "tracing"] }
 tokio-metrics = "0.1"
 
 [dependencies.nimiq]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -50,7 +50,7 @@ nimiq-blockchain-interface = { path = "../blockchain-interface" }
 nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
 nimiq-bls = { path = "../bls" }
 nimiq-consensus = { path = "../consensus", default-features = false }
-nimiq-database = { path = "../database" }
+nimiq-database = { path = "../database", optional = true }
 nimiq-genesis = { path = "../genesis", default-features = false }
 nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git", optional=true}
 nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git", optional=true}
@@ -76,7 +76,7 @@ nimiq-test-log = { path = "../test-log" }
 [features]
 deadlock = ["parking_lot/deadlock_detection"]
 default = ["full-consensus"]
-full-consensus = ["nimiq-blockchain", "nimiq-consensus/full", "nimiq-mempool"]
+full-consensus = ["nimiq-blockchain", "nimiq-consensus/full", "nimiq-database"]
 launcher = []
 signal-handling = ["signal-hook", "tokio"]
 logging = ["file-rotate", "nimiq-log", "serde_json", "tokio", "tracing-subscriber"]
@@ -85,8 +85,8 @@ metrics-server = ["nimiq-metrics-server", "nimiq-network-libp2p/metrics", "nimiq
 panic = ["log-panics"]
 rpc-server = ["nimiq-jsonrpc-core", "nimiq-jsonrpc-server", "nimiq-rpc-server", "nimiq-wallet", "validator"]
 tokio-console = ["console-subscriber", "logging", "tokio"]
-validator = ["nimiq-validator", "nimiq-validator-network", "nimiq-rpc-server"]
-wallet = ["nimiq-wallet"]
+validator = ["nimiq-database", "nimiq-mempool", "nimiq-validator", "nimiq-validator-network", "nimiq-rpc-server"]
+wallet = ["nimiq-database", "nimiq-wallet"]
 websocket = ["nimiq-network-libp2p/websocket"]
-zkp-storage = ["nimiq-zkp-component/zkp-storage"]
+zkp-storage = ["nimiq-database", "nimiq-zkp-component/zkp-storage"]
 zkp-prover = ["nimiq-zkp-component/zkp-prover"]

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -203,6 +203,12 @@ impl ClientInner {
         let network_events = network.subscribe_events();
 
         // Open database
+        #[cfg(any(
+            feature = "full-consensus",
+            feature = "validator",
+            feature = "wallet",
+            feature = "zkp-storage"
+        ))]
         let environment = config.storage.database(
             config.network_id,
             config.consensus.sync_mode,

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -13,6 +13,12 @@ use strum_macros::Display;
 use beserial::Deserialize;
 #[cfg(feature = "validator")]
 use nimiq_bls::{KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
+#[cfg(any(
+    feature = "full-consensus",
+    feature = "validator",
+    feature = "wallet",
+    feature = "zkp-storage"
+))]
 use nimiq_database::{mdbx::MdbxEnvironment, volatile::VolatileEnvironment, Environment};
 #[cfg(feature = "validator")]
 use nimiq_keys::{Address, KeyPair, PrivateKey};
@@ -279,6 +285,12 @@ impl StorageConfig {
     ///
     /// Returns a `Result` which is either a `Environment` or a `Error`.
     ///
+    #[cfg(any(
+        feature = "full-consensus",
+        feature = "validator",
+        feature = "wallet",
+        feature = "zkp-storage"
+    ))]
     pub fn database(
         &self,
         network_id: NetworkId,

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -7,6 +7,12 @@ pub enum Error {
     #[error("Configuration error: {0}")]
     Config(String), // TODO
 
+    #[cfg(any(
+        feature = "full-consensus",
+        feature = "validator",
+        feature = "wallet",
+        feature = "zkp-storage"
+    ))]
     #[error("MDBX error: {0}")]
     Lmdb(#[from] nimiq_database::Error),
 

--- a/lib/src/extras/metrics_server.rs
+++ b/lib/src/extras/metrics_server.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_consensus::ConsensusProxy;
+#[cfg(feature = "nimiq-mempool")]
 use nimiq_mempool::mempool::Mempool;
 use nimiq_network_interface::network::Network;
 
@@ -11,11 +12,13 @@ pub use nimiq_metrics_server::NimiqTaskMonitor;
 pub fn start_metrics_server<TNetwork: Network>(
     addr: SocketAddr,
     blockchain_proxy: BlockchainProxy,
-    mempool: Option<Arc<Mempool>>,
+    #[cfg(feature = "nimiq-mempool")] mempool: Option<Arc<Mempool>>,
     consensus_proxy: ConsensusProxy<TNetwork>,
     network: Arc<nimiq_network_libp2p::Network>,
     task_monitors: &[NimiqTaskMonitor],
 ) {
+    #[cfg(not(feature = "nimiq-mempool"))]
+    let mempool = None;
     nimiq_metrics_server::start_metrics_server(
         addr,
         blockchain_proxy,

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -20,13 +20,14 @@ maintenance = { status = "experimental" }
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-tokio = { version = "1.24", features = ["rt-multi-thread", "time", "tracing"] }
+tokio = { version = "1.24", features = ["macros", "rt-multi-thread", "time"] }
 tokio-metrics = "0.1"
 
 [dependencies.nimiq]
 package = "nimiq-lib"
 path = "../lib"
 version = "0.1"
+default-features = false
 features = [
     "deadlock",
     "logging",


### PR DESCRIPTION
Make the `nimiq-database` dependency of `lib` optional and factorize the features that requires it such that it is properly included when needed.
Also improve `tokio` feature selection for the regular client and the light one.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
