### PR TITLE
Transaction history optimizations

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -21,7 +21,8 @@ use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 use crate::consensus::head_requests::{HeadRequests, HeadRequestsResult};
 #[cfg(feature = "full")]
 use crate::messages::{
-    RequestBatchSet, RequestHistoryChunk, RequestTransactionsByAddress, RequestTransactionsProof,
+    RequestBatchSet, RequestHistoryChunk, RequestTransactionReceiptsByAddress,
+    RequestTransactionsProof,
 };
 use crate::messages::{RequestBlock, RequestHead, RequestMacroChain, RequestMissingBlocks};
 #[cfg(feature = "full")]
@@ -158,7 +159,7 @@ impl<N: Network> Consensus<N> {
                 let stream = network.receive_requests::<RequestTransactionsProof>();
                 executor.exec(Box::pin(request_handler(network, stream, blockchain)));
 
-                let stream = network.receive_requests::<RequestTransactionsByAddress>();
+                let stream = network.receive_requests::<RequestTransactionReceiptsByAddress>();
                 executor.exec(Box::pin(request_handler(network, stream, blockchain)));
             }
             BlockchainProxy::Light(_) => {}

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -352,10 +352,10 @@ impl Handle<ResponseTransactionsProof, Arc<RwLock<Blockchain>>> for RequestTrans
 }
 
 #[cfg(feature = "full")]
-impl Handle<ResponseTransactionsByAddress, Arc<RwLock<Blockchain>>>
-    for RequestTransactionsByAddress
+impl Handle<ResponseTransactionReceiptsByAddress, Arc<RwLock<Blockchain>>>
+    for RequestTransactionReceiptsByAddress
 {
-    fn handle(&self, blockchain: &Arc<RwLock<Blockchain>>) -> ResponseTransactionsByAddress {
+    fn handle(&self, blockchain: &Arc<RwLock<Blockchain>>) -> ResponseTransactionReceiptsByAddress {
         let blockchain = blockchain.read();
 
         // Get the transaction hashes for this address.
@@ -365,13 +365,19 @@ impl Handle<ResponseTransactionsByAddress, Arc<RwLock<Blockchain>>>
             None,
         );
 
-        let mut transactions = vec![];
+        let mut receipts = vec![];
 
         for hash in tx_hashes {
             // Get all the extended transactions that correspond to this hash.
-            transactions.extend(blockchain.history_store.get_ext_tx_by_hash(&hash, None));
+            receipts.extend(
+                blockchain
+                    .history_store
+                    .get_ext_tx_by_hash(&hash, None)
+                    .iter()
+                    .map(|ext_tx| (ext_tx.tx_hash(), ext_tx.block_number)),
+            );
         }
 
-        ResponseTransactionsByAddress { transactions }
+        ResponseTransactionReceiptsByAddress { receipts }
     }
 }

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -7,9 +7,7 @@ use nimiq_blockchain::HistoryTreeChunk;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_network_interface::request::{RequestCommon, RequestMarker};
-use nimiq_transaction::{
-    extended_transaction::ExtendedTransaction, history_proof::HistoryTreeProof,
-};
+use nimiq_transaction::history_proof::HistoryTreeProof;
 
 mod handlers;
 
@@ -232,20 +230,21 @@ impl RequestCommon for RequestTransactionsProof {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RequestTransactionsByAddress {
+pub struct RequestTransactionReceiptsByAddress {
     pub address: Address,
     pub max: Option<u16>,
 }
 
-impl RequestCommon for RequestTransactionsByAddress {
+impl RequestCommon for RequestTransactionReceiptsByAddress {
     type Kind = RequestMarker;
     const TYPE_ID: u16 = 214;
-    type Response = ResponseTransactionsByAddress;
+    type Response = ResponseTransactionReceiptsByAddress;
     const MAX_REQUESTS: u32 = MAX_REQUEST_TRANSACTIONS_BY_ADDRESS;
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct ResponseTransactionsByAddress {
+pub struct ResponseTransactionReceiptsByAddress {
+    /// Tuples of `(transaction_hash, block_number)`
     #[beserial(len_type(u16, limit = 128))]
-    pub transactions: Vec<ExtendedTransaction>,
+    pub receipts: Vec<(Blake2bHash, u32)>,
 }


### PR DESCRIPTION
## What's in this pull request?

Two optimizations for requesting and receiving transactions by address as added in
- #1346 
- #1356 

1. Change `TransactionsByAddress` network messages into `TransactionReceiptsByAddress` and only transmit transaction hashes and their block number, not whole `ExtendedTransactions`. The whole extended transactions are part of the following `TransactionsProof` messages, and are used from there when retrieved. By only sending transaction receipts in the first round-trip, we prevent the double-sending of whole extended transactions over the network.
2. In the client, batch received transaction receipts by epoch when requesting their proof, reducing number of proofs requested if more than one transaction is in the same epoch, making the process more efficient for both requester and responder nodes.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
