### PR TITLE
lib: Update example config file for zkp prover keys

### DIFF
--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -97,7 +97,7 @@ sync_mode = "full"
 
 # Defines the path for the proving keys folders
 # Default: ".zkp"
-# proving_keys_path = "some_folder" #defaults to .zkp folder
+# prover_keys_path = "some_folder" #defaults to .zkp folder
 
 ##############################################################################
 #


### PR DESCRIPTION
Update the example configuration file located in the `lib` crate to also reflect the recent change of the zkp prover key field from `proving_keys_path` to `prover_keys_path`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
