### PR TITLE
Request previous macro block if required for batch finalization

### DIFF
--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -108,7 +108,7 @@ impl PeerMacroRequests {
 ///   3. Request the last (if any) election or checkpoint blocks
 /// If during the process, a peer is deemed as outdated, then it is emitted
 pub struct LightMacroSync<TNetwork: Network> {
-    /// The blockchain, only a light variant is supported for LightMacroSync
+    /// The blockchain
     pub(crate) blockchain: BlockchainProxy,
     /// Reference to the network
     pub(crate) network: Arc<TNetwork>,

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -136,6 +136,29 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         }
     }
 
+    pub(crate) fn request_single_macro_block(
+        &mut self,
+        peer_id: TNetwork::PeerId,
+        block_hash: Blake2bHash,
+    ) {
+        let mut peer_requests = PeerMacroRequests::new();
+        let network = Arc::clone(&self.network);
+
+        peer_requests.push_request(block_hash.clone());
+
+        self.block_headers.push(
+            async move {
+                (
+                    Self::request_macro_block(network, peer_id, block_hash).await,
+                    peer_id,
+                )
+            }
+            .boxed(),
+        );
+
+        self.peer_requests.insert(peer_id, peer_requests);
+    }
+
     pub(crate) fn request_macro_headers(
         &mut self,
         mut epoch_ids: EpochIds<TNetwork::PeerId>,


### PR DESCRIPTION
## What's in this pull request?
For the light macro sync, we might be missing the previous slots after pushing a zkp.
The solution is to request the previous macro block if required for batch finalization. 
Additionally, we made sure that the sync_stream poll functions follow the stream conventions.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
