### PR TITLE
Use standard parking lot crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,16 +2998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.6"
-source = "git+https://github.com/styppo/parking_lot.git#3830254eb8738fb87d85d6fd802f9186891777d5"
-dependencies = [
- "backtrace",
- "log",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,7 +3349,7 @@ dependencies = [
  "nimiq-trie",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde",
  "strum_macros",
@@ -3423,7 +3413,7 @@ dependencies = [
  "nimiq-trie",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "tempfile",
  "tracing",
@@ -3457,7 +3447,7 @@ dependencies = [
  "nimiq-transaction-builder",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "prometheus-client",
  "rand 0.8.5",
  "thiserror",
@@ -3477,7 +3467,7 @@ dependencies = [
  "nimiq-hash",
  "nimiq-primitives",
  "nimiq-transaction",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "thiserror",
  "tokio-stream",
  "tracing",
@@ -3495,7 +3485,7 @@ dependencies = [
  "nimiq-light-blockchain",
  "nimiq-primitives",
  "nimiq-transaction",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "tokio-stream",
 ]
 
@@ -3517,7 +3507,7 @@ dependencies = [
  "nimiq-hash",
  "nimiq-test-log",
  "nimiq-utils",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde",
  "thiserror",
@@ -3583,7 +3573,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-validator-network",
  "nimiq-zkp-component",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "pin-project",
  "rand 0.8.5",
  "thiserror",
@@ -3675,7 +3665,7 @@ dependencies = [
  "nimiq-primitives",
  "nimiq-test-log",
  "nimiq-utils",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "thiserror",
  "tokio",
@@ -3846,7 +3836,7 @@ dependencies = [
  "nimiq-validator-network",
  "nimiq-wallet",
  "nimiq-zkp-component",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3883,7 +3873,7 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "thiserror",
  "tokio",
@@ -3937,7 +3927,7 @@ dependencies = [
  "nimiq-transaction-builder",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "prometheus-client",
  "rand 0.8.5",
  "tokio",
@@ -3959,7 +3949,7 @@ dependencies = [
  "nimiq-mempool",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "prometheus-client",
  "tokio",
  "tokio-metrics",
@@ -4079,7 +4069,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-utils",
  "nimiq-validator-network",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "pin-project",
  "pin-project-lite 0.2.9",
  "prometheus-client",
@@ -4102,7 +4092,7 @@ dependencies = [
  "futures-util",
  "nimiq-network-interface",
  "nimiq-test-log",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4135,7 +4125,7 @@ dependencies = [
  "nimiq-utils",
  "num-traits",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "regex",
  "serde",
  "strum_macros",
@@ -4193,7 +4183,7 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-vrf",
  "nimiq-zkp-component",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4235,7 +4225,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-wallet",
  "nimiq-zkp-component",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4308,7 +4298,7 @@ dependencies = [
  "nimiq-log",
  "nimiq-primitives",
  "nimiq-test-log-proc-macro",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "tracing",
  "tracing-subscriber 0.3.16",
 ]
@@ -4358,7 +4348,7 @@ dependencies = [
  "nimiq-validator-network",
  "nimiq-vrf",
  "nimiq-zkp-component",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "tokio",
@@ -4453,7 +4443,7 @@ dependencies = [
  "nimiq-hash",
  "nimiq-keys",
  "nimiq-test-log",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -4499,7 +4489,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-validator-network",
  "nimiq-vrf",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "tokio",
  "tokio-metrics",
@@ -4611,7 +4601,7 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-utils",
  "nimiq-validator-network",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "tempfile",
  "thiserror",
@@ -4834,19 +4824,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api",
  "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "git+https://github.com/styppo/parking_lot.git#3830254eb8738fb87d85d6fd802f9186891777d5"
-dependencies = [
- "backtrace",
- "lock_api 0.4.6 (git+https://github.com/styppo/parking_lot.git)",
- "log",
- "parking_lot_core 0.9.1 (git+https://github.com/styppo/parking_lot.git)",
 ]
 
 [[package]]
@@ -4855,8 +4834,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -4878,18 +4857,6 @@ name = "parking_lot_core"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.32.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.1"
-source = "git+https://github.com/styppo/parking_lot.git#3830254eb8738fb87d85d6fd802f9186891777d5"
 dependencies = [
  "backtrace",
  "cfg-if",

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -19,8 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 log = { package = "tracing", version = "0.1", features = ["log"] }
 hex = "0.4"
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
-
+parking_lot = "0.12"
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account" }
 nimiq-block = { path = "../primitives/block" }

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 beserial = { path = "../beserial", features = ["derive"] }
 futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 thiserror = "1.0"
 tokio-stream = { version = "0.1", features = ["sync"] }
 

--- a/blockchain-proxy/Cargo.toml
+++ b/blockchain-proxy/Cargo.toml
@@ -15,7 +15,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures = { package = "futures-util", version = "0.3" }
 

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.25", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 prometheus-client = { version = "0.18.1", optional = true}
 rand = "0.8"
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -301,7 +301,7 @@ impl Blockchain {
         txn.commit();
 
         // Upgrade the lock as late as possible.
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         if let Block::Macro(ref macro_block) = chain_info.head {
             this.state.macro_info = chain_info.clone();

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -107,7 +107,7 @@ impl Blockchain {
         txn.commit();
 
         // Upgrade the lock as late as possible.
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         if let Block::Macro(ref macro_block) = chain_info.head {
             this.state.macro_info = chain_info.clone();
@@ -200,7 +200,7 @@ impl Blockchain {
         read_txn.close();
 
         // Upgrade the blockchain lock
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         // Store the election block header.
         if let Block::Macro(ref macro_block) = block {
@@ -295,7 +295,7 @@ impl Blockchain {
         txn.commit();
 
         // Upgrade the lock as late as possible.
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         if let Block::Macro(ref macro_block) = chain_info.head {
             this.state.macro_info = chain_info.clone();

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.3.4"
 thiserror = "1.0"
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -23,7 +23,7 @@ gloo-timers = { version = "0.2.6" , features = [ "futures" ]}
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 lazy_static = "1.4.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 pin-project = "1.0"
 rand = "0.8"
 thiserror = "1.0"

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1"
 futures = { package = "futures-util", version = "0.3", features = ["sink"] }
 lazy_static = "1.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 rand = "0.8"
 thiserror = "1.0"
 tokio = { version = "1.25", features = ["rt", "time"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4"
 # human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
 log = { package = "tracing", version = "0.1", features = ["log"] }
 log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 rand = "0.8"
 rand_chacha = "0.3.1"
 serde = "1.0"

--- a/lib/src/extras/deadlock.rs
+++ b/lib/src/extras/deadlock.rs
@@ -13,8 +13,8 @@ pub fn initialize_deadlock_detection() {
         }
 
         log::error!("{} deadlocks detected", deadlocks.len());
-        for (i, deadlock) in deadlocks.iter().enumerate() {
-            log::error!("Deadlock #{}: {:#?}", i, deadlock);
+        for (i, _deadlock) in deadlocks.iter().enumerate() {
+            log::error!("Deadlock #{}", i);
         }
     });
 }

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }
 thiserror = "1.0"
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 tokio-stream = { version = "0.1", features = ["sync"] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -132,7 +132,7 @@ impl LightBlockchain {
                 PushResult::Forked
             }
         };
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
         // Otherwise, we are creating/extending a fork. Store ChainInfo.
         this.chain_store.put_chain_info(chain_info);
 
@@ -146,7 +146,7 @@ impl LightBlockchain {
         mut prev_info: ChainInfo,
     ) -> Result<PushResult, PushError> {
         // Upgrade the blockchain lock
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         let is_election_block = Policy::is_election_block_at(chain_info.head.block_number());
         let is_macro_block = Policy::is_macro_block_at(chain_info.head.block_number());
@@ -211,7 +211,7 @@ impl LightBlockchain {
         chain_info: ChainInfo,
     ) -> Result<PushResult, PushError> {
         // Upgrade the blockchain lock
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         let target_block = chain_info.head.header();
         log::debug!(block = %target_block, "Rebranching");
@@ -377,7 +377,7 @@ impl LightBlockchain {
         }
 
         // Upgrade the blockchain lock
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         // Store the election block header.
         this.chain_store.put_election(header);

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -68,7 +68,7 @@ impl LightBlockchain {
         // At this point we know that the block is correct. We just have to push it.
 
         // Upgrade the blockchain lock
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         // Create the chain info for the new block.
         let chain_info = ChainInfo::new(block.clone(), true);
@@ -139,7 +139,7 @@ impl LightBlockchain {
         // At this point we know that the block is correct. We just have to push it.
 
         // Upgrade the blockchain lock
-        let mut this = RwLockUpgradableReadGuard::upgrade_untimed(this);
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
         // Create the chain info for the new block.
         let chain_info = ChainInfo::new(block.clone(), true);

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 prometheus-client = { version = "0.18.1", optional = true}
 futures = { package = "futures-util", version = "0.3" }
 keyed_priority_queue = "0.4"

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 futures = "0.3"
 hyper = { version = "0.14.23", features = ["server", "tcp", "http2"] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 prometheus-client = "0.18.1"
 tokio = { version = "1.25", features = [
     "macros",

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -28,7 +28,7 @@ instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 ip_network = "0.4"
 libp2p-websys-transport = { git = "https://github.com/jsdanielh/libp2p-websys-transport.git", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 pin-project = "1.0"
 pin-project-lite = "0.2.9"
 prometheus-client = { version = "0.18.1", optional = true}

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -21,11 +21,10 @@ async-trait = "0.1"
 derive_more = "0.99"
 futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 thiserror = "1.0"
 tokio = { version = "1.25", features = [
     "rt",
-    "rt-multi-thread",
     "sync",
 ] }
 tokio-stream = "0.1"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = { version = "1.2", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 num-traits = { version = "0.2", optional = true }
 once_cell = "1.17"
-parking_lot = { git = "https://github.com/styppo/parking_lot.git", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
 regex = { version = "1.7", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.24"

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 hex = { version = "0.4" }
 lazy_static = "1.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.24"

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.2"
 thiserror = "1.0"
 clap = { version = "4.1", features = ["derive"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 
 beserial = { path = "../beserial" }
 nimiq-account = { path = "../primitives/account", features = ["serde-derive"] }

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 futures = { package = "futures-util", version = "0.3" }
 hex = "0.4.2"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2"

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -8,5 +8,5 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 nimiq-log = { path = "../log" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }
 nimiq-test-log-proc-macro = { path = "proc-macro" }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -16,7 +16,7 @@ futures = { package = "futures-util", version = "0.3" }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 rand = "0.8"
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 tokio = { version = "1.25", features = ["rt", "time", "tracing"] }
 tokio-stream = "0.1"
 rand_chacha = "0.3.1"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -22,7 +22,7 @@ futures = { package = "futures-util", version = "0.3" }
 hex = { version = "0.4", optional = true }
 libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false, optional = true }
 log = { package = "tracing", version = "0.1", optional = true, features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 rand = { version = "0.8", optional = true }
 rand_core = { version = "0.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -18,7 +18,7 @@ futures = { package = "futures-util", version = "0.3" }
 lazy_static = "1.3"
 linked-hash-map = "0.5.6"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 rand = "0.8"
 tokio = { version = "1.25", features = ["rt", "time", "tracing"] }
 tokio-metrics = "0.1"

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = "0.1"
 futures = { package = "futures-util", version = "0.3" }
 lazy_static = "1.4.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
-parking_lot = { git = "https://github.com/styppo/parking_lot.git" }
+parking_lot = "0.12"
 rand = "0.8"
 thiserror = "1.0"
 tokio = { version = "1.25", features = ["macros", "rt", "sync"] }


### PR DESCRIPTION
- The parking lot that we were using is not compatible with WASM targets because of the Instant version that was being used
- The fork was being used because it provided additional details in case of deadlocks, however currently that extra information is not being used


- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
