### PR TITLE
Add several fixes for the `devnet` script

### DIFF
--- a/scripts/devnet/control_settings.py
+++ b/scripts/devnet/control_settings.py
@@ -93,12 +93,23 @@ class ControlSettings:
     General topology settings
 
     :param restart_settings: Optional restart settings. Setting this to None is
-        equivalent of running in continuous mode.
+        equivalent of running in continuous mode. If this argument isn't
+        passed continuous mode is assumed and `monitor_interval` is required.
     :type restart_settings: Optional[RestartSettings]
+    :param monitor_interval: Optional integer specifying for how long nodes
+        should freely run before monitoring if they panicked or stopped
+        producing blocks. This only takes effect in continuous mode (not
+        passing `restart_settings`).
+    :type monitor_interval: Optiona[int]
     """
 
-    def __init__(self, restart_settings: Optional[RestartSettings] = None):
+    def __init__(self, restart_settings: Optional[RestartSettings] = None,
+                 monitor_interval: Optional[int] = None):
+        if restart_settings is None and monitor_interval is None:
+            raise Exception("Either restart settings or monitor interval "
+                            "should be passed")
         self.restart_settings = restart_settings
+        self.monitor_interval = monitor_interval
 
     def is_continuous(self):
         """
@@ -117,3 +128,12 @@ class ControlSettings:
         :rtype: Optional[RestartSettings]
         """
         return self.restart_settings
+
+    def get_monitor_interval(self):
+        """
+        Gets the monitor interval setting.
+
+        :return: The monitor interval setting
+        :rtype: Optional[int]
+        """
+        return self.monitor_interval

--- a/scripts/devnet/devnet.py
+++ b/scripts/devnet/devnet.py
@@ -33,6 +33,14 @@ def setup_logging(args):
         datefmt='%Y-%m-%d %H:%M:%S')
 
 
+def check_positive(value):
+    int_value = int(value)
+    if int_value <= 0:
+        raise argparse.ArgumentTypeError(
+            f"{value}: Expected positive (non zero) integer value")
+    return int_value
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('-t', '--topology', type=str, required=True,
@@ -49,7 +57,7 @@ def parse_args():
     parser.add_argument('-e', "--erase", action='store_true',
                         help="Erase all of the validator state as part of "
                         "restarting it")
-    parser.add_argument('-r', "--restarts", type=int, default=10,
+    parser.add_argument('-r', "--restarts", type=check_positive, default=10,
                         help="The number of times you want to kill/restart "
                         "validators (by default 10 times)(0 means no restarts)"
                         )
@@ -59,10 +67,10 @@ def parse_args():
     parser.add_argument('-k', "--kills", type=int, default=1,
                         help="How many validators are killed each cycle, by "
                         "default just 1")
-    parser.add_argument('-dt', "--down-time", type=int, default=10,
+    parser.add_argument('-dt', "--down-time", type=check_positive, default=10,
                         help="Time in seconds that validators are taken down, "
                         "by default 10s")
-    parser.add_argument('-ut', "--up-time", type=int, default=40,
+    parser.add_argument('-ut', "--up-time", type=check_positive, default=40,
                         help="Time in seconds during which all validators are "
                         "up, by default 40s")
     parser.add_argument('-d', "--db", action='store_true',
@@ -83,7 +91,7 @@ def main():
     setup_logging(args)
 
     if args.continuous:
-        control_settings = ControlSettings()
+        control_settings = ControlSettings(monitor_interval=args.up_time)
     else:
         restart_settings = RestartSettings(
             args.up_time, args.down_time, args.restarts, args.kills, args.db,
@@ -97,15 +105,15 @@ def main():
         ['git', 'rev-parse', '--show-toplevel'], text=True).rstrip()
 
     # Create the logs dir
-    logs_dir = nimiq_dir + "/" + "temp-logs" + "/" + ts
+    logs_dir = f"{nimiq_dir}/temp-logs/{ts}"
     Path(logs_dir).mkdir(parents=True, exist_ok=False)
 
     # Create the conf dir
-    conf_dir = logs_dir + "/" + "conf"
+    conf_dir = f"{logs_dir}/conf"
     Path(conf_dir).mkdir(parents=False, exist_ok=False)
 
     # Create the state dir
-    state_dir = nimiq_dir + "/" + "temp-state" + "/" + ts
+    state_dir = f"{nimiq_dir}/temp-state/{ts}"
     Path(state_dir).mkdir(parents=True, exist_ok=False)
 
     # Create the loki settings

--- a/scripts/devnet/node.py
+++ b/scripts/devnet/node.py
@@ -158,7 +158,7 @@ class Node:
         """
         if self.process is not None:
             raise Exception(
-                "Process for {} has already been started".format(self.name))
+                f"Process for {self.name} has already been started")
         # Prepare the genesis environment variable
         genesis_file = self.topology_settings.get_conf_dir() + \
             '/' + "dev-albatross.toml"
@@ -190,10 +190,10 @@ class Node:
         if self.process is not None:
             self.process.send_signal(signal.SIGINT)
             if will_be_restarted:
-                log_str = "################################## RESTART ########"
-                "###################"
-                subprocess.run(["echo", log_str, ">>", self.get_log()],
-                               check=True, capture_output=True)
+                log_str = "\n################################## RESTART ######"
+                "#####################\n"
+                with open(self.get_log(), 'a') as log_file:
+                    log_file.write(log_str)
                 self.process = None
 
     def check_panics(self):
@@ -204,7 +204,7 @@ class Node:
         :rtype: bool
         """
         panics = subprocess.run(["grep", "ERROR.*panic[[:blank:]]",
-                                self.get_log()], capture_output=True,
+                                 self.get_log()], capture_output=True,
                                 shell=False, text=True).stdout
         return len(panics) != 0
 
@@ -274,7 +274,7 @@ class Node:
         # We need to use shell to use the '*' wildcard such that the state
         # dir doesn't get removed as well.
         # Also the command needs to be a string
-        subprocess.run("rm -r {}/*".format(self.get_state_dir()),
+        subprocess.run(f"rm -r {self.get_state_dir()}/*",
                        shell=True, check=True, capture_output=True)
         log_str = "\n################################## NODE STATE DELETED ##"
         "#########################\n"


### PR DESCRIPTION
Add several fixes for the `devnet` script:
- Fix variable usage before declaration for continous mode.
- Add a `monitor_interval` to `ControlSettings` to let a node run that amount of time before checking for panics, blocks produced and the rest of the checks in cointinous mode.
- Use literal string interpolation instead of `format` for string formatting.
- Replace file writing/appending with native file operations rather than `subprocess` commands.
- Add better argument checks for arguments that must be positive integers.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
