### PR TITLE
Use the validator services flag

### DIFF
--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -28,8 +28,11 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                     self.peers.remove(&peer_id);
                 }
                 Ok(NetworkEvent::PeerJoined(peer_id)) => {
-                    // Request epoch_ids from the peer that joined.
-                    self.add_peer(peer_id);
+                    // Query if that peer provides the necessary services for syncing
+                    if self.network.peer_provides_required_services(peer_id) {
+                        // Request epoch_ids from the peer that joined.
+                        self.add_peer(peer_id);
+                    }
                 }
                 Err(_) => return Poll::Ready(None),
             }

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -35,8 +35,11 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     self.remove_peer_requests(peer_id);
                 }
                 Ok(NetworkEvent::PeerJoined(peer_id)) => {
-                    // Request zkps and start the macro sync process
-                    self.add_peer(peer_id);
+                    // Query if that peer provides the necessary services for syncing
+                    if self.network.peer_provides_required_services(peer_id) {
+                        // Request zkps and start the macro sync process
+                        self.add_peer(peer_id);
+                    }
                 }
                 Err(_) => return Poll::Ready(None),
             }

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -178,8 +178,14 @@ impl ClientInner {
             identity_keypair.public().to_peer_id().to_base58()
         );
 
-        let (provided_services, required_services) =
+        let (mut provided_services, required_services) =
             generate_service_flags(config.consensus.sync_mode);
+
+        // We update the services flags depending on our validator configuration
+        #[cfg(feature = "validator")]
+        if config.validator.is_some() {
+            provided_services |= Services::VALIDATOR;
+        }
 
         // Generate my peer contact from identity keypair and my provided services
         // Filter out unspecified IP addresses since those are not addresses suitable


### PR DESCRIPTION
If a node is configured as a validator, then it is interested in other validator nodes (regardless of the services that are provided by those other validators) However, for the syncing process, we only care about those peers that provide the required services for us

