### PR TITLE
Fix several clippy warnings

### DIFF
--- a/beserial/beserial_derive/src/lib.rs
+++ b/beserial/beserial_derive/src/lib.rs
@@ -120,14 +120,14 @@ fn parse_field_attribs(attrs: &[syn::Attribute]) -> Option<FieldAttribute> {
                                                         && !cmp_ident(value, "u16")
                                                         && !cmp_ident(value, "u32")
                                                     {
-                                                        panic!("beserial(len_type) must be one of [u8, u16, u32], but was {:?}", value);
+                                                        panic!("beserial(len_type) must be one of [u8, u16, u32], but was {value:?}");
                                                     }
                                                     len_type =
                                                         Some(value.get_ident().cloned().unwrap());
                                                 }
                                                 Meta::NameValue(name_value) => {
                                                     if !cmp_ident(&name_value.path, "limit") {
-                                                        panic!("beserial(len_type) can only have an additional limit attribute, but was {:?}", name_value);
+                                                        panic!("beserial(len_type) can only have an additional limit attribute, but was {name_value:?}");
                                                     }
                                                     // We do have something like beserial(discriminant = 123).
                                                     // Parse discriminant.
@@ -177,7 +177,7 @@ fn parse_field_attribs(attrs: &[syn::Attribute]) -> Option<FieldAttribute> {
                                 } else if cmp_ident(path, "uvar") {
                                     return Some(FieldAttribute::Uvar);
                                 } else {
-                                    panic!("unknown flag for beserial: {:?}", path)
+                                    panic!("unknown flag for beserial: {path:?}")
                                 }
                             }
                             Meta::NameValue(ref name_value) => {
@@ -196,7 +196,7 @@ fn parse_field_attribs(attrs: &[syn::Attribute]) -> Option<FieldAttribute> {
                                         panic!("non-integer discriminant");
                                     }
                                 } else {
-                                    panic!("unknown flag for beserial: {:?}", name_value)
+                                    panic!("unknown flag for beserial: {name_value:?}")
                                 }
                             }
                         }
@@ -227,7 +227,7 @@ fn parse_enum_attribs(ast: &syn::DeriveInput) -> (Option<syn::Ident>, bool) {
                         if cmp_ident(attr_ident, "uvar") {
                             uvar = true;
                         } else {
-                            panic!("unknown flag for beserial: {:?}", attr_ident)
+                            panic!("unknown flag for beserial: {attr_ident:?}")
                         }
                     }
                 }
@@ -345,8 +345,7 @@ fn impl_serialize(ast: &syn::DeriveInput) -> TokenStream {
             } else {
                 enum_type.unwrap_or_else(|| {
                     panic!(
-                        "Serialize can not be derived for enum {} without repr(u*) or repr(i*)",
-                        name
+                        "Serialize can not be derived for enum {name} without repr(u*) or repr(i*)"
                     )
                 })
             };
@@ -423,7 +422,7 @@ fn impl_serialize(ast: &syn::DeriveInput) -> TokenStream {
                             let mut serialized_size_body_fields = Vec::<TokenStream>::new();
 
                             for (i, field) in fields.unnamed.iter().enumerate() {
-                                let ident = syn::Ident::new(&format!("f{}", i), Span::call_site());
+                                let ident = syn::Ident::new(&format!("f{i}"), Span::call_site());
                                 if let Some((serialize, serialized_size)) =
                                     impl_serialize_field(field, 0, Some(&ident))
                                 {
@@ -473,7 +472,7 @@ fn impl_serialize(ast: &syn::DeriveInput) -> TokenStream {
                 }
             }
         }
-        Data::Union(_) => panic!("Serialize can not be derived for Union {}", name),
+        Data::Union(_) => panic!("Serialize can not be derived for Union {name}"),
     };
 
     let gen = quote! {
@@ -571,8 +570,7 @@ fn impl_deserialize(ast: &syn::DeriveInput) -> TokenStream {
             } else {
                 enum_type.unwrap_or_else(|| {
                     panic!(
-                        "Deserialize can not be derived for enum {} without repr(u*) or repr(i*)",
-                        name
+                        "Deserialize can not be derived for enum {name} without repr(u*) or repr(i*)"
                     )
                 })
             };
@@ -703,7 +701,7 @@ fn impl_deserialize(ast: &syn::DeriveInput) -> TokenStream {
                 });
             }
         }
