### PR TITLE
Fix documentation links and clippy lints

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -270,7 +270,7 @@ impl Blockchain {
 
         // Use the just built history tree to set the `ChainInfo`'s total history length
         chain_info.history_tree_len =
-            this.history_store.len(block.epoch_number(), Some(&mut txn)) as u64;
+            this.history_store.len(block.epoch_number(), Some(&txn)) as u64;
 
         this.chain_store
             .put_chain_info(&mut txn, &block_hash, &chain_info, true);

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -14,10 +14,12 @@ pub struct Policy {
     /// How many batches constitute an epoch
     pub batches_per_epoch: u16,
     /// Tendermint's initial timeout, in milliseconds.
-    /// See https://arxiv.org/abs/1807.04938v3 for more information.
+    ///
+    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
     pub tendermint_timeout_init: u64,
     /// Tendermint's timeout delta, in milliseconds.
-    /// See https://arxiv.org/abs/1807.04938v3 for more information.
+    ///
+    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
     pub tendermint_timeout_delta: u64,
     /// Maximum size of accounts trie chunks.
     pub state_chunks_max_size: u32,

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -104,6 +104,7 @@ pub struct TransactionBuilder {
 // Basic builder functionality.
 impl TransactionBuilder {
     /// Creates an new, empty `TransactionBuilder`.
+    ///
     /// Only if all required fields are set, transactions can be generated via [`generate`].
     ///
     /// # Examples
@@ -164,19 +165,22 @@ impl TransactionBuilder {
     }
 
     /// Sets the `value` to be transferred by the transaction.
+    ///
     /// The value is a *required* field and must always be set.
     ///
     /// Most transactions have to have non-zero transaction values.
     /// The only exceptions are signalling transactions to:
-    /// * [`update validator details`]
-    /// * [`retire validators`]
-    /// * [`re-activate validators`]
-    /// * [`unpark validators`]
-    /// * [`update staker details`]
-    /// * [`retire staker funds`]
-    /// * [`re-activate staker funds`]
+    /// * `update validator details`
+    /// * `retire validators`
+    /// * `re-activate validators`
+    /// * `unpark validators`
+    /// * `update staker details`
+    /// * `retire staker funds`
+    /// * `re-activate staker funds`
+    ///
     /// Signalling transactions have a special status as they also require an additional step
-    /// during the proof generation (see [`SignallingProofBuilder`]).
+    /// during the proof generation (see
+    /// [`StakingProofBuilder`](proof::staking_contract::StakingProofBuilder)).
     ///
     /// # Examples
     ///
@@ -193,6 +197,7 @@ impl TransactionBuilder {
     }
 
     /// Sets the transaction `fee` that needs to be paid.
+    ///
     /// The fee is not mandatory and will default to 0 if not provided.
     ///
     /// # Examples
@@ -226,6 +231,7 @@ impl TransactionBuilder {
     }
 
     /// Sets the `sender` address of a transaction.
+    ///
     /// The sender is a *required* field and must always be set.
     ///
     /// # Examples
@@ -246,13 +252,14 @@ impl TransactionBuilder {
     }
 
     /// Sets the `sender_type`, which describes the account type of the sender.
+    ///
     /// This field is optional and will default to `AccountType::Basic`.
     ///
     /// Since the sender type determines the type of proof required for the transaction,
     /// it is essential to set it to the correct type.
     ///
     /// The proof builder can be determined as follows:
-    /// 1. If the transaction is a [`signalling transaction`], it will be a [`SignallingProofBuilder`].
+    /// 1. If the transaction is a `signalling transaction`, it will be a [`StakingProofBuilder`].
     /// 2. Otherwise, the following mapping holds depending on `sender_type`:
     ///     - `AccountType::Basic`: [`BasicProofBuilder`]
     ///     - `AccountType::Vesting`: [`BasicProofBuilder`]
@@ -289,17 +296,16 @@ impl TransactionBuilder {
     /// let htlc_proof_builder = proof_builder.unwrap_htlc();
     /// ```
     ///
-    /// [`signalling transaction`]: struct.TransactionBuilder.html#method.with_value
-    /// [`SignallingProofBuilder`]: proof/staking_contract/struct.SignallingProofBuilder.html
-    /// [`BasicProofBuilder`]: proof/struct.BasicProofBuilder.html
-    /// [`HtlcProofBuilder`]: proof/htlc_contract/struct.HtlcProofBuilder.html
-    /// [`StakingProofBuilder`]: proof/staking_contract/struct.StakingRecipientBuilder.html
+    /// [`BasicProofBuilder`]: proof::BasicProofBuilder
+    /// [`HtlcProofBuilder`]: proof::htlc_contract::HtlcProofBuilder
+    /// [`StakingProofBuilder`]: proof::staking_contract::StakingProofBuilder
     pub fn with_sender_type(&mut self, sender_type: AccountType) -> &mut Self {
         self.sender_type = Some(sender_type);
         self
     }
 
     /// Sets the transaction's `recipient`.
+    ///
     /// [`Recipient`]'s can be easily created using builder methods that will automatically
     /// populate the transaction's data field depending on the chosen type of recipient.
     /// The recipient is a *required* field.
@@ -340,6 +346,7 @@ impl TransactionBuilder {
     }
 
     /// Sets the `network_id` for the transaction.
+    ///
     /// The network id is a *required* field and must always be set.
     /// It restricts the validity of the transaction to a network and prevents replay attacks.
     ///
@@ -358,6 +365,7 @@ impl TransactionBuilder {
     }
 
     /// Sets the `validity_start_height` for the transaction.
+    ///
     /// The validity start height is a *required* field and must always be set.
     /// It restricts the validity of the transaction to a blockchain height
     /// and prevents replay attacks.
@@ -379,6 +387,7 @@ impl TransactionBuilder {
 
     /// This method tries putting together the preliminary transaction
     /// in order to move to the proof building phase by returning a [`TransactionProofBuilder`].
+    ///
     /// In case of a failure, it returns a [`TransactionBuilderError`].
     ///
     /// # Examples

--- a/transaction-builder/src/proof/staking_contract.rs
+++ b/transaction-builder/src/proof/staking_contract.rs
@@ -8,10 +8,11 @@ use nimiq_transaction::{SignatureProof, Transaction};
 use crate::proof::TransactionProofBuilder;
 
 /// The `StakingDataBuilder` can be used to build the data for incoming staking transactions.
+///
 /// Such transactions still require a normal proof builder to be used in addition.
 ///
-/// Thus, the [`generate`] method of this proof builder will return another proof builder
-/// instead of the final transaction.
+/// Thus, the [`generate`](StakingDataBuilder::generate) method of this proof builder will return
+/// another proof builder instead of the final transaction.
 #[derive(Clone, Debug)]
 pub struct StakingDataBuilder {
     pub transaction: Transaction,

--- a/utils/src/tagged_signing.rs
+++ b/utils/src/tagged_signing.rs
@@ -21,9 +21,9 @@ use beserial::{Deserialize, Serialize};
 ///
 /// Please document the tags used here to avoid collisions:
 ///
-///  - `0x01`: [`ChallengeNonce`](nimiq_network_libp2p::discovery::protocol::ChallengeNonce)
-///  - `0x02`: [`PeerContact`](nimiq_network_libp2p::discovery::peer_contacts::PeerContact)
-///  - `0x03`: [`ValidatorRecord`]
+///  - `0x01`: [`ChallengeNonce`](../../nimiq_network_libp2p/discovery/protocol/struct.ChallengeNonce.html)
+///  - `0x02`: [`PeerContact`](../../nimiq_network_libp2p/discovery/peer_contacts/struct.PeerContact.html)
+///  - `0x03`: [`ValidatorRecord`](../../nimiq_validator_network/validator_record/struct.ValidatorRecord.html)
 ///
 pub trait TaggedSignable: Serialize {
     const TAG: u8;

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -60,7 +60,9 @@ impl std::fmt::Debug for VrfEntropy {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A struct containing a VRF Seed. It is simply the serialized output of the VXEdDSA algorithm.
-/// https://www.signal.org/docs/specifications/xeddsa/#vxeddsa
+///
+/// <https://www.signal.org/docs/specifications/xeddsa/#vxeddsa>
+///
 /// Note that this signature is NOT unique for a given message and public key. In fact, if a signer
 /// produces two VRF seeds for the same message they will be different (with overwhelmingly high
 /// probability). This is because the signing algorithm uses a random input, similar to a Schnorr


### PR DESCRIPTION
Fix `clippy::unnecessary_mut_passed` and ignore the false-positive `clippy::redundant_async_block`. Fix broken links in documentation.