### PR TITLE
ci: Re-add dumping of deadlock thread information

### DIFF
--- a/lib/src/extras/deadlock.rs
+++ b/lib/src/extras/deadlock.rs
@@ -13,8 +13,12 @@ pub fn initialize_deadlock_detection() {
         }
 
         log::error!("{} deadlocks detected", deadlocks.len());
-        for (i, _deadlock) in deadlocks.iter().enumerate() {
+        for (i, threads) in deadlocks.iter().enumerate() {
             log::error!("Deadlock #{}", i);
+            for t in threads {
+                log::error!("Thread Id {:#?}", t.thread_id());
+                log::error!("{:#?}", t.backtrace());
+            }
         }
     });
 }

--- a/scripts/devnet/topology.py
+++ b/scripts/devnet/topology.py
@@ -328,7 +328,7 @@ class Topology:
                     time.sleep(2)
 
                 logging.info(
-                    "Producing blocks for {up_time}s with all ""nodes up")
+                    f"Producing blocks for {up_time}s with all nodes up")
                 self.__run_monitor_for(up_time)
 
             time.sleep(30)


### PR DESCRIPTION
- Re-add dumping of deadlock thread information which was removed when switching to the standard `parking_lot` dependency.
- Fix log message for the devnet script.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
