### PR TITLE
Move libp2p to a fork and enable CI wasm checks

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -110,6 +110,36 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --release --all-features
 
+  web-client:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: "Free up disk space"
+      run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: cargo-${{ hashFiles('**/Cargo.toml') }}
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Install Protoc
+      run: sudo apt-get install protobuf-compiler
+    - name: Install wasm-pack
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: wasm-pack
+    - name: Compile to wasm and generate bindings
+      working-directory: ./web-client
+      run: wasm-pack build --target web
+
   reconnect-test:
     runs-on: ubuntu-20.04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,8 +2516,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "bytes",
  "futures",
@@ -2549,8 +2548,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2583,8 +2581,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e42a271c1b49f789b92f7fc87749fa79ce5c7bdc88cbdfacb818a4bca47fec5"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2597,8 +2594,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a173171c71c29bb156f98886c7c4824596de3903dadf01e2e79d2ccdcf38cd9f"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.1",
@@ -2606,11 +2602,13 @@ dependencies = [
  "bytes",
  "fnv",
  "futures",
+ "futures-timer",
  "hex_fmt",
  "instant",
  "libp2p-core",
  "libp2p-swarm",
  "log",
+ "pin-project",
  "prometheus-client",
  "prost 0.11.0",
  "prost-build",
@@ -2626,9 +2624,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c052d0026f4817b44869bfb6810f4e1112f43aec8553f2cb38881c524b563abf"
+version = "0.41.0"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "asynchronous-codec",
  "futures",
@@ -2647,9 +2644,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
+version = "0.42.0"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
@@ -2676,8 +2672,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f378264aade9872d6ccd315c0accc18be3a35d15fc1b9c36e5b6f983b62b5b"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "data-encoding",
  "futures",
@@ -2696,8 +2691,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "libp2p-core",
  "libp2p-gossipsub",
@@ -2711,8 +2705,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978cb57efe82e892ec6f348a536bfbd9fee677adbe5689d7a93ad3a9bffbf2e"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -2734,8 +2727,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "929fcace45a112536e22b3dcfd4db538723ef9c3cb79f672b98be2cc8e25f37f"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2750,8 +2742,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.7.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "bytes",
  "futures",
@@ -2771,8 +2762,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3236168796727bfcf4927f766393415361e2c644b08bedb6a6b13d957c9a4884"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2788,9 +2778,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
+version = "0.41.0"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "either",
  "fnv",
@@ -2812,9 +2801,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
+version = "0.30.2"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "heck 0.4.0",
  "quote",
@@ -2824,8 +2812,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257baf6df8f2df39678b86c578961d48cc8b68642a12f0f763f56c8e5858d"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2840,8 +2827,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.1.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7905ce0d040576634e8a3229a7587cc8beab83f79db6023800f1792895defa8"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2858,8 +2844,7 @@ dependencies = [
 [[package]]
 name = "libp2p-webrtc"
 version = "0.4.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb6cd86dd68cba72308ea05de1cebf3ba0ae6e187c40548167955d4e3970f6a"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2889,8 +2874,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d705506030d5c0aaf2882437c70dab437605f21c5f9811978f694e6917a3b54"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "either",
  "futures",
@@ -2908,8 +2892,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f63594a0aa818642d9d4915c791945053877253f08a3626f13416b5cd928a29"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3197,8 +3180,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "bytes",
  "futures",
@@ -5155,8 +5137,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5645,8 +5626,7 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 [[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
+source = "git+https://github.com/jsdanielh/rust-libp2p.git#94d669b3e4dd99d7735c2fd1cbc0412b8fad7353"
 dependencies = [
  "futures",
  "pin-project",

--- a/beserial/Cargo.toml
+++ b/beserial/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 arrayvec = "0.7.2"
 beserial_derive = { path = "beserial_derive", version = "0.1.0", optional = true }
 bitvec = { version = "1.0", optional = true }
-libp2p = { version = "0.50", default-features = false, optional = true }
+libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false, optional = true }
 byteorder = "1.2"
 thiserror = "1.0"
 num-traits = "0.2"

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -53,7 +53,7 @@ nimiq-utils = { path = "../utils", features = [
 nimiq-validator-network = { path = "../validator-network" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-libp2p = { version = "0.50", default-features = false, features = [
+libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false, features = [
     "gossipsub",
     "identify",
     "kad",
@@ -65,7 +65,7 @@ libp2p = { version = "0.50", default-features = false, features = [
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-libp2p = { version = "0.50", default-features = false, features = [
+libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false, features = [
     "gossipsub",
     "identify",
     "kad",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 clear_on_drop = { version = "0.2", optional = true }
 futures = { package = "futures-util", version = "0.3" }
 hex = { version = "0.4", optional = true }
-libp2p = { version = "0.50", default-features = false, optional = true }
+libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false, optional = true }
 log = { package = "tracing", version = "0.1", optional = true, features = ["log"] }
 parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
 rand = { version = "0.8", optional = true }


### PR DESCRIPTION
- Move the `libp2p` dependency to a fork to enable compilation for `wasm` and non-`wasm` targets.
  This is due to the fact that the `gossipsub` protocol got the `wasm` support dropped in this [PR](https://github.com/libp2p/rust-libp2p/pull/2506).   
- Add a job in the `build+test` Github Actions workflow for compiling to `wasm` and generating the JS bindings for the `web-client`

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
