### PR TITLE
Consensus: Receive a task executor

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -71,7 +71,13 @@ async fn main_inner() -> Result<(), Error> {
 
     // Create client from config.
     log::info!("Initializing client");
-    let mut client: Client = Client::from_config(config).await?;
+    let mut client: Client = Client::from_config(
+        config,
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
+    )
+    .await?;
     log::info!("Client initialized");
 
     // Initialize RPC server

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -219,6 +219,9 @@ pub async fn sync_two_peers(
         syncer2,
         1,
         zkp_prover2_proxy,
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
     );
     let consensus2_proxy = consensus2.proxy();
     let events = blockchain2_proxy.read().notifier_as_stream();

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -35,7 +35,6 @@ use crate::config::consts;
 #[cfg(feature = "metrics-server")]
 use crate::config::consts::default_bind;
 use crate::{
-    client::Client,
     config::{
         command_line::CommandLine,
         config_file::{self, ConfigFile, Seed},
@@ -626,12 +625,6 @@ impl ClientConfig {
     pub fn builder() -> ClientConfigBuilder {
         ClientConfigBuilder::default()
     }
-
-    /// Instantiates the Nimiq client from this configuration
-    ///
-    pub async fn instantiate_client(self) -> Result<Client, Error> {
-        Client::from_config(self).await
-    }
 }
 
 impl ClientConfigBuilder {
@@ -644,12 +637,6 @@ impl ClientConfigBuilder {
 
         self.build_internal()
             .map_err(|e| Error::config_error(e.to_string()))
-    }
-
-    /// Short cut to build the config and instantiate the client
-    ///
-    pub async fn instantiate_client(&self) -> Result<Client, Error> {
-        self.build()?.instantiate_client().await
     }
 
     /// Sets the network ID to the Albatross DevNet

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -14,3 +14,5 @@ pub mod slots;
 pub mod transaction;
 #[cfg(feature = "trie")]
 pub mod trie;
+
+pub mod task_executor;

--- a/primitives/src/task_executor.rs
+++ b/primitives/src/task_executor.rs
@@ -1,0 +1,15 @@
+use std::{future::Future, pin::Pin};
+
+/// This a trait used to abstract the task executor that is used in several modules.
+/// For instance, it can be used to execute tasks with tokio or wasm-bindgen if needed
+/// This is the same approach that is used within some components of libp2p
+pub trait TaskExecutor {
+    /// Run the given future in the background until it ends.
+    fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
+}
+
+impl<F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>)> TaskExecutor for F {
+    fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
+        self(f)
+    }
+}

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -197,7 +197,13 @@ async fn main_inner() -> Result<(), Error> {
 
     // Create client from config.
     log::info!("Initializing client");
-    let mut client: Client = Client::from_config(config).await?;
+    let mut client: Client = Client::from_config(
+        config,
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
+    )
+    .await?;
     log::info!("Client initialized");
 
     // Initialize RPC server

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -99,6 +99,9 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
             syncer,
             1,
             zkp_proxy.proxy(),
+            Box::new(|fut| {
+                tokio::spawn(fut);
+            }),
         );
 
         Node {

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -35,9 +35,14 @@ async fn light_client() {
 
     // Create client from config.
     log::info!("Initializing light client");
-    let mut client: Client = Client::from_config(config)
-        .await
-        .expect("Build client failed");
+    let mut client: Client = Client::from_config(
+        config,
+        Box::new(|fut| {
+            spawn_local(fut);
+        }),
+    )
+    .await
+    .expect("Build client failed");
     log::info!("Web client initialized");
 
     // Start consensus.


### PR DESCRIPTION
This is used to make consensus generic over the executor that is used to spawn its tasks. For instance, for all non-web clients we use tokio::spawn. For web-clients we use wasm-bindgen::spawn_local

