### PR TITLE
Rework web client into a struct that can be accessed by JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4514,9 +4514,15 @@ dependencies = [
 name = "nimiq-web-client"
 version = "0.1.0"
 dependencies = [
+ "beserial",
  "futures-util",
  "gloo-timers",
+ "nimiq-blockchain-interface",
+ "nimiq-blockchain-proxy",
+ "nimiq-consensus",
+ "nimiq-hash",
  "nimiq-lib",
+ "nimiq-network-interface",
  "nimiq-network-libp2p",
  "tracing",
  "wasm-bindgen",

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -27,6 +27,12 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 
+beserial = { path = "../beserial", features = ["derive"] }
+nimiq-blockchain-interface = { path = "../blockchain-interface" }
+nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
+nimiq-consensus = { path = "../consensus", default-features = false }
+nimiq-hash = { path = "../hash" }
+nimiq-network-interface = { path = "../network-interface" }
 nimiq-network-libp2p = { path = "../network-libp2p" }
 
 [dependencies.nimiq]

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -5,12 +5,6 @@
     <title>Nimiq Web client example</title>
   </head>
   <body>
-    <script type="module">
-      import init, { nimiq_web_client } from "./pkg/nimiq_web_client.js";
-      init().then(() => {
-	    nimiq_web_client();
-      });
-    </script>
+    <script type="module" src="module.js"></script>
   </body>
 </html>
-

--- a/web-client/module.js
+++ b/web-client/module.js
@@ -1,0 +1,80 @@
+import init, { WebClient } from "./pkg/nimiq_web_client.js";
+
+init().then(async () => {
+    const client = await WebClient.create();
+    client.subscribe_consensus();
+    client.subscribe_blocks();
+    client.subscribe_peers();
+    // client.subscribe_statistics();
+});
+
+window.__wasm_imports = {
+    /**
+     * @param {boolean} established
+     */
+    consensus_listener(established) {
+        console.log(`Consensus: ${established ? 'established =)' : 'lost =('}`);
+    },
+
+    /**
+     * @param {string} type
+     * @param {Uint8Array} serializedBlock
+     * @param {number?} rebranchLength
+     */
+    block_listener(type, serializedBlock, rebranchLength) {
+        // Rudimentary block parsing - TODO: Properly deserialize the whole light block
+
+        /** @type {Uint8Array} */
+        let blockNumberBytes;
+
+        /** @type {Uint8Array} */
+        let timestampBytes;
+
+        const blockType = serializedBlock[0];
+        if (blockType === 1) {
+            // Macro block
+            const _version = serializedBlock.subarray(1, 1 + 2); // u16
+            blockNumberBytes = serializedBlock.subarray(3, 3 + 4); // u32
+            const _round = serializedBlock.subarray(7, 7 + 4); // u32
+            timestampBytes = serializedBlock.subarray(11, 11 + 8); // u64
+        } else if (blockType === 2) {
+            // Micro block
+            const _version = serializedBlock.subarray(1, 1 + 2); // u16
+            blockNumberBytes = serializedBlock.subarray(3, 3 + 4); // u32
+            timestampBytes = serializedBlock.subarray(7, 7 + 8); // u64
+        } else {
+            throw new Error(`Invalid block type: ${blockType}`);
+        }
+
+        const blockNumber = new Uint32Array(new Uint8Array(blockNumberBytes).reverse().buffer)[0];
+        const timestampBig = new BigUint64Array(new Uint8Array(timestampBytes).reverse().buffer)[0];
+        const timestamp = parseInt(timestampBig.toString(10));
+
+        console.log([
+            'Blockchain:',
+            type,
+            ...(rebranchLength ? [rebranchLength] : []),
+            'at',
+            blockNumber,
+            `(${new Date(timestamp).toISOString().substring(0, 19).replace('T', ' ')} UTC)`
+        ].join(' '));
+    },
+
+    /**
+     * @param {'joined' | 'left'} type
+     * @param {string} peerId
+     * @param {number} numPeers
+     */
+    peer_listener(type, peerId, numPeers) {
+        console.log(`Peer ${type}: ${peerId} - now ${numPeers} peers connected`);
+    },
+
+    /**
+     * @param {boolean} established
+     * @param {number} blockNumber
+     * @param {number} numPeers
+     */
+    statistics_listener(established, blockNumber, numPeers) {
+        console.log({ established, blockNumber, numPeers });
+    },
+}

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -16,81 +16,176 @@ pub use nimiq::{
     extras::{panic::initialize_panic_reporting, web_logging::initialize_web_logging},
 };
 
+use beserial::Serialize;
+use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_consensus::ConsensusEvent;
+use nimiq_hash::Blake2bHash;
+use nimiq_network_interface::network::{Network, NetworkEvent};
 use nimiq_network_libp2p::Multiaddr;
 
-async fn light_client() {
-    let log_settings = LogSettings {
-        level: Some(LevelFilter::DEBUG),
-        ..Default::default()
-    };
+#[wasm_bindgen]
+pub struct WebClient {
+    #[wasm_bindgen(skip)]
+    pub inner: Client,
+}
 
-    // Initialize logging with config values.
-    initialize_web_logging(Some(&log_settings)).expect("Web logging initialization failed");
+#[wasm_bindgen]
+impl WebClient {
+    pub async fn create() -> WebClient {
+        let log_settings = LogSettings {
+            level: Some(LevelFilter::DEBUG),
+            ..Default::default()
+        };
 
-    // Initialize panic hook.
-    initialize_panic_reporting();
+        // Initialize logging with config values.
+        initialize_web_logging(Some(&log_settings)).expect("Web logging initialization failed");
 
-    // Create config builder.
-    let mut builder = ClientConfig::builder();
+        // Initialize panic hook.
+        initialize_panic_reporting();
 
-    // Finalize config.
-    let mut config = builder
-        .volatile()
-        .light()
-        .build()
-        .expect("Build configuration failed");
+        // Create config builder.
+        let mut builder = ClientConfig::builder();
 
-    let seed = Seed {
-        address: Multiaddr::from_str("/dns4/seed1.v2.nimiq-testnet.com/tcp/8443/ws").unwrap(),
-    };
-    config.network.seeds = vec![seed];
+        // Finalize config.
+        let mut config = builder
+            .volatile()
+            .light()
+            .build()
+            .expect("Build configuration failed");
 
-    log::debug!("Final configuration: {:#?}", config);
+        let seed = Seed {
+            address: Multiaddr::from_str("/dns4/seed1.v2.nimiq-testnet.com/tcp/8443/ws").unwrap(),
+        };
+        config.network.seeds = vec![seed];
 
-    // Create client from config.
-    log::info!("Initializing light client");
-    let mut client: Client = Client::from_config(
-        config,
-        Box::new(|fut| {
-            spawn_local(fut);
-        }),
-    )
-    .await
-    .expect("Client initialization failed ");
-    log::info!("Web client initialized");
+        log::debug!(?config, "Final configuration");
 
-    // Start consensus.
-    let consensus = client.take_consensus().unwrap();
+        // Create client from config.
+        log::info!("Initializing light client");
+        let mut client: Client = Client::from_config(
+            config,
+            Box::new(|fut| {
+                spawn_local(fut);
+            }),
+        )
+        .await
+        .expect("Client initialization failed");
+        log::info!("Web client initialized");
 
-    log::info!("Spawning consensus");
-    spawn_local(consensus);
+        // Start consensus.
+        let consensus = client.take_consensus().unwrap();
+        log::info!("Spawning consensus");
+        spawn_local(consensus);
 
-    let consensus = client.consensus_proxy();
+        let zkp_component = client.take_zkp_component().unwrap();
+        spawn_local(zkp_component);
 
-    let zkp_component = client.take_zkp_component().unwrap();
-    spawn_local(zkp_component);
-
-    // Create the "monitor" future which never completes to keep the client alive.
-    // This closure is executed after the client has been initialized.
-    // TODO Get rid of this. Make the Client a future/stream instead.
-    let mut statistics_interval = LogSettings::default_statistics_interval();
-    let mut show_statistics = true;
-    if statistics_interval == 0 {
-        statistics_interval = 10;
-        show_statistics = false;
+        WebClient { inner: client }
     }
 
-    // Run periodically
-    let interval = IntervalStream::new(statistics_interval as u32 * 1000);
+    pub async fn subscribe_consensus(&self) {
+        let mut consensus_events = self.inner.consensus_proxy().subscribe_events();
 
-    interval
-        .for_each(|_| async {
-            if show_statistics {
-                match client.network().network_info().await {
+        loop {
+            match consensus_events.next().await {
+                Some(Ok(ConsensusEvent::Established)) => {
+                    consensus_listener(true);
+                }
+                Some(Ok(ConsensusEvent::Lost)) => {
+                    consensus_listener(false);
+                }
+                Some(Err(_error)) => {} // Ignore stream errors
+                None => {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub async fn subscribe_blocks(&self) {
+        let blockchain = self.inner.consensus_proxy().blockchain;
+        let mut blockchain_events = blockchain.read().notifier_as_stream();
+
+        fn emit_block(
+            blockchain: &BlockchainProxy,
+            ty: &str,
+            hash: Blake2bHash,
+            rebranch_length: Option<usize>,
+        ) {
+            if let Ok(block) = blockchain.read().get_block(&hash, false) {
+                block_listener(ty, block.header().serialize_to_vec(), rebranch_length);
+            }
+        }
+
+        loop {
+            match blockchain_events.next().await {
+                Some(BlockchainEvent::Extended(hash)) => {
+                    emit_block(&blockchain, "extended", hash, None);
+                }
+                Some(BlockchainEvent::HistoryAdopted(hash)) => {
+                    emit_block(&blockchain, "history-adopted", hash, None);
+                }
+                Some(BlockchainEvent::EpochFinalized(hash)) => {
+                    emit_block(&blockchain, "epoch-finalized", hash, None);
+                }
+                Some(BlockchainEvent::Finalized(hash)) => {
+                    emit_block(&blockchain, "finalized", hash, None);
+                }
+                Some(BlockchainEvent::Rebranched(_, new_chain)) => {
+                    emit_block(
+                        &blockchain,
+                        "rebranched",
+                        new_chain.last().unwrap().to_owned().0,
+                        Some(new_chain.len()),
+                    );
+                }
+                None => {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub async fn subscribe_peers(&self) {
+        let network = self.inner.network();
+        let mut network_events = network.subscribe_events();
+
+        loop {
+            match network_events.next().await {
+                Some(Ok(NetworkEvent::PeerJoined(peer_id))) => {
+                    peer_listener("joined", peer_id.to_string(), network.peer_count());
+                }
+                Some(Ok(NetworkEvent::PeerLeft(peer_id))) => {
+                    peer_listener("left", peer_id.to_string(), network.peer_count());
+                }
+                Some(Err(_error)) => {} // Ignore stream errors
+                None => {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub async fn subscribe_statistics(&self) {
+        let statistics_interval = LogSettings::default_statistics_interval();
+
+        if statistics_interval == 0 {
+            return;
+        }
+
+        // Run periodically
+        let interval = IntervalStream::new(statistics_interval as u32 * 1000);
+
+        let consensus = self.inner.consensus_proxy();
+
+        interval
+            .for_each(|_| async {
+                match self.inner.network().network_info().await {
                     Ok(network_info) => {
-                        let head = client.blockchain_head();
+                        let head = self.inner.blockchain_head();
 
-                        log::info!(
+                        log::debug!(
                             block_number = head.block_number(),
                             num_peers = network_info.num_peers(),
                             status = consensus.is_established(),
@@ -98,18 +193,34 @@ async fn light_client() {
                             consensus.is_established(),
                             head.block_number(),
                             head.hash(),
-                        )
+                        );
+
+                        statistics_listener(
+                            consensus.is_established(),
+                            head.block_number(),
+                            network_info.num_peers(),
+                        );
                     }
                     Err(err) => {
                         log::error!("Error retrieving NetworkInfo: {:?}", err);
                     }
                 };
-            }
-        })
-        .await;
+            })
+            .await;
+    }
 }
 
 #[wasm_bindgen]
-pub fn nimiq_web_client() {
-    spawn_local(light_client());
+extern "C" {
+    #[wasm_bindgen(js_namespace = __wasm_imports)]
+    fn consensus_listener(established: bool);
+
+    #[wasm_bindgen(js_namespace = __wasm_imports)]
+    fn block_listener(ty: &str, serialized_block: Vec<u8>, rebranch_length: Option<usize>);
+
+    #[wasm_bindgen(js_namespace = __wasm_imports)]
+    fn peer_listener(ty: &str, peer_id: String, num_peers: usize);
+
+    #[wasm_bindgen(js_namespace = __wasm_imports)]
+    fn statistics_listener(established: bool, block_number: u32, num_peers: usize);
 }


### PR DESCRIPTION
## What's in this pull request?
Change the web client to be a struct, which is represented as a class in Javascript, exposing it's methods to be called from JS. For now it only implements subscription methods, which then use separately exposed-from-JS global listeners to communicate the events back to JS. But it can now be easily extended to provide active methods that return data to JS, or send signed transactions to the network, etc.

Interestingly, since the created `Client` is stored in Rust's heap (or stack, I can never remember which is which) when it's made available to JS with `wasm_bindgen`, it is never dereferenced and lives forever (technically only until `.free()` is called on it from JS-side, which is never). So we do not need the statistics-interval-hack anymore to keep the client in-scope =).

> **Note for reviewers:** It is recommended to hide whitespace changes when reviewing, as most existing code in `lib.rs` has simply been indented by one level.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
