### PR TITLE
Get rid of forked `ed25519-zebra` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,15 +1591,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
-source = "git+https://github.com/nimiq/ed25519-zebra.git?branch=main#9bef4281db3fc6feb994ed74b0c97bfa6648230d"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek 3.2.0",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
  "zeroize",
 ]
 

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -111,7 +111,7 @@ impl Signature {
     /// validator's signature by its number of slots.
     #[must_use]
     pub fn multiply(&self, x: u16) -> Self {
-        let signature = self.signature.mul(&[x as u64]);
+        let signature = self.signature.mul([x as u64]);
         Signature {
             signature,
             compressed: CompressedSignature::from(signature),

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 curve25519-dalek = "3"
-ed25519-zebra = { git = "https://github.com/nimiq/ed25519-zebra.git", branch = "main" }
+ed25519-zebra = "3.1"
 data-encoding = "2.3"
 thiserror = "1.0"
 hex = "0.4"

--- a/keys/src/multisig.rs
+++ b/keys/src/multisig.rs
@@ -236,7 +236,7 @@ impl KeyPair {
         let s = Scalar::from_hash::<sha2::Sha512>(h);
 
         // Get a scalar representation of the private key
-        let sk = self.private.as_zebra().to_scalar();
+        let sk = self.private.0.to_scalar();
 
         // Compute H(C||P)*sk
         s * sk

--- a/keys/src/private_key.rs
+++ b/keys/src/private_key.rs
@@ -39,11 +39,6 @@ impl PrivateKey {
     }
 
     #[inline]
-    pub(crate) fn as_zebra(&self) -> &ed25519_zebra::SigningKey {
-        &self.0
-    }
-
-    #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, KeysError> {
         Ok(PrivateKey(ed25519_zebra::SigningKey::try_from(bytes)?))
     }

--- a/keys/src/public_key.rs
+++ b/keys/src/public_key.rs
@@ -20,8 +20,8 @@ impl PublicKey {
     pub const SIZE: usize = 32;
 
     pub fn verify(&self, signature: &Signature, data: &[u8]) -> bool {
-        if let Ok(vk) = ed25519_zebra::VerificationKey::try_from(*self.as_zebra()) {
-            vk.verify(signature.as_zebra(), data).is_ok()
+        if let Ok(vk) = ed25519_zebra::VerificationKey::try_from(self.0) {
+            vk.verify(&signature.0, data).is_ok()
         } else {
             false
         }
@@ -33,11 +33,6 @@ impl PublicKey {
             .as_ref()
             .try_into()
             .expect("Obtained slice with an unexpected size")
-    }
-
-    #[inline]
-    pub(crate) fn as_zebra(&self) -> &ed25519_zebra::VerificationKeyBytes {
-        &self.0
     }
 
     #[inline]
@@ -110,7 +105,7 @@ impl PartialOrd for PublicKey {
 
 impl<'a> From<&'a PrivateKey> for PublicKey {
     fn from(private_key: &'a PrivateKey) -> Self {
-        let public_key = ed25519_zebra::VerificationKeyBytes::from(private_key.as_zebra());
+        let public_key = ed25519_zebra::VerificationKeyBytes::from(&private_key.0);
         PublicKey(public_key)
     }
 }

--- a/keys/src/public_key.rs
+++ b/keys/src/public_key.rs
@@ -151,7 +151,6 @@ impl SerializeContent for PublicKey {
 
 impl Hash for PublicKey {}
 
-#[allow(clippy::derive_hash_xor_eq)]
 impl std::hash::Hash for PublicKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         std::hash::Hash::hash(self.as_bytes(), state);

--- a/keys/src/signature.rs
+++ b/keys/src/signature.rs
@@ -25,11 +25,6 @@ impl Signature {
     }
 
     #[inline]
-    pub(crate) fn as_zebra(&self) -> &ed25519_zebra::Signature {
-        &self.0
-    }
-
-    #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, KeysError> {
         Ok(Signature(ed25519_zebra::Signature::try_from(bytes)?))
     }

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -169,21 +169,17 @@ pub struct ConsensusSettings {
     pub min_peers: Option<usize>,
 }
 
-#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 /// Synchronization mode used by the client based upon its client type
 pub enum SyncMode {
+    #[default]
     /// Synchronization mode used by History nodes (full transaction history is maintained)
     History,
     /// Full Nodes. They use LightMacroSync + State Sync to reach consensus
     Full,
     /// Light nodes use LightMacroSync + BlockLiveSync to reach consensus
     Light,
-}
-impl Default for SyncMode {
-    fn default() -> Self {
-        SyncMode::History
-    }
 }
 
 #[derive(Debug, Error)]
@@ -213,7 +209,7 @@ impl From<SyncMode> for config::SyncMode {
     }
 }
 
-#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 // TODO: I think we can directly use `NetworkId` here
 pub enum Network {
@@ -221,14 +217,9 @@ pub enum Network {
     Test,
     Dev,
     TestAlbatross,
+    #[default]
     DevAlbatross,
     UnitAlbatross,
-}
-
-impl Default for Network {
-    fn default() -> Self {
-        Network::DevAlbatross
-    }
 }
 
 impl FromStr for Network {

--- a/primitives/account/src/receipts.rs
+++ b/primitives/account/src/receipts.rs
@@ -113,7 +113,6 @@ impl SerializeContent for Receipt {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)] // TODO: Shouldn't be necessary
 impl Hash for Receipt {
     fn hash<H: HashOutput>(&self) -> H {
         let h = H::Builder::default();

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -206,7 +206,6 @@ impl Message for MacroHeader {
     const PREFIX: u8 = PREFIX_TENDERMINT_PROPOSAL;
 }
 
-#[allow(clippy::derive_hash_xor_eq)] // TODO: Shouldn't be necessary
 impl Hash for MacroHeader {}
 
 impl fmt::Display for MacroHeader {
@@ -278,7 +277,6 @@ impl MacroBody {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)] // TODO: Shouldn't be necessary
 impl Hash for MacroBody {}
 
 #[derive(Error, Debug)]

--- a/primitives/subscription/src/lib.rs
+++ b/primitives/subscription/src/lib.rs
@@ -5,10 +5,11 @@ use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_transaction::Transaction;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[repr(u8)]
 pub enum Subscription {
     #[beserial(discriminant = 0)]
+    #[default]
     None,
     #[beserial(discriminant = 1)]
     Any,
@@ -16,12 +17,6 @@ pub enum Subscription {
     Addresses(#[beserial(len_type(u16))] HashSet<Address>),
     #[beserial(discriminant = 3)]
     MinFee(Coin), // Fee per byte
-}
-
-impl Default for Subscription {
-    fn default() -> Self {
-        Subscription::None
-    }
 }
 
 impl Subscription {

--- a/primitives/transaction/src/account/htlc_contract.rs
+++ b/primitives/transaction/src/account/htlc_contract.rs
@@ -161,21 +161,18 @@ impl AccountTransactionVerification for HashedTimeLockedContractVerifier {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize, Display)]
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Display, Eq, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[repr(u8)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub enum HashAlgorithm {
+    #[default]
     Blake2b = 1,
     Sha256 = 3,
 }
 
-impl Default for HashAlgorithm {
-    fn default() -> Self {
-        HashAlgorithm::Blake2b
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[repr(u8)]
 pub enum ProofType {
     RegularTransfer = 1,
@@ -192,7 +189,7 @@ impl AnyHash {
     }
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreationTransactionData {
     pub sender: Address,

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -392,7 +392,7 @@ async fn spam(
             SpamType::Vesting,
         ];
 
-        let dist = WeightedIndex::new(&config.weights).unwrap();
+        let dist = WeightedIndex::new(config.weights).unwrap();
         let mut rng = thread_rng();
         let new_count;
 

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -153,7 +153,7 @@ impl VrfSeed {
         rng.fill_bytes(&mut Z[..]);
 
         // Unpack the private and public keys.
-        let a = keypair.private.0.s;
+        let a = keypair.private.to_scalar();
         let A_bytes = keypair.public.as_bytes();
 
         // Concatenate use case prefix and entropy to form message. Note that we use the entropy


### PR DESCRIPTION
It was forked to make the `s` field of `SigningKey` public, it's the computed scalar for the ed25519 signature. Since its computation is specified in RFC 8032, we can compute it ourselves and get rid of the fork.

The actual computation is cheap enough (0.3µs) so that the double computation isn't a problem.
