### PR TITLE
database: Fix some clippy warnings

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -138,7 +138,7 @@ impl<'env> Transaction<'env> {
         }
     }
 
-    pub fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> Cursor<'txn> {
+    pub fn cursor<'txn>(&'txn self, db: &Database) -> Cursor<'txn> {
         match *self {
             Transaction::VolatileRead(ref txn) => Cursor::VolatileCursor(txn.cursor(db)),
             Transaction::VolatileWrite(ref txn) => Cursor::VolatileCursor(txn.cursor(db)),
@@ -173,7 +173,7 @@ impl<'env> ReadTransaction<'env> {
 
     pub fn close(self) {}
 
-    pub fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> Cursor<'txn> {
+    pub fn cursor<'txn>(&'txn self, db: &Database) -> Cursor<'txn> {
         self.0.cursor(db)
     }
 }
@@ -293,11 +293,11 @@ impl<'env> WriteTransaction<'env> {
 
     pub fn abort(self) {}
 
-    pub fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> Cursor<'txn> {
+    pub fn cursor<'txn>(&'txn self, db: &Database) -> Cursor<'txn> {
         self.0.cursor(db)
     }
 
-    pub fn write_cursor<'txn, 'db>(&'txn self, db: &'db Database) -> WriteCursor<'txn> {
+    pub fn write_cursor<'txn>(&'txn self, db: &Database) -> WriteCursor<'txn> {
         match self.0 {
             Transaction::VolatileWrite(ref txn) => {
                 WriteCursor::VolatileCursor(txn.write_cursor(db))

--- a/database/src/mdbx.rs
+++ b/database/src/mdbx.rs
@@ -178,7 +178,7 @@ impl<'env> MdbxReadTransaction<'env> {
         Some(FromDatabaseValue::copy_from_database(&result?).unwrap())
     }
 
-    pub(super) fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> MdbxCursor<'txn> {
+    pub(super) fn cursor<'txn>(&'txn self, db: &Database) -> MdbxCursor<'txn> {
         let db = self
             .txn
             .open_db(Some(&db.persistent().unwrap().db))
@@ -289,7 +289,7 @@ impl<'env> MdbxWriteTransaction<'env> {
         self.txn.commit().unwrap();
     }
 
-    pub(super) fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> MdbxCursor<'txn> {
+    pub(super) fn cursor<'txn>(&'txn self, db: &Database) -> MdbxCursor<'txn> {
         let db = self
             .txn
             .open_db(Some(&db.persistent().unwrap().db))
@@ -302,7 +302,7 @@ impl<'env> MdbxWriteTransaction<'env> {
         }
     }
 
-    pub(super) fn write_cursor<'txn, 'db>(&'txn self, db: &'db Database) -> MdbxWriteCursor<'txn> {
+    pub(super) fn write_cursor<'txn>(&'txn self, db: &Database) -> MdbxWriteCursor<'txn> {
         let db = self
             .txn
             .open_db(Some(&db.persistent().unwrap().db))

--- a/database/src/volatile.rs
+++ b/database/src/volatile.rs
@@ -81,7 +81,7 @@ impl<'env> VolatileReadTransaction<'env> {
         self.0.get(&db.0, key)
     }
 
-    pub(super) fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> VolatileCursor<'txn> {
+    pub(super) fn cursor<'txn>(&'txn self, db: &Database) -> VolatileCursor<'txn> {
         VolatileCursor(self.0.cursor(db))
     }
 }
@@ -138,14 +138,11 @@ impl<'env> VolatileWriteTransaction<'env> {
         self.0.commit()
     }
 
-    pub(super) fn cursor<'txn, 'db>(&'txn self, db: &'db Database) -> VolatileCursor<'txn> {
+    pub(super) fn cursor<'txn>(&'txn self, db: &Database) -> VolatileCursor<'txn> {
         VolatileCursor(self.0.cursor(db))
     }
 
-    pub(super) fn write_cursor<'txn, 'db>(
-        &'txn self,
-        db: &'db Database,
-    ) -> VolatileWriteCursor<'txn> {
+    pub(super) fn write_cursor<'txn>(&'txn self, db: &Database) -> VolatileWriteCursor<'txn> {
         VolatileWriteCursor(self.0.write_cursor(db))
     }
 


### PR DESCRIPTION
Fix some clippy warnings in the `database` crate related to explicit lifetimes that could be elided.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
