### PR TITLE
Update the `libp2p-websys-transport` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websys-transport"
 version = "0.1.3"
-source = "git+https://github.com/jsdanielh/libp2p-websys-transport.git#355d8927bed2d064309f79415496708b0d41a4a0"
+source = "git+https://github.com/jsdanielh/libp2p-websys-transport.git#e43ccc661caf6f57e9d800366febee2c7f6c35a6"
 dependencies = [
  "futures",
  "js-sys",


### PR DESCRIPTION
Update the `libp2p-websys-transport` dependency to fix an exception after a connection to a peer fails. This was noticeable only in Chrome/Safari browsers.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
