### PR TITLE
Avoiding duplicates in the pending for deletion rate limiting

### DIFF
--- a/network-libp2p/src/rate_limiting.rs
+++ b/network-libp2p/src/rate_limiting.rs
@@ -1,12 +1,100 @@
-use std::time::Duration;
+use std::{
+    cmp::Ordering,
+    collections::{BTreeSet, HashMap},
+    time::Duration,
+};
 
 #[cfg(not(feature = "tokio-time"))]
 use instant::Instant;
+use libp2p::PeerId;
 #[cfg(feature = "tokio-time")]
 use tokio::time::Instant;
 
+/// Holds the expiration time for a given peer and request type. This struct defines the ordering for the btree set.
+/// The smaller expiration times come first.
+#[derive(Debug, Eq, Hash, PartialEq, Clone)]
+pub(crate) struct Expiration {
+    pub(crate) peer_id: PeerId,
+    pub(crate) req_type: u16,
+    pub(crate) expiration_time: Instant,
+}
+
+impl Expiration {
+    pub(crate) fn new(peer_id: PeerId, req_type: u16, expiration_time: Instant) -> Self {
+        Self {
+            peer_id,
+            req_type,
+            expiration_time,
+        }
+    }
+}
+
+impl Ord for Expiration {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.expiration_time
+            .cmp(&other.expiration_time)
+            .then_with(|| self.peer_id.cmp(&other.peer_id))
+            .then_with(|| self.req_type.cmp(&other.req_type))
+    }
+}
+impl PartialOrd for Expiration {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// The structure to be used to store the pending to delete rate limits.
+/// We must ensure there are no duplicates, constant complexity while accessing peer and request type and ordering by
+/// expiration time.
+/// These structs should contain the same information and maintain consistency.
+#[derive(Debug, Default)]
+pub(crate) struct PendingDeletion {
+    /// The hash map of the rate limits.
+    by_peer_and_req_type: HashMap<(PeerId, u16), RateLimit>,
+    /// The ordered set of rate limits by expiration time, peer id and request type.
+    by_expiration_time: BTreeSet<Expiration>,
+}
+
+impl PendingDeletion {
+    /// Retrieves the first item by expiration.
+    pub(crate) fn first(&self) -> Option<&Expiration> {
+        self.by_expiration_time.first()
+    }
+
+    /// Adds to both structures the new entry. If the entry already exists we replace it on both structs.
+    pub(crate) fn insert(&mut self, peer_id: PeerId, req_type: u16, rate_limit: &RateLimit) {
+        if let Some(expiration_peer) = self
+            .by_peer_and_req_type
+            .insert((peer_id, req_type), rate_limit.clone())
+        {
+            self.by_expiration_time.remove(&Expiration::new(
+                peer_id,
+                req_type,
+                expiration_peer.next_reset_time(),
+            ));
+        }
+        self.by_expiration_time.insert(Expiration::new(
+            peer_id,
+            req_type,
+            rate_limit.next_reset_time(),
+        ));
+    }
+
+    /// Removes the first item by expiration date, on both structures.
+    pub(crate) fn remove_first(&mut self) {
+        if let Some(peer_expiration) = self.by_expiration_time.pop_first() {
+            assert!(
+                self.by_peer_and_req_type
+                    .remove(&(peer_expiration.peer_id, peer_expiration.req_type))
+                    .is_some(),
+                "The pending for deletion rate limits should be consistent among them"
+            )
+        }
+    }
+}
+
 /// The structure to be used to limit the number of requests to a limit of allowed_occurrences within a block_range.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq, Clone)]
 pub struct RateLimit {
     /// Max allowed requests.
     allowed_occurrences: u32,
@@ -14,7 +102,7 @@ pub struct RateLimit {
     time_window: Duration,
     /// The timestamp of the last reset.
     last_reset: Instant,
-    /// The counter of requests submited within the current block range.
+    /// The counter of requests submitted within the current block range.
     occurrences_counter: u32,
 }
 
@@ -41,7 +129,7 @@ impl RateLimit {
         self.occurrences_counter <= self.allowed_occurrences
     }
 
-    /// Checks if this object can be deleted by undertanding if there are still active counters.
+    /// Checks if this object can be deleted by understanding if there are still active counters.
     pub fn can_delete(&self, current_time: Instant) -> bool {
         self.occurrences_counter == 0 || self.next_reset_time() <= current_time
     }

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -34,10 +34,10 @@ use nimiq_utils::time::OffsetTime;
 
 /// The max number of TestRequests per peer (used for regular tests only).
 const MAX_REQUEST_RESPONSE_TEST_REQUEST: u32 = 1000;
-/// The max number of TestRequests per peer. This is used exclusivly for rate limiting testing.
+/// The max number of TestRequests per peer. This is used exclusively for rate limiting testing.
 const MAX_REQUEST_RESPONSE_STRESS_TEST_REQUEST: u32 = 2;
 /// The range to restrict the responses to the requests on the testing of the network layer.
-/// This is used exclusivly for rate limiting testing.
+/// This is used exclusively for rate limiting testing.
 const TEST_MAX_REQUEST_RESPONSE_STRESS_TEST_WINDOW: Duration = Duration::from_secs(100);
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -869,7 +869,7 @@ async fn it_can_reset_requests_rate_with_reconnections() {
     reconnect_successfully(&net1, addr1.clone(), &net3).await;
     send_n_request_to_fail(&net1, &net3, 1).await;
 
-    // Reconnect peer 2 and ensure the requests succed, the reset should happen.
+    // Reconnect peer 2 and ensure the requests succeed, the reset should happen.
     reconnect_successfully(&net1, addr1, &net2).await;
     send_n_request_to_succeed(&net1, &net2, TestRequest4::MAX_REQUESTS).await;
 


### PR DESCRIPTION
## What's in this pull request?
We allowed duplicates on the pending for deletion rate limits. Then, the invariant for not removing non-existent (active) rate limits would break and we would panic.

The solution is to have two structures for the rate limiting pending for deletion, one to be queried by the peer and req type and the other to be ordered by expiration time. This way we can efficiently check if the peer is already marked for deletion.

#### This fixes #1251.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
