### PR TITLE
Use a task executor in the ZKP component

### DIFF
--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -410,6 +410,9 @@ mod tests {
             let zkp_component = nimiq_zkp_component::ZKPComponent::new(
                 chain1.clone(),
                 Arc::clone(&net1),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -458,6 +461,9 @@ mod tests {
             let zkp_component = nimiq_zkp_component::ZKPComponent::new(
                 chain1.clone(),
                 Arc::clone(&net1),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -479,6 +485,9 @@ mod tests {
             let zkp_component2 = nimiq_zkp_component::ZKPComponent::new(
                 chain2.clone(),
                 Arc::clone(&net2),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -530,6 +539,9 @@ mod tests {
             let zkp_component = nimiq_zkp_component::ZKPComponent::new(
                 chain1.clone(),
                 Arc::clone(&net1),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -551,6 +563,9 @@ mod tests {
             let zkp_component2 = nimiq_zkp_component::ZKPComponent::new(
                 chain2.clone(),
                 Arc::clone(&net2),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -602,6 +617,9 @@ mod tests {
             let zkp_component = nimiq_zkp_component::ZKPComponent::new(
                 chain1.clone(),
                 Arc::clone(&net1),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -623,6 +641,9 @@ mod tests {
             let zkp_component2 = nimiq_zkp_component::ZKPComponent::new(
                 chain2.clone(),
                 Arc::clone(&net2),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -669,6 +690,9 @@ mod tests {
             let zkp_component = nimiq_zkp_component::ZKPComponent::new(
                 chain1.clone(),
                 Arc::clone(&net1),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -690,6 +714,9 @@ mod tests {
             let zkp_component2 = nimiq_zkp_component::ZKPComponent::new(
                 chain2.clone(),
                 Arc::clone(&net2),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -773,6 +800,9 @@ mod tests {
             let zkp_component = nimiq_zkp_component::ZKPComponent::new(
                 chain1.clone(),
                 Arc::clone(&net1),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),
@@ -794,6 +824,9 @@ mod tests {
             let zkp_component2 = nimiq_zkp_component::ZKPComponent::new(
                 chain2.clone(),
                 Arc::clone(&net2),
+                Box::new(|fut| {
+                    tokio::spawn(fut);
+                }),
                 false,
                 None,
                 PathBuf::from(KEYS_PATH),

--- a/consensus/tests/history_sync.rs
+++ b/consensus/tests/history_sync.rs
@@ -198,6 +198,9 @@ async fn sync_ingredients() {
     let zkp_prover1 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain1),
         Arc::clone(&net1),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -241,6 +244,9 @@ async fn sync_ingredients() {
     let zkp_prover2 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain2),
         Arc::clone(&net2),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -127,6 +127,9 @@ pub async fn sync_two_peers(
     let zkp_prover1 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain1),
         Arc::clone(&net1),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -177,6 +180,9 @@ pub async fn sync_two_peers(
     let zkp_prover2 = ZKPComponent::new(
         blockchain2_proxy.clone(),
         Arc::clone(&net2),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -120,7 +120,7 @@ pub fn generate_service_flags(sync_mode: SyncMode) -> (Services, Services) {
 impl ClientInner {
     async fn from_config(
         config: ClientConfig,
-        executor: impl TaskExecutor + Send + 'static,
+        executor: impl TaskExecutor + Send + 'static + Clone,
     ) -> Result<Client, Error> {
         // Get network info (i.e. which specific blockchain we're on)
         if !config.network_id.is_albatross() {
@@ -254,6 +254,7 @@ impl ClientInner {
                 let zkp_component = ZKPComponent::new(
                     blockchain_proxy.clone(),
                     Arc::clone(&network),
+                    executor.clone(),
                     #[cfg(feature = "zkp-prover")]
                     config.zkp.prover_active,
                     #[cfg(feature = "zkp-prover")]
@@ -288,6 +289,7 @@ impl ClientInner {
                 let zkp_component = ZKPComponent::new(
                     blockchain_proxy.clone(),
                     Arc::clone(&network),
+                    executor.clone(),
                     #[cfg(feature = "zkp-prover")]
                     config.zkp.prover_active,
                     #[cfg(feature = "zkp-prover")]
@@ -315,6 +317,7 @@ impl ClientInner {
                 let zkp_component = ZKPComponent::new(
                     blockchain_proxy.clone(),
                     Arc::clone(&network),
+                    executor.clone(),
                     #[cfg(feature = "zkp-prover")]
                     config.zkp.prover_active,
                     #[cfg(feature = "zkp-prover")]
@@ -449,7 +452,7 @@ pub struct Client {
 impl Client {
     pub async fn from_config(
         config: ClientConfig,
-        executor: impl TaskExecutor + Send + 'static,
+        executor: impl TaskExecutor + Send + 'static + Clone,
     ) -> Result<Self, Error> {
         ClientInner::from_config(config, executor).await
     }

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -76,6 +76,9 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
         let zkp_proxy = ZKPComponent::new(
             BlockchainProxy::from(&blockchain),
             Arc::clone(&network),
+            Box::new(|fut| {
+                tokio::spawn(fut);
+            }),
             is_prover_active,
             Some(zkp_test_exe()),
             PathBuf::from(KEYS_PATH),

--- a/zkp-component/tests/zkp_component.rs
+++ b/zkp-component/tests/zkp_component.rs
@@ -54,6 +54,9 @@ async fn builds_valid_genesis_proof() {
     let zkp_prover = ZKPComponent::new(
         BlockchainProxy::from(&blockchain),
         Arc::clone(&network),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -99,6 +102,9 @@ async fn loads_valid_zkp_state_from_db() {
     let zkp_prover = ZKPComponent::new(
         BlockchainProxy::from(&blockchain),
         Arc::clone(&network),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -135,6 +141,9 @@ async fn does_not_load_invalid_zkp_state_from_db() {
     let zkp_prover = ZKPComponent::new(
         BlockchainProxy::from(&blockchain),
         Arc::clone(&network),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -164,6 +173,9 @@ async fn can_produce_two_consecutive_valid_zk_proofs() {
     let zkp_prover = ZKPComponent::new(
         BlockchainProxy::from(&blockchain),
         Arc::clone(&network),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         true,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),

--- a/zkp-component/tests/zkp_requests.rs
+++ b/zkp-component/tests/zkp_requests.rs
@@ -57,6 +57,9 @@ async fn peers_dont_reply_with_outdated_proof() {
     let _zkp_prover2 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain),
         Arc::clone(&network2),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -67,6 +70,9 @@ async fn peers_dont_reply_with_outdated_proof() {
     let _zkp_prover3 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain),
         Arc::clone(&network3),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -130,6 +136,9 @@ async fn peers_reply_with_valid_proof() {
     let _zkp_prover2 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain2),
         Arc::clone(&network2),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -140,6 +149,9 @@ async fn peers_reply_with_valid_proof() {
     let _zkp_prover3 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain3),
         Arc::clone(&network3),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -213,6 +225,9 @@ async fn peers_reply_with_valid_proof_and_election_block() {
     let _zkp_prover2 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain2),
         Arc::clone(&network2),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),
@@ -223,6 +238,9 @@ async fn peers_reply_with_valid_proof_and_election_block() {
     let _zkp_prover3 = ZKPComponent::new(
         BlockchainProxy::from(&blockchain3),
         Arc::clone(&network3),
+        Box::new(|fut| {
+            tokio::spawn(fut);
+        }),
         false,
         Some(zkp_test_exe()),
         PathBuf::from(KEYS_PATH),


### PR DESCRIPTION
A task executor is needed for the ZKP component in order to make it compatible for both wasm and not wasm platforms

