### PR TITLE
Return PlainTransactionDetails from tx sending methods

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -57,37 +57,22 @@ impl<N: Network> ConsensusProxy<N> {
         BroadcastStream::new(self.events.subscribe())
     }
 
-    pub async fn request_transactions_by_address(
+    pub async fn request_transaction_receipts_by_address(
         &self,
         address: Address,
-        since_block_height: u32,
-        ignored_hashes: Vec<Blake2bHash>,
         min_peers: usize,
         max: Option<u16>,
-    ) -> Result<Vec<ExtendedTransaction>, RequestError> {
-        // First we tell the network to provide us with a vector that contains all the connected peers that support such services
-        // Note: If the network could not provide enough peers that satisfies our requirement, then an error would be returned
-        let peers = self
-            .network
-            .get_peers_by_services(Services::TRANSACTION_INDEX, min_peers)
-            .await
-            .map_err(|error| {
-                log::error!(
-                    err = %error,
-                    "The transactions by address request couldn't be fulfilled"
-                );
+    ) -> Result<Vec<(Blake2bHash, u32)>, RequestError> {
+        let mut optained_receipts = HashSet::new();
 
-                RequestError::OutboundRequest(OutboundRequestError::SendError)
-            })?;
-
-        let mut verified_transactions = HashMap::new();
-
-        // At this point we obtained a list of connected peers that could satisfy our request,
-        // so we perform the request to each of those peers:
-        for peer_id in peers {
+        // We obtain a list of connected peers that could satisfy our request and perform the request to each one:
+        for peer_id in self
+            .get_peers_for_service(Services::TRANSACTION_INDEX, min_peers)
+            .await?
+        {
             log::debug!(
                 peer_id = %peer_id,
-                "Performing txns by address request to peer",
+                "Performing txn receipts by address request to peer",
             );
             let response = self
                 .network
@@ -106,130 +91,201 @@ impl<N: Network> ConsensusProxy<N> {
                         "Obtained txn receipts response, length {} ",
                         response.receipts.len()
                     );
-
-                    let blockchain = self.blockchain.read();
-
-                    // Group transaction hashes by the block number that proves those transactions to reduce the number of requests
-                    // There are three categories of block numbers:
-                    //  - Finalized epochs: we use the election block number that finalized the respective epoch
-                    //  - Finalized batch in the current epoch: We use the latest checkpoint block number
-                    //  - Current batch: We use the current head to prove those transactions
-
-                    // This is the structure where we group transactions by their proving block number
-                    let mut hashes_by_block = HashMap::new();
-                    let election_head_number = blockchain.election_head().block_number();
-                    let checkpoint_head_number = blockchain.macro_head().block_number();
-                    let current_head_number = blockchain.head().block_number();
-
-                    for (hash, block_number) in response.receipts {
-                        if block_number < since_block_height {
-                            continue;
-                        }
-
-                        if ignored_hashes.contains(&hash) {
-                            continue;
-                        }
-
-                        // If the transaction was already verified, then we don't need to verify it again
-                        if verified_transactions.contains_key(&hash) {
-                            continue;
-                        }
-
-                        if block_number <= election_head_number {
-                            // First Case: Transactions from finalized epochs
-                            hashes_by_block
-                                .entry(Policy::election_block_after(block_number))
-                                .or_insert(vec![])
-                                .push(hash);
-                        } else if block_number <= checkpoint_head_number {
-                            // Second Case: Transactions from a finalized batch in the current epoch
-                            hashes_by_block
-                                .entry(checkpoint_head_number)
-                                .or_insert(vec![])
-                                .push(hash);
-                        } else {
-                            // Third Case: Transanctions from the current batch
-                            hashes_by_block
-                                .entry(current_head_number)
-                                .or_insert(vec![])
-                                .push(hash);
-                        }
-                    }
-
-                    // We drop the blockchain lock because it's no longer needed while we request proofs
-                    drop(blockchain);
-
-                    // Now we request proofs for each block and its hashes, according to its classification
-                    for (block_number, hashes) in hashes_by_block {
-                        log::debug!(
-                            block_number=%block_number,
-                            "Performing txn proof requests for block number",
-                        );
-                        let response = self
-                            .network
-                            .request::<RequestTransactionsProof>(
-                                RequestTransactionsProof {
-                                    hashes,
-                                    block_number,
-                                },
-                                peer_id,
-                            )
-                            .await;
-                        match response {
-                            Ok(proof_response) => {
-                                // We verify the transaction using the proof
-                                if let Some(proof) = proof_response.proof {
-                                    if let Some(block) = proof_response.block {
-                                        log::debug!(peer=%peer_id,"New txns proof and block from peer");
-
-                                        // TODO: We are currently assuming that the provided block was included in the chain
-                                        // but we also need some additional information to prove the block is part of the chain.
-                                        let verification_result = proof
-                                            .verify(block.history_root().clone())
-                                            .map_or(false, |result| result);
-
-                                        if verification_result {
-                                            for tx in proof.history {
-                                                verified_transactions.insert(tx.tx_hash(), tx);
-                                            }
-                                        } else {
-                                            // The proof didn't verify so we disconnect from this peer
-                                            log::debug!(peer=%peer_id,"Disconnecting from peer because the transaction proof didn't verify");
-                                            self.network
-                                                .disconnect_peer(peer_id, CloseReason::Other)
-                                                .await;
-                                            break;
-                                        }
-                                    } else {
-                                        // If we receive a proof but we do not recieve a block, we disconnect from the peer
-                                        log::debug!(peer=%peer_id,"Disconnecting from peer due to an inconsistency in the transaction proof response");
-                                        self.network
-                                            .disconnect_peer(peer_id, CloseReason::Other)
-                                            .await;
-                                        break;
-                                    }
-                                } else {
-                                    log::debug!(peer=%peer_id, "We requested a transaction proof but the peer didn't provide any");
-                                }
-                            }
-                            Err(error) => {
-                                // If there was a request error with this peer we don't request anymore proofs from it
-                                log::error!(peer=%peer_id, err=%error,"There was an error requesting transactions proof from peer");
-                                break;
-                            }
-                        }
-                    }
+                    optained_receipts.extend(response.receipts);
                 }
                 Err(error) => {
                     // If there was a request error with this peer we log an error
-                    log::error!(peer=%peer_id, err=%error,"There was an error requesting transactions from peer");
+                    log::error!(peer=%peer_id, err=%error,"There was an error requesting transaction receipts from peer");
+                }
+            }
+        }
+
+        let mut receipts: Vec<_> = optained_receipts.into_iter().collect();
+        receipts.sort_unstable_by_key(|receipt| receipt.1);
+        receipts.reverse(); // Return newest receipts (highest block_number) first
+
+        Ok(receipts)
+    }
+
+    pub async fn request_transactions_by_address(
+        &self,
+        address: Address,
+        since_block_height: u32,
+        ignored_hashes: Vec<Blake2bHash>,
+        min_peers: usize,
+        max: Option<u16>,
+    ) -> Result<Vec<ExtendedTransaction>, RequestError> {
+        let receipts = self
+            .request_transaction_receipts_by_address(address, min_peers, max)
+            .await?
+            .into_iter()
+            .filter(|(hash, block_number)| {
+                block_number > &since_block_height && !ignored_hashes.contains(hash)
+            })
+            .collect();
+
+        self.prove_transactions_from_receipts(receipts, min_peers)
+            .await
+    }
+
+    pub async fn request_transaction_by_hash_and_block_number(
+        &self,
+        tx_hash: Blake2bHash,
+        block_number: u32,
+        min_peers: usize,
+    ) -> Result<ExtendedTransaction, RequestError> {
+        let receipts = vec![(tx_hash, block_number)];
+        let mut txs = self
+            .prove_transactions_from_receipts(receipts, min_peers)
+            .await?;
+        match txs.pop() {
+            Some(tx) => Ok(tx),
+            None => Err(RequestError::OutboundRequest(
+                OutboundRequestError::NoReceiver,
+            )),
+        }
+    }
+
+    async fn get_peers_for_service(
+        &self,
+        services: Services,
+        min_peers: usize,
+    ) -> Result<Vec<<N as Network>::PeerId>, RequestError> {
+        // First we tell the network to provide us with a vector that contains all the connected peers that support such services
+        // Note: If the network could not provide enough peers that satisfies our requirement, then an error would be returned
+        self.network
+            .get_peers_by_services(services, min_peers)
+            .await
+            .map_err(|error| {
+                log::error!(
+                    err = %error,
+                    "The request couldn't be fulfilled"
+                );
+
+                RequestError::OutboundRequest(OutboundRequestError::SendError)
+            })
+    }
+
+    async fn prove_transactions_from_receipts(
+        &self,
+        receipts: Vec<(Blake2bHash, u32)>,
+        min_peers: usize,
+    ) -> Result<Vec<ExtendedTransaction>, RequestError> {
+        // Group transaction hashes by the block number that proves those transactions to reduce the number of requests
+        // There are three categories of block numbers:
+        //  - Finalized epochs: we use the election block number that finalized the respective epoch
+        //  - Finalized batch in the current epoch: We use the latest checkpoint block number
+        //  - Current batch: We use the current head to prove those transactions
+
+        let blockchain = self.blockchain.read();
+        let election_head_number = blockchain.election_head().block_number();
+        let checkpoint_head_number = blockchain.macro_head().block_number();
+        let current_head_number = blockchain.head().block_number();
+
+        // We drop the blockchain lock because it's no longer needed while we request proofs
+        drop(blockchain);
+
+        let mut verified_transactions = HashMap::new();
+
+        // We obtain a list of connected peers that could satisfy our request and perform the request to each one:
+        for peer_id in self
+            .get_peers_for_service(Services::TRANSACTION_INDEX, min_peers)
+            .await?
+        {
+            // This is the structure where we group transactions by their proving block number
+            let mut hashes_by_block = HashMap::new();
+
+            for (hash, block_number) in &receipts {
+                // If the transaction was already verified, then we don't need to verify it again
+                if verified_transactions.contains_key(hash) {
+                    continue;
+                }
+
+                if block_number <= &election_head_number {
+                    // First Case: Transactions from finalized epochs
+                    hashes_by_block
+                        .entry(Policy::election_block_after(*block_number))
+                        .or_insert(vec![])
+                        .push(hash.clone());
+                } else if block_number <= &checkpoint_head_number {
+                    // Second Case: Transactions from a finalized batch in the current epoch
+                    hashes_by_block
+                        .entry(checkpoint_head_number)
+                        .or_insert(vec![])
+                        .push(hash.clone());
+                } else {
+                    // Third Case: Transanctions from the current batch
+                    hashes_by_block
+                        .entry(current_head_number)
+                        .or_insert(vec![])
+                        .push(hash.clone());
+                }
+            }
+
+            // Now we request proofs for each block and its hashes, according to its classification
+            for (block_number, hashes) in hashes_by_block {
+                log::debug!(
+                    block_number=%block_number,
+                    "Performing txn proof request for block number",
+                );
+                let response = self
+                    .network
+                    .request::<RequestTransactionsProof>(
+                        RequestTransactionsProof {
+                            hashes,
+                            block_number,
+                        },
+                        peer_id,
+                    )
+                    .await;
+                match response {
+                    Ok(proof_response) => {
+                        // We verify the transaction using the proof
+                        if let Some(proof) = proof_response.proof {
+                            if let Some(block) = proof_response.block {
+                                log::debug!(peer=%peer_id,"New txns proof and block from peer");
+
+                                // TODO: We are currently assuming that the provided block was included in the chain
+                                // but we also need some additional information to prove the block is part of the chain.
+                                let verification_result = proof
+                                    .verify(block.history_root().clone())
+                                    .map_or(false, |result| result);
+
+                                if verification_result {
+                                    for tx in proof.history {
+                                        verified_transactions.insert(tx.tx_hash(), tx);
+                                    }
+                                } else {
+                                    // The proof didn't verify so we disconnect from this peer
+                                    log::debug!(peer=%peer_id,"Disconnecting from peer because the transaction proof didn't verify");
+                                    self.network
+                                        .disconnect_peer(peer_id, CloseReason::Other)
+                                        .await;
+                                    break;
+                                }
+                            } else {
+                                // If we receive a proof but we do not recieve a block, we disconnect from the peer
+                                log::debug!(peer=%peer_id,"Disconnecting from peer due to an inconsistency in the transaction proof response");
+                                self.network
+                                    .disconnect_peer(peer_id, CloseReason::Other)
+                                    .await;
+                                break;
+                            }
+                        } else {
+                            log::debug!(peer=%peer_id, "We requested a transaction proof but the peer didn't provide any");
+                        }
+                    }
+                    Err(error) => {
+                        // If there was a request error with this peer we don't request anymore proofs from it
+                        log::error!(peer=%peer_id, err=%error,"There was an error requesting transaction proof from peer");
+                        break;
+                    }
                 }
             }
         }
 
         // Sort transactions by block_number
-        let mut transactions: Vec<ExtendedTransaction> =
-            verified_transactions.into_values().collect();
+        let mut transactions: Vec<_> = verified_transactions.into_values().collect();
         transactions.sort_unstable_by_key(|ext_tx| ext_tx.block_number);
         transactions.reverse(); // Return newest transaction (highest block_number) first
 

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -456,7 +456,7 @@ impl Handle<ResponseTransactionReceiptsByAddress, Arc<RwLock<Blockchain>>>
         // Get the transaction hashes for this address.
         let tx_hashes = blockchain.history_store.get_tx_hashes_by_address(
             &self.address,
-            self.max.unwrap_or(500),
+            self.max.unwrap_or(500).min(500),
             None,
         );
 

--- a/web-client/module.js
+++ b/web-client/module.js
@@ -81,8 +81,7 @@ init().then(async () => {
             ).sign(keyPair);
         }
 
-        await client.sendTransaction(transaction);
-        return transaction.hash();
+        return client.sendTransaction(transaction);
     }
 
     /**
@@ -108,8 +107,7 @@ init().then(async () => {
             BigInt(fee),
         ).sign(keyPair);
 
-        await client.sendTransaction(transaction);
-        return transaction.hash();
+        return client.sendTransaction(transaction);
     }
 
     /**
@@ -133,8 +131,7 @@ init().then(async () => {
             BigInt(fee),
         ).sign(keyPair);
 
-        await client.sendTransaction(transaction);
-        return transaction.hash();
+        return client.sendTransaction(transaction);
     }
 
     /**
@@ -158,8 +155,7 @@ init().then(async () => {
             BigInt(fee),
         ).sign(keyPair);
 
-        await client.sendTransaction(transaction);
-        return transaction.hash();
+        return client.sendTransaction(transaction);
     }
 });
 

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -592,6 +592,26 @@ impl PlainTransactionDetails {
     }
 }
 
+/// JSON-compatible and human-readable format of transaction receipts.
+#[derive(serde::Serialize, serde::Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PlainTransactionReceipt {
+    /// The transaction's unique hash, used as its identifier. Sometimes also called `txId`.
+    pub transaction_hash: String,
+    /// The transaction's block height where it is included in the blockchain.
+    pub block_height: u32,
+}
+
+impl PlainTransactionReceipt {
+    /// Creates a PlainTransactionReceipt struct that can be serialized to JS.
+    pub fn from_receipt(receipt: &(Blake2bHash, u32)) -> Self {
+        Self {
+            transaction_hash: receipt.0.to_hex(),
+            block_height: receipt.1,
+        }
+    }
+}
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(typescript_type = "PlainTransaction")]
@@ -602,4 +622,10 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "PlainTransactionDetails[]")]
     pub type PlainTransactionDetailsArrayType;
+
+    #[wasm_bindgen(typescript_type = "PlainTransactionReceipt")]
+    pub type PlainTransactionReceiptType;
+
+    #[wasm_bindgen(typescript_type = "PlainTransactionReceipt[]")]
+    pub type PlainTransactionReceiptArrayType;
 }


### PR DESCRIPTION
Just like the 1.0 client, the Albatross WASM client should return `PlainTransactionDetails` from its transaction-sending methods. Since we do not have any way to listen to transaction-inclusion events currently, this PR implements a receipt-polling method. It works, but is obviously inefficient. It will be reworked once transaction-inclusion events can be subscribed to.

To facilitate the receipt-polling and single-transaction proving most efficiently, I restructured the big `request_transactions_by_address` method in consensus_proxy into smaller, reusable chunks.

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
