### PR TITLE
Remove `itertools` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,7 +3515,6 @@ version = "0.1.0"
 dependencies = [
  "beserial",
  "hex",
- "itertools",
  "nimiq-test-log",
  "num-traits",
  "rand 0.8.5",
@@ -4052,7 +4051,6 @@ dependencies = [
  "beserial",
  "bitvec",
  "hex",
- "itertools",
  "lazy_static",
  "nimiq-bls",
  "nimiq-database-value",

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -17,7 +17,6 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-itertools = "0.10"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -19,7 +19,6 @@ maintenance = { status = "experimental" }
 [dependencies]
 bitvec = "1.0"
 hex = { version = "0.4", optional = true }
-itertools = { version = "0.10", optional = true }
 lazy_static = { version = "1.2", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 num-traits = { version = "0.2", optional = true }
@@ -51,7 +50,7 @@ key-nibbles = ["hex", "nimiq-keys", "nimiq-database-value"]
 networks = ["thiserror"]
 policy = ["lazy_static", "nimiq-keys", "num-traits", "parking_lot"]
 serde-derive = ["serde"]
-slots = ["beserial/bitvec", "itertools", "nimiq-bls", "nimiq-keys", "nimiq-utils", "policy"]
+slots = ["beserial/bitvec", "nimiq-bls", "nimiq-keys", "nimiq-utils", "policy"]
 transaction = ["thiserror"]
 trie = ["key-nibbles", "nimiq-hash", "thiserror"]
 ts-types = ["serde", "tsify", "wasm-bindgen"]

--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -316,7 +316,7 @@ impl ops::Add<&KeyNibbles> for &KeyNibbles {
                 .copy_from_slice(&other.bytes[..other.bytes_len()]);
         } else {
             // Complex case: the lhs ends in the middle of a byte.
-            let mut next_byte = bytes[(self.bytes_len() - 1)];
+            let mut next_byte = bytes[self.bytes_len() - 1];
             let mut bytes_length = self.bytes_len() - 1;
 
             for (count, byte) in other.bytes[..other.bytes_len()].iter().enumerate() {


### PR DESCRIPTION
It was only being used for `.zip_longest()` which is easily emulated.