### PR TITLE
ci: Fix parsing of reason of failure

### DIFF
--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -93,8 +93,8 @@ jobs:
     - name: Retrieve failure reason
       if: always()
       run: |
-          if [ -f temp-state/RESULT.TXT ]; then
-            echo "FAIL_REASON=$(cat temp-state/RESULT.TXT)" >> $GITHUB_OUTPUT
+          if [ -f temp-state/*/RESULT.TXT ]; then
+            echo "FAIL_REASON=$(cat temp-state/*/RESULT.TXT)" >> $GITHUB_OUTPUT
           else
             echo "FAIL_REASON=other" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -89,8 +89,8 @@ jobs:
     - name: Retrieve failure reason
       if: always()
       run: |
-          if [ -f temp-state/RESULT.TXT ]; then
-            echo "FAIL_REASON=$(cat temp-state/RESULT.TXT)" >> $GITHUB_OUTPUT
+          if [ -f temp-state/*/RESULT.TXT ]; then
+            echo "FAIL_REASON=$(cat temp-state/*/RESULT.TXT)" >> $GITHUB_OUTPUT
           else
             echo "FAIL_REASON=other" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Fix parsing of the reason of failure (`FAIL_REASON`) for the devnet GH actions workflows.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
