### PR TITLE
Fix log lines with inconsistent time stamp length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ name = "nimiq-log"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
+ "time",
  "tracing",
  "tracing-log",
  "tracing-subscriber 0.3.16",

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 ansi_term = "0.12"
 log = { package = "tracing", version = "0.1", features = ["log"] }
+time = { version = "0.3", features = ["formatting"] }
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["time"] }

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -1,6 +1,7 @@
 use ansi_term::{Color, Style};
 use log::{level_filters::LevelFilter, Event, Level, Subscriber};
 use std::{env, fmt};
+use time::format_description::well_known::Iso8601;
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::fmt::format::Writer;
@@ -230,7 +231,7 @@ pub struct MaybeSystemTime(pub bool);
 impl FormatTime for MaybeSystemTime {
     fn format_time(&self, w: &mut Writer) -> fmt::Result {
         if self.0 {
-            UtcTime::rfc_3339().format_time(w)
+            UtcTime::new(Iso8601::DEFAULT).format_time(w)
         } else {
             ().format_time(w)
         }


### PR DESCRIPTION
```
2023-03-11T22:36:37.103000064Z INFO  client               | PeerId: 12D3KooWSdcyvNDekA7KiGisbw77SkCj58m5JxVoF3iKAhcMybqP
2023-03-11T22:36:37.104Z INFO  client               | Client configured as a light node
2023-03-11T22:36:37.104Z DEBUG client               | listen_addresses = []
2023-03-11T22:36:37.107000064Z DEBUG peer_contacts        | Adding peer contact peer_id=12D3KooWSdcyvNDekA7KiGisbw77SkCj58m5JxVoF3iKAhcMybqP addresses=[]
```

```
2023-03-11T22:36:37.103000064Z INFO  client               | PeerId: 12D3KooWSdcyvNDekA7KiGisbw77SkCj58m5JxVoF3iKAhcMybqP
2023-03-11T22:36:37.104000000Z INFO  client               | Client configured as a light node
2023-03-11T22:36:37.104000000Z DEBUG client               | listen_addresses = []
2023-03-11T22:36:37.107000064Z DEBUG peer_contacts        | Adding peer contact peer_id=12D3KooWSdcyvNDekA7KiGisbw77SkCj58m5JxVoF3iKAhcMybqP addresses=[]
```

See also https://github.com/tokio-rs/tracing/issues/1729.