### PR TITLE
network-libp2p: Deterministically close duplicated connections

### DIFF
--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -164,6 +164,7 @@ impl NimiqBehaviour {
         // Connection pool behaviour
         let pool = ConnectionPoolBehaviour::new(
             Arc::clone(&contacts),
+            peer_id,
             config.seeds,
             config.discovery.required_services,
         );

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -213,13 +213,15 @@ impl NetworkBehaviour for DiscoveryBehaviour {
                     });
                 // Peer failed to connect with some of our own addresses, remove them from our own addresses
                 if let Some(failed_addresses) = failed_addresses {
-                    debug!(
-                        ?failed_addresses,
-                        "Removing failed address from own addresses"
-                    );
-                    self.peer_contact_book
-                        .write()
-                        .remove_own_addresses(failed_addresses.clone(), &self.keypair)
+                    if !failed_addresses.is_empty() {
+                        debug!(
+                            ?failed_addresses,
+                            "Removing failed address from own addresses"
+                        );
+                        self.peer_contact_book
+                            .write()
+                            .remove_own_addresses(failed_addresses.clone(), &self.keypair)
+                    }
                 }
             }
         } else {

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -12,6 +12,7 @@ use futures::{ready, stream::BoxStream, Stream, StreamExt};
 use instant::Instant;
 use libp2p::core::transport::MemoryTransport;
 use libp2p::gossipsub::PeerScoreParams;
+use libp2p::swarm::dial_opts::PeerCondition;
 use libp2p::{
     core,
     core::{muxing::StreamMuxerBox, transport::Boxed},
@@ -1054,7 +1055,13 @@ impl Network {
             NetworkAction::Dial { peer_id, output } => {
                 if output
                     .send(
-                        Swarm::dial(swarm, DialOpts::peer_id(peer_id).build()).map_err(Into::into),
+                        Swarm::dial(
+                            swarm,
+                            DialOpts::peer_id(peer_id)
+                                .condition(PeerCondition::Disconnected)
+                                .build(),
+                        )
+                        .map_err(Into::into),
                     )
                     .is_err()
                 {

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -9,7 +9,10 @@ use libp2p::{
     },
     identity::Keypair,
     noise::{self, NoiseConfig},
-    swarm::{dial_opts::DialOpts, KeepAlive, Swarm, SwarmEvent},
+    swarm::{
+        dial_opts::{DialOpts, PeerCondition},
+        KeepAlive, Swarm, SwarmEvent,
+    },
     yamux::YamuxConfig,
     PeerId, Transport,
 };
@@ -100,7 +103,13 @@ impl TestNode {
     }
 
     pub fn dial_peer_id(&mut self, peer_id: &PeerId) {
-        Swarm::dial(&mut self.swarm, DialOpts::peer_id(*peer_id).build()).unwrap();
+        Swarm::dial(
+            &mut self.swarm,
+            DialOpts::peer_id(*peer_id)
+                .condition(PeerCondition::Disconnected)
+                .build(),
+        )
+        .unwrap();
     }
 }
 


### PR DESCRIPTION
Change the connection pool behaviour to deterministically choose what connections must be closed when there are multiple to the same peer. The behaviour will close the connection if there are any previous connection and if the peer ID value is less or equal than the local (own) peer ID.

This fixes #1412.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
