### PR TITLE
Add address filter to get_transactions_by_address

### DIFF
--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -91,6 +91,14 @@ pub enum BlockchainCommand {
         /// The address to query by.
         address: Address,
 
+        /// Filter transactions by recipient addresses. Empty list means no filter.
+        /// If both `from` and `to` are empty, all transactions are returned.
+        from: Vec<Address>,
+
+        /// Filter transactions by sender addresses. Empty list means no filter.
+        /// If both `from` and `to` are empty, all transactions are returned.
+        to: Vec<Address>,
+
         /// Max number of transactions to fetch. If absent it defaults to 500.
         #[clap(long)]
         max: Option<u16>,
@@ -267,6 +275,8 @@ impl HandleSubcommand for BlockchainCommand {
 
             BlockchainCommand::TransactionsByAddress {
                 address,
+                from,
+                to,
                 max,
                 just_hash,
             } => {
@@ -283,7 +293,7 @@ impl HandleSubcommand for BlockchainCommand {
                         "{:#?}",
                         client
                             .blockchain
-                            .get_transactions_by_address(address, max)
+                            .get_transactions_by_address(address, from, to, max)
                             .await?
                     )
                 }

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -78,6 +78,8 @@ pub trait BlockchainInterface {
     async fn get_transactions_by_address(
         &mut self,
         address: Address,
+        from: Vec<Address>,
+        to: Vec<Address>,
         max: Option<u16>,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 


### PR DESCRIPTION
## What's in this pull request?

This pull request adds the ability to filter transactions by sender and recipient addresses in the `get_transactions_by_address` function of the Nimiq RPC interface. The new functionality allows users to retrieve only transactions that involve specific addresses, which is useful for filtering out irrelevant transactions when performing analysis or debugging.

More parameters could be added in the future such as `block_ranges` (`start_block` and `to_block`).

The current implementation is not the most efficient as it fetches the transaction from `blockchain.history_store.get_ext_tx_by_hash` and then filter them out. Improving the current solution requires a database update.

#### This fixes #___.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
