### PR TITLE
Array of plain JS transaction objects from getTransactionsByAddress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-utils"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,6 +4068,8 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tracing",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4321,6 +4336,8 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tracing",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4504,6 +4521,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "tracing",
+ "tsify",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -5921,6 +5939,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6781,6 +6810,33 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tsify"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfafeca19605f1239ad9a30b9f15b58e53abedfbf237390506276029329a32ee"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d637b54262b1c6b8c2c88ce30fbef4e72613cb71c0e0b6fc09747052eb59a152"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,6 +4483,7 @@ version = "0.1.0"
 dependencies = [
  "beserial",
  "futures-util",
+ "hex",
  "js-sys",
  "nimiq-blockchain-interface",
  "nimiq-blockchain-proxy",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,6 +29,8 @@ regex = { version = "1.7", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum_macros = "0.24"
 thiserror = { version = "1.0", optional = true }
+tsify = { version = "0.4", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 
 beserial = { path = "../beserial", features = ["derive"] }
 nimiq-bls = { path = "../bls", features = ["beserial"], optional = true }
@@ -52,3 +54,4 @@ serde-derive = ["serde"]
 slots = ["beserial/bitvec", "itertools", "nimiq-bls", "nimiq-keys", "nimiq-utils", "policy"]
 transaction = ["thiserror"]
 trie = ["key-nibbles", "nimiq-hash", "thiserror"]
+ts-types = ["serde", "tsify", "wasm-bindgen"]

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -15,17 +15,26 @@ use crate::{
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Display)]
 #[repr(u8)]
 #[cfg_attr(
-    feature = "serde-derive",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(try_from = "u8", into = "u8")
+    any(feature = "serde-derive", feature = "ts-types"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde-derive", serde(try_from = "u8", into = "u8"))]
+#[cfg_attr(
+    feature = "ts-types",
+    derive(tsify::Tsify),
+    serde(rename = "PlainAccountType", rename_all = "lowercase"),
+    wasm_bindgen::prelude::wasm_bindgen
 )]
 pub enum AccountType {
     Basic = 0,
     Vesting = 1,
     HTLC = 2,
     Staking = 3,
+    #[cfg_attr(feature = "ts-types", serde(skip))]
     StakingValidator = 4,
+    #[cfg_attr(feature = "ts-types", serde(skip))]
     StakingValidatorsStaker = 5,
+    #[cfg_attr(feature = "ts-types", serde(skip))]
     StakingStaker = 6,
 }
 

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -18,6 +18,8 @@ num-traits = "0.2"
 serde = { version = "1.0", optional = true }
 strum_macros = "0.24"
 thiserror = "1.0"
+tsify = { version = "0.4", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 
 beserial = { path = "../../beserial", features = ["derive"] }
 nimiq-bls = { path = "../../bls", features = ["serde-derive"] }
@@ -36,3 +38,4 @@ nimiq-test-log = { path = "../../test-log" }
 
 [features]
 serde-derive = ["serde"]
+ts-types = ["serde", "tsify", "wasm-bindgen"]

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -71,6 +71,12 @@ pub struct TransactionReceipt {
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "ts-types",
+    derive(serde::Serialize, serde::Deserialize, tsify::Tsify),
+    serde(rename = "PlainTransactionFormat", rename_all = "lowercase"),
+    wasm_bindgen::prelude::wasm_bindgen
+)]
 pub enum TransactionFormat {
     Basic = 0,
     Extended = 1,

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -27,6 +27,7 @@ js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = {version = "1.0.152", features = ["derive"] }
 serde-wasm-bindgen = "0.5"
+tsify = { version = "0.4", features= ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3.22", features = ["EventTarget", "Window"]}
@@ -38,8 +39,8 @@ nimiq-consensus = { path = "../consensus", default-features = false }
 nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = {path = "../primitives", features = ["coin", "networks"]}
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-primitives = {path = "../primitives", features = ["coin", "networks", "ts-types"]}
+nimiq-transaction = { path = "../primitives/transaction", features = ["ts-types"] }
 nimiq-transaction-builder = { path = "../transaction-builder" }
 
 [dependencies.nimiq]

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }
+hex = "0.4"
 js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = {version = "1.0.152", features = ["derive"] }

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -39,7 +39,7 @@ nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-primitives = {path = "../primitives", features = ["coin", "networks"]}
-nimiq-transaction = { path = "../primitives/transaction", features=["serde-derive"] }
+nimiq-transaction = { path = "../primitives/transaction" }
 nimiq-transaction-builder = { path = "../transaction-builder" }
 
 [dependencies.nimiq]

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -23,11 +23,11 @@ use nimiq_network_interface::{
     network::{CloseReason, Network, NetworkEvent},
     Multiaddr,
 };
-use nimiq_transaction::ExecutedTransaction;
+use nimiq_primitives::policy::Policy;
 
 use crate::address::Address;
 use crate::peer_info::PeerInfo;
-use crate::transaction::{Transaction, Transactions};
+use crate::transaction::{PlainTransactionDetails, PlainTransactionDetailsArrayType, Transaction};
 use crate::transaction_builder::TransactionBuilder;
 use crate::utils::{from_network_id, to_network_id};
 
@@ -559,40 +559,39 @@ impl Client {
         self.listener_id
     }
 
-    /// This function is used to query the network for transactions from some specific address, that
+    /// This function is used to query the network for transactions from a specific address, that
     /// have been included in the chain.
-    /// The obtained transactions correspond to extended transactions.
-    /// They are verified before being returned.
+    /// The obtained transactions are verified before being returned.
     /// Up to a max number of transactions are returned from newest to oldest.
-    /// A minimum number of peers needs to be specified.
     /// If the network does not have at least min_peers to query, then an error is returned
     #[wasm_bindgen(js_name = getTransactionsByAddress)]
-    pub async fn get_transations_from_address(
+    pub async fn get_transations_by_address(
         &self,
         address: Address,
-        max: u16,
-        min_peers: usize,
-    ) -> Result<JsValue, JsError> {
+        max: Option<u16>,
+        min_peers: Option<usize>,
+    ) -> Result<PlainTransactionDetailsArrayType, JsError> {
         let transactions = self
             .inner
             .consensus_proxy()
-            .request_transactions_by_address(address.native(), min_peers, Some(max))
+            .request_transactions_by_address(address.native(), min_peers.unwrap_or(1), max)
             .await?;
 
-        let executed_txs: Vec<ExecutedTransaction> = transactions
+        let current_block = self.get_head_height();
+        let last_macro_block = Policy::last_macro_block(current_block);
+
+        let plain_tx_details: Vec<PlainTransactionDetails> = transactions
             .into_iter()
-            .map(|ext_transaction| ext_transaction.into_transaction().unwrap())
+            .map(|ext_tx| {
+                PlainTransactionDetails::from_extended_transaction(
+                    &ext_tx,
+                    current_block,
+                    last_macro_block,
+                )
+            })
             .collect();
 
-        // TODO: We are converting executed transactions into regular transactions, which loses the execution result of the txn
-        // This could be provided as an aditional field.
-        let js_transactions: Vec<Transaction> = executed_txs
-            .into_iter()
-            .map(|executed_tx| Transaction::from_native(executed_tx.get_raw_transaction().clone()))
-            .collect();
-
-        // We serialize to JSON using `serde-wasm-bindgen`, in order to be able to use the transactions from JS side (we return a JsValue)
-        Ok(serde_wasm_bindgen::to_value(&Transactions::new(js_transactions)).unwrap())
+        Ok(serde_wasm_bindgen::to_value(&plain_tx_details)?.into())
     }
 }
 

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -440,19 +440,21 @@ impl PlainTransaction {
     }
 }
 
-enum TransactionState {
-    _New,
-    _Pending,
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransactionState {
+    New,
+    Pending,
     Included,
     Confirmed,
-    _Invalidated,
-    _Expired,
+    Invalidated,
+    Expired,
 }
 
 pub struct PlainTransactionDetails {
     transaction: PlainTransaction,
 
-    pub state: String,
+    pub state: TransactionState,
     pub execution_result: Option<bool>,
     pub block_height: Option<u32>,
     pub confirmations: Option<u32>,
@@ -539,22 +541,11 @@ impl PlainTransactionDetails {
             transaction: PlainTransaction::from_transaction(
                 executed_transaction.get_raw_transaction(),
             ),
-            state: PlainTransactionDetails::transaction_state_to_string(state),
+            state,
             execution_result: Some(executed_transaction.succeeded()),
             block_height: Some(block_number),
             timestamp: Some(block_time),
             confirmations: Some(block_number - current_block + 1),
-        }
-    }
-
-    fn transaction_state_to_string(state: TransactionState) -> String {
-        match state {
-            TransactionState::_New => "new".to_string(),
-            TransactionState::_Pending => "pending".to_string(),
-            TransactionState::Included => "included".to_string(),
-            TransactionState::Confirmed => "confirmed".to_string(),
-            TransactionState::_Invalidated => "invalidated".to_string(),
-            TransactionState::_Expired => "expired".to_string(),
         }
     }
 }

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -12,20 +12,6 @@ use crate::address::Address;
 use crate::key_pair::KeyPair;
 use crate::utils::{from_network_id, to_network_id};
 
-#[wasm_bindgen]
-#[derive(serde::Serialize, serde::Deserialize)]
-/// This struct reperesents a list of transactions.
-/// It is simply a wrapper around Transaction to represent more than one transaction
-pub struct Transactions {
-    txns: Vec<Transaction>,
-}
-
-impl Transactions {
-    pub fn new(txns: Vec<Transaction>) -> Self {
-        Transactions { txns }
-    }
-}
-
 /// Transactions describe a transfer of value, usually from the sender to the recipient.
 /// However, transactions can also have no value, when they are used to _signal_ a change in the staking contract.
 ///
@@ -34,7 +20,6 @@ impl Transactions {
 /// Transactions require a valid signature proof over their serialized content.
 /// Furthermore, transactions are only valid for 2 hours after their validity-start block height.
 #[wasm_bindgen(inspectable)]
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Transaction {
     inner: nimiq_transaction::Transaction,
 }
@@ -544,4 +529,7 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "PlainTransactionDetails")]
     pub type PlainTransactionDetailsType;
+
+    #[wasm_bindgen(typescript_type = "PlainTransactionDetails[]")]
+    pub type PlainTransactionDetailsArrayType;
 }


### PR DESCRIPTION
## What's in this pull request?

- Adds fully TS-typed plain Transaction and TransactionDetails structs equalling those in the 1.0 client
- Updates `client.getTransactionsByAddress` to return serialized `PlainTransactionDetails[]`, because wasm-bindgen cannot return `Vec<T>` where `T` is a wasm-bindgen annotated struct
- Workaround a serde shortcoming by manually serializing `PlainTransactionDetails` structs to produce JS Objects

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
