### PR TITLE
ci: Improve `devnet` script

### DIFF
--- a/scripts/devnet/node.py
+++ b/scripts/devnet/node.py
@@ -1,7 +1,8 @@
+import os
 import subprocess
 import signal
-import os
 import re
+import time
 from enum import Enum
 from typing import Optional
 from jinja2 import Environment
@@ -189,9 +190,10 @@ class Node:
         """
         if self.process is not None:
             self.process.send_signal(signal.SIGINT)
+            time.sleep(1)
             if will_be_restarted:
-                log_str = "\n################################## RESTART ######"
-                "#####################\n"
+                log_str = "\n\n################################## RESTART ####"
+                "#######################\n\n"
                 with open(self.get_log(), 'a') as log_file:
                     log_file.write(log_str)
                 self.process = None
@@ -260,8 +262,8 @@ class Node:
         log_file = open(self.get_log(), 'a+')
         subprocess.run(["rm", "-r", self.get_db()],
                        check=True, capture_output=True)
-        log_str = "\n################################## NODE DB DELETED #####"
-        "######################\n"
+        log_str = "\n\n################################## NODE DB DELETED ###"
+        "########################\n\n"
         log_file.write(log_str)
         log_file.close()
 
@@ -276,8 +278,8 @@ class Node:
         # Also the command needs to be a string
         subprocess.run(f"rm -r {self.get_state_dir()}/*",
                        shell=True, check=True, capture_output=True)
-        log_str = "\n################################## NODE STATE DELETED ##"
-        "#########################\n"
+        log_str = "\n\n################################ NODE STATE DELETED ##"
+        "###########################\n\n"
         log_file.write(log_str)
         log_file.close()
 

--- a/scripts/devnet/topology.py
+++ b/scripts/devnet/topology.py
@@ -1,10 +1,9 @@
 import logging
 import random
-import time
 import signal
-import tomli
 import sys
-import subprocess
+import time
+import tomli
 from jinja2 import Environment, FileSystemLoader
 from topology_settings import TopologySettings
 from control_settings import ControlSettings
@@ -306,7 +305,6 @@ class Topology:
                 for node in nodes_to_restart:
                     logging.info(f"Killing {node.get_name()}")
                     node.kill(True)
-                    time.sleep(1)
                     if erase_state:
                         logging.info(
                             f"Erasing state for {node.get_name()}")


### PR DESCRIPTION
Improve the `devnet` script by waiting some time after sending the `SIGINT` signal to the process to then add the proper output to the log file when the node was restarted or its state or DB was deleted.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
