### PR TITLE
WASM Client: Convert subscriptions to listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ version = "0.1.0"
 dependencies = [
  "beserial",
  "futures-util",
- "gloo-timers",
+ "js-sys",
  "nimiq-blockchain-interface",
  "nimiq-blockchain-proxy",
  "nimiq-bls",

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }
-gloo-timers = "0.2"
+js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
## What's in this pull request?

- Add various block getter methods that are also available on the 1.0 client
- Convert subscriptions into event listeners with the same API as the 1.0 client
  - Remove the need for global imports from JS to emit subscription events
  - Instead take listener closures from JS and store them in a list
  - Start native rust event streams only once and emit events to the stored listeners
  - When adding a listener, a numeric handle is returned with which this listener can be removed again as well
  - Listener methods are typed correctly with a custom external type with a TS annotation
  - Remove statistic subscription, as the three data points it emitted are emitted by the three other available event sources

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
