### PR TITLE
Transaction inclusion proofs enhancements 

### DIFF
--- a/blockchain-interface/src/chain_info.rs
+++ b/blockchain-interface/src/chain_info.rs
@@ -26,8 +26,6 @@ pub struct ChainInfo {
     pub cum_ext_tx_size: u64,
     /// The accumulated extended transaction count in the current epoch. Resets at election blocks.
     pub cum_ext_tx_count: u64,
-    /// The accumulated extended transaction count as of the latest macro block. Resets at election blocks.
-    pub cum_ext_tx_count_at_macro: u64,
     /// A boolean stating if this block can be pruned.
     pub prunable: bool,
     /// Missing range of the accounts before this block.
@@ -47,7 +45,6 @@ impl ChainInfo {
             cum_tx_fees: Coin::ZERO,
             cum_ext_tx_size: 0,
             cum_ext_tx_count: 0,
-            cum_ext_tx_count_at_macro: 0,
             prunable,
             prev_missing_range: None,
         }
@@ -77,18 +74,6 @@ impl ChainInfo {
             prev_info.cum_ext_tx_count + block.num_transactions() as u64
         };
 
-        // Reset the transaction count-at-previous-macro-block accumulator if this is the first block of an epoch.
-        // If the current block is a macro block, set the counter to the accumulated transaction count.
-        // Otherwise, continue with the previous block's transaction counter.
-        let cum_ext_tx_count_at_macro =
-            if Policy::is_election_block_at(prev_info.head.block_number()) {
-                0 // Reset after election blocks
-            } else if Policy::is_macro_block_at(block.block_number()) {
-                cum_ext_tx_count // Update to current transaction count at macro blocks
-            } else {
-                prev_info.cum_ext_tx_count // Don't update at micro blocks
-            };
-
         let prunable = !block.is_election();
 
         ChainInfo {
@@ -98,7 +83,6 @@ impl ChainInfo {
             cum_tx_fees,
             cum_ext_tx_size: 0,
             cum_ext_tx_count,
-            cum_ext_tx_count_at_macro,
             prunable,
             prev_missing_range,
         }
@@ -160,7 +144,6 @@ impl Serialize for ChainInfo {
         size += Serialize::serialize(&self.cum_tx_fees, writer)?;
         size += Serialize::serialize(&self.cum_ext_tx_size, writer)?;
         size += Serialize::serialize(&self.cum_ext_tx_count, writer)?;
-        size += Serialize::serialize(&self.cum_ext_tx_count_at_macro, writer)?;
         size += Serialize::serialize(&self.prunable, writer)?;
         size += Serialize::serialize(&self.prev_missing_range, writer)?;
 
@@ -187,7 +170,6 @@ impl Serialize for ChainInfo {
         size += Serialize::serialized_size(&self.cum_tx_fees);
         size += Serialize::serialized_size(&self.cum_ext_tx_size);
         size += Serialize::serialized_size(&self.cum_ext_tx_count);
-        size += Serialize::serialized_size(&self.cum_ext_tx_count_at_macro);
         size += Serialize::serialized_size(&self.prunable);
         size += Serialize::serialized_size(&self.prev_missing_range);
         size
@@ -236,7 +218,6 @@ impl Deserialize for ChainInfo {
         let cum_tx_fees = Deserialize::deserialize(reader)?;
         let cum_ext_tx_size = Deserialize::deserialize(reader)?;
         let cum_ext_tx_count = Deserialize::deserialize(reader)?;
-        let cum_ext_tx_count_at_macro = Deserialize::deserialize(reader)?;
         let prunable = Deserialize::deserialize(reader)?;
         let prev_missing_range = Deserialize::deserialize(reader)?;
 
@@ -247,7 +228,6 @@ impl Deserialize for ChainInfo {
             cum_tx_fees,
             cum_ext_tx_size,
             cum_ext_tx_count,
-            cum_ext_tx_count_at_macro,
             prunable,
             prev_missing_range,
         })

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -133,7 +133,6 @@ impl Blockchain {
             cum_tx_fees,
             cum_ext_tx_size,
             cum_ext_tx_count,
-            cum_ext_tx_count_at_macro: cum_ext_tx_count,
             prunable: false,
             prev_missing_range: None,
         };

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -273,6 +273,9 @@ impl Blockchain {
 
         chain_info.on_main_chain = true;
         chain_info.set_cumulative_ext_tx_size(&prev_info, block_log.total_tx_size());
+        chain_info.history_tree_len =
+            this.history_store
+                .len(Policy::epoch_at(block_number), Some(&txn)) as u64;
         prev_info.main_chain_successor = Some(chain_info.head.hash());
 
         this.chain_store

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -95,9 +95,11 @@ impl<N: Network> ConsensusProxy<N> {
 
             match response {
                 Ok(response) => {
+                    log::info!("Obtained response, length {} ", response.receipts.len());
+
                     let blockchain = self.blockchain.read();
 
-                    // Group transaction hashes by the block number that proofs those transactions to reduce the number of requests
+                    // Group transaction hashes by the block number that proves those transactions to reduce the number of requests
                     // There are three categories of block numbers:
                     //  - Finalized epochs: we use the election block number that finalized the respective epoch
                     //  - Finalized batch in the current epoch: We use the latest checkpoint block number
@@ -105,11 +107,8 @@ impl<N: Network> ConsensusProxy<N> {
 
                     // This is the structure where we group transactions by their proving block number
                     let mut hashes_by_block = HashMap::new();
-
                     let election_head_number = blockchain.election_head().block_number();
-
                     let checkpoint_head_number = blockchain.macro_head().block_number();
-
                     let current_head_number = blockchain.head().block_number();
 
                     for (hash, block_number) in response.receipts {

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -145,7 +145,7 @@ impl<N: Network> ConsensusProxy<N> {
                         }
                     }
 
-                    // We drop the blockchain lock because is no longer needed while we request proofs
+                    // We drop the blockchain lock because it's no longer needed while we request proofs
                     drop(blockchain);
 
                     // Now we request proofs for each block and its hashes, according to its classification

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -323,9 +323,9 @@ impl Handle<ResponseTransactionsProof, Arc<RwLock<Blockchain>>> for RequestTrans
         // We cannot prove transactions from the future
         if self.block_number > current_head {
             log::info!(
-                "Requested txn proof from the future, current_head {}, requested block number {}",
                 current_head,
-                self.block_number
+                requested_block_number = self.block_number,
+                "Requested txn proof from the future",
             );
             return ResponseTransactionsProof {
                 proof: None,
@@ -365,8 +365,8 @@ impl Handle<ResponseTransactionsProof, Arc<RwLock<Blockchain>>> for RequestTrans
             // Otherwise, the requester should use the latest epoch number.
             if self.block_number < election_head {
                 log::info!(
-                    "Requested txn proof that corresponds to a finalized epoch, should use the election block instead {}",
-                    self.block_number
+                    block_number = self.block_number,
+                    "Requested txn proof that corresponds to a finalized epoch, should use the election block instead",
                 );
                 return ResponseTransactionsProof {
                     proof: None,
@@ -381,8 +381,8 @@ impl Handle<ResponseTransactionsProof, Arc<RwLock<Blockchain>>> for RequestTrans
 
             if let Some(block) = block.clone() {
                 let chain_info = blockchain.get_chain_info(&block.hash(), false, None);
-                let current_txn_count = chain_info.unwrap().cum_ext_tx_count;
-                verifier_state = Some(current_txn_count as usize);
+                let history_tree_len = chain_info.unwrap().history_tree_len;
+                verifier_state = Some(history_tree_len as usize);
             } else {
                 //If we could not find a block, we cannot fulfil the request
                 log::info!("Could not find the desired block to create the txn proof");

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -359,7 +359,7 @@ impl Handle<ResponseTransactionsProof, Arc<RwLock<Blockchain>>> for RequestTrans
                 None,
             );
 
-            verifier_state = Some(chain_info.unwrap().cum_ext_tx_count_at_macro as usize);
+            verifier_state = Some(chain_info.unwrap().cum_ext_tx_count as usize);
         } else {
             // If we were provided a block number corresponding to a micro block, it needs to correspond to the current batch
             // Otherwise, the requester should use the latest checkpoing number

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -232,7 +232,8 @@ impl Block {
         }
     }
 
-    /// Return the number of transactions in the block.
+    /// Return the number of transactions in the block. If the block is a Macro
+    /// block it just returns zero, since Macro blocks don't contain any transactions.
     pub fn num_transactions(&self) -> usize {
         self.transactions().map_or(0, |txs| txs.len())
     }

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -232,8 +232,7 @@ impl Block {
         }
     }
 
-    /// Return the number of transactions in the block. If the block is a Macro
-    /// block it just returns zero, since Macro blocks don't contain any transactions.
+    /// Return the number of transactions in the block.
     pub fn num_transactions(&self) -> usize {
         self.transactions().map_or(0, |txs| txs.len())
     }

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -42,6 +42,9 @@ mod transaction;
 mod transaction_builder;
 mod utils;
 
+/// Maximum number of transactions that can be requested by address
+pub const MAX_TRANSACTIONS_BY_ADDRESS: u16 = 128;
+
 /// Use this to provide initialization-time configuration to the Client.
 /// This is a simplified version of the configuration that is used for regular nodes,
 /// since not all configuration knobs are available when running inside a browser.
@@ -563,6 +566,14 @@ impl Client {
         max: Option<u16>,
         min_peers: Option<usize>,
     ) -> Result<PlainTransactionDetailsArrayType, JsError> {
+        if let Some(max) = max {
+            if max > MAX_TRANSACTIONS_BY_ADDRESS {
+                return Err(JsError::new(
+                    "The maximum number of transactions exceeds the one that is supported",
+                ));
+            }
+        }
+
         let transactions = self
             .inner
             .consensus_proxy()


### PR DESCRIPTION
When generating transaction inclusion proofs there are multiple cases that need to be considered in order to generate a proof that can be verified. From the requester side, transactions can be grouped into: 

1. Transactions that belong to finalized epochs (currently hashes_by_epoch )
2. Transactions that belong to an unfinished epoch, but have a checkpoint block that finalizes them
3. Transactions that belong to the current batch

To prove those transactions:
For 1 we essentially do what we are currently doing: use the election block of that epoch to prove those transactions
For 2 we should use the last_macro_block of the current epoch, and use the current MMR length to generate the proof
For 3 we use the last micro block number of the current batch, and the current MMR length to generate the proof 