### PR TITLE
Adapt arguments of getTransactionsByAddress to be 1.0-compatible

### DIFF
--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -458,11 +458,11 @@ pub enum TransactionState {
 /// JSON-compatible and human-readable format of transactions, including details about its state in the
 /// blockchain. Contains all fields from {@link PlainTransaction}, plus additional fields such as
 /// `blockHeight` and `timestamp` if the transaction is included in the blockchain.
-#[derive(Tsify)]
+#[derive(serde::Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 pub struct PlainTransactionDetails {
     #[serde(flatten)]
-    transaction: PlainTransaction,
+    pub transaction: PlainTransaction,
 
     pub state: TransactionState,
     #[tsify(optional)]


### PR DESCRIPTION
## What's in this pull request?

These new arguments follow the same order, type, and name as the 1.0 client method arguments.

Additionally, they are also a nice feature to have to be able to filter by block height and known transactions, reducing the number of proofs requested from the network.

This PR has conflicts with #1425, so when either is merged, the other will need to be rebased and merge-conflicts solved.

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
