### PR TITLE
network-libp2p: Allow only a connection per peer

### DIFF
--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -560,6 +560,14 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
                 connections = other_established,
                 "Already have connections established to this peer",
             );
+            // Notify the handler that the connection must be closed
+            self.actions
+                .push_back(NetworkBehaviourAction::NotifyHandler {
+                    peer_id: *peer_id,
+                    handler: NotifyHandler::One(*connection_id),
+                    event: ConnectionPoolHandlerError::AlreadyConnected,
+                });
+            self.wake();
             return;
         }
 

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -24,6 +24,10 @@ pub enum ConnectionPoolHandlerError {
     #[error("IP is banned")]
     BannedIp,
 
+    /// There is already a connection for this Peer
+    #[error("Peer is already connected")]
+    AlreadyConnected,
+
     /// Maximum connections per IPv4 subnet has been reached
     #[error("Maximum connections per IPV4 subnet has been reached")]
     MaxIpv4SubnetConnectionsReached,


### PR DESCRIPTION
Allow only a connection per peer by making the connection pool behaviour to close a connection if we see more than a connection to the same peer.
This also fixes instabilities in the
`connection_stress_and_reconnect` test that were produced because the test was hanging waiting to receive events for a closed connection but they were sometimes never emitted because there were duplicated connections to a peer and only one of them was being closed.

This closes #832.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
