### PR TITLE
Fix accepted_block_announcements counter

### DIFF
--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -189,6 +189,9 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Stream for Syncer<N, M
         while let Poll::Ready(Some(result)) = self.live_sync.poll_next_unpin(cx) {
             match result {
                 LiveSyncEvent::PushEvent(push_event) => {
+                    if let LiveSyncPushEvent::AcceptedAnnouncedBlock(..) = push_event {
+                        self.accepted_announcements = self.accepted_announcements.saturating_add(1);
+                    }
                     return Poll::Ready(Some(push_event));
                 }
                 LiveSyncEvent::PeerEvent(peer_event) => match peer_event {


### PR DESCRIPTION
## What's in this pull request?
At some point during the refactoring/merging, the incrementing of the accepted block announcements got lost.
Since this is one of the conditions for consensus, we reintroduce the increment.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
