### PR TITLE
lib: Remove ANSI escape codes from web logging

### DIFF
--- a/lib/src/extras/web_logging.rs
+++ b/lib/src/extras/web_logging.rs
@@ -54,7 +54,7 @@ pub fn initialize_web_logging(settings_opt: Option<&LogSettings>) -> Result<(), 
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(MakeConsoleWriter)
-                .with_ansi(settings.file.is_none())
+                .with_ansi(false)
                 .event_format(Formatting(MaybeSystemTime(settings.timestamps)))
                 .with_filter(filter),
         )


### PR DESCRIPTION
Remove ANSI escape codes from web logging in the `lib` crate.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
