### PR TITLE
Expose getTransactionsByAddress to JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,6 +4500,7 @@ dependencies = [
  "nimiq-transaction-builder",
  "nimiq-zkp-component",
  "parking_lot 0.12.1",
+ "serde",
  "serde-wasm-bindgen",
  "tracing",
  "wasm-bindgen",

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -9,9 +9,11 @@ use nimiq_blockchain_interface::{
 use nimiq_database::WriteTransaction;
 use nimiq_primitives::coin::Coin;
 use nimiq_primitives::policy::Policy;
-use nimiq_transaction::extended_transaction::{ExtTxData, ExtendedTransaction};
-use nimiq_transaction::inherent::{Inherent, InherentType};
-use nimiq_transaction::Transaction;
+use nimiq_transaction::{
+    extended_transaction::{ExtTxData, ExtendedTransaction},
+    inherent::{Inherent, InherentType},
+    Transaction,
+};
 
 use crate::Blockchain;
 

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -18,12 +18,11 @@ use nimiq_mmr::store::memory::MemoryStore;
 use nimiq_primitives::policy::Policy;
 use nimiq_transaction::{
     extended_transaction::{ExtTxData, ExtendedTransaction},
+    history_proof::HistoryTreeProof,
     inherent::InherentType,
 };
 
-use crate::history::{
-    mmr_store::MMRStore, ordered_hash::OrderedHash, HistoryTreeChunk, HistoryTreeProof,
-};
+use crate::history::{mmr_store::MMRStore, ordered_hash::OrderedHash, HistoryTreeChunk};
 
 /// A struct that contains databases to store history trees (which are Merkle Mountain Ranges
 /// constructed from the list of extended transactions in an epoch) and extended transactions (which

--- a/blockchain/src/history/mod.rs
+++ b/blockchain/src/history/mod.rs
@@ -1,9 +1,7 @@
 pub use history_store::HistoryStore;
 pub use history_tree_chunk::{HistoryTreeChunk, CHUNK_SIZE};
-pub use history_tree_proof::HistoryTreeProof;
 
 mod history_store;
 mod history_tree_chunk;
-mod history_tree_proof;
 mod mmr_store;
 mod ordered_hash;

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -123,8 +123,9 @@ impl<N: Network> ConsensusProxy<N> {
                                             .map_or(false, |result| result);
 
                                         if verification_result {
-                                            verified_transactions
-                                                .insert(transaction.tx_hash(), transaction);
+                                            for tx in proof.history {
+                                                verified_transactions.insert(tx.tx_hash(), tx);
+                                            }
                                         } else {
                                             // The proof didn't verify so we disconnect from this peer
                                             log::debug!(peer=%peer_id,"Disconnecting from peer because the transaction proof didn't verify");

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -5,10 +6,19 @@ use tokio::sync::broadcast::Sender as BroadcastSender;
 use tokio_stream::wrappers::BroadcastStream;
 
 use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_network_interface::network::Network;
+use nimiq_keys::Address;
+use nimiq_network_interface::{
+    network::{CloseReason, Network},
+    peer_info::Services,
+    request::{OutboundRequestError, RequestError},
+};
 use nimiq_primitives::account::AccountType;
-use nimiq_transaction::{ControlTransactionTopic, Transaction, TransactionTopic};
+use nimiq_transaction::{
+    extended_transaction::ExtendedTransaction, ControlTransactionTopic, Transaction,
+    TransactionTopic,
+};
 
+use crate::messages::{RequestTransactionsByAddress, RequestTransactionsProof};
 use crate::ConsensusEvent;
 
 pub struct ConsensusProxy<N: Network> {
@@ -43,5 +53,113 @@ impl<N: Network> ConsensusProxy<N> {
 
     pub fn subscribe_events(&self) -> BroadcastStream<ConsensusEvent> {
         BroadcastStream::new(self.events.subscribe())
+    }
+
+    pub async fn request_transactions_by_address(
+        &self,
+        address: Address,
+        min_peers: usize,
+        max: Option<u16>,
+    ) -> Result<Vec<ExtendedTransaction>, RequestError> {
+        // First we tell the network to provide us with a vector that contains all the connected peers that support such services
+        // Note: If the network could not provide enough peers that satisfies our requirement, then an error would be returned
+        let peers = self
+            .network
+            .get_peers_by_services(Services::TRANSACTION_INDEX, min_peers)
+            .await
+            .map_err(|error| {
+                log::error!(
+                    err = %error,
+                    "The transactions by address request couldn't be fulfilled"
+                );
+
+                RequestError::OutboundRequest(OutboundRequestError::SendError)
+            })?;
+
+        let mut verified_transactions = HashMap::new();
+
+        // At this point we obtained a list of connected peers that could satisfy our request,
+        // so we perform the request to each of those peers:
+        for peer_id in peers {
+            let response = self
+                .network
+                .request::<RequestTransactionsByAddress>(
+                    RequestTransactionsByAddress {
+                        address: address.clone(),
+                        max,
+                    },
+                    peer_id,
+                )
+                .await;
+
+            match response {
+                Ok(response) => {
+                    // Now we request proofs for each transaction we requested.
+                    for transaction in response.transactions {
+                        // If the transaction was already verified, then we don't need to verify it again
+                        if verified_transactions.contains_key(&transaction.tx_hash()) {
+                            continue;
+                        }
+
+                        let response = self
+                            .network
+                            .request::<RequestTransactionsProof>(
+                                RequestTransactionsProof {
+                                    hashes: vec![transaction.tx_hash()],
+                                    block_number: transaction.block_number,
+                                },
+                                peer_id,
+                            )
+                            .await;
+                        match response {
+                            Ok(proof_response) => {
+                                // We verify the transaction using the proof
+                                if let Some(proof) = proof_response.proof {
+                                    if let Some(block) = proof_response.block {
+                                        // TODO: We are currently assuming that the provided block was included in the chain
+                                        // but we also need some additional information to prove the block is part of the chain.
+                                        let verification_result = proof
+                                            .verify(block.history_root().clone())
+                                            .map_or(false, |result| result);
+
+                                        if verification_result {
+                                            verified_transactions
+                                                .insert(transaction.tx_hash(), transaction);
+                                        } else {
+                                            // The proof didn't verify so we disconnect from this peer
+                                            log::debug!(peer=%peer_id,"Disconnecting from peer because the transaction proof didn't verify");
+                                            self.network
+                                                .disconnect_peer(peer_id, CloseReason::Other)
+                                                .await;
+                                            break;
+                                        }
+                                    } else {
+                                        // If we receive a proof but we do not recieve a block, we disconnect from the peer
+                                        log::debug!(peer=%peer_id,"Disconnecting from peer due to an inconsistency in the transaction proof response");
+                                        self.network
+                                            .disconnect_peer(peer_id, CloseReason::Other)
+                                            .await;
+                                        break;
+                                    }
+                                } else {
+                                    log::debug!(peer=%peer_id, "We requested a transaction proof but the peer didn't provide any");
+                                }
+                            }
+                            Err(error) => {
+                                // If there was a request error with this peer we don't request anymore proofs from it
+                                log::error!(peer=%peer_id, err=%error,"There was an error requesting transactions proof from peer");
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    // If there was a request error with this peer we log an error
+                    log::error!(peer=%peer_id, err=%error,"There was an error requesting transactions from peer");
+                }
+            }
+        }
+
+        Ok(verified_transactions.into_values().collect())
     }
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -20,7 +20,9 @@ use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 
 use crate::consensus::head_requests::{HeadRequests, HeadRequestsResult};
 #[cfg(feature = "full")]
-use crate::messages::{RequestBatchSet, RequestHistoryChunk, RequestTransactionsProof};
+use crate::messages::{
+    RequestBatchSet, RequestHistoryChunk, RequestTransactionsByAddress, RequestTransactionsProof,
+};
 use crate::messages::{RequestBlock, RequestHead, RequestMacroChain, RequestMissingBlocks};
 #[cfg(feature = "full")]
 use crate::sync::live::state_queue::RequestChunk;
@@ -154,6 +156,9 @@ impl<N: Network> Consensus<N> {
                 executor.exec(Box::pin(request_handler(network, stream, blockchain)));
 
                 let stream = network.receive_requests::<RequestTransactionsProof>();
+                executor.exec(Box::pin(request_handler(network, stream, blockchain)));
+
+                let stream = network.receive_requests::<RequestTransactionsByAddress>();
                 executor.exec(Box::pin(request_handler(network, stream, blockchain)));
             }
             BlockchainProxy::Light(_) => {}

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -3,13 +3,13 @@ use std::fmt::{Debug, Formatter};
 use beserial::{Deserialize, Serialize};
 use nimiq_block::{Block, MacroBlock};
 #[cfg(feature = "full")]
-use nimiq_blockchain::{HistoryTreeChunk, HistoryTreeProof};
+use nimiq_blockchain::HistoryTreeChunk;
 use nimiq_hash::Blake2bHash;
-#[cfg(feature = "full")]
 use nimiq_keys::Address;
 use nimiq_network_interface::request::{RequestCommon, RequestMarker};
-#[cfg(feature = "full")]
-use nimiq_transaction::extended_transaction::ExtendedTransaction;
+use nimiq_transaction::{
+    extended_transaction::ExtendedTransaction, history_proof::HistoryTreeProof,
+};
 
 mod handlers;
 
@@ -211,22 +211,19 @@ impl RequestCommon for RequestHead {
     const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_HEAD;
 }
 
-#[cfg(feature = "full")]
 #[derive(Serialize, Deserialize)]
 pub struct ResponseTransactionsProof {
-    proof: Option<HistoryTreeProof>,
-    block: Option<Block>,
+    pub proof: Option<HistoryTreeProof>,
+    pub block: Option<Block>,
 }
 
-#[cfg(feature = "full")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestTransactionsProof {
     #[beserial(len_type(u16, limit = 128))]
-    hashes: Vec<Blake2bHash>,
-    epoch_number: u32,
+    pub hashes: Vec<Blake2bHash>,
+    pub block_number: u32,
 }
 
-#[cfg(feature = "full")]
 impl RequestCommon for RequestTransactionsProof {
     type Kind = RequestMarker;
     const TYPE_ID: u16 = 213;
@@ -234,14 +231,12 @@ impl RequestCommon for RequestTransactionsProof {
     const MAX_REQUESTS: u32 = MAX_REQUEST_TRANSACTIONS_PROOF;
 }
 
-#[cfg(feature = "full")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestTransactionsByAddress {
-    address: Address,
-    max: Option<u16>,
+    pub address: Address,
+    pub max: Option<u16>,
 }
 
-#[cfg(feature = "full")]
 impl RequestCommon for RequestTransactionsByAddress {
     type Kind = RequestMarker;
     const TYPE_ID: u16 = 214;
@@ -249,9 +244,8 @@ impl RequestCommon for RequestTransactionsByAddress {
     const MAX_REQUESTS: u32 = MAX_REQUEST_TRANSACTIONS_BY_ADDRESS;
 }
 
-#[cfg(feature = "full")]
 #[derive(Serialize, Deserialize)]
 pub struct ResponseTransactionsByAddress {
     #[beserial(len_type(u16, limit = 128))]
-    transactions: Vec<ExtendedTransaction>,
+    pub transactions: Vec<ExtendedTransaction>,
 }

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -81,6 +81,16 @@ pub trait Network: Send + Sync + Unpin + 'static {
     /// If the peer isn't found, `None` is returned.
     fn get_peer_info(&self, peer_id: Self::PeerId) -> Option<PeerInfo>;
 
+    /// Gets the set of connected peers that provide the supplied services.
+    /// If we currently don't have min number of connected peer that provides those services,
+    /// we dial peers.
+    /// If there aren't enough peers in the network that provides the required services, we return an error
+    async fn get_peers_by_services(
+        &self,
+        services: Services,
+        min_peers: usize,
+    ) -> Result<Vec<Self::PeerId>, Self::Error>;
+
     /// Returns true when the given peer provides the services flags that are required by us
     fn peer_provides_required_services(&self, peer_id: Self::PeerId) -> bool;
 

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -365,7 +365,7 @@ impl ConnectionPoolBehaviour {
     }
 
     /// This function is used to select a list of peers, based on services flag, in order to dial them.
-    /// num_peers is used to specify how many peers are selected
+    /// `num_peers` is used to specify how many peers are selected
     /// The number of peers returned equals num_peers unless there are less available peers
     pub fn choose_peers_to_dial_by_services(
         &self,

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -14,6 +14,9 @@ pub enum NetworkError {
     #[error("Network action was cancelled")]
     Cancelled,
 
+    #[error("We could not find any peer that satisfies the desired services")]
+    PeersNotFound,
+
     #[error("Serialization error: {0}")]
     Serialization(#[from] beserial::SerializingError),
 

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1781,8 +1781,8 @@ impl NetworkInterface for Network {
             }
         }
 
-        // If we don't have enough connected peer that support the desired services,
-        // we tell the network to connect to new peers that supports such services.
+        // If we don't have enough connected peers that support the desired services,
+        // we tell the network to connect to new peers that support such services.
         if filtered_peers.len() < min_peers {
             let num_peers = min_peers - filtered_peers.len();
 

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -581,4 +581,12 @@ impl Network for MockNetwork {
     fn get_peer_info(&self, peer_id: Self::PeerId) -> Option<PeerInfo> {
         self.peers.read().get(&peer_id).cloned()
     }
+
+    async fn get_peers_by_services(
+        &self,
+        _services: Services,
+        _peers: usize,
+    ) -> Result<Vec<Self::PeerId>, MockNetworkError> {
+        Ok(self.get_peers())
+    }
 }

--- a/primitives/transaction/src/history_proof.rs
+++ b/primitives/transaction/src/history_proof.rs
@@ -4,13 +4,14 @@ use beserial::{
 };
 use nimiq_hash::Blake2bHash;
 use nimiq_mmr::mmr::proof::Proof;
-use nimiq_transaction::extended_transaction::ExtendedTransaction;
+
+use crate::extended_transaction::ExtendedTransaction;
 
 /// Struct containing a vector of extended transactions together with a Merkle proof for them. It
 /// allows one to prove/verify that specific transactions are part of the History Tree.
 pub struct HistoryTreeProof {
-    pub(crate) proof: Proof<Blake2bHash>,
-    pub(crate) positions: Vec<usize>,
+    pub proof: Proof<Blake2bHash>,
+    pub positions: Vec<usize>,
     pub history: Vec<ExtendedTransaction>,
 }
 

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -28,6 +28,7 @@ use crate::account::AccountTransactionVerification;
 
 pub mod account;
 pub mod extended_transaction;
+pub mod history_proof;
 pub mod inherent;
 pub mod reward;
 
@@ -205,6 +206,7 @@ impl PartialEq for ExecutedTransaction {
 }
 
 #[derive(Clone, Eq, Debug)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Transaction {
     pub data: Vec<u8>,

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -24,6 +24,7 @@ crate-type = ["cdylib"]
 futures = { package = "futures-util", version = "0.3" }
 js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
+serde = {version = "1.0.152", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
@@ -37,7 +38,7 @@ nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-primitives = {path = "../primitives", features = ["coin", "networks"]}
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-transaction = { path = "../primitives/transaction", features=["serde-derive"] }
 nimiq-transaction-builder = { path = "../transaction-builder" }
 
 [dependencies.nimiq]

--- a/web-client/src/address.rs
+++ b/web-client/src/address.rs
@@ -41,4 +41,8 @@ impl Address {
     pub fn native_ref(&self) -> &nimiq_keys::Address {
         &self.inner
     }
+
+    pub fn native(&self) -> nimiq_keys::Address {
+        self.inner.clone()
+    }
 }

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -10,6 +10,20 @@ use crate::address::Address;
 use crate::key_pair::KeyPair;
 use crate::utils::{from_network_id, to_network_id};
 
+#[wasm_bindgen]
+#[derive(serde::Serialize, serde::Deserialize)]
+/// This struct reperesents a list of transactions.
+/// It is simply a wrapper around Transaction to represent more than one transaction
+pub struct Transactions {
+    txns: Vec<Transaction>,
+}
+
+impl Transactions {
+    pub fn new(txns: Vec<Transaction>) -> Self {
+        Transactions { txns }
+    }
+}
+
 /// Transactions describe a transfer of value, usually from the sender to the recipient.
 /// However, transactions can also have no value, when they are used to _signal_ a change in the staking contract.
 ///
@@ -18,6 +32,7 @@ use crate::utils::{from_network_id, to_network_id};
 /// Transactions require a valid signature proof over their serialized content.
 /// Furthermore, transactions are only valid for 2 hours after their validity-start block height.
 #[wasm_bindgen(inspectable)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Transaction {
     inner: nimiq_transaction::Transaction,
 }


### PR DESCRIPTION
Provide functionality that queries the network in order to get transactions that belong to some specific address.
For this particular request, history nodes would provide the transaction details and an inclusion proof of those transactions.
The final list of transactions are serialized and returned to JS via a JsValue