### PR TITLE
Implement listener for offline/online events in the web-client, add fixes and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -623,6 +623,7 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
         // If the connection was closed for any reason, don't dial the peer again.
         // FIXME We want to be more selective here and only mark peers as down for specific CloseReasons.
         self.peer_ids.mark_down(*peer_id);
+        self.addresses.mark_down(address.clone());
 
         self.maintain_peers();
     }

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -322,6 +322,23 @@ impl ConnectionPoolBehaviour {
         self.maintain_peers();
     }
 
+    /// Tells the behaviour to restart connecting to other peers.
+    /// For this, it clears the set of peers and addresses marked as down
+    /// and tells the network to start connecting again.
+    pub fn restart_connecting(&mut self) {
+        // Clean up the nodes marked as down
+        self.addresses.reset_down();
+        self.peer_ids.reset_down();
+        self.start_connecting();
+    }
+
+    /// Tells the behaviour to stop connecting to other peers.
+    /// This is useful when we are sure we have no possibility of getting a
+    /// connection such as in a network outage.
+    pub fn stop_connecting(&mut self) {
+        self.active = false;
+    }
+
     fn choose_peers_to_dial(&self) -> Vec<PeerId> {
         let num_peers = usize::min(
             self.config.peer_count_desired - self.peer_ids.num_connected(),

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -27,6 +27,7 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3.22", features = ["EventTarget", "Window"]}
 
 beserial = { path = "../beserial", features = ["derive"] }
 nimiq-blockchain-interface = { path = "../blockchain-interface" }


### PR DESCRIPTION
- Add `rustdoc` documentation for the connection pool behaviour in the `network-libp2p` crate.
- Implement listener for offline/online events in the web-client
  - Implement listener for `Window` offline and online events in the `web-client`.
  - Add a function to the `network-libp2p` crate to allow a client to instruct the network to try to start new peer connections. This is used in the `web-client` for the `offline` event such that the client doesn't issue new connections when it's offline.
  - Change the `start_connecting` functionality in the connection pool behaviour such that it resets the peers marked as `down` if     the function is called a second time and if no dial attempts or connected peers are found. This is used in the `web-client` to `restart` network connection attempts when the `online` event is detected.
- Fix issue in the connection pool behaviour when closing a connection for a peer that doesn't have the `ip` protocol in its
  `Multiaddr`. The issue was that the code wasn't marking the connection as closed in the behaviour connection state and it wasn't matching the state on the rest of the network.
- Fix the procedure to close a connection in the connection pool behaviour by also marking an `address` as down when the connection is closed.

Relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
