### PR TITLE
ci: Use a maintained version for Rust toolchain

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -18,7 +18,7 @@ jobs:
           ~/.cargo/git
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -43,7 +43,7 @@ jobs:
           ~/.cargo/git
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -96,7 +96,7 @@ jobs:
           ~/.cargo/git
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -124,7 +124,7 @@ jobs:
           ~/.cargo/git
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable
@@ -161,7 +161,7 @@ jobs:
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Set up Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable

--- a/.github/workflows/build_crate_features.yml
+++ b/.github/workflows/build_crate_features.yml
@@ -19,7 +19,7 @@ jobs:
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Set up Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -57,7 +57,7 @@ jobs:
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Set up Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -54,7 +54,7 @@ jobs:
           target
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Set up Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: stable


### PR DESCRIPTION
Change to use `dtolnay/rust-toolchain` instead of `actions-rs/toolchain` since the latter is unmaintained.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
