### PR TITLE
Moving zkprover proof generation logic to the poll function.

### DIFF
--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -178,6 +178,13 @@ impl Blockchain {
             }
         }
 
+        // Correctly set flag for verifying the history root.
+        let history_root = history_store
+            .get_history_tree_root(Policy::epoch_at(main_chain.head.block_number()), None);
+        let can_verify_history = history_root
+            .map(|history_root| &history_root == main_chain.head.history_root())
+            .unwrap_or(false);
+
         // Load macro chain from store.
         let macro_chain_info = chain_store
             .get_chain_info_at(
@@ -257,7 +264,7 @@ impl Blockchain {
                 election_head_hash,
                 current_slots: Some(current_slots),
                 previous_slots: last_slots,
-                can_verify_history: true,
+                can_verify_history,
             },
             tx_verification_cache: Arc::new(DEFAULT_TX_VERIFICATION_CACHE),
             #[cfg(feature = "metrics")]

--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 
 use nimiq_account::{Account, Accounts, BlockLog};
@@ -62,6 +62,8 @@ pub struct BlockchainConfig {
     /// Maximum number of epochs (other than the current one) that the ChainStore will store fully.
     /// Epochs older than this number will be pruned.
     pub max_epochs_stored: u32,
+    /// The path for the ZKP verifying keys.
+    pub keys_path: PathBuf,
 }
 
 impl Default for BlockchainConfig {
@@ -69,6 +71,7 @@ impl Default for BlockchainConfig {
         Self {
             keep_history: true,
             max_epochs_stored: Policy::MIN_EPOCHS_STORED,
+            keys_path: PathBuf::new(),
         }
     }
 }

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -53,8 +53,9 @@ impl Blockchain {
             .chain_store
             .get_block_at(0, true, Some(&read_txn))
             .unwrap();
+        let genesis_hash = genesis_block.hash();
 
-        let initial_header_hash = <[u8; 32]>::from(genesis_block.hash());
+        let initial_header_hash = <[u8; 32]>::from(genesis_hash.clone());
         let initial_public_keys = genesis_block.validators().unwrap().voting_keys_g2();
         let final_block_number = block.block_number();
         let final_header_hash = <[u8; 32]>::from(block.hash());
@@ -93,6 +94,11 @@ impl Blockchain {
         this.history_store.clear(&mut txn);
         // Prune the Chain Store.
         this.chain_store.clear(&mut txn);
+
+        // Restore genesis block.
+        let genesis_info = ChainInfo::new(genesis_block, true);
+        this.chain_store
+            .put_chain_info(&mut txn, &genesis_hash, &genesis_info, true);
 
         this.chain_store
             .put_chain_info(&mut txn, &block_hash, &chain_info, true);

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -1,4 +1,4 @@
-use std::{cmp, mem, path::PathBuf};
+use std::{cmp, mem};
 
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 
@@ -69,7 +69,7 @@ impl Blockchain {
             final_header_hash,
             final_public_keys,
             proof,
-            &PathBuf::new(), // use the current directory
+            &this.config.keys_path,
         );
 
         if verify_result.is_err() || !verify_result.unwrap() {

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -379,6 +379,7 @@ mod tests {
     fn light_blockchain() -> BlockchainProxy {
         BlockchainProxy::Light(Arc::new(RwLock::new(LightBlockchain::new(
             NetworkId::UnitAlbatross,
+            PathBuf::from(KEYS_PATH),
         ))))
     }
 

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -158,7 +158,10 @@ pub async fn sync_two_peers(
             BlockchainProxy::from(blockchain2)
         }
         SyncMode::Light => {
-            let blockchain2 = Arc::new(RwLock::new(LightBlockchain::new(NetworkId::UnitAlbatross)));
+            let blockchain2 = Arc::new(RwLock::new(LightBlockchain::new(
+                NetworkId::UnitAlbatross,
+                PathBuf::from(KEYS_PATH),
+            )));
             BlockchainProxy::from(blockchain2)
         }
     };

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -274,6 +274,7 @@ impl ClientInner {
             #[cfg(feature = "full-consensus")]
             SyncMode::Full => {
                 blockchain_config.keep_history = false;
+                blockchain_config.keys_path = config.zkp.setup_keys_path.clone();
                 let blockchain = Arc::new(RwLock::new(
                     Blockchain::new(
                         environment.clone(),
@@ -306,7 +307,10 @@ impl ClientInner {
                 (blockchain_proxy, syncer, zkp_component)
             }
             SyncMode::Light => {
-                let blockchain = Arc::new(RwLock::new(LightBlockchain::new(config.network_id)));
+                let blockchain = Arc::new(RwLock::new(LightBlockchain::new(
+                    config.network_id,
+                    config.zkp.setup_keys_path.clone(),
+                )));
                 let blockchain_proxy = BlockchainProxy::from(&blockchain);
                 let zkp_component = ZKPComponent::new(
                     blockchain_proxy.clone(),

--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 
@@ -23,39 +23,41 @@ const BROADCAST_MAX_CAPACITY: usize = 256;
 /// The Blockchain struct. It stores all information of the blockchain that is known to the Nano
 /// nodes.
 pub struct LightBlockchain {
-    // The network ID. It determines if this is the mainnet or one of the testnets.
+    /// The network ID. It determines if this is the mainnet or one of the testnets.
     pub network_id: NetworkId,
-    // The OffsetTime struct. It allows us to query the current time.
+    /// The OffsetTime struct. It allows us to query the current time.
     pub time: Arc<OffsetTime>,
-    // The head of the main chain.
+    /// The head of the main chain.
     pub head: Block,
-    // The last macro block.
+    /// The last macro block.
     pub macro_head: MacroBlock,
-    // The last election block.
+    /// The last election block.
     pub election_head: MacroBlock,
-    // The validators for the current epoch.
+    /// The validators for the current epoch.
     pub current_validators: Option<Validators>,
-    // The genesis block.
+    /// The genesis block.
     pub genesis_block: Block,
-    // The chain store is a database containing all of the chain infos in the current batch.
+    /// The chain store is a database containing all of the chain infos in the current batch.
     pub chain_store: ChainStore,
     /// The notifier processes events relative to the blockchain.
     pub notifier: BroadcastSender<BlockchainEvent>,
     /// The fork notifier processes fork events.
     pub fork_notifier: BroadcastSender<ForkEvent>,
+    /// The path to the ZKP directory needed for the verification keys.
+    pub keys_path: PathBuf,
 }
 
 /// Implements methods to start a Blockchain.
 impl LightBlockchain {
     /// Creates a new blockchain from a given network ID.
-    pub fn new(network_id: NetworkId) -> Self {
+    pub fn new(network_id: NetworkId, keys_path: PathBuf) -> Self {
         let network_info = NetworkInfo::from_network_id(network_id);
         let genesis_block = network_info.genesis_block::<Block>();
-        Self::with_genesis(network_id, genesis_block)
+        Self::with_genesis(network_id, genesis_block, keys_path)
     }
 
     /// Creates a new blockchain with a given network ID and genesis block.
-    pub fn with_genesis(network_id: NetworkId, genesis_block: Block) -> Self {
+    pub fn with_genesis(network_id: NetworkId, genesis_block: Block, keys_path: PathBuf) -> Self {
         let time = Arc::new(OffsetTime::new());
 
         let chain_info = ChainInfo::new(genesis_block.clone(), true);
@@ -78,6 +80,7 @@ impl LightBlockchain {
             chain_store,
             notifier: tx,
             fork_notifier: tx_fork,
+            keys_path,
         }
     }
 

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use parking_lot::RwLockUpgradableReadGuard;
 
 use nimiq_block::{Block, BlockError};
@@ -60,7 +58,7 @@ impl LightBlockchain {
             final_header_hash,
             final_public_keys,
             proof,
-            &PathBuf::new(), // use the current directory
+            &this.keys_path,
         );
 
         if verify_result.is_err() || !verify_result.unwrap() {

--- a/light-blockchain/tests/push.rs
+++ b/light-blockchain/tests/push.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use nimiq_block::{Block, BlockError, SkipBlockProof};
 use nimiq_block_production::{
@@ -46,8 +46,10 @@ impl Default for TemporaryLightBlockProducer {
 
 impl TemporaryLightBlockProducer {
     pub fn new() -> Self {
-        let light_blockchain =
-            Arc::new(RwLock::new(LightBlockchain::new(NetworkId::UnitAlbatross)));
+        let light_blockchain = Arc::new(RwLock::new(LightBlockchain::new(
+            NetworkId::UnitAlbatross,
+            PathBuf::new(),
+        )));
 
         let temp_producer = TemporaryBlockProducer::new();
         let blockchain = Arc::clone(&temp_producer.blockchain);

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -276,12 +276,7 @@ impl<N: Network> ZKPComponent<N> {
 
         // Sends the new event to the notifier stream.
         let event = ZKPEvent::new(proof_source, zk_proof, new_block);
-        if let Err(e) = self.zkp_events_notifier.send(event.clone()) {
-            log::error!(
-                "Error sending the proof (from peer) to the events notifier {}",
-                e
-            );
-        }
+        _ = self.zkp_events_notifier.send(event.clone());
 
         Ok(event)
     }
@@ -369,13 +364,11 @@ impl<N: Network> Future for ZKPComponent<N> {
                         proof_storage.set_zkp(&self.zkp_state.read().clone().into());
                     }
 
-                    if let Err(e) = self.zkp_events_notifier.send(ZKPEvent::new(
+                    _ = self.zkp_events_notifier.send(ZKPEvent::new(
                         ProofSource::SelfGenerated,
                         zk_proof,
                         block,
-                    )) {
-                        log::error!("Error sending the proof to events notifier {}", e);
-                    }
+                    ));
                 }
                 Poll::Ready(None) => {
                     // The stream was closed so we quit as well.

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -300,8 +300,10 @@ impl<N: Network> Future for ZKPComponent<N> {
                     );
 
                     // Log errors.
-                    if let Err(ref e) = result {
-                        log::error!("Error pushing the new zk proof {}", e);
+                    match result {
+                        Err(Error::OutdatedProof) => log::trace!("ZK Proof was outdated"),
+                        Err(ref e) => log::error!("Error pushing the new zk proof {}", e),
+                        _ => {}
                     }
 
                     // Return verification result if channel exists.

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -170,9 +170,9 @@ impl<N: Network> ZKProver<N> {
             self.sender = Some(sender);
         } else {
             log::debug!(
-                "Won't generate zkp for a block of the past; block height: {}, current height: {}",
-                zkp_state.latest_block_number,
-                block.block_number()
+                block_height = zkp_state.latest_block_number,
+                current_height = block.block_number(),
+                "Won't generate zkp for a block of the past",
             );
         }
     }
@@ -187,7 +187,7 @@ impl<N: Network> Stream for ZKProver<N> {
             self.pending_election_blocks.push_back(block);
         }
 
-        // Launches new proof generate, if we have a pending election block are and no proof generation is launched yet.
+        // Launches new proof generation, if we have a pending election block are and no proof generation is launched yet.
         // We need to loop in case we already received a zkp for one of the blocks in the list.
         while self.proof_future.is_none() {
             if let Some(block) = self.pending_election_blocks.pop_front() {
@@ -226,7 +226,7 @@ impl<N: Network> Stream for ZKProver<N> {
                         return Poll::Ready(Some((proof, block)));
                     }
                     Err(e) => {
-                        log::error!("Error generating ZK Proof for block {}", e);
+                        log::error!(error = %e, "Error generating ZK Proof for block");
                     }
                 };
             }

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::error::Error;
 use std::future;
 use std::path::PathBuf;
@@ -5,7 +6,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::{stream, FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt};
+use parking_lot::lock_api::RwLockUpgradableReadGuard;
+use parking_lot::{RwLock, RwLockWriteGuard};
+use tokio::sync::oneshot::{channel, Sender};
+
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction};
@@ -13,14 +18,9 @@ use nimiq_genesis::NetworkInfo;
 use nimiq_nano_primitives::state_commitment;
 use nimiq_network_interface::network::Network;
 use nimiq_primitives::policy::Policy;
-use parking_lot::lock_api::RwLockUpgradableReadGuard;
-use parking_lot::{RwLock, RwLockWriteGuard};
-
-use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 
 use crate::proof_gen_utils::*;
 use crate::types::*;
-use crate::zkp_component::BROADCAST_MAX_CAPACITY;
 
 /// ZK Prover generates the zk proof for an election block. It has:
 ///
@@ -33,9 +33,14 @@ use crate::zkp_component::BROADCAST_MAX_CAPACITY;
 pub struct ZKProver<N: Network> {
     network: Arc<N>,
     zkp_state: Arc<RwLock<ZKPState>>,
-    sender: BroadcastSender<()>,
-    proof_stream:
-        Pin<Box<dyn Stream<Item = Result<(ZKPState, MacroBlock), ZKProofGenerationError>> + Send>>,
+    sender: Option<Sender<()>>,
+    pending_election_blocks: VecDeque<MacroBlock>,
+    election_stream: BoxStream<'static, MacroBlock>,
+    genesis_state: Vec<u8>,
+    proof_future:
+        Option<BoxFuture<'static, Result<(ZKPState, MacroBlock), ZKProofGenerationError>>>,
+    keys_path: PathBuf,
+    prover_path: Option<PathBuf>,
 }
 
 impl<N: Network> ZKProver<N> {
@@ -56,8 +61,32 @@ impl<N: Network> ZKProver<N> {
             public_keys,
         );
 
+        // Prepends the election blocks from the blockchain for which we don't have a proof yet
+        let blockchain_rg = blockchain.read();
+        let current_state_height = zkp_state.read().latest_block_number;
+        let blockchain_election_height = blockchain_rg.state.election_head.block_number();
+
+        let pending_election_blocks = if blockchain_election_height > current_state_height {
+            blockchain_rg
+                .get_macro_blocks(
+                    &zkp_state.read().latest_header_hash,
+                    (blockchain_election_height - current_state_height)
+                        / Policy::blocks_per_epoch(),
+                    true,
+                    Direction::Forward,
+                    true,
+                    None,
+                )
+                .expect("Fetching election blocks for zkp prover initialization failed")
+                .drain(..)
+                .map(|block| block.unwrap_macro())
+                .collect()
+        } else {
+            VecDeque::new()
+        };
+
         // Gets the stream of blockchain events and converts it into an election macro block stream
-        let blockchain_election_rx = blockchain.read().notifier_as_stream();
+        let blockchain_election_rx = blockchain_rg.notifier_as_stream();
         let blockchain2 = Arc::clone(&blockchain);
 
         let blockchain_election_rx = blockchain_election_rx.filter_map(move |event| {
@@ -75,83 +104,23 @@ impl<N: Network> ZKProver<N> {
             future::ready(result)
         });
 
-        // Prepends the election blocks from the blockchain for which we don't have a proof yet
-        let blockchain_rg = blockchain.read();
-        let current_state_height = zkp_state.read().latest_block_number;
-        let blockchain_election_height = blockchain_rg.state.election_head.block_number();
-
-        let blocks = if blockchain_election_height > current_state_height {
-            blockchain_rg
-                .get_macro_blocks(
-                    &zkp_state.read().latest_header_hash,
-                    (blockchain_election_height - current_state_height)
-                        / Policy::blocks_per_epoch(),
-                    true,
-                    Direction::Forward,
-                    true,
-                    None,
-                )
-                .expect("Fetching election blocks for zkp prover initialization failed")
-                .drain(..)
-                .map(|block| block.unwrap_macro())
-                .collect()
-        } else {
-            vec![]
-        };
-        let blockchain_election_rx = stream::iter(blocks).chain(blockchain_election_rx);
-        drop(blockchain_rg);
-
-        // Upon every election block, a proof generation process is launched.
-        // The assertion holds true since we should only start generating the next proof after its predecessor's
-        // proof has been pushed into our state.
-        //
-        // Note: The election block stream may have blocks that are too old relative to our zkp state;
-        // thus we will filter those blocks out.
-        let (sender, recv) = broadcast(BROADCAST_MAX_CAPACITY);
-        let zkp_state2 = Arc::clone(&zkp_state);
-        let proof_stream = blockchain_election_rx
-            .filter_map(move |block| {
-                let genesis_state3 = genesis_state.clone();
-                let zkp_state3 = Arc::clone(&zkp_state2);
-                let recv = recv.resubscribe();
-                let zkp_state = zkp_state3.read();
-                let prover_path = prover_path.clone();
-                let keys_path2 = keys_path.clone();
-                assert!(
-                    zkp_state.latest_block_number
-                        >= block.block_number() - Policy::blocks_per_epoch(),
-                    "The current state (block height: {}) should never lag behind more than one epoch. Current height: {}",
-                    zkp_state.latest_block_number,
-                    block.block_number(),
-                );
-                if zkp_state.latest_block_number
-                    == block.block_number() - Policy::blocks_per_epoch()
-                {
-                    launch_generate_new_proof(
-                        recv,
-                        ProofInput {
-                            block: block.clone(),
-                            latest_pks: zkp_state.latest_pks.clone(),
-                            latest_header_hash: zkp_state.latest_header_hash.clone(),
-                            previous_proof: zkp_state.latest_proof.clone(),
-                            genesis_state: genesis_state3,
-                            keys_path: keys_path2,
-                        },
-                        prover_path,
-                    )
-                    .map(|res| Some(res.map(|state| (state, block))))
-                    .left_future()
-                } else {
-                    future::ready(None).right_future()
-                }
-            })
-            .boxed();
-
         Self {
             network,
             zkp_state,
-            sender,
-            proof_stream,
+            sender: None,
+            genesis_state,
+            pending_election_blocks,
+            election_stream: Box::pin(blockchain_election_rx),
+            proof_future: None,
+            keys_path,
+            prover_path,
+        }
+    }
+
+    /// This sends the kill signal to the proof generation process.
+    pub(crate) fn cancel_current_proof_production(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            sender.send(()).unwrap();
         }
     }
 
@@ -165,9 +134,47 @@ impl<N: Network> ZKProver<N> {
         });
     }
 
-    /// This sends the kill signal to the proof generation process.
-    pub(crate) fn cancel_current_proof_production(&mut self) {
-        self.sender.send(()).unwrap();
+    // Upon every election block, a proof generation process is launched.
+    // The assertion holds true since we should only start generating the next proof after its predecessor's
+    // proof has been pushed into our state.
+    //
+    // Note: The election block stream may have blocks that are too old relative to our zkp state;
+    // thus we will filter those blocks out.
+    fn launch_proof_generation(&mut self, block: MacroBlock) {
+        let zkp_state = self.zkp_state.read();
+        assert!(
+                zkp_state.latest_block_number
+                >= block.block_number() - Policy::blocks_per_epoch(),
+                "The current state (block height: {}) should never lag behind more than one epoch. Current height: {}",
+                zkp_state.latest_block_number,
+                block.block_number(),
+            );
+        if zkp_state.latest_block_number == block.block_number() - Policy::blocks_per_epoch() {
+            let (sender, recv) = channel();
+            self.proof_future = Some(
+                launch_generate_new_proof(
+                    recv,
+                    ProofInput {
+                        block: block.clone(),
+                        latest_pks: zkp_state.latest_pks.clone(),
+                        latest_header_hash: zkp_state.latest_header_hash.clone(),
+                        previous_proof: zkp_state.latest_proof.clone(),
+                        genesis_state: self.genesis_state.clone(),
+                        keys_path: self.keys_path.clone(),
+                    },
+                    self.prover_path.clone(),
+                )
+                .map(|res| res.map(|state| (state, block)))
+                .boxed(),
+            );
+            self.sender = Some(sender);
+        } else {
+            log::debug!(
+                "Won't generate zkp for a block of the past; block height: {}, current height: {}",
+                zkp_state.latest_block_number,
+                block.block_number()
+            );
+        }
     }
 }
 
@@ -175,35 +182,54 @@ impl<N: Network> Stream for ZKProver<N> {
     type Item = (ZKProof, MacroBlock);
 
     fn poll_next(mut self: Pin<&mut ZKProver<N>>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        // Fetch and store the new election blocks.
+        while let Poll::Ready(Some(block)) = self.election_stream.poll_next_unpin(cx) {
+            self.pending_election_blocks.push_back(block);
+        }
+
+        // Launches new proof generate, if we have a pending election block are and no proof generation is launched yet.
+        // We need to loop in case we already received a zkp for one of the blocks in the list.
+        while self.proof_future.is_none() {
+            if let Some(block) = self.pending_election_blocks.pop_front() {
+                self.launch_proof_generation(block);
+            } else {
+                break;
+            }
+        }
+
         // If a new proof was generated it sets the state and broadcasts the new proof.
-        while let Poll::Ready(Some(proof)) = self.proof_stream.poll_next_unpin(cx) {
-            match proof {
-                Ok((new_zkp_state, block)) => {
-                    assert!(
-                        new_zkp_state.latest_proof.is_some(),
-                        "The generate new proof should never produces a empty proof"
-                    );
-                    let zkp_state_lock = self.zkp_state.upgradable_read();
+        if let Some(ref mut proof_future) = self.proof_future {
+            if let Poll::Ready(proof) = proof_future.poll_unpin(cx) {
+                self.proof_future = None;
+                self.sender = None;
+                match proof {
+                    Ok((new_zkp_state, block)) => {
+                        assert!(
+                            new_zkp_state.latest_proof.is_some(),
+                            "The generate new proof should never produces a empty proof"
+                        );
+                        let zkp_state_lock = self.zkp_state.upgradable_read();
 
-                    // If we received a more recent proof in the meanwhile, we should have cancelled the proof generation process already.
-                    assert!(
-                        zkp_state_lock.latest_block_number < new_zkp_state.latest_block_number,
-                        "The generated proof should always be more recent than the current state"
-                    );
+                        // If we received a more recent proof in the meanwhile, we should have cancelled the proof generation process already.
+                        assert!(
+                            zkp_state_lock.latest_block_number < new_zkp_state.latest_block_number,
+                            "The generated proof should always be more recent than the current state"
+                        );
 
-                    let mut zkp_state_lock = RwLockUpgradableReadGuard::upgrade(zkp_state_lock);
-                    *zkp_state_lock = new_zkp_state;
+                        let mut zkp_state_lock = RwLockUpgradableReadGuard::upgrade(zkp_state_lock);
+                        *zkp_state_lock = new_zkp_state;
 
-                    let zkp_state_lock = RwLockWriteGuard::downgrade(zkp_state_lock);
+                        let zkp_state_lock = RwLockWriteGuard::downgrade(zkp_state_lock);
 
-                    let proof: ZKProof = zkp_state_lock.clone().into();
-                    Self::broadcast_zk_proof(&self.network, proof.clone());
-                    return Poll::Ready(Some((proof, block)));
-                }
-                Err(e) => {
-                    log::error!("Error generating ZK Proof for block {}", e);
-                }
-            };
+                        let proof: ZKProof = zkp_state_lock.clone().into();
+                        Self::broadcast_zk_proof(&self.network, proof.clone());
+                        return Poll::Ready(Some((proof, block)));
+                    }
+                    Err(e) => {
+                        log::error!("Error generating ZK Proof for block {}", e);
+                    }
+                };
+            }
         }
 
         Poll::Pending

--- a/zkp-component/tests/zkp_prover.rs
+++ b/zkp-component/tests/zkp_prover.rs
@@ -4,7 +4,7 @@ use nimiq_zkp_component::{
     proof_gen_utils::launch_generate_new_proof,
     types::{ProofInput, ZKProofGenerationError},
 };
-use tokio::sync::broadcast;
+use tokio::sync::oneshot;
 
 #[test]
 fn can_locate_prover_binary() {
@@ -13,7 +13,7 @@ fn can_locate_prover_binary() {
 
 #[test(tokio::test)]
 async fn can_launch_process_and_parse_output() {
-    let (_send, recv) = broadcast::channel(1);
+    let (_send, recv) = oneshot::channel();
     let proof_input: ProofInput = Default::default();
 
     let result = launch_generate_new_proof(recv, proof_input, Some(zkp_test_exe())).await;
@@ -23,7 +23,7 @@ async fn can_launch_process_and_parse_output() {
 
 #[test(tokio::test)]
 async fn can_launch_process_and_kill() {
-    let (send, recv) = broadcast::channel(1);
+    let (send, recv) = oneshot::channel();
     let proof_input: ProofInput = Default::default();
 
     let result = tokio::spawn(launch_generate_new_proof(


### PR DESCRIPTION
## What's in this pull request?

The ZKP prover would panic after producing one ZKP.
This would happen due to receiver lagging on the blockchain stream and the corresponding buffer being full.

We fixed it by keeping our own election block only buffer instead and moving some of the logic.

Also:
- fixes an issue with the path for the verifying keys in the blockchains,
- properly sets the `can_verify_history` flag, which previously caused issues on restarts of full nodes.

#### This fixes #1162.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
