### PR TITLE
Update the `file-rotate` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -933,7 +933,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1746,9 +1745,9 @@ checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
 
 [[package]]
 name = "file-rotate"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f549a61332cfe588f485923f46bfb2c273b0a3634b379cec00acb1d2236a3acb"
+checksum = "0ff9cc595c02801d7e61675928f8c4698cab40b68b837884936a6b24fcf711e1"
 dependencies = [
  "chrono",
  "flate2",
@@ -3661,7 +3660,7 @@ dependencies = [
  "nimiq-vrf",
  "serde",
  "thiserror",
- "time 0.3.19",
+ "time",
  "toml",
  "tracing",
  "tracing-subscriber 0.3.16",
@@ -3866,7 +3865,7 @@ dependencies = [
  "signal-hook",
  "strum_macros",
  "thiserror",
- "time 0.3.19",
+ "time",
  "tokio",
  "toml",
  "tracing",
@@ -5497,7 +5496,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.19",
+ "time",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -5510,7 +5509,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.19",
+ "time",
  "yasna",
 ]
 
@@ -6003,7 +6002,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -6369,16 +6368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -6752,7 +6741,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.19",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -7250,7 +7239,7 @@ dependencies = [
  "sha2 0.10.2",
  "stun",
  "thiserror",
- "time 0.3.19",
+ "time",
  "tokio",
  "turn",
  "url",
@@ -7744,7 +7733,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -7762,7 +7751,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]
@@ -7785,7 +7774,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time 0.3.19",
+ "time",
 ]
 
 [[package]]


### PR DESCRIPTION
Update the `file-rotate` dependency from version 0.7.1 to version 0.7.2 to get rid of the chained `time 0.1.43` dependency which was suffering the security issue `CWE-476`.

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
