### PR TITLE
Update the `yamux` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7767,9 +7767,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
+checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
  "futures",
  "log",


### PR DESCRIPTION
Update the `yamux` dependency from version 0.10.1 to version 0.10.2 to pull a fix for a call to `SinkImpl::poll_ready` after error as described in [this rust-libp2p
issue](https://github.com/libp2p/rust-libp2p/issues/2598).

This fixes #1319.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
