### PR TITLE
network-libp2p: Add test for banning a peer

### DIFF
--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -592,6 +592,9 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
         if self.addresses.is_banned(address.clone()) {
             debug!(%address, "Address is banned");
             close_reason = Some(ConnectionPoolHandlerError::BannedIp);
+        } else if self.peer_ids.is_banned(*peer_id) {
+            debug!(%peer_id, "Peer is banned");
+            close_reason = Some(ConnectionPoolHandlerError::BannedPeer);
         }
 
         // Get IP from multiaddress if it exists.

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -20,13 +20,17 @@ pub struct ConnectionPoolHandler {
 /// Connection Pool errors
 #[derive(Clone, Debug, Error)]
 pub enum ConnectionPoolHandlerError {
+    /// There is already a connection for this Peer
+    #[error("Peer is already connected")]
+    AlreadyConnected,
+
     /// Ip is banned
     #[error("IP is banned")]
     BannedIp,
 
-    /// There is already a connection for this Peer
-    #[error("Peer is already connected")]
-    AlreadyConnected,
+    /// Peer is banned
+    #[error("Peer is banned")]
+    BannedPeer,
 
     /// Maximum connections per IPv4 subnet has been reached
     #[error("Maximum connections per IPV4 subnet has been reached")]


### PR DESCRIPTION
Add test for banning a peer and fix the banned peer detection by also checking if the peer ID is banned.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
