### PR TITLE
network-libp2p: Improve the discovery behaviour

### DIFF
--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -275,7 +275,10 @@ impl ConnectionPoolBehaviour {
             .query(self.required_services)
             .filter_map(|contact| {
                 let peer_id = contact.peer_id();
-                if peer_id != own_peer_id && self.peer_ids.can_dial(peer_id) {
+                if peer_id != own_peer_id
+                    && self.peer_ids.can_dial(peer_id)
+                    && contact.addresses().count() > 0
+                {
                     Some(*peer_id)
                 } else {
                     None

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -375,7 +375,10 @@ impl ConnectionHandler for DiscoveryHandler {
                                     let mut peer_contact_book = self.peer_contact_book.write();
 
                                     // Update our own peer contact given the observed addresses we received
-                                    peer_contact_book.add_own_addresses(observed_addresses.clone());
+                                    peer_contact_book.add_own_addresses(
+                                        observed_addresses.clone(),
+                                        &self.keypair,
+                                    );
 
                                     // Send the HandshakeAck
                                     let response_signature =
@@ -481,6 +484,8 @@ impl ConnectionHandler for DiscoveryHandler {
                                         peer_contacts,
                                         self.config.required_services,
                                     );
+
+                                    drop(peer_contact_book);
 
                                     // Store peer contact in handler
                                     self._peer_contact = Some(peer_contact.clone());

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -16,7 +16,9 @@ pub const REQRES_PROTOCOL: &[u8] = b"/nimiq/reqres/0.0.1";
 pub const MESSAGE_PROTOCOL: &[u8] = b"/nimiq/message/0.0.1";
 pub const DISCOVERY_PROTOCOL: &[u8] = b"/nimiq/discovery/0.0.1";
 
-pub use libp2p::{self, identity::Keypair, swarm::NetworkInfo, Multiaddr, PeerId};
+pub use libp2p::{
+    self, identity::Keypair, multiaddr::Protocol, swarm::NetworkInfo, Multiaddr, PeerId,
+};
 
 pub use config::Config;
 pub use error::NetworkError;

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -540,7 +540,7 @@ impl Network {
                             %peer_id,
                             address = %addr,
                             %error,
-                            "Failed to reach address",
+                            "Removing addresses that caused dial failures",
                         );
                         swarm.behaviour_mut().remove_peer_address(peer_id, addr);
                     }

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -8,7 +8,9 @@ use libp2p::{
     swarm::KeepAlive,
 };
 use rand::{thread_rng, Rng};
-use tokio::time::{Duration, Instant};
+use tokio::time::Duration;
+#[cfg(feature = "tokio-time")]
+use tokio::time::Instant;
 
 use beserial::{Deserialize, Serialize};
 #[cfg(feature = "tokio-time")]


### PR DESCRIPTION
Improve the discovery behaviour by introducing these changes:
- Change the `client` code in the `lib` crate to not specify an address for our own peer contact when the listen address is unspecified.
- Add observed addresses to our own contact when they are discovered by the `Discovery` behaviour at a successful connection to a peer.
- Remove addresses from our own contact when a peer report them as failed to dial.
- Add functions in `PeerContactBook` to add or remove addresses for our own contact.
- Also add some missing `rustdoc` documentation for some functions in the implementation of `PeerContactBook`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
