### PR TITLE
network-libp2p: Re-add the libp2p `ping` behaviour

### DIFF
--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -26,6 +26,7 @@ use libp2p::{
         Quorum, Record,
     },
     noise,
+    ping::Success as PingSuccess,
     request_response::{OutboundFailure, RequestId, RequestResponseMessage, ResponseChannel},
     swarm::{dial_opts::DialOpts, ConnectionLimits, NetworkInfo, SwarmBuilder, SwarmEvent},
     yamux, Multiaddr, PeerId, Swarm, Transport,
@@ -840,6 +841,23 @@ impl Network {
                                 );
                             }
                         }
+                    }
+                    NimiqEvent::Ping(event) => {
+                        match event.result {
+                            Err(error) => {
+                                log::debug!(%error, ?event.peer, "Ping failed with peer");
+                            }
+                            Ok(PingSuccess::Pong) => {
+                                log::trace!(?event.peer, "Responded Ping from peer");
+                            }
+                            Ok(PingSuccess::Ping { rtt }) => {
+                                log::trace!(
+                                    ?event.peer,
+                                    ?rtt,
+                                    "Sent Ping and received response to/from peer",
+                                );
+                            }
+                        };
                     }
                     NimiqEvent::Pool(event) => {
                         match event {


### PR DESCRIPTION
Re-add the libp2p `ping` behaviour to improve detection of broken peer connections, specially when the current peer gets a connection outage event.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
