### PR TITLE
Wasm-JS interactivity, part two: staking roundtrip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,6 +4545,7 @@ dependencies = [
  "nimiq-network-mock",
  "nimiq-primitives",
  "nimiq-transaction",
+ "nimiq-transaction-builder",
  "nimiq-zkp-component",
  "parking_lot 0.12.1",
  "serde-wasm-bindgen",

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -37,6 +37,7 @@ nimiq-keys = { path = "../keys" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-primitives = {path = "../primitives", features = ["coin", "networks"]}
 nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-transaction-builder = { path = "../transaction-builder" }
 
 [dependencies.nimiq]
 package = "nimiq-lib"

--- a/web-client/module.js
+++ b/web-client/module.js
@@ -26,7 +26,7 @@ init().then(async () => {
 
         const keyPair = Nimiq.KeyPair.derive(Nimiq.PrivateKey.fromHex(privateKey));
 
-        const transaction = Nimiq.Transaction.basic(
+        const transaction = Nimiq.Transaction.newBasicTransaction(
             keyPair.toAddress(),
             Nimiq.Address.fromString(recipient),
             BigInt(amount),

--- a/web-client/module.js
+++ b/web-client/module.js
@@ -3,8 +3,11 @@ import init, * as Nimiq from "./pkg/nimiq_web_client.js";
 window.Nimiq = Nimiq;
 
 init().then(async () => {
-    const config = new Nimiq.WebClientConfiguration(["/dns4/seed1.v2.nimiq-testnet.com/tcp/8443/ws"], "debug");
-    const client = await Nimiq.WebClient.create(config);
+    const config = new Nimiq.ClientConfiguration();
+    config.seedNodes(['/dns4/seed1.v2.nimiq-testnet.com/tcp/8443/ws']);
+    config.logLevel('debug');
+
+    const client = await config.instantiateClient();
     window.client = client; // Prevent garbage collection and for playing around
 
     client.subscribe_consensus();

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -28,6 +28,7 @@ use nimiq_network_interface::{
 
 use crate::peer_info::PeerInfo;
 use crate::transaction::Transaction;
+use crate::transaction_builder::TransactionBuilder;
 use crate::utils::{from_network_id, to_network_id};
 
 mod address;
@@ -38,6 +39,7 @@ mod public_key;
 mod signature;
 mod signature_proof;
 mod transaction;
+mod transaction_builder;
 mod utils;
 
 /// Use this to provide initialization-time configuration to the Client.
@@ -98,13 +100,14 @@ impl ClientConfiguration {
 
 /// Nimiq Albatross client that runs in browsers via WASM and is exposed to Javascript.
 ///
-/// Usage:
+/// ### Usage:
+///
 /// ```js
 /// import init, * as Nimiq from "./pkg/nimiq_web_client.js";
 ///
 /// init().then(async () => {
-///     const configBuilder = Nimiq.ClientConfiguration.builder();
-///     const client = await configBuilder.instantiateClient();
+///     const config = new Nimiq.ClientConfiguration();
+///     const client = await config.instantiateClient();
 ///     // ...
 /// });
 /// ```
@@ -336,6 +339,12 @@ impl Client {
     #[wasm_bindgen(js_name = blockNumber)]
     pub fn block_number(&self) -> u32 {
         self.inner.blockchain_head().block_number()
+    }
+
+    /// Instantiates a transaction builder class that provides helper methods to create transactions.
+    #[wasm_bindgen(js_name = transactionBuilder)]
+    pub fn transaction_builder(&self) -> TransactionBuilder {
+        TransactionBuilder::new(self.network_id, self.inner.blockchain())
     }
 
     /// Sends a transaction to the network. This method does not check if the

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -329,10 +329,10 @@ impl WebClient {
         Ok(())
     }
 
-    /// Sends a hex-encoded transaction to the network. This method does not check if the
+    /// Sends a serialized transaction to the network. This method does not check if the
     /// transaction gets included into a block.
     ///
-    /// Throws when the transaction cannot be parsed from the hex string or in case of a networking error.
+    /// Throws when the transaction cannot be parsed from the byte array or in case of a networking error.
     #[wasm_bindgen(js_name = sendRawTransaction)]
     pub async fn send_raw_transaction(&self, raw_tx: &[u8]) -> Result<(), JsError> {
         let tx = nimiq_transaction::Transaction::deserialize_from_vec(raw_tx)?;

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -27,7 +27,8 @@ impl Transaction {
     /// The returned transaction is not yet signed. You can sign it e.g. with `KeyPair.signTransaction`.
     ///
     /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
-    pub fn basic(
+    #[wasm_bindgen(js_name = newBasicTransaction)]
+    pub fn new_basic_transaction(
         sender: &Address,
         recipient: &Address,
         value: u64,
@@ -47,7 +48,7 @@ impl Transaction {
         ))
     }
 
-    /// Computes the transaction's hash, which is is used as its unique identifier on the blockchain.
+    /// Computes the transaction's hash, which is used as its unique identifier on the blockchain.
     pub fn hash(&self) -> String {
         let hash: Blake2bHash = self.inner.hash();
         // TODO: Return an instance of Hash

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -2,9 +2,12 @@ use wasm_bindgen::prelude::*;
 
 use beserial::Serialize;
 use nimiq_hash::{Blake2bHash, Hash};
-use nimiq_primitives::coin::Coin;
+use nimiq_primitives::{account::AccountType, coin::Coin};
+use nimiq_transaction::TransactionFlags;
+use nimiq_transaction_builder::TransactionProofBuilder;
 
 use crate::address::Address;
+use crate::key_pair::KeyPair;
 use crate::utils::{from_network_id, to_network_id};
 
 /// Transactions describe a transfer of value, usually from the sender to the recipient.
@@ -14,38 +17,165 @@ use crate::utils::{from_network_id, to_network_id};
 ///
 /// Transactions require a valid signature proof over their serialized content.
 /// Furthermore, transactions are only valid for 2 hours after their validity-start block height.
-#[wasm_bindgen]
+#[wasm_bindgen(inspectable)]
 pub struct Transaction {
     inner: nimiq_transaction::Transaction,
 }
 
 #[wasm_bindgen]
 impl Transaction {
-    /// Creates a basic transaction that simply transfers `value` amount of luna (NIM's smallest unit)
-    /// from the sender to the recipient.
+    /// Creates a new unsigned transaction that transfers `value` amount of luna (NIM's smallest unit)
+    /// from the sender to the recipient, where both sender and recipient can be any account type,
+    /// and custom extra data can be added to the transaction.
     ///
-    /// The returned transaction is not yet signed. You can sign it e.g. with `KeyPair.signTransaction`.
+    /// ### Basic transactions
+    /// If both the sender and recipient types are omitted or `0` and both data and flags are empty,
+    /// a smaller basic transaction is created.
     ///
-    /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
-    #[wasm_bindgen(js_name = newBasicTransaction)]
-    pub fn new_basic_transaction(
+    /// ### Extended transactions
+    /// If no flags are given, but sender type is not basic (`0`) or data is set, an extended
+    /// transaction is created.
+    ///
+    /// ### Contract creation transactions
+    /// To create a new vesting or HTLC contract, set `flags` to `0b1` and specify the contract
+    /// type as the `recipient_type`: `1` for vesting, `2` for HTLC. The `data` bytes must have
+    /// the correct format of contract creation data for the respective contract type.
+    ///
+    /// ### Signalling transactions
+    /// To interact with the staking contract, signalling transaction are often used to not
+    /// transfer any value, but to simply _signal_ a state change instead, such as changing one's
+    /// delegation from one validator to another. To create such a transaction, set `flags` to `
+    /// 0b10` and populate the `data` bytes accordingly.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when an account type is unknown, the numbers given for value and fee do not fit
+    /// within a u64 or the networkId is unknown. Also throws when no data or recipient type is
+    /// given for contract creation transactions, or no data is given for signalling transactions.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
         sender: &Address,
+        sender_type: Option<u8>,
         recipient: &Address,
+        recipient_type: Option<u8>,
         value: u64,
-        fee: u64,
+        fee: Option<u64>,
+        data: Option<Vec<u8>>,
+        flags: Option<u8>,
         validity_start_height: u32,
         network_id: u8,
     ) -> Result<Transaction, JsError> {
-        Ok(Transaction::from_native(
-            nimiq_transaction::Transaction::new_basic(
+        let flags = TransactionFlags::try_from(flags.unwrap_or(0b0))?;
+
+        let tx = if flags.is_empty() {
+            // This also creates basic transactions
+            nimiq_transaction::Transaction::new_extended(
                 sender.native_ref().clone(),
+                AccountType::try_from(sender_type.unwrap_or(0))?,
                 recipient.native_ref().clone(),
+                AccountType::try_from(recipient_type.unwrap_or(0))?,
                 Coin::try_from(value)?,
-                Coin::try_from(fee)?,
+                Coin::try_from(fee.unwrap_or(0))?,
+                data.unwrap_or(Vec::new()),
                 validity_start_height,
                 to_network_id(network_id)?,
-            ),
-        ))
+            )
+        } else if flags.contains(TransactionFlags::CONTRACT_CREATION) {
+            nimiq_transaction::Transaction::new_contract_creation(
+                data.unwrap_throw(),
+                sender.native_ref().clone(),
+                AccountType::try_from(sender_type.unwrap_or(0))?,
+                AccountType::try_from(recipient_type.unwrap_throw())?,
+                Coin::try_from(value)?,
+                Coin::try_from(fee.unwrap_or(0))?,
+                validity_start_height,
+                to_network_id(network_id)?,
+            )
+        } else if flags.contains(TransactionFlags::SIGNALLING) {
+            nimiq_transaction::Transaction::new_signalling(
+                sender.native_ref().clone(),
+                AccountType::try_from(sender_type.unwrap_or(0))?,
+                recipient.native_ref().clone(),
+                AccountType::try_from(recipient_type.unwrap_or(3))?,
+                Coin::try_from(value)?,
+                Coin::try_from(fee.unwrap_or(0))?,
+                data.unwrap_throw(),
+                validity_start_height,
+                to_network_id(network_id)?,
+            )
+        } else {
+            return Err(JsError::new("Invalid flags"));
+        };
+
+        Ok(Transaction::from_native(tx))
+    }
+
+    /// Signs the transaction with the provided key pair. Automatically determines the format
+    /// of the signature proof required for the transaction.
+    ///
+    /// ### Limitations
+    /// - HTLC redemption is not supported and will throw.
+    /// - Validator deletion transactions are not and cannot be supported.
+    /// - For transaction to the staking contract, both signatures are made with the same keypair,
+    ///   so it is not possible to interact with a staker that is different from the sender address
+    ///   or using a different cold or signing key for validator transactions.
+    pub fn sign(&self, key_pair: &KeyPair) -> Result<Transaction, JsError> {
+        let proof_builder = TransactionProofBuilder::new(self.native_ref().clone());
+        let signed_transaction = match proof_builder {
+            TransactionProofBuilder::Basic(mut builder) => {
+                builder.sign_with_key_pair(key_pair.native_ref());
+                builder.generate().unwrap()
+            }
+            TransactionProofBuilder::Vesting(mut builder) => {
+                builder.sign_with_key_pair(key_pair.native_ref());
+                builder.generate().unwrap()
+            }
+            TransactionProofBuilder::Htlc(mut _builder) => {
+                // TODO: Create a separate HTLC signing method that takes the type of proof as an argument
+                return Err(JsError::new(
+                    "HTLC redemption transactions are not supported",
+                ));
+
+                // // Redeem
+                // let sig = builder.signature_with_key_pair(key_pair);
+                // builder.regular_transfer(hash_algorithm, pre_image, hash_count, hash_root, sig);
+
+                // // Refund
+                // let sig = builder.signature_with_key_pair(key_pair);
+                // builder.timeout_resolve(sig);
+
+                // // Early resolve
+                // builder.early_resolve(htlc_sender_signature, htlc_recipient_signature);
+
+                // // Sign early
+                // let sig = builder.signature_with_key_pair(key_pair);
+                // return Ok(sig);
+
+                // builder.generate().unwrap()
+            }
+            TransactionProofBuilder::OutStaking(mut builder) => {
+                // There is no way to distinguish between an unstaking and validator-deletion transaction
+                // from the transaction itself.
+                // Validator-deletion transactions are thus not supported.
+                // builder.delete_validator(key_pair.native_ref());
+
+                builder.unstake(key_pair.native_ref());
+                builder.generate().unwrap()
+            }
+            TransactionProofBuilder::InStaking(mut builder) => {
+                // It is possible to add an additional argument `secondary_key_pair: Option<&KeyPair>` with
+                // https://docs.rs/wasm-bindgen-derive/latest/wasm_bindgen_derive/#optional-arguments.
+                // TODO: Support signing for differing staker and validator signing & cold keys.
+                let secondary_key_pair: Option<&KeyPair> = None;
+
+                builder.sign_with_key_pair(secondary_key_pair.unwrap_or(key_pair).native_ref());
+                let mut builder = builder.generate().unwrap().unwrap_basic();
+                builder.sign_with_key_pair(key_pair.native_ref());
+                builder.generate().unwrap()
+            }
+        };
+
+        Ok(Transaction::from_native(signed_transaction))
     }
 
     /// Computes the transaction's hash, which is used as its unique identifier on the blockchain.

--- a/web-client/src/transaction_builder.rs
+++ b/web-client/src/transaction_builder.rs
@@ -1,0 +1,266 @@
+use wasm_bindgen::prelude::*;
+
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_primitives::{account::AccountType, coin::Coin, policy::Policy};
+use nimiq_transaction_builder::Recipient;
+
+use crate::address::Address;
+use crate::transaction::Transaction;
+use crate::utils::to_network_id;
+
+/// The TransactionBuilder class provides helper methods to easily create standard types of transactions.
+/// It can only be instantiated from a Client with `client.transactionBuilder()`.
+#[wasm_bindgen]
+pub struct TransactionBuilder {
+    network_id: u8,
+    blockchain: BlockchainProxy,
+}
+
+impl TransactionBuilder {
+    pub fn new(network_id: u8, blockchain: BlockchainProxy) -> Self {
+        Self {
+            network_id,
+            blockchain,
+        }
+    }
+
+    pub fn block_number(&self) -> u32 {
+        self.blockchain.read().block_number()
+    }
+}
+
+#[wasm_bindgen]
+impl TransactionBuilder {
+    /// Creates a basic transaction that transfers `value` amount of luna (NIM's smallest unit) from the
+    /// sender to the recipient.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
+    #[wasm_bindgen(js_name = newBasic)]
+    pub fn new_basic(
+        &self,
+        sender: &Address,
+        recipient: &Address,
+        value: u64,
+        fee: Option<u64>,
+        validity_start_height: Option<u32>,
+        network_id: Option<u8>,
+    ) -> Result<Transaction, JsError> {
+        let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
+        builder
+            .with_sender(sender.native_ref().clone())
+            .with_recipient(Recipient::new_basic(recipient.native_ref().clone()))
+            .with_value(Coin::try_from(value)?)
+            .with_fee(Coin::try_from(fee.unwrap_or(0))?)
+            .with_validity_start_height(
+                validity_start_height.unwrap_or_else(|| self.block_number()),
+            )
+            .with_network_id(to_network_id(network_id.unwrap_or(self.network_id))?);
+
+        let proof_builder = builder.generate()?;
+        let tx = proof_builder.preliminary_transaction().to_owned();
+        Ok(Transaction::from_native(tx))
+    }
+
+    /// Creates a basic transaction that transfers `value` amount of luna (NIM's smallest unit) from the
+    /// sender to the recipient. It can include arbitrary `data`, up to 64 bytes.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
+    #[wasm_bindgen(js_name = newBasicWithData)]
+    pub fn new_basic_with_data(
+        &self,
+        sender: &Address,
+        recipient: &Address,
+        data: Vec<u8>,
+        value: u64,
+        fee: Option<u64>,
+        validity_start_height: Option<u32>,
+        network_id: Option<u8>,
+    ) -> Result<Transaction, JsError> {
+        let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
+        builder
+            .with_sender(sender.native_ref().clone())
+            .with_recipient(Recipient::new_basic_with_data(
+                recipient.native_ref().clone(),
+                data,
+            ))
+            .with_value(Coin::try_from(value)?)
+            .with_fee(Coin::try_from(fee.unwrap_or(0))?)
+            .with_validity_start_height(
+                validity_start_height.unwrap_or_else(|| self.block_number()),
+            )
+            .with_network_id(to_network_id(network_id.unwrap_or(self.network_id))?);
+
+        let proof_builder = builder.generate()?;
+        let tx = proof_builder.preliminary_transaction().to_owned();
+        Ok(Transaction::from_native(tx))
+    }
+
+    // pub fn new_create_vesting()
+
+    // pub fn new_redeem_vesting()
+
+    // pub fn new_create_htlc()
+
+    // pub fn new_redeem_htlc()
+
+    // pub fn new_refund_htlc()
+
+    // pub fn new_redeem_htlc_early()
+
+    // pub fn sign_htlc_early()
+
+    /// Creates a new staker in the staking contract and transfers `value` amount of luna (NIM's smallest unit)
+    /// from the sender account to this new staker.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
+    #[wasm_bindgen(js_name = newCreateStaker)]
+    pub fn new_create_staker(
+        &self,
+        sender: &Address,
+        delegation: &Address,
+        value: u64,
+        fee: Option<u64>,
+        validity_start_height: Option<u32>,
+        network_id: Option<u8>,
+    ) -> Result<Transaction, JsError> {
+        let mut recipient = Recipient::new_staking_builder();
+        recipient.create_staker(Some(delegation.native_ref().clone()));
+
+        let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
+        builder
+            .with_sender(sender.native_ref().clone())
+            .with_recipient(recipient.generate().unwrap())
+            .with_value(Coin::try_from(value)?)
+            .with_fee(Coin::try_from(fee.unwrap_or(0))?)
+            .with_validity_start_height(
+                validity_start_height.unwrap_or_else(|| self.block_number()),
+            )
+            .with_network_id(to_network_id(network_id.unwrap_or(self.network_id))?);
+
+        let proof_builder = builder.generate()?;
+        let tx = proof_builder.preliminary_transaction().to_owned();
+        Ok(Transaction::from_native(tx))
+    }
+
+    /// Adds stake to a staker in the staking contract and transfers `value` amount of luna (NIM's smallest unit)
+    /// from the sender account to this staker.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
+    #[wasm_bindgen(js_name = newStake)]
+    pub fn new_stake(
+        &self,
+        sender: &Address,
+        staker_address: &Address,
+        value: u64,
+        fee: Option<u64>,
+        validity_start_height: Option<u32>,
+        network_id: Option<u8>,
+    ) -> Result<Transaction, JsError> {
+        let mut recipient = Recipient::new_staking_builder();
+        recipient.stake(staker_address.native_ref().clone());
+
+        let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
+        builder
+            .with_sender(sender.native_ref().clone())
+            .with_recipient(recipient.generate().unwrap())
+            .with_value(Coin::try_from(value)?)
+            .with_fee(Coin::try_from(fee.unwrap_or(0))?)
+            .with_validity_start_height(
+                validity_start_height.unwrap_or_else(|| self.block_number()),
+            )
+            .with_network_id(to_network_id(network_id.unwrap_or(self.network_id))?);
+
+        let proof_builder = builder.generate()?;
+        let tx = proof_builder.preliminary_transaction().to_owned();
+        Ok(Transaction::from_native(tx))
+    }
+
+    /// Updates a staker in the staking contract to stake for a different validator. This is a
+    /// signalling transaction and as such does not transfer any value.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when the number given for fee does not fit within a u64 or the networkId is unknown.
+    #[wasm_bindgen(js_name = newUpdateStaker)]
+    pub fn new_update_staker(
+        &self,
+        sender: &Address,
+        new_delegation: &Address,
+        fee: Option<u64>,
+        validity_start_height: Option<u32>,
+        network_id: Option<u8>,
+    ) -> Result<Transaction, JsError> {
+        let mut recipient = Recipient::new_staking_builder();
+        recipient.update_staker(Some(new_delegation.native_ref().clone()));
+
+        let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
+        builder
+            .with_sender(sender.native_ref().clone())
+            .with_recipient(recipient.generate().unwrap())
+            .with_value(Coin::ZERO)
+            .with_fee(Coin::try_from(fee.unwrap_or(0))?)
+            .with_validity_start_height(
+                validity_start_height.unwrap_or_else(|| self.block_number()),
+            )
+            .with_network_id(to_network_id(network_id.unwrap_or(self.network_id))?);
+
+        let proof_builder = builder.generate()?;
+        let tx = proof_builder.preliminary_transaction().to_owned();
+        Ok(Transaction::from_native(tx))
+    }
+
+    /// Unstakes stake from the staking contract and transfers `value` amount of luna (NIM's smallest unit)
+    /// from the staker to the recipient.
+    ///
+    /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
+    ///
+    /// Throws when the numbers given for value and fee do not fit within a u64 or the networkId is unknown.
+    #[wasm_bindgen(js_name = newUnstake)]
+    pub fn new_unstake(
+        &self,
+        recipient: &Address,
+        value: u64,
+        fee: Option<u64>,
+        validity_start_height: Option<u32>,
+        network_id: Option<u8>,
+    ) -> Result<Transaction, JsError> {
+        let recipient = Recipient::new_basic(recipient.native_ref().clone());
+
+        let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
+        builder
+            .with_sender(Policy::STAKING_CONTRACT_ADDRESS)
+            .with_sender_type(AccountType::Staking)
+            .with_recipient(recipient)
+            .with_value(Coin::try_from(value)?)
+            .with_fee(Coin::try_from(fee.unwrap_or(0))?)
+            .with_validity_start_height(
+                validity_start_height.unwrap_or_else(|| self.block_number()),
+            )
+            .with_network_id(to_network_id(network_id.unwrap_or(self.network_id))?);
+
+        let proof_builder = builder.generate()?;
+        let tx = proof_builder.preliminary_transaction().to_owned();
+        Ok(Transaction::from_native(tx))
+    }
+
+    // pub fn new_create_validator()
+
+    // pub fn new_update_validator()
+
+    // pub fn new_inactivate_validator()
+
+    // pub fn new_reactivate_validator()
+
+    // pub fn new_unpark_validator()
+
+    // pub fn new_delete_validator()
+}


### PR DESCRIPTION
## What's in this pull request?

Makes it possible to easily create and sign all transactions necessary to start staking, add stake, update delegation, and unstake.

- Add creation methods for different transaction types
  - Introduces a `TransactionBuilder` class that is instantiated from the client and receives the client's `network_id` and a blockchain proxy (to access the current head block number), allowing users to omit these when creating transactions.
  - Adds a `tx.sign(keyPair)` method that automatically signs the transaction with the correct signature(s) format if possible.
  - Adds a constructor function to `Transaction` to allow the creation of arbitrary transactions which the transaction builder does not yet cover.
- Adapt Client and Configuration to feel closer to the core-js client API.
- Fix rustdocs

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