-        Data::Union(_) => panic!("Deserialize can not be derived for Union {}", name),
+        Data::Union(_) => panic!("Deserialize can not be derived for Union {name}"),
     };
 
     let gen = quote! {

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -208,7 +208,7 @@ impl Blockchain {
                 let batch_info = match batch_info {
                     Ok(batch_info) => batch_info,
                     Err(e) => {
-                        panic!("Failed to revert - {:?}", e);
+                        panic!("Failed to revert - {e:?}");
                     }
                 };
 

--- a/bls/examples/gen_sig.rs
+++ b/bls/examples/gen_sig.rs
@@ -12,5 +12,5 @@ fn main() {
 
     let sig = keypair.sign(&message);
 
-    println!("Signature:\n {}", sig);
+    println!("Signature:\n {sig}");
 }

--- a/bls/src/rand_gen.rs
+++ b/bls/src/rand_gen.rs
@@ -72,22 +72,7 @@ pub fn generate_random_seed() -> Vec<u8> {
     let block_14 = "000000000000000000132006558a816203cb442aeb9162ba1d8f6dac5f0a00ec";
 
     let concatenated = format!(
-        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
-        block_00,
-        block_01,
-        block_02,
-        block_03,
-        block_04,
-        block_05,
-        block_06,
-        block_07,
-        block_08,
-        block_09,
-        block_10,
-        block_11,
-        block_12,
-        block_13,
-        block_14
+        "{block_00}{block_01}{block_02}{block_03}{block_04}{block_05}{block_06}{block_07}{block_08}{block_09}{block_10}{block_11}{block_12}{block_13}{block_14}"
     );
 
     let random_bytes = hex::decode(concatenated).unwrap();

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -330,7 +330,7 @@ impl fmt::Display for BitSet {
                 let consecutive_last = last_value.map(|lv| lv + 1 == value).unwrap_or(false);
                 let consecutive_next = value + 1 == *next_value;
                 if !(consecutive_last && consecutive_next) {
-                    write!(f, "{}", value)?;
+                    write!(f, "{value}")?;
                     if consecutive_next {
                         write!(f, "-")?;
                     } else {
@@ -338,7 +338,7 @@ impl fmt::Display for BitSet {
                     }
                 }
             } else {
-                write!(f, "{}", value)?;
+                write!(f, "{value}")?;
             }
             last_value = Some(value);
         }

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -353,7 +353,7 @@ mod tests {
             Some(MacroSyncReturn::Good(_)) => {
                 assert_eq!(chain.read().block_number(), 0);
             }
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
     }
 
@@ -389,7 +389,7 @@ mod tests {
             Some(MacroSyncReturn::Good(_)) => {
                 assert_eq!(chain1.read().head(), chain2.read().head());
             }
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
     }
 
@@ -429,7 +429,7 @@ mod tests {
             Some(MacroSyncReturn::Good(_)) => {
                 assert_eq!(chain1.read().head(), chain2.read().head());
             }
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
     }
 
@@ -459,7 +459,7 @@ mod tests {
             Some(MacroSyncReturn::Good(_)) => {
                 assert_eq!(chain1.read().head(), chain2.read().head());
             }
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
     }
 
@@ -515,7 +515,7 @@ mod tests {
         );
 
         let num_blocks = Policy::blocks_per_batch() + Policy::blocks_per_batch() / 2;
-        copy_chain_with_limit(&*chain2, &*chain1, num_blocks as usize);
+        copy_chain_with_limit(&chain2, &chain1, num_blocks as usize);
         assert_eq!(chain1.read().block_number(), num_blocks);
 
         let mut sync = HistoryMacroSync::<MockNetwork>::new(
@@ -552,11 +552,11 @@ mod tests {
         produce_macro_blocks_with_txns(&producer, &chain2, 1, 1, 0);
         assert_eq!(chain2.read().block_number(), Policy::blocks_per_batch());
 
-        copy_chain(&*chain2, &*chain3);
+        copy_chain(&chain2, &chain3);
         produce_macro_blocks_with_txns(&producer, &chain3, 1, 1, 0);
         assert_eq!(chain3.read().block_number(), 2 * Policy::blocks_per_batch());
 
-        copy_chain(&*chain3, &*chain4);
+        copy_chain(&chain3, &chain4);
         produce_macro_blocks_with_txns(&producer, &chain4, 1, 1, 0);
         assert_eq!(chain4.read().block_number(), 3 * Policy::blocks_per_batch());
 
@@ -576,15 +576,15 @@ mod tests {
 
         match sync.next().await {
             Some(MacroSyncReturn::Good(peer_id)) if peer_id == net4.peer_id() => {}
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
         match sync.next().await {
             Some(MacroSyncReturn::Outdated(peer_id)) if peer_id == net3.peer_id() => {}
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
         match sync.next().await {
             Some(MacroSyncReturn::Outdated(peer_id)) if peer_id == net2.peer_id() => {}
-            res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+            res => panic!("Unexpected HistorySyncReturn: {res:?}"),
         }
 
         assert_eq!(chain1.read().head(), chain4.read().head());

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -438,7 +438,7 @@ mod tests {
                     // Verify the peer was removed
                     assert_eq!(sync.peer_requests.len(), 0);
                 }
-                res => panic!("Unexpected MacroSyncReturn: {:?}", res),
+                res => panic!("Unexpected MacroSyncReturn: {res:?}"),
             }
         }
 
@@ -495,7 +495,7 @@ mod tests {
                 Some(MacroSyncReturn::Good(_)) => {
                     assert_eq!(chain1.read().head(), chain2.read().head());
                 }
-                res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+                res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
         }
 
@@ -519,7 +519,7 @@ mod tests {
             if let BlockchainProxy::Full(ref chain2) = chain2 {
                 produce_macro_blocks_with_txns(
                     &producer,
-                    &chain2,
+                    chain2,
                     Policy::batches_per_epoch() as usize,
                     1,
                     0,
@@ -567,7 +567,7 @@ mod tests {
                 Some(MacroSyncReturn::Good(_)) => {
                     assert_eq!(chain1.read().head(), chain2.read().head());
                 }
-                res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+                res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
         }
 
@@ -588,7 +588,7 @@ mod tests {
             if let BlockchainProxy::Full(ref chain2) = chain2 {
                 produce_macro_blocks_with_txns(
                     &producer,
-                    &chain2,
+                    chain2,
                     (Policy::batches_per_epoch() + 1) as usize,
                     1,
                     0,
@@ -639,7 +639,7 @@ mod tests {
                 Some(MacroSyncReturn::Good(_)) => {
                     assert_eq!(chain1.read().head(), chain2.read().head());
                 }
-                res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+                res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
         }
 
@@ -659,7 +659,7 @@ mod tests {
             let num_batches = (Policy::batches_per_epoch() - 1) as usize;
             let producer = BlockProducer::new(signing_key(), voting_key());
             if let BlockchainProxy::Full(ref chain2) = chain2 {
-                produce_macro_blocks_with_txns(&producer, &chain2, num_batches, 1, 0);
+                produce_macro_blocks_with_txns(&producer, chain2, num_batches, 1, 0);
             }
             assert_eq!(
                 chain2.read().block_number(),
@@ -706,7 +706,7 @@ mod tests {
                 Some(MacroSyncReturn::Good(_)) => {
                     assert_eq!(chain1.read().head(), chain2.read().head());
                 }
-                res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+                res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
         }
 
@@ -728,7 +728,7 @@ mod tests {
             if let BlockchainProxy::Full(ref chain2) = chain2 {
                 produce_macro_blocks_with_txns(
                     &producer,
-                    &chain2,
+                    chain2,
                     Policy::batches_per_epoch() as usize * (num_extra_epochs + 2) as usize,
                     1,
                     0,
@@ -741,7 +741,7 @@ mod tests {
             if let BlockchainProxy::Full(ref chain1) = chain1 {
                 let block_to_delete = chain2
                     .read()
-                    .get_block_at(Policy::blocks_per_epoch() as u32, true)
+                    .get_block_at(Policy::blocks_per_epoch(), true)
                     .unwrap();
 
                 assert_eq!(
@@ -753,7 +753,7 @@ mod tests {
                         chain1.upgradable_read(),
                         chain2
                             .read()
-                            .get_block_at(Policy::blocks_per_epoch() as u32 * 2, true)
+                            .get_block_at(Policy::blocks_per_epoch() * 2, true)
                             .unwrap(),
                     ),
                     Ok(PushResult::Extended),
@@ -810,7 +810,7 @@ mod tests {
                 Some(MacroSyncReturn::Good(_)) => {
                     assert_eq!(chain1.read().head(), chain2.read().head());
                 }
-                res => panic!("Unexpected HistorySyncReturn: {:?}", res),
+                res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
 
             assert_eq!(

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -70,7 +70,7 @@ pub enum ResponseChunk {
 impl Display for ResponseChunk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ResponseChunk::Chunk(chunk) => write!(f, "ResponseChunk::Chunk({})", chunk),
+            ResponseChunk::Chunk(chunk) => write!(f, "ResponseChunk::Chunk({chunk})"),
             ResponseChunk::IncompleteState => {
                 write!(f, "ResponseChunk::IncompleteState")
             }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -28,7 +28,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
         match self {
-            CreateDirectory(e) => write!(f, "couldn't create directory for DB: {}", e),
+            CreateDirectory(e) => write!(f, "couldn't create directory for DB: {e}"),
             Mdbx(e) => e.fmt(f),
         }
     }

--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -72,7 +72,7 @@ where
     D: Deserializer<'de>,
 {
     let s: String = Deserialize::deserialize(deserializer)?;
-    Address::from_user_friendly_address(&s).map_err(|e| Error::custom(format!("{:?}", e)))
+    Address::from_user_friendly_address(&s).map_err(|e| Error::custom(format!("{e:?}")))
 }
 
 #[allow(dead_code)]
@@ -83,8 +83,7 @@ where
     let opt: Option<String> = Deserialize::deserialize(deserializer)?;
     if let Some(s) = opt {
         Ok(Some(
-            Address::from_user_friendly_address(&s)
-                .map_err(|e| Error::custom(format!("{:?}", e)))?,
+            Address::from_user_friendly_address(&s).map_err(|e| Error::custom(format!("{e:?}")))?,
         ))
     } else {
         Ok(None)
@@ -127,7 +126,7 @@ where
     if let Some(s) = opt {
         Ok(Some(
             OffsetDateTime::parse(&s, &time::format_description::well_known::Rfc3339)
-                .map_err(|e| Error::custom(format!("{:?}", e)))?,
+                .map_err(|e| Error::custom(format!("{e:?}")))?,
         ))
     } else {
         Ok(None)

--- a/genesis-builder/src/main.rs
+++ b/genesis-builder/src/main.rs
@@ -30,11 +30,11 @@ fn main() {
             .generate(env)
             .unwrap();
 
-        println!("Genesis Block: {}", hash);
-        println!("{:#?}", block);
+        println!("Genesis Block: {hash}");
+        println!("{block:#?}");
         println!();
         println!("Genesis Accounts:");
-        println!("{:#?}", accounts);
+        println!("{accounts:#?}");
     } else {
         usage(args);
     }

--- a/genesis/build.rs
+++ b/genesis/build.rs
@@ -9,11 +9,10 @@ use nimiq_hash::Blake2bHash;
 fn write_genesis_rs(directory: &Path, name: &str, genesis_hash: &Blake2bHash) {
     let genesis_rs = format!(
         r#"GenesisData {{
-            block: include_bytes!(concat!(env!("OUT_DIR"), "/genesis/{}/block.dat")),
-            hash: "{}".into(),
-            accounts: include_bytes!(concat!(env!("OUT_DIR"), "/genesis/{}/accounts.dat")),
+            block: include_bytes!(concat!(env!("OUT_DIR"), "/genesis/{name}/block.dat")),
+            hash: "{genesis_hash}".into(),
+            accounts: include_bytes!(concat!(env!("OUT_DIR"), "/genesis/{name}/accounts.dat")),
     }}"#,
-        name, genesis_hash, name,
     );
     log::debug!("Writing genesis source code: {}", &genesis_rs);
     fs::write(directory.join("genesis.rs"), genesis_rs.as_bytes()).unwrap();
@@ -25,7 +24,7 @@ fn generate_albatross(name: &str, out_dir: &Path, src_dir: &Path) {
     let directory = out_dir.join(name);
     fs::create_dir_all(&directory).unwrap();
 
-    let genesis_config = src_dir.join(format!("{}.toml", name));
+    let genesis_config = src_dir.join(format!("{name}.toml"));
     log::info!("genesis source file: {}", genesis_config.display());
 
     let env = VolatileEnvironment::new(10).expect("Could not open a volatile database");

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -68,7 +68,7 @@ impl NetworkInfo {
     pub fn from_network_id(network_id: NetworkId) -> &'static Self {
         NETWORK_MAP
             .get(&network_id)
-            .unwrap_or_else(|| panic!("No such network ID: {}", network_id))
+            .unwrap_or_else(|| panic!("No such network ID: {network_id}"))
     }
 }
 

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -126,7 +126,7 @@ impl<
         let level = self
             .levels
             .get(level)
-            .unwrap_or_else(|| panic!("Attempted to start invalid level {}", level));
+            .unwrap_or_else(|| panic!("Attempted to start invalid level {level}"));
         trace!("Starting level {}: Peers: {:?}", level.id, level.peer_ids);
 
         // Try to Start the level
@@ -162,12 +162,10 @@ impl<
 
     /// Check if a level was completed TODO: remove contribution parameter as it is not used at all.
     fn check_completed_level(&self, _contribution: P::Contribution, level: usize) {
-        let level = self.levels.get(level).unwrap_or_else(|| {
-            panic!(
-                "Attempted to check completeness of invalid level: {}",
-                level
-            )
-        });
+        let level = self
+            .levels
+            .get(level)
+            .unwrap_or_else(|| panic!("Attempted to check completeness of invalid level: {level}"));
 
         // check if level already is completed
         {
@@ -216,10 +214,7 @@ impl<
 
             // if there is an aggregate contribution for given level i send it out to the peers of that level.
             if let Some(multisig) = combined {
-                let level = self
-                    .levels
-                    .get(i)
-                    .unwrap_or_else(|| panic!("No level {}", i));
+                let level = self.levels.get(i).unwrap_or_else(|| panic!("No level {i}"));
                 if level.update_signature_to_send(&multisig.clone()) {
                     // XXX Do this without cloning
                     self.send_update(multisig, level, self.config.peer_count);

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -224,7 +224,7 @@ impl<
         let votes = self
             .weights
             .signature_weight(signature)
-            .unwrap_or_else(|| panic!("Missing weights for signature: {:?}", signature));
+            .unwrap_or_else(|| panic!("Missing weights for signature: {signature:?}"));
 
         trace!(
             "is_final(): votes={}, final={}",

--- a/handel/src/partitioner.rs
+++ b/handel/src/partitioner.rs
@@ -109,7 +109,7 @@ impl Partitioner for BinomialPartitioner {
         for contribution in contributions.iter().skip(1) {
             combined
                 .combine(contribution)
-                .unwrap_or_else(|e| panic!("Failed to combine contributions: {}", e));
+                .unwrap_or_else(|e| panic!("Failed to combine contributions: {e}"));
         }
 
         Some(combined)

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -95,10 +95,7 @@ impl<P: Partitioner, C: AggregatableContribution> ReplaceStore<P, C> {
             //     .unwrap_or_else(|e| trace!("check_merge: combining contributions failed: {}", e));
 
             let individual_verified = self.individual_verified.get(level).unwrap_or_else(|| {
-                panic!(
-                    "Individual verified contributions BitSet is missing for level {}",
-                    level
-                )
+                panic!("Individual verified contributions BitSet is missing for level {level}")
             });
 
             // the bits set here are verified individual signatures that can be added to `contribution`
@@ -117,20 +114,17 @@ impl<P: Partitioner, C: AggregatableContribution> ReplaceStore<P, C> {
                         .individual_contributions
                         .get(level)
                         .unwrap_or_else(|| {
-                            panic!("Individual contribution missing for level {}", level)
+                            panic!("Individual contribution missing for level {level}")
                         })
                         .get(&id)
                         .unwrap_or_else(|| {
-                            panic!(
-                                "Individual contributioon {} missing for level {}",
-                                id, level
-                            )
+                            panic!("Individual contributioon {id} missing for level {level}")
                         });
 
                     // merge individual signature into multisig
                     contribution
                         .combine(&individual.0)
-                        .unwrap_or_else(|e| panic!("Individual contribution from id={} can't be added to aggregate contributions: {}", id, e));
+                        .unwrap_or_else(|e| panic!("Individual contribution from id={id} can't be added to aggregate contributions: {e}"));
                 }
 
                 Some(contribution)
@@ -148,11 +142,11 @@ impl<P: Partitioner, C: AggregatableContribution> ContributionStore for ReplaceS
         if let Identity::Single(id) = identity {
             self.individual_verified
                 .get_mut(level)
-                .unwrap_or_else(|| panic!("Missing Level {}", level))
+                .unwrap_or_else(|| panic!("Missing Level {level}"))
                 .insert(id);
             self.individual_contributions
                 .get_mut(level)
-                .unwrap_or_else(|| panic!("Missing Level {}", level))
+                .unwrap_or_else(|| panic!("Missing Level {level}"))
                 .insert(id, (contribution.clone(), identity.clone()));
         }
 
@@ -179,13 +173,13 @@ impl<P: Partitioner, C: AggregatableContribution> ContributionStore for ReplaceS
     fn individual_verified(&self, level: usize) -> &BitSet {
         self.individual_verified
             .get(level)
-            .unwrap_or_else(|| panic!("Invalid level: {}", level))
+            .unwrap_or_else(|| panic!("Invalid level: {level}"))
     }
 
     fn individual_signature(&self, level: usize, peer_id: usize) -> Option<&Self::Contribution> {
         self.individual_contributions
             .get(level)
-            .unwrap_or_else(|| panic!("Invalid level: {}", level))
+            .unwrap_or_else(|| panic!("Invalid level: {level}"))
             .get(&peer_id)
             .map(|(c, _)| c)
     }

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -279,7 +279,7 @@ impl StorageConfig {
         sync_mode: SyncMode,
         db_config: DatabaseConfig,
     ) -> Result<Environment, Error> {
-        let db_name = format!("{}-{}-consensus", network_id, sync_mode).to_lowercase();
+        let db_name = format!("{network_id}-{sync_mode}-consensus").to_lowercase();
         log::info!("Opening database: {}", db_name);
 
         Ok(match self {
@@ -760,8 +760,7 @@ impl ClientConfigBuilder {
                         Ok(parsed) => Some(parsed),
                         Err(err) => {
                             return Err(Error::config_error(format!(
-                                "Failed parsing RPC server address {}",
-                                err
+                                "Failed parsing RPC server address {err}"
                             )))
                         }
                     },
@@ -776,7 +775,7 @@ impl ClientConfigBuilder {
                         .iter()
                         .map(|s| {
                             s.parse::<IpAddr>()
-                                .map_err(|e| Error::config_error(format!("Invalid IP: {}", e)))
+                                .map_err(|e| Error::config_error(format!("Invalid IP: {e}")))
                         })
                         .collect::<Result<Vec<IpAddr>, Error>>();
                     Some(result?)
@@ -812,8 +811,7 @@ impl ClientConfigBuilder {
                         Ok(parsed) => Some(parsed),
                         Err(err) => {
                             return Err(Error::config_error(format!(
-                                "Failed parsing metrics server address {}",
-                                err
+                                "Failed parsing metrics server address {err}"
                             )))
                         }
                     },

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -408,7 +408,7 @@ mod tests {
 
         match store.get_chain_info_at(0, false) {
             Err(e) => {
-                assert!(true, "Error getting chain info: {}", e)
+                assert!(true, "Error getting chain info: {e}")
             }
             Ok(info) => {
                 assert!(info.on_main_chain);
@@ -425,7 +425,7 @@ mod tests {
 
         match store.get_chain_info_at(0, false) {
             Err(e) => {
-                assert!(true, "Error getting chain info: {}", e)
+                assert!(true, "Error getting chain info: {e}")
             }
             Ok(info) => {
                 assert!(info.on_main_chain);

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -81,7 +81,7 @@ impl TargetsExt for Targets {
         let directives = match env::var(ENV) {
             Ok(v) => v,
             Err(env::VarError::NotPresent) => return self,
-            Err(env::VarError::NotUnicode(_)) => panic!("env var {} contains non-UTF-8 value", ENV),
+            Err(env::VarError::NotUnicode(_)) => panic!("env var {ENV} contains non-UTF-8 value"),
         };
         for dir in directives.split(',') {
             let mut iter = dir.splitn(2, '=');

--- a/metrics-server/src/tokio_task.rs
+++ b/metrics-server/src/tokio_task.rs
@@ -92,7 +92,7 @@ impl TokioTaskMetrics {
         if let Some(gauge) = self.metric_gauges.get(&name) {
             gauge.set(value);
         } else {
-            panic!("Unexpected metric name: {}", name);
+            panic!("Unexpected metric name: {name}");
         }
     }
 

--- a/nano-zkp/examples/prover/prove.rs
+++ b/nano-zkp/examples/prover/prove.rs
@@ -36,7 +36,7 @@ fn main() {
     for i in 0..number_epochs {
         // Get random parameters.
         let (initial_pks, initial_header_hash, final_pks, block, genesis_state_commitment_opt) =
-            create_test_blocks(i as u64);
+            create_test_blocks(i);
 
         // Create genesis data.
         if i == 0 {

--- a/nano-zkp/examples/verify.rs
+++ b/nano-zkp/examples/verify.rs
@@ -32,10 +32,10 @@ fn main() {
     let (initial_pks, initial_header_hash, _, _, _) = create_test_blocks(0);
 
     // Get final random parameters.
-    let (final_pks, final_header_hash, _, _, _) = create_test_blocks(number_epochs as u64);
+    let (final_pks, final_header_hash, _, _, _) = create_test_blocks(number_epochs);
 
     // Load the proof from file.
-    let mut file = File::open(format!("proofs/proof_epoch_{}.bin", number_epochs)).unwrap();
+    let mut file = File::open(format!("proofs/proof_epoch_{number_epochs}.bin")).unwrap();
 
     let proof = Proof::deserialize_unchecked(&mut file).unwrap();
 
@@ -56,7 +56,7 @@ fn main() {
     )
     .unwrap();
 
-    println!("Proof verification finished. It returned {}.", result);
+    println!("Proof verification finished. It returned {result}.");
 
     println!("====== Proof verification for Nano Sync finished ======");
     println!("Total time elapsed: {:?}", start.elapsed());

--- a/nano-zkp/src/nano_zkp/prove.rs
+++ b/nano-zkp/src/nano_zkp/prove.rs
@@ -103,7 +103,7 @@ impl NanoZKP {
         #[allow(clippy::needless_range_loop)]
         for i in 0..32 {
             current_proof += 1;
-            if proof_caching && proofs.join(format!("pk_tree_5_{}.bin", i)).exists() {
+            if proof_caching && proofs.join(format!("pk_tree_5_{i}.bin")).exists() {
                 continue;
             }
 
@@ -130,7 +130,7 @@ impl NanoZKP {
         // Start generating proofs for PKTree level 4.
         for i in 0..16 {
             current_proof += 1;
-            if proof_caching && proofs.join(format!("pk_tree_4_{}.bin", i)).exists() {
+            if proof_caching && proofs.join(format!("pk_tree_4_{i}.bin")).exists() {
                 continue;
             }
 
@@ -158,7 +158,7 @@ impl NanoZKP {
         // Start generating proofs for PKTree level 3.
         for i in 0..8 {
             current_proof += 1;
-            if proof_caching && proofs.join(format!("pk_tree_3_{}.bin", i)).exists() {
+            if proof_caching && proofs.join(format!("pk_tree_3_{i}.bin")).exists() {
                 continue;
             }
 
@@ -186,7 +186,7 @@ impl NanoZKP {
         // Start generating proofs for PKTree level 2.
         for i in 0..4 {
             current_proof += 1;
-            if proof_caching && proofs.join(format!("pk_tree_2_{}.bin", i)).exists() {
+            if proof_caching && proofs.join(format!("pk_tree_2_{i}.bin")).exists() {
                 continue;
             }
 
@@ -214,7 +214,7 @@ impl NanoZKP {
         // Start generating proofs for PKTree level 1.
         for i in 0..2 {
             current_proof += 1;
-            if proof_caching && proofs.join(format!("pk_tree_1_{}.bin", i)).exists() {
+            if proof_caching && proofs.join(format!("pk_tree_1_{i}.bin")).exists() {
                 continue;
             }
 
@@ -363,7 +363,7 @@ impl NanoZKP {
         dir_path: &Path,
     ) -> Result<(), NanoZKPError> {
         // Load the proving key from file.
-        let mut file = File::open(dir_path.join("proving_keys").join(format!("{}.bin", name)))?;
+        let mut file = File::open(dir_path.join("proving_keys").join(format!("{name}.bin")))?;
 
         let proving_key = ProvingKey::deserialize_unchecked(&mut file)?;
 
@@ -415,11 +415,7 @@ impl NanoZKP {
         // Optionally verify the proof.
         if debug_mode {
             // Load the proving key from file.
-            let mut file = File::open(
-                dir_path
-                    .join("verifying_keys")
-                    .join(format!("{}.bin", name)),
-            )?;
+            let mut file = File::open(dir_path.join("verifying_keys").join(format!("{name}.bin")))?;
 
             let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
 
@@ -462,26 +458,26 @@ impl NanoZKP {
         let verifying_keys = dir_path.join("verifying_keys");
         let proofs = dir_path.join("proofs");
         // Load the proving key from file.
-        let mut file = File::open(proving_keys.join(format!("{}.bin", name)))?;
+        let mut file = File::open(proving_keys.join(format!("{name}.bin")))?;
 
         let proving_key = ProvingKey::deserialize_unchecked(&mut file)?;
 
         // Load the verifying key from file.
-        let mut file = File::open(verifying_keys.join(format!("{}.bin", vk_file)))?;
+        let mut file = File::open(verifying_keys.join(format!("{vk_file}.bin")))?;
 
         let vk_child = VerifyingKey::deserialize_unchecked(&mut file)?;
 
         // Load the left proof from file.
         let left_position = 2 * position;
 
-        let mut file = File::open(proofs.join(format!("{}_{}.bin", vk_file, left_position)))?;
+        let mut file = File::open(proofs.join(format!("{vk_file}_{left_position}.bin")))?;
 
         let left_proof = Proof::deserialize_unchecked(&mut file)?;
 
         // Load the right proof from file.
         let right_position = 2 * position + 1;
 
-        let mut file = File::open(proofs.join(format!("{}_{}.bin", vk_file, right_position)))?;
+        let mut file = File::open(proofs.join(format!("{vk_file}_{right_position}.bin")))?;
 
         let right_proof = Proof::deserialize_unchecked(&mut file)?;
 
@@ -554,7 +550,7 @@ impl NanoZKP {
         // Optionally verify the proof.
         if debug_mode {
             // Load the proving key from file.
-            let mut file = File::open(verifying_keys.join(format!("{}.bin", name)))?;
+            let mut file = File::open(verifying_keys.join(format!("{name}.bin")))?;
 
             let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
 
@@ -600,26 +596,26 @@ impl NanoZKP {
         let proofs = dir_path.join("proofs");
 
         // Load the proving key from file.
-        let mut file = File::open(proving_keys.join(format!("{}.bin", name)))?;
+        let mut file = File::open(proving_keys.join(format!("{name}.bin")))?;
 
         let proving_key = ProvingKey::deserialize_unchecked(&mut file)?;
 
         // Load the verifying key from file.
-        let mut file = File::open(verifying_keys.join(format!("{}.bin", vk_file)))?;
+        let mut file = File::open(verifying_keys.join(format!("{vk_file}.bin")))?;
 
         let vk_child = VerifyingKey::deserialize_unchecked(&mut file)?;
 
         // Load the left proof from file.
         let left_position = 2 * position;
 
-        let mut file = File::open(proofs.join(format!("{}_{}.bin", vk_file, left_position)))?;
+        let mut file = File::open(proofs.join(format!("{vk_file}_{left_position}.bin")))?;
 
         let left_proof = Proof::deserialize_unchecked(&mut file)?;
 
         // Load the right proof from file.
         let right_position = 2 * position + 1;
 
-        let mut file = File::open(proofs.join(format!("{}_{}.bin", vk_file, right_position)))?;
+        let mut file = File::open(proofs.join(format!("{vk_file}_{right_position}.bin")))?;
 
         let right_proof = Proof::deserialize_unchecked(&mut file)?;
 
@@ -686,7 +682,7 @@ impl NanoZKP {
         // Optionally verify the proof.
         if debug_mode {
             // Load the proving key from file.
-            let mut file = File::open(verifying_keys.join(format!("{}.bin", name)))?;
+            let mut file = File::open(verifying_keys.join(format!("{name}.bin")))?;
 
             let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
 
@@ -1112,10 +1108,10 @@ impl NanoZKP {
 
         let suffix = match number {
             None => "".to_string(),
-            Some(n) => format!("_{}", n),
+            Some(n) => format!("_{n}"),
         };
 
-        let mut file = File::create(proofs.join(format!("{}{}.bin", name, suffix)))?;
+        let mut file = File::create(proofs.join(format!("{name}{suffix}.bin")))?;
 
         pk.serialize_unchecked(&mut file)?;
 

--- a/nano-zkp/src/nano_zkp/setup.rs
+++ b/nano-zkp/src/nano_zkp/setup.rs
@@ -64,8 +64,8 @@ impl NanoZKP {
         let proving_keys = path.join("proving_keys");
 
         for i in 0..5 {
-            if !verifying_keys.join(format!("pk_tree_{}.bin", i)).exists()
-                || (prover_active && !proving_keys.join(format!("pk_tree_{}.bin", i)).exists())
+            if !verifying_keys.join(format!("pk_tree_{i}.bin")).exists()
+                || (prover_active && !proving_keys.join(format!("pk_tree_{i}.bin")).exists())
             {
                 return false;
             }
@@ -127,7 +127,7 @@ impl NanoZKP {
         let mut file = File::open(
             dir_path
                 .join("verifying_keys")
-                .join(format!("{}.bin", vk_file)),
+                .join(format!("{vk_file}.bin")),
         )?;
 
         let vk_child = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -185,7 +185,7 @@ impl NanoZKP {
         let mut file = File::open(
             dir_path
                 .join("verifying_keys")
-                .join(format!("{}.bin", vk_file)),
+                .join(format!("{vk_file}.bin")),
         )?;
 
         let vk_child = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -446,7 +446,7 @@ impl NanoZKP {
             DirBuilder::new().create(&proving_keys)?;
         }
 
-        let mut file = File::create(proving_keys.join(format!("{}.bin", name)))?;
+        let mut file = File::create(proving_keys.join(format!("{name}.bin")))?;
 
         pk.serialize_unchecked(&mut file)?;
 
@@ -457,7 +457,7 @@ impl NanoZKP {
             DirBuilder::new().create(&verifying_keys)?;
         }
 
-        let mut file = File::create(verifying_keys.join(format!("{}.bin", name)))?;
+        let mut file = File::create(verifying_keys.join(format!("{name}.bin")))?;
 
         vk.serialize_unchecked(&mut file)?;
 

--- a/network-mock/src/lib.rs
+++ b/network-mock/src/lib.rs
@@ -80,7 +80,7 @@ pub mod tests {
         if let Some(Ok(NetworkEvent::PeerJoined(peer_id))) = events.next().await {
             assert_eq!(peer_id, expected_peer_id);
         } else {
-            panic!("Expected PeerJoined event with id={}", expected_peer_id);
+            panic!("Expected PeerJoined event with id={expected_peer_id}");
         }
     }
 
@@ -91,7 +91,7 @@ pub mod tests {
         if let Some(Ok(NetworkEvent::PeerLeft(peer_id))) = events.next().await {
             assert_eq!(peer_id, expected_peer_id);
         } else {
-            panic!("Expected PeerLeft event with id={}", expected_peer_id);
+            panic!("Expected PeerLeft event with id={expected_peer_id}");
         }
     }
 

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -83,10 +83,7 @@ impl MockNetwork {
 
             // Insert out peer map into global peer maps table
             if hub.peer_maps.insert(address, peers.clone()).is_some() {
-                panic!(
-                    "address/peer_id of MockNetwork must be unique: address={}",
-                    address
-                );
+                panic!("address/peer_id of MockNetwork must be unique: address={address}");
             }
 
             // Insert our is_connected bool into the hub

--- a/primitives/block/examples/pk_tree.rs
+++ b/primitives/block/examples/pk_tree.rs
@@ -27,7 +27,7 @@ fn main() {
     let validators = generate_uncompressed_validators();
 
     for i in 0..50 {
-        println!("{}", i);
+        println!("{i}");
         MacroBlock::pk_tree_root(&validators).expect("PK tree root building failed");
     }
 }

--- a/primitives/mmr/src/mmr/peaks.rs
+++ b/primitives/mmr/src/mmr/peaks.rs
@@ -121,13 +121,13 @@ mod tests {
             let pi = PeakIterator::new(size);
             let calc_peaks: Vec<Position> = pi.collect();
             let peaks: Vec<Position> = peaks.iter().map(|i| Position::from(*i)).collect();
-            assert_eq!(calc_peaks, peaks, "Peaks for size {}", size);
+            assert_eq!(calc_peaks, peaks, "Peaks for size {size}");
 
             // Reversed peaks.
             let pi = RevPeakIterator::new(size);
             let calc_peaks: Vec<Position> = pi.collect();
             let peaks: Vec<Position> = peaks.into_iter().rev().collect();
-            assert_eq!(calc_peaks, peaks, "Rev Peaks for size {}", size);
+            assert_eq!(calc_peaks, peaks, "Rev Peaks for size {size}");
         }
 
         test_peaks(0, vec![]);

--- a/primitives/mmr/src/mmr/position.rs
+++ b/primitives/mmr/src/mmr/position.rs
@@ -235,16 +235,11 @@ mod tests {
                 Op::Set => Position::from(index),
             };
 
-            assert_eq!(pos.index, index, "op {}", j);
-            assert_eq!(
-                pos.height, height,
-                "wrong height @ index {}, op {}",
-                index, j
-            );
+            assert_eq!(pos.index, index, "op {j}");
+            assert_eq!(pos.height, height, "wrong height @ index {index}, op {j}");
             assert_eq!(
                 pos.right_node, right_node,
-                "wrong right_node @ index {}, op {}",
-                index, j
+                "wrong right_node @ index {index}, op {j}"
             );
 
             assert_eq!(pos.left_child().is_none(), pos.height == 0);
@@ -302,7 +297,7 @@ mod tests {
             (13, 6),
         ];
         for (right, left) in pairs {
-            assert_eq!(move_left(right + 1), left + 1, "move left from {}", right);
+            assert_eq!(move_left(right + 1), left + 1, "move left from {right}");
         }
     }
 

--- a/primitives/mmr/src/mmr/proof.rs
+++ b/primitives/mmr/src/mmr/proof.rs
@@ -304,9 +304,7 @@ mod tests {
                         Node::Store(index) => mmr.store.get(*index).unwrap(),
                         Node::Hash(h) => h.clone(),
                     },
-                    "Proof node {} should be {:?}",
-                    i,
-                    node
+                    "Proof node {i} should be {node:?}"
                 );
             }
 
@@ -512,9 +510,7 @@ mod tests {
                         Node::Store(index) => mmr.store.get(*index).unwrap(),
                         Node::Hash(h) => h.clone(),
                     },
-                    "Proof node {} should be {:?}",
-                    i,
-                    node
+                    "Proof node {i} should be {node:?}"
                 );
             }
 

--- a/primitives/src/coin.rs
+++ b/primitives/src/coin.rs
@@ -227,7 +227,7 @@ lazy_static! {
     static ref COIN_PARSE_REGEX: Regex = {
         let r = r"^(?P<int_part>\d+)(.(?P<frac_part>\d{1,5})0*)?$";
         Regex::new(r)
-            .unwrap_or_else(|e| panic!("Failed to compile regex: {}: {}", r, e))
+            .unwrap_or_else(|e| panic!("Failed to compile regex: {r}: {e}"))
     };
 }
 

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -1699,10 +1699,10 @@ mod tests {
 
         trie.put_chunk(
             &mut txn,
-            key_3.clone(),
+            key_3,
             TrieChunk::new(
                 Some(key_1.clone()),
-                vec![Item::new(key_2.clone(), vec![99])],
+                vec![Item::new(key_2, vec![99])],
                 TrieProof::new(vec![proof_value_2.clone(), proof_root.clone()]),
             ),
             proof_root.hash_assert(),
@@ -1713,7 +1713,7 @@ mod tests {
 
         trie.put_chunk(
             &mut txn,
-            key_1.clone(),
+            key_1,
             TrieChunk::new(
                 None,
                 Vec::new(),
@@ -1828,8 +1828,7 @@ mod tests {
 
         let start = chunk.end_key.unwrap();
         let chunk = original.get_chunk_with_proof(&txn, start.clone().., 2);
-        trie.put_chunk(&mut txn, start, chunk, hash.clone())
-            .unwrap();
+        trie.put_chunk(&mut txn, start, chunk, hash).unwrap();
         assert_eq!(trie.count_nodes(&txn), (0, 2, 2));
         assert!(trie.is_complete(&txn));
 
@@ -1854,7 +1853,7 @@ mod tests {
             .map(|i| {
                 (
                     i,
-                    MerkleRadixTrie::new_incomplete(env.clone(), &format!("copy{}", i)),
+                    MerkleRadixTrie::new_incomplete(env.clone(), &format!("copy{i}")),
                 )
             })
             .collect();
@@ -1910,7 +1909,7 @@ mod tests {
             .map(|i| {
                 (
                     i,
-                    MerkleRadixTrie::new_incomplete(env.clone(), &format!("copy{}", i)),
+                    MerkleRadixTrie::new_incomplete(env.clone(), &format!("copy{i}")),
                 )
             })
             .collect();
@@ -1965,7 +1964,7 @@ mod tests {
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let tries: Vec<_> = (1..5)
             .map(|i| {
-                let trie = MerkleRadixTrie::new(env.clone(), &format!("copy{}", i));
+                let trie = MerkleRadixTrie::new(env.clone(), &format!("copy{i}"));
                 let mut txn = WriteTransaction::new(&env);
                 trie.put(&mut txn, &key_1, 80085).expect("complete trie");
                 trie.put(&mut txn, &key_2, 999).expect("complete trie");
@@ -2193,9 +2192,7 @@ mod tests {
         assert_eq!(original.count_nodes(&txn), (0, 1, 1));
         assert!(!original.is_complete(&txn));
 
-        original
-            .put_chunk(&mut txn, key_1, chunk.clone(), hash.clone())
-            .unwrap();
+        original.put_chunk(&mut txn, key_1, chunk, hash).unwrap();
         assert_eq!(original.count_nodes(&txn), (0, 2, 2));
         assert!(original.is_complete(&txn));
     }

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -134,7 +134,7 @@ async fn run_app(opt: Opt) -> Result<(), Error> {
 async fn main() {
     if let Err(e) = dotenv::dotenv() {
         if !e.not_found() {
-            panic!("could not read .env file: {}", e);
+            panic!("could not read .env file: {e}");
         }
     }
     tracing_subscriber::fmt()
@@ -142,7 +142,7 @@ async fn main() {
         .init();
 
     if let Err(e) = run_app(Opt::parse()).await {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
         std::process::exit(1);
     }
 }

--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -124,7 +124,7 @@ impl HandleSubcommand for AccountCommand {
             }
             AccountCommand::Import { password, key_data } => {
                 let address = client.wallet.import_raw_key(key_data, password).await?;
-                println!("{:#?}", address);
+                println!("{address:#?}");
             }
             AccountCommand::IsImported { address } => {
                 println!("{:#?}", client.wallet.is_account_imported(address).await?);

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -194,7 +194,7 @@ impl HandleSubcommand for BlockchainCommand {
                         .get_latest_block(Some(include_transactions))
                         .await
                 }?;
-                println!("{:#?}", block)
+                println!("{block:#?}")
             }
             BlockchainCommand::BlockNumber {} => {
                 println!("{:#?}", client.blockchain.get_block_number().await?)
@@ -333,13 +333,13 @@ impl HandleSubcommand for BlockchainCommand {
                         .await?;
 
                     while let Some(block) = stream.next().await {
-                        println!("{:#?}", block);
+                        println!("{block:#?}");
                     }
                 } else {
                     let mut stream = client.blockchain.subscribe_for_head_block_hash().await?;
 
                     while let Some(block_hash) = stream.next().await {
-                        println!("{:#?}", block_hash);
+                        println!("{block_hash:#?}");
                     }
                 }
             }
@@ -349,7 +349,7 @@ impl HandleSubcommand for BlockchainCommand {
                     .subscribe_for_validator_election_by_address(address)
                     .await?;
                 while let Some(validator) = stream.next().await {
-                    println!("{:#?}", validator);
+                    println!("{validator:#?}");
                 }
             }
             BlockchainCommand::FollowLogsOfAddressesAndTypes {
@@ -362,7 +362,7 @@ impl HandleSubcommand for BlockchainCommand {
                     .await?;
 
                 while let Some(blocklog) = stream.next().await {
-                    println!("{:#?}", blocklog);
+                    println!("{blocklog:#?}");
                 }
             }
         }

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -300,7 +300,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -312,7 +312,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::NewStaker {
@@ -333,7 +333,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -346,7 +346,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::Stake {
@@ -365,7 +365,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -377,7 +377,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::UpdateStaker {
@@ -397,7 +397,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -409,7 +409,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::Unstake {
@@ -428,7 +428,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -440,7 +440,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -466,7 +466,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -481,7 +481,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::VestingRedeem {
@@ -502,7 +502,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -515,7 +515,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -545,7 +545,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -562,7 +562,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::RedeemRegularHTLC {
@@ -591,7 +591,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -608,7 +608,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::RedeemHTLCTimeout {
@@ -629,7 +629,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -642,7 +642,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::RedeemHTLCEarly {
@@ -666,7 +666,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -680,7 +680,7 @@ impl HandleSubcommand for TransactionCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
             TransactionCommand::SignRedeemHTLCEarly {
@@ -702,7 +702,7 @@ impl HandleSubcommand for TransactionCommand {
                         validity_start_height,
                     )
                     .await?;
-                println!("{:#?}", tx);
+                println!("{tx:#?}");
             }
         }
         Ok(())

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -161,7 +161,7 @@ impl HandleSubcommand for ValidatorCommand {
                     .validator
                     .set_automatic_reactivation(automatic_reactivate)
                     .await?;
-                println!("Auto reactivate set to {}", automatic_reactivate);
+                println!("Auto reactivate set to {automatic_reactivate}");
             }
 
             ValidatorCommand::CreateNewValidator {
@@ -187,7 +187,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -202,7 +202,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -229,7 +229,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -244,7 +244,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -265,7 +265,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -277,7 +277,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -298,7 +298,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -310,7 +310,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -331,7 +331,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -343,7 +343,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
 
@@ -363,7 +363,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", tx);
+                    println!("{tx:#?}");
                 } else {
                     let txid = client
                         .consensus
@@ -375,7 +375,7 @@ impl HandleSubcommand for ValidatorCommand {
                             tx_commons.common_tx_fields.validity_start_height,
                         )
                         .await?;
-                    println!("{:#?}", txid);
+                    println!("{txid:#?}");
                 }
             }
         }

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -72,8 +72,8 @@ impl Default for ValidityStartHeight {
 impl Display for ValidityStartHeight {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::Absolute(n) => write!(f, "{}", n),
-            Self::Relative(n) => write!(f, "+{}", n),
+            Self::Absolute(n) => write!(f, "{n}"),
+            Self::Relative(n) => write!(f, "+{n}"),
         }
     }
 }
@@ -946,7 +946,7 @@ impl ZKPState {
         let latest_proof = zkp_state
             .latest_proof
             .as_ref()
-            .map(|latest_proof| format!("{:?}", latest_proof));
+            .map(|latest_proof| format!("{latest_proof:?}"));
         Self {
             latest_header_hash: zkp_state.latest_header_hash.clone(),
             latest_block_number: zkp_state.latest_block_number,

--- a/test-utils/src/zkp_test_data.rs
+++ b/test-utils/src/zkp_test_data.rs
@@ -37,8 +37,7 @@ pub fn zkp_test_exe() -> std::path::PathBuf {
 
     assert!(
         path.exists(),
-        "Run `cargo test --all-features` to build the test prover binary at {:?}",
-        path
+        "Run `cargo test --all-features` to build the test prover binary at {path:?}"
     );
     path
 }

--- a/tools/src/address/main.rs
+++ b/tools/src/address/main.rs
@@ -17,7 +17,7 @@ fn main() {
         match parse_private_key(p) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("Error parsing private key: {}", e);
+                eprintln!("Error parsing private key: {e}");
                 process::exit(1);
             }
         }

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -129,7 +129,7 @@ fn main() {
     exit(match run_app() {
         Ok(_) => 0,
         Err(e) => {
-            eprintln!("Error: {}", e);
+            eprintln!("Error: {e}");
             1
         }
     });


### PR DESCRIPTION
Fix several clippy warnings in crates such as:
- `beserial`
- `blockchain`
- `bls`
- `collections`
- `consensus`
- `database`
- `genesis-builder`
- `genesis`
- `handel`
- `lib`
- `light-blockchain`
- `log`
- `metrics-server`
- `nano-zkp`
- `network-mock`
- `block primitives`
- `mmr` primitives
- `primitives`
- `trie` primitives
- `rpc-client`
- `rpc-interface`
- `test-utils`
- `tools`

Most of the warnings fixed are related to the usage of variables in the `format!` macro.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
