### PR TITLE
Fixing zkp-prover and parallel features always enabled 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ members = [
   "zkp-circuits",
 ]
 
+resolver = "2"
+
 # Force nimiq-bls and nimiq-zkp to be built with optimization level 2 in
 # the test profiles. This is necessary in order to have decent tests
 # performance. We do the same with nimiq-bls dev profile because it is compiled

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -69,7 +69,7 @@ nimiq-utils = { path = "../utils", features = ["time", "key-store"] }
 nimiq-validator = { path = "../validator", optional = true, features = ["trusted_push"] }
 nimiq-validator-network = { path = "../validator-network", optional = true }
 nimiq-wallet = { path = "../wallet", optional = true }
-nimiq-zkp = { path = "../zkp", features = ["zkp-prover"] }
+nimiq-zkp = { path = "../zkp" }
 nimiq-zkp-circuits = { path = "../zkp-circuits" }
 nimiq-zkp-component = { path = "../zkp-component" }
 nimiq-zkp-primitives = { path = "../zkp-primitives" }
@@ -87,7 +87,7 @@ logging = ["file-rotate", "nimiq-log", "serde_json", "tokio", "tracing-subscribe
 loki = ["logging", "tracing-loki"]
 metrics-server = ["nimiq-metrics-server", "nimiq-network-libp2p/metrics", "nimiq-validator/metrics"]
 panic = ["log-panics"]
-parallel = ["nimiq-zkp-primitives/parallel", "nimiq-zkp-component/parallel", "nimiq-zkp/parallel", "nimiq-zkp-circuits/parallel"]
+parallel = ["nimiq-zkp/parallel", "nimiq-zkp-circuits/parallel", "nimiq-zkp-component/parallel", "nimiq-zkp-primitives/parallel"]
 rpc-server = ["nimiq-jsonrpc-core", "nimiq-jsonrpc-server", "nimiq-rpc-server", "nimiq-wallet", "validator"]
 signal-handling = ["signal-hook", "tokio"]
 tokio-console = ["console-subscriber", "logging", "tokio/tracing"]
@@ -96,4 +96,4 @@ validator = ["database-storage", "nimiq-mempool", "nimiq-validator", "nimiq-vali
 wallet = ["database-storage", "nimiq-wallet"]
 wasm-websocket = ["nimiq-network-libp2p/wasm-websocket"]
 web-logging = ["nimiq-log", "time/wasm-bindgen", "tracing-subscriber", "tracing-web"]
-zkp-prover = ["nimiq-zkp-component/zkp-prover", "nimiq-zkp-primitives/zkp-prover"]
+zkp-prover = ["nimiq-zkp/zkp-prover", "nimiq-zkp-circuits/zkp-prover", "nimiq-zkp-component/zkp-prover", "nimiq-zkp-primitives/zkp-prover"]

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -39,8 +39,9 @@ use nimiq_wallet::WalletStore;
 #[cfg(feature = "zkp-prover")]
 use nimiq_zkp::ZKP_VERIFYING_KEY;
 #[cfg(feature = "zkp-prover")]
-use nimiq_zkp_circuits::setup::{
-    all_files_created, load_verifying_key_from_file, setup, DEFAULT_KEYS_PATH, DEVELOPMENT_SEED,
+use nimiq_zkp_circuits::{
+    setup::{all_files_created, load_verifying_key_from_file, setup, DEVELOPMENT_SEED},
+    DEFAULT_KEYS_PATH,
 };
 #[cfg(feature = "database-storage")]
 use nimiq_zkp_component::proof_store::{DBProofStore, ProofStore};
@@ -147,13 +148,13 @@ impl ClientInner {
         // If the Prover is active for devnet we need to ensure that the proving keys are present.
         if config.network_id == NetworkId::DevAlbatross
             && config.zkp.prover_active
-            && !all_files_created(&config.zkp.proving_keys_path, config.zkp.prover_active)
+            && !all_files_created(&config.zkp.prover_keys_path, config.zkp.prover_active)
         {
             log::info!("Setting up zero-knowledge prover keys for devnet.");
             log::info!("This task only needs to be run once and might take about an hour.");
             log::info!(
                 "Alternatively, you can place the proving keys in this folder: {:?}.",
-                config.zkp.proving_keys_path
+                config.zkp.prover_keys_path
             );
             setup(
                 ChaCha20Rng::from_seed(DEVELOPMENT_SEED),
@@ -161,7 +162,7 @@ impl ClientInner {
                 config.zkp.prover_active,
             )?;
             log::info!("Setting the verification key.");
-            let vk = load_verifying_key_from_file(&config.zkp.proving_keys_path)?;
+            let vk = load_verifying_key_from_file(&config.zkp.prover_keys_path)?;
             assert_eq!(vk, *ZKP_VERIFYING_KEY, "Verifying keys don't match. The build in verifying keys don't match the newly generated ones.");
             log::debug!("Finished ZKP setup.");
         }
@@ -269,7 +270,7 @@ impl ClientInner {
                         executor.clone(),
                         config.zkp.prover_active,
                         None,
-                        Some(config.zkp.proving_keys_path),
+                        config.zkp.prover_keys_path,
                         zkp_storage,
                     )
                     .await
@@ -321,7 +322,7 @@ impl ClientInner {
                         executor.clone(),
                         config.zkp.prover_active,
                         None,
-                        Some(config.zkp.proving_keys_path),
+                        config.zkp.prover_keys_path,
                         zkp_storage,
                     )
                     .await

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -24,7 +24,7 @@ use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_utils::file_store::FileStore;
 #[cfg(feature = "validator")]
 use nimiq_utils::key_rng::SecureGenerate;
-use nimiq_zkp_circuits::setup::DEFAULT_KEYS_PATH;
+use nimiq_zkp_circuits::DEFAULT_KEYS_PATH;
 
 #[cfg(any(feature = "rpc-server", feature = "metrics-server"))]
 use crate::config::consts;
@@ -742,13 +742,14 @@ impl ClientConfigBuilder {
 
         // Configure the zk prover
         if let Some(zkp_settings) = config_file.zkp.as_ref() {
-            let mut proving_keys_path = PathBuf::from(DEFAULT_KEYS_PATH);
-            if let Some(zkp_path) = zkp_settings.proving_keys_path.as_ref() {
-                proving_keys_path = PathBuf::from(zkp_path);
+            let mut prover_keys_path = PathBuf::from(DEFAULT_KEYS_PATH);
+            if let Some(zkp_path) = zkp_settings.prover_keys_path.as_ref() {
+                prover_keys_path = PathBuf::from(zkp_path);
             }
+
             self.zkp = Some(ZKPConfig {
                 prover_active: zkp_settings.prover_active,
-                proving_keys_path,
+                prover_keys_path,
             });
         }
 
@@ -865,15 +866,15 @@ pub struct ZKPConfig {
     /// ZK Proof generation activation config.
     pub prover_active: bool,
 
-    /// Proving keys path for the zkp prover.
-    pub proving_keys_path: PathBuf,
+    /// Prover keys path for the zkp prover.
+    pub prover_keys_path: PathBuf,
 }
 
 impl Default for ZKPConfig {
     fn default() -> Self {
         Self {
             prover_active: false,
-            proving_keys_path: PathBuf::from(DEFAULT_KEYS_PATH),
+            prover_keys_path: PathBuf::from(DEFAULT_KEYS_PATH),
         }
     }
 }

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -480,5 +480,5 @@ pub struct ZKPSettings {
     #[serde(default)]
     pub prover_active: bool,
     #[serde(default)]
-    pub proving_keys_path: Option<String>,
+    pub prover_keys_path: Option<String>,
 }

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -81,7 +81,7 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
             }),
             is_prover_active,
             Some(zkp_test_exe()),
-            Some(PathBuf::from(ZKP_TEST_KEYS_PATH)),
+            PathBuf::from(ZKP_TEST_KEYS_PATH),
             zkp_storage,
         )
         .await;

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -39,5 +39,5 @@ nimiq-test-log = { path = "../test-log" }
 
 
 [features]
-zkp-prover = ["ark-crypto-primitives/r1cs", "ark-mnt4-753/r1cs", "ark-mnt6-753/r1cs", "ark-groth16/r1cs"]
+zkp-prover = ["ark-crypto-primitives/r1cs", "ark-mnt4-753/r1cs", "ark-mnt6-753/r1cs", "ark-groth16/r1cs", "nimiq-zkp-primitives/zkp-prover"]
 parallel = ["ark-crypto-primitives/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel", "nimiq-zkp-primitives/parallel"]

--- a/zkp-circuits/src/lib.rs
+++ b/zkp-circuits/src/lib.rs
@@ -1,12 +1,9 @@
 #[cfg(feature = "zkp-prover")]
-pub use setup::DEFAULT_KEYS_PATH;
-#[cfg(feature = "zkp-prover")]
-pub use setup::DEVELOPMENT_SEED;
-
-#[cfg(feature = "zkp-prover")]
 pub mod circuits;
 #[cfg(feature = "zkp-prover")]
 pub(crate) mod gadgets;
 #[cfg(feature = "zkp-prover")]
 pub mod setup;
 pub mod utils;
+
+pub const DEFAULT_KEYS_PATH: &str = ".zkp";

--- a/zkp-circuits/src/setup.rs
+++ b/zkp-circuits/src/setup.rs
@@ -26,7 +26,6 @@ use nimiq_bls::utils::bytes_to_bits;
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::{MacroBlock, NanoZKPError, PK_TREE_BREADTH, PK_TREE_DEPTH};
 
-pub const DEFAULT_KEYS_PATH: &str = ".zkp";
 pub const DEVELOPMENT_SEED: [u8; 32] = [
     1, 0, 52, 0, 0, 0, 0, 0, 1, 0, 10, 0, 22, 32, 0, 0, 2, 0, 55, 49, 0, 11, 0, 0, 3, 0, 0, 0, 0,
     0, 2, 92,

--- a/zkp-circuits/zkp-setup/main.rs
+++ b/zkp-circuits/zkp-setup/main.rs
@@ -5,8 +5,8 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 
 use nimiq_zkp_circuits::{
-    setup::{setup, DEFAULT_KEYS_PATH},
-    DEVELOPMENT_SEED,
+    setup::{setup, DEVELOPMENT_SEED},
+    DEFAULT_KEYS_PATH,
 };
 use nimiq_zkp_primitives::NanoZKPError;
 

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -78,6 +78,6 @@ nimiq-test-utils = { path = "../test-utils" }
 
 [features]
 database-storage = ["nimiq-database"]
-parallel = ["nimiq-zkp-primitives/parallel", "nimiq-zkp/parallel", "nimiq-zkp-circuits/parallel", "ark-groth16/parallel"]
+parallel = ["nimiq-zkp/parallel", "nimiq-zkp-circuits/parallel",  "nimiq-zkp-primitives/parallel", "ark-groth16/parallel"]
 test-prover = ["nimiq-log", "zkp-prover", "tracing-subscriber"]
-zkp-prover = ["nimiq-blockchain", "nimiq-zkp/zkp-prover", "tokio/io-util", "tokio/process"]
+zkp-prover = ["nimiq-blockchain", "nimiq-blockchain-proxy/full", "nimiq-zkp/zkp-prover", "nimiq-zkp-circuits/zkp-prover", "nimiq-zkp-primitives/zkp-prover", "tokio/io-util", "tokio/process"]

--- a/zkp-component/src/proof_gen_utils.rs
+++ b/zkp-component/src/proof_gen_utils.rs
@@ -25,7 +25,7 @@ pub fn generate_new_proof(
     latest_header_hash: [u8; 32],
     previous_proof: Option<Proof<MNT6_753>>,
     genesis_state: Vec<u8>,
-    proving_keys_path: &Path,
+    prover_keys_path: &Path,
 ) -> Result<ZKPState, ZKProofGenerationError> {
     let validators = block.get_validators();
 
@@ -46,7 +46,7 @@ pub fn generate_new_proof(
             previous_proof.map(|proof| (proof, genesis_state.clone())),
             true,
             true,
-            proving_keys_path,
+            prover_keys_path,
         );
 
         return match proof {

--- a/zkp-component/src/prover_binary.rs
+++ b/zkp-component/src/prover_binary.rs
@@ -25,7 +25,7 @@ pub async fn prover_main() -> Result<(), SerializingError> {
             proof_input.latest_header_hash.into(),
             proof_input.previous_proof,
             proof_input.genesis_state,
-            &proof_input.proving_keys_path,
+            &proof_input.prover_keys_path,
         ),
         Err(e) => Err(ZKProofGenerationError::from(e)),
     };

--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -306,7 +306,7 @@ pub struct ProofInput {
     pub latest_header_hash: Blake2bHash,
     pub previous_proof: Option<Proof<MNT6_753>>,
     pub genesis_state: Vec<u8>,
-    pub proving_keys_path: PathBuf,
+    pub prover_keys_path: PathBuf,
 }
 
 /// The serialization of the ProofInput is unsafe over the network.
@@ -340,7 +340,7 @@ impl Serialize for ProofInput {
 
         size += SerializeWithLength::serialize::<u8, _>(&self.genesis_state, writer)?;
 
-        let path_buf = self.proving_keys_path.to_string_lossy().to_string();
+        let path_buf = self.prover_keys_path.to_string_lossy().to_string();
         size += SerializeWithLength::serialize::<u16, _>(&path_buf, writer)?;
 
         Ok(size)
@@ -362,7 +362,7 @@ impl Serialize for ProofInput {
 
         size += SerializeWithLength::serialized_size::<u8>(&self.genesis_state);
 
-        let path_buf = self.proving_keys_path.to_string_lossy().to_string();
+        let path_buf = self.prover_keys_path.to_string_lossy().to_string();
         size += SerializeWithLength::serialized_size::<u16>(&path_buf);
 
         size
@@ -409,7 +409,7 @@ impl Deserialize for ProofInput {
             latest_header_hash,
             previous_proof,
             genesis_state,
-            proving_keys_path: PathBuf::from(path_buf),
+            prover_keys_path: PathBuf::from(path_buf),
         })
     }
 }

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -167,7 +167,7 @@ impl<N: Network> ZKPComponent<N> {
         executor: impl TaskExecutor + Send + 'static,
         is_prover_active: bool,
         prover_path: Option<PathBuf>,
-        proving_keys_path: Option<PathBuf>,
+        prover_keys_path: PathBuf,
         proof_storage: Option<Box<dyn ProofStore>>,
     ) -> Self {
         let mut zkp_component = Self::new(blockchain, network, executor, proof_storage).await;
@@ -180,7 +180,7 @@ impl<N: Network> ZKPComponent<N> {
                     Arc::clone(&zkp_component.network),
                     Arc::clone(&zkp_component.zkp_state),
                     prover_path,
-                    proving_keys_path,
+                    prover_keys_path,
                 )
                 .await,
             ),

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -17,7 +17,6 @@ use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction}
 use nimiq_genesis::NetworkInfo;
 use nimiq_network_interface::network::Network;
 use nimiq_primitives::policy::Policy;
-use nimiq_zkp_circuits::DEFAULT_KEYS_PATH;
 use nimiq_zkp_primitives::state_commitment;
 
 use crate::proof_gen_utils::*;
@@ -44,7 +43,7 @@ pub struct ZKProver<N: Network> {
     genesis_state: Vec<u8>,
     proof_future:
         Option<BoxFuture<'static, Result<(ZKPState, MacroBlock), ZKProofGenerationError>>>,
-    proving_keys_path: PathBuf,
+    prover_keys_path: PathBuf,
     prover_path: Option<PathBuf>,
 }
 
@@ -54,7 +53,7 @@ impl<N: Network> ZKProver<N> {
         network: Arc<N>,
         zkp_state: Arc<RwLock<ZKPState>>,
         prover_path: Option<PathBuf>,
-        proving_keys_path: Option<PathBuf>,
+        prover_keys_path: PathBuf,
     ) -> Self {
         let network_info = NetworkInfo::from_network_id(blockchain.read().network_id());
         let genesis_block = network_info.genesis_block::<Block>().unwrap_macro();
@@ -109,8 +108,6 @@ impl<N: Network> ZKProver<N> {
             future::ready(result)
         });
 
-        let proving_keys_path = proving_keys_path.unwrap_or(PathBuf::from(DEFAULT_KEYS_PATH));
-
         Self {
             network,
             zkp_state,
@@ -119,7 +116,7 @@ impl<N: Network> ZKProver<N> {
             pending_election_blocks,
             election_stream: Box::pin(blockchain_election_rx),
             proof_future: None,
-            proving_keys_path,
+            prover_keys_path,
             prover_path,
         }
     }
@@ -167,7 +164,7 @@ impl<N: Network> ZKProver<N> {
                         latest_header_hash: zkp_state.latest_header_hash.clone(),
                         previous_proof: zkp_state.latest_proof.clone(),
                         genesis_state: self.genesis_state.clone(),
-                        proving_keys_path: self.proving_keys_path.clone(),
+                        prover_keys_path: self.prover_keys_path.clone(),
                     },
                     self.prover_path.clone(),
                 )

--- a/zkp-component/tests/types.rs
+++ b/zkp-component/tests/types.rs
@@ -79,7 +79,7 @@ fn it_serializes_and_deserializes_proof_input() {
         block: MacroBlock::default(),
         previous_proof: Some(Proof::default()),
         genesis_state: vec![1, 2, 4, 6, 7, 8, 9, 0],
-        proving_keys_path: PathBuf::from(ZKP_TEST_KEYS_PATH),
+        prover_keys_path: PathBuf::from(ZKP_TEST_KEYS_PATH),
     };
     let serialized = Serialize::serialize_to_vec(&proof_input);
     let deserialized: ProofInput = Deserialize::deserialize_from_vec(&serialized).unwrap();
@@ -91,7 +91,7 @@ fn it_serializes_and_deserializes_proof_input() {
         block: MacroBlock::default(),
         previous_proof: None,
         genesis_state: vec![],
-        proving_keys_path: PathBuf::from(ZKP_TEST_KEYS_PATH),
+        prover_keys_path: PathBuf::from(ZKP_TEST_KEYS_PATH),
     };
     let serialized = Serialize::serialize_to_vec(&proof_input);
     let deserialized: ProofInput = Deserialize::deserialize_from_vec(&serialized).unwrap();

--- a/zkp-component/tests/zkp_component.rs
+++ b/zkp-component/tests/zkp_component.rs
@@ -168,7 +168,7 @@ async fn can_produce_two_consecutive_valid_zk_proofs() {
         }),
         true,
         Some(zkp_test_exe()),
-        Some(PathBuf::from(ZKP_TEST_KEYS_PATH)),
+        PathBuf::from(ZKP_TEST_KEYS_PATH),
         None,
     )
     .await;

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -12,8 +12,9 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 
 [build-dependencies]
 ark-serialize = "0.3"
-nimiq-zkp-primitives = { path = "../zkp-primitives", features = ["zkp-prover"] }
-nimiq-zkp-circuits = { path = "../zkp-circuits", features = ["zkp-prover"] }
+
+nimiq-zkp-primitives = { path = "../zkp-primitives", features = ["zkp-prover", "parallel"] }
+nimiq-zkp-circuits = { path = "../zkp-circuits", features = ["zkp-prover", "parallel"] }
 
 [dependencies]
 ark-crypto-primitives = "0.3"
@@ -37,14 +38,14 @@ beserial = { path = "../beserial", features = ["derive"]}
 nimiq-bls = { path = "../bls" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }
 nimiq-zkp-circuits = { path = "../zkp-circuits" }
-nimiq-zkp-primitives = { path = "../zkp-primitives", default-features = false }
+nimiq-zkp-primitives = { path = "../zkp-primitives" }
 
 [dev-dependencies]
 nimiq-test-log = { path = "../test-log" }
 
 [features]
-parallel = ["ark-crypto-primitives/parallel", "nimiq-zkp-circuits/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel", "nimiq-zkp-primitives/parallel"]
-zkp-prover = ["ark-crypto-primitives/r1cs", "ark-mnt4-753/r1cs", "ark-mnt6-753/r1cs", "ark-groth16/r1cs"]
+parallel = ["nimiq-zkp-circuits/parallel", "nimiq-zkp-primitives/parallel", "ark-crypto-primitives/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel"]
+zkp-prover = ["nimiq-zkp-circuits/zkp-prover", "nimiq-zkp-primitives/zkp-prover", "ark-crypto-primitives/r1cs", "ark-mnt4-753/r1cs", "ark-mnt6-753/r1cs", "ark-groth16/r1cs"]
 
 [[example]]
 name = "setup"

--- a/zkp/build.rs
+++ b/zkp/build.rs
@@ -1,6 +1,7 @@
 use std::{env, fs::File, path::Path};
 
 use ark_serialize::CanonicalSerialize;
+
 use nimiq_zkp_circuits::setup::{all_files_created, load_verifying_key_from_file};
 use nimiq_zkp_primitives::NanoZKPError;
 

--- a/zkp/src/nano_zkp/prove.rs
+++ b/zkp/src/nano_zkp/prove.rs
@@ -24,7 +24,6 @@ use nimiq_zkp_circuits::{
         MacroBlockWrapperCircuit, MergerWrapperCircuit, PKTreeNodeCircuit as NodeMNT6,
     },
     utils::pack_inputs,
-    DEFAULT_KEYS_PATH,
 };
 use nimiq_zkp_primitives::{
     merkle_tree_prove, pk_tree_construct, serialize_g1_mnt6, serialize_g2_mnt6, state_commitment,
@@ -56,11 +55,11 @@ pub fn prove(
     // This is a flag indicating if we want to run this function in debug mode. It will verify
     // each proof it creates right after the proof is generated.
     debug_mode: bool,
-    // The path to where the `proving_keys` folder is stored in.
-    proving_keys_path: &Path,
+    // The path to where the `prover_keys` folder is stored in.
+    prover_keys_path: &Path,
 ) -> Result<Proof<MNT6_753>, NanoZKPError> {
     let rng = &mut thread_rng();
-    let proofs = proving_keys_path.join("proofs");
+    let proofs = prover_keys_path.join("proofs");
 
     // Serialize the initial public keys into bits and chunk them into the number of leaves.
     let mut bytes = Vec::new();
@@ -123,7 +122,7 @@ pub fn prove(
             &initial_pk_tree_root,
             &block.signer_bitmap,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -151,7 +150,7 @@ pub fn prove(
             &initial_pk_tree_root,
             &block.signer_bitmap,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -179,7 +178,7 @@ pub fn prove(
             &initial_pk_tree_root,
             &block.signer_bitmap,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -207,7 +206,7 @@ pub fn prove(
             &initial_pk_tree_root,
             &block.signer_bitmap,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -235,7 +234,7 @@ pub fn prove(
             &initial_pk_tree_root,
             &block.signer_bitmap,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -258,7 +257,7 @@ pub fn prove(
             &initial_pk_tree_root,
             &block.signer_bitmap,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -280,7 +279,7 @@ pub fn prove(
             &final_pk_tree_root,
             &block,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -300,7 +299,7 @@ pub fn prove(
             &final_pks,
             &block,
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -321,7 +320,7 @@ pub fn prove(
             &block,
             genesis_data.clone(),
             debug_mode,
-            proving_keys_path,
+            prover_keys_path,
         )?;
     }
 
@@ -341,7 +340,7 @@ pub fn prove(
         &block,
         genesis_data,
         debug_mode,
-        proving_keys_path,
+        prover_keys_path,
     )?;
 
     // Delete cached proofs.
@@ -414,8 +413,8 @@ fn prove_pk_tree_leaf<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
-        let mut file = File::open(Path::new(DEFAULT_KEYS_PATH).join(format!("{name}.bin")))?;
+        // Load the verifying key from file.
+        let mut file = File::open(dir_path.join("verifying_keys").join(format!("{name}.bin")))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
 
@@ -455,7 +454,7 @@ fn prove_pk_tree_node_mnt6<R: CryptoRng + Rng>(
     dir_path: &Path,
 ) -> Result<(), NanoZKPError> {
     let proving_keys = dir_path.join("proving_keys");
-    let verifying_keys = Path::new(DEFAULT_KEYS_PATH).join("verifying_keys");
+    let verifying_keys = dir_path.join("verifying_keys");
     let proofs = dir_path.join("proofs");
     // Load the proving key from file.
     let mut file = File::open(proving_keys.join(format!("{name}.bin")))?;
@@ -549,7 +548,7 @@ fn prove_pk_tree_node_mnt6<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
+        // Load the verifying key from file.
         let mut file = File::open(verifying_keys.join(format!("{name}.bin")))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -592,7 +591,7 @@ fn prove_pk_tree_node_mnt4<R: CryptoRng + Rng>(
     dir_path: &Path,
 ) -> Result<(), NanoZKPError> {
     let proving_keys = dir_path.join("proving_keys");
-    let verifying_keys = Path::new(DEFAULT_KEYS_PATH).join("verifying_keys");
+    let verifying_keys = dir_path.join("verifying_keys");
     let proofs = dir_path.join("proofs");
 
     // Load the proving key from file.
@@ -681,7 +680,7 @@ fn prove_pk_tree_node_mnt4<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
+        // Load the verifying key from file.
         let mut file = File::open(verifying_keys.join(format!("{name}.bin")))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -721,7 +720,7 @@ fn prove_macro_block<R: CryptoRng + Rng>(
     path: &Path,
 ) -> Result<(), NanoZKPError> {
     let proving_keys = path.join("proving_keys");
-    let verifying_keys = Path::new(DEFAULT_KEYS_PATH).join("verifying_keys");
+    let verifying_keys = path.join("verifying_keys");
     let proofs = path.join("proofs");
 
     // Load the proving key from file.
@@ -786,7 +785,7 @@ fn prove_macro_block<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
+        // Load the verifying key from file.
         let mut file = File::open(verifying_keys.join("macro_block.bin"))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -820,7 +819,7 @@ fn prove_macro_block_wrapper<R: CryptoRng + Rng>(
     path: &Path,
 ) -> Result<(), NanoZKPError> {
     let proving_keys = path.join("proving_keys");
-    let verifying_keys = Path::new(DEFAULT_KEYS_PATH).join("verifying_keys");
+    let verifying_keys = path.join("verifying_keys");
     let proofs = path.join("proofs");
 
     // Load the proving key from file.
@@ -864,7 +863,7 @@ fn prove_macro_block_wrapper<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
+        // Load the verifying key from file.
         let mut file = File::open(verifying_keys.join("macro_block_wrapper.bin"))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -899,7 +898,7 @@ fn prove_merger<R: CryptoRng + Rng>(
     path: &Path,
 ) -> Result<(), NanoZKPError> {
     let proving_keys = path.join("proving_keys");
-    let verifying_keys = Path::new(DEFAULT_KEYS_PATH).join("verifying_keys");
+    let verifying_keys = path.join("verifying_keys");
     let proofs = path.join("proofs");
     // Load the proving key from file.
     let mut file = File::open(proving_keys.join("merger.bin"))?;
@@ -972,7 +971,7 @@ fn prove_merger<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
+        // Load the verifying key from file.
         let mut file = File::open(verifying_keys.join("merger.bin"))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;
@@ -1009,7 +1008,7 @@ fn prove_merger_wrapper<R: CryptoRng + Rng>(
     path: &Path,
 ) -> Result<Proof<MNT6_753>, NanoZKPError> {
     let proving_keys = path.join("proving_keys");
-    let verifying_keys = Path::new(DEFAULT_KEYS_PATH).join("verifying_keys");
+    let verifying_keys = path.join("verifying_keys");
     let proofs = path.join("proofs");
     // Load the proving key from file.
     let mut file = File::open(proving_keys.join("merger_wrapper.bin"))?;
@@ -1065,7 +1064,7 @@ fn prove_merger_wrapper<R: CryptoRng + Rng>(
 
     // Optionally verify the proof.
     if debug_mode {
-        // Load the proving key from file.
+        // Load the verifying key from file.
         let mut file = File::open(verifying_keys.join("merger_wrapper.bin"))?;
 
         let verifying_key = VerifyingKey::deserialize_unchecked(&mut file)?;


### PR DESCRIPTION
## What's in this pull request?
### The probem: 
The features 'parallel' and 'zkp-prover' were being compiled for the web client. This was caused by the cargo's feature unification. Cargo was unifying build dependencies with "regular" dependencies and always activate them. This would enable parallel computations for the zk proof verification causing the web client to crash after receiving a ZKP from a peer. 

### The changes:
- Main fix: set the resolver to 2 on the main cargo.toml of the repository
- Adjusting the zkp-prover feature for the new zkp crate (zkp-primitives, zkp, zkp-circuits), in order to avoid the feature being always enabled
- Simplifying the config and settings for the zkp component

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
