### PR TITLE
Enable the network to ban peers

### DIFF
--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -80,7 +80,9 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                             "Request macro chain failed: invalid checkpoint block number {}, checkpoint_epoch={}",
                             checkpoint.block_number, checkpoint_epoch
                         );
-                        network.disconnect_peer(peer_id, CloseReason::Other).await;
+                        network
+                            .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                            .await;
                         return None;
                     }
                 }
@@ -103,7 +105,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
             }
             Err(e) => {
                 log::error!("Request macro chain failed: {:?}", e);
-                network.disconnect_peer(peer_id, CloseReason::Other).await;
+                network.disconnect_peer(peer_id, CloseReason::Error).await;
                 None
             }
         }

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -167,14 +167,14 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         self.peer_requests.remove(&peer_id);
     }
 
-    pub fn disconnect_peer(&mut self, peer_id: TNetwork::PeerId) {
+    pub fn disconnect_peer(&mut self, peer_id: TNetwork::PeerId, reason: CloseReason) {
         // Remove all pending peer requests (if any)
         self.remove_peer_requests(peer_id);
         let network = Arc::clone(&self.network);
         // We disconnect from this peer
         self.executor.exec(Box::pin({
             async move {
-                network.disconnect_peer(peer_id, CloseReason::Other).await;
+                network.disconnect_peer(peer_id, reason).await;
             }
         }));
     }

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -106,7 +106,9 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                             checkpoint_epoch = checkpoint_epoch,
                             "Request macro chain failed: invalid checkpoint"
                         );
-                        network.disconnect_peer(peer_id, CloseReason::Other).await;
+                        network
+                            .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                            .await;
                         return None;
                     }
                 }
@@ -129,7 +131,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             }
             Err(error) => {
                 log::error!(%error, "Request macro chain failed");
-                network.disconnect_peer(peer_id, CloseReason::Other).await;
+                network.disconnect_peer(peer_id, CloseReason::Error).await;
                 None
             }
         }

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -44,10 +44,19 @@ pub trait PubsubId<PeerId>: Clone + Send + Sync + Debug {
 }
 
 #[derive(Copy, Clone, Debug)]
+/// Reasons for closing a connection
 pub enum CloseReason {
+    /// Reason is unknown or doesn't fit the other reasons
     Other,
+    /// The other peer closed the connection
     RemoteClosed,
+    /// We need to close the connection to this peer because we are going offline
+    /// and don't want new connections.
+    GoingOffline,
+    /// There was an error and there is need to close the connection
     Error,
+    /// Peer is malicious. This will cause the peer ID and address to get banned.
+    MaliciousPeer,
 }
 
 #[derive(Debug, Error)]

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -186,20 +186,25 @@ impl NimiqBehaviour {
         }
     }
 
+    /// Adds a peer address into the DHT
     pub fn add_peer_address(&mut self, peer_id: PeerId, address: Multiaddr) {
         // Add address to the DHT
         self.dht.add_address(&peer_id, address);
     }
 
+    /// Removes a peer from the DHT
     pub fn remove_peer(&mut self, peer_id: PeerId) {
         self.dht.remove_peer(&peer_id);
     }
 
+    /// Removes a peer address from the DHT
     pub fn remove_peer_address(&mut self, peer_id: PeerId, address: Multiaddr) {
         // Remove address from the DHT
         self.dht.remove_address(&peer_id, &address);
     }
 
+    /// Updates the scores of all peers in the peer contact book.
+    /// Updates are performed with the score values of Gossipsub
     pub fn update_scores(&self, contacts: Arc<RwLock<PeerContactBook>>) {
         contacts.read().update_scores(&self.gossipsub);
     }

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -27,11 +27,11 @@ use nimiq_utils::time::OffsetTime;
 use crate::{
     connection_pool::{
         behaviour::{ConnectionPoolBehaviour, ConnectionPoolEvent},
-        handler::HandlerError as ConnectionPoolError,
+        handler::ConnectionPoolHandlerError,
     },
     discovery::{
         behaviour::{DiscoveryBehaviour, DiscoveryEvent},
-        handler::HandlerError as DiscoveryError,
+        handler::DiscoveryHandlerError,
         peer_contacts::PeerContactBook,
     },
     dispatch::codecs::typed::{IncomingRequest, MessageCodec, OutgoingResponse, ReqResProtocol},
@@ -42,12 +42,15 @@ pub type NimiqNetworkBehaviourError = EitherError<
     EitherError<
         EitherError<
             EitherError<
-                EitherError<EitherError<std::io::Error, DiscoveryError>, GossipsubHandlerError>,
+                EitherError<
+                    EitherError<std::io::Error, DiscoveryHandlerError>,
+                    GossipsubHandlerError,
+                >,
                 std::io::Error,
             >,
             PingFailure,
         >,
-        ConnectionPoolError,
+        ConnectionPoolHandlerError,
     >,
     ConnectionHandlerUpgrErr<std::io::Error>,
 >;

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -23,7 +23,7 @@ use rand::thread_rng;
 use wasm_timer::Interval;
 
 use nimiq_macros::store_waker;
-use nimiq_network_interface::peer_info::Services;
+use nimiq_network_interface::{network::CloseReason, peer_info::Services};
 
 use crate::discovery::peer_contacts::PeerContactBook;
 
@@ -337,6 +337,17 @@ impl ConnectionPoolBehaviour {
     /// connection such as in a network outage.
     pub fn stop_connecting(&mut self) {
         self.active = false;
+    }
+
+    /// Closes a peer connection with a reason
+    pub fn close_connection(&mut self, peer_id: PeerId, reason: CloseReason) {
+        self.actions
+            .push_back(NetworkBehaviourAction::NotifyHandler {
+                peer_id,
+                handler: NotifyHandler::Any,
+                event: ConnectionPoolHandlerError::Other(reason),
+            });
+        self.wake();
     }
 
     fn choose_peers_to_dial(&self) -> Vec<PeerId> {

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -8,16 +8,48 @@ use libp2p::{
 use std::task::{Context, Poll};
 use thiserror::Error;
 
-#[derive(Default)]
-pub struct ConnectionPoolHandler {}
+use nimiq_network_interface::network::CloseReason;
 
-#[derive(Debug, Error)]
-pub enum ConnectionPoolHandlerError {}
+#[derive(Default)]
+pub struct ConnectionPoolHandler {
+    /// If set to `Some` it indicates that the current connection handler
+    /// must be closed with the reason specified.
+    close_reason: Option<ConnectionPoolHandlerError>,
+}
+
+/// Connection Pool errors
+#[derive(Clone, Debug, Error)]
+pub enum ConnectionPoolHandlerError {
+    /// Ip is banned
+    #[error("IP is banned")]
+    BannedIp,
+
+    /// Maximum connections per IPv4 subnet has been reached
+    #[error("Maximum connections per IPV4 subnet has been reached")]
+    MaxIpv4SubnetConnectionsReached,
+
+    /// Maximum connections per IPv6 subnet has been reached
+    #[error("Maximum connections per IPv6 subnet has been reached")]
+    MaxIpv6SubnetConnectionsReached,
+
+    /// Maximum peer connections has been reached
+    #[error("Maximum peer connections has been reached")]
+    MaxPeerConnectionsReached,
+
+    ///Maximum peers connections per IP has been reached
+    #[error("Maximum peers connections per IP has been reached")]
+    MaxPeerPerIPConnectionsReached,
+
+    /// The application sent the network to close the connection with the
+    /// provided reason
+    #[error("Application sent a close action with reason: {0:?}")]
+    Other(CloseReason),
+}
 
 // Implement ConnectionHandler without an actual protocol, which
 // implies a DeniedUpgrade protocol
 impl ConnectionHandler for ConnectionPoolHandler {
-    type InEvent = ();
+    type InEvent = ConnectionPoolHandlerError; // Only receive errors as events for this handler
     type OutEvent = ();
     type Error = ConnectionPoolHandlerError;
     type InboundProtocol = DeniedUpgrade;
@@ -45,7 +77,11 @@ impl ConnectionHandler for ConnectionPoolHandler {
         unreachable!("`DeniedUpgrade` is never successful.")
     }
 
-    fn inject_event(&mut self, _event: ()) {}
+    fn inject_event(&mut self, close_reason: ConnectionPoolHandlerError) {
+        if self.close_reason.is_none() {
+            self.close_reason = Some(close_reason);
+        }
+    }
 
     fn inject_dial_upgrade_error(
         &mut self,
@@ -64,6 +100,9 @@ impl ConnectionHandler for ConnectionPoolHandler {
         &mut self,
         _cx: &mut Context,
     ) -> Poll<ConnectionHandlerEvent<DeniedUpgrade, (), (), ConnectionPoolHandlerError>> {
+        if let Some(reason) = self.close_reason.take() {
+            return Poll::Ready(ConnectionHandlerEvent::Close(reason.into()));
+        }
         Poll::Pending
     }
 }

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -101,7 +101,7 @@ impl ConnectionHandler for ConnectionPoolHandler {
         _cx: &mut Context,
     ) -> Poll<ConnectionHandlerEvent<DeniedUpgrade, (), (), ConnectionPoolHandlerError>> {
         if let Some(reason) = self.close_reason.take() {
-            return Poll::Ready(ConnectionHandlerEvent::Close(reason.into()));
+            return Poll::Ready(ConnectionHandlerEvent::Close(reason));
         }
         Poll::Pending
     }

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -12,14 +12,14 @@ use thiserror::Error;
 pub struct ConnectionPoolHandler {}
 
 #[derive(Debug, Error)]
-pub enum HandlerError {}
+pub enum ConnectionPoolHandlerError {}
 
 // Implement ConnectionHandler without an actual protocol, which
 // implies a DeniedUpgrade protocol
 impl ConnectionHandler for ConnectionPoolHandler {
     type InEvent = ();
     type OutEvent = ();
-    type Error = HandlerError;
+    type Error = ConnectionPoolHandlerError;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = DeniedUpgrade;
     type InboundOpenInfo = ();
@@ -63,7 +63,7 @@ impl ConnectionHandler for ConnectionPoolHandler {
     fn poll(
         &mut self,
         _cx: &mut Context,
-    ) -> Poll<ConnectionHandlerEvent<DeniedUpgrade, (), (), HandlerError>> {
+    ) -> Poll<ConnectionHandlerEvent<DeniedUpgrade, (), (), ConnectionPoolHandlerError>> {
         Poll::Pending
     }
 }

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1579,17 +1579,20 @@ impl Network {
         }
     }
 
+    /// Gets the number of connected peers
     pub fn peer_count(&self) -> usize {
         self.connected_peers.read().len()
     }
 
-    pub async fn disconnect(&self) {
+    /// Disconnects from (closes the connection to) all peers with a reason
+    pub async fn disconnect(&self, reason: CloseReason) {
         for peer_id in self.get_peers() {
-            self.disconnect_peer(peer_id, CloseReason::Other).await;
+            self.disconnect_peer(peer_id, reason).await;
         }
     }
 
     #[cfg(feature = "metrics")]
+    /// Gets the network metrics
     pub fn metrics(&self) -> Arc<NetworkMetrics> {
         self.metrics.clone()
     }

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -402,7 +402,7 @@ async fn connections_are_properly_closed_events() {
     let mut events1 = net1.subscribe_events();
     let mut events2 = net2.subscribe_events();
 
-    net2.disconnect_peer(*net1.local_peer_id(), CloseReason::Other)
+    net2.disconnect_peer(*net1.local_peer_id(), CloseReason::GoingOffline)
         .await;
     log::debug!("Closed peer");
 
@@ -426,7 +426,8 @@ async fn connections_are_properly_closed_peers() {
     let net1_peer_id = *net1.local_peer_id();
     drop(net1);
 
-    net2.disconnect_peer(net1_peer_id, CloseReason::Other).await;
+    net2.disconnect_peer(net1_peer_id, CloseReason::GoingOffline)
+        .await;
     log::debug!("Closed peer");
 
     let event2 = events2.next().await.unwrap().unwrap();

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -590,7 +590,7 @@ async fn disconnect_successfully(net1: &Arc<Network>, net2: &Arc<Network>) {
     let mut events2 = net2.subscribe_events();
 
     log::debug!("Disconnecting peer 1 from peer 2");
-    net2.disconnect_peer(net1.get_local_peer_id(), CloseReason::Other)
+    net2.disconnect_peer(net1.get_local_peer_id(), CloseReason::GoingOffline)
         .await;
 
     log::debug!("Waiting for disconnect events");

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -9,7 +9,7 @@ use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis_builder::GenesisBuilder;
 use nimiq_handel::update::{LevelUpdate, LevelUpdateMessage};
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
-use nimiq_network_interface::network::Network as NetworkInterface;
+use nimiq_network_interface::network::{CloseReason, Network as NetworkInterface};
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::MockHub;
 use nimiq_test_log::test;
@@ -114,7 +114,11 @@ async fn four_validators_can_do_skip_block() {
 
     // Disconnect the next block producer.
     let validator = pop_validator_for_slot(&mut validators, 1, 1);
-    validator.consensus.network.disconnect().await;
+    validator
+        .consensus
+        .network
+        .disconnect(CloseReason::GoingOffline)
+        .await;
     drop(validator);
     log::info!("Peer disconnection");
 
@@ -207,10 +211,18 @@ async fn validator_can_catch_up() {
     // Disconnect the block producers for the next 3 skip blocks. remember the one which is supposed to actually create the block (3rd skip block)
     let (validator, _) = {
         let validator = validator_for_slot(&mut validators, 1, 1);
-        validator.consensus.network.disconnect().await;
+        validator
+            .consensus
+            .network
+            .disconnect(CloseReason::GoingOffline)
+            .await;
         let id1 = validator.validator_slot_band();
         let validator = validator_for_slot(&mut validators, 2, 2);
-        validator.consensus.network.disconnect().await;
+        validator
+            .consensus
+            .network
+            .disconnect(CloseReason::GoingOffline)
+            .await;
         let id2 = validator.validator_slot_band();
         assert_ne!(id2, id1);
 
@@ -222,7 +234,11 @@ async fn validator_can_catch_up() {
         // });
 
         let validator = validator_for_slot(&validators, 3, 3);
-        validator.consensus.network.disconnect().await;
+        validator
+            .consensus
+            .network
+            .disconnect(CloseReason::GoingOffline)
+            .await;
         assert_ne!(id1, validator.validator_slot_band());
         assert_ne!(id2, validator.validator_slot_band());
         (validator, validator.consensus.network.clone())

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -384,17 +384,14 @@ impl Client {
 
         // Register offline closure
         let offline_closure = Closure::<dyn Fn()>::new(move || {
-            let network = network1.clone();
-            spawn_local(async move {
-                let network = network.clone();
-                network.stop_connecting().await;
-            });
             let peers = network1.get_peers();
             for peer in peers {
                 let network = network1.clone();
                 spawn_local(async move {
                     let network = network.clone();
-                    network.disconnect_peer(peer, CloseReason::Other).await;
+                    network
+                        .disconnect_peer(peer, CloseReason::GoingOffline)
+                        .await;
                 });
             }
         });

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -384,16 +384,11 @@ impl Client {
 
         // Register offline closure
         let offline_closure = Closure::<dyn Fn()>::new(move || {
-            let peers = network1.get_peers();
-            for peer in peers {
-                let network = network1.clone();
-                spawn_local(async move {
-                    let network = network.clone();
-                    network
-                        .disconnect_peer(peer, CloseReason::GoingOffline)
-                        .await;
-                });
-            }
+            let network = network1.clone();
+            spawn_local(async move {
+                let network = network.clone();
+                network.disconnect(CloseReason::GoingOffline).await;
+            });
         });
         window
             .add_event_listener_with_callback("offline", offline_closure.as_ref().unchecked_ref())


### PR DESCRIPTION
- Use a proper reason for closing a peer connection in several places of the codebase.
- Use a reason as well when disconnecting from every peer.
- Make the web client use the `disconnect` function from the network instead of iterating over all peers.
- Add basic infrastructure for banning a peer.
- Refined network interface close reasons and added a special close reason for banning a peer.
- Change the procedure to close a peer connection when instructed by upper layers. Instead of directly instructing the `swarm` to close the connection, now the network signals the connection pool to close it emitting an error and making use of the `CloseReason` that is sent by the callers.
- Add an enumeration for close connection reasons or errors that can happen in the connection pool handler.
- Properly close connections in the connection pool behaviour by notifying the corresponding connection handler with a reason such that it can then close the connection with a reason.
- Rename discovery and connection pool handler errors to better identify them outside the handler implementation.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
