### PR TITLE
ci: Improve devnet messages and process killing

### DIFF
--- a/scripts/devnet/node.py
+++ b/scripts/devnet/node.py
@@ -189,11 +189,16 @@ class Node:
         :type will_be_restarted: bool
         """
         if self.process is not None:
+            # Try to kill the process with SIGINT
             self.process.send_signal(signal.SIGINT)
             time.sleep(1)
+            # If the process is still alive, send SIGKILL
+            if self.process is not None:
+                self.process.send_signal(signal.SIGKILL)
+                time.sleep(1)
             if will_be_restarted:
-                log_str = "\n\n################################## RESTART ####"
-                "#######################\n\n"
+                log_str = ("\n\n################################## RESTART ###"
+                           "########################\n\n")
                 with open(self.get_log(), 'a') as log_file:
                     log_file.write(log_str)
                 self.process = None
@@ -262,8 +267,8 @@ class Node:
         log_file = open(self.get_log(), 'a+')
         subprocess.run(["rm", "-r", self.get_db()],
                        check=True, capture_output=True)
-        log_str = "\n\n################################## NODE DB DELETED ###"
-        "########################\n\n"
+        log_str = ("\n\n################################## NODE DB DELETED ###"
+                   "########################\n\n")
         log_file.write(log_str)
         log_file.close()
 
@@ -278,8 +283,8 @@ class Node:
         # Also the command needs to be a string
         subprocess.run(f"rm -r {self.get_state_dir()}/*",
                        shell=True, check=True, capture_output=True)
-        log_str = "\n\n################################ NODE STATE DELETED ##"
-        "###########################\n\n"
+        log_str = ("\n\n################################ NODE STATE DELETED ##"
+                   "###########################\n\n")
         log_file.write(log_str)
         log_file.close()
 


### PR DESCRIPTION
- Improve how messages are print in the devnet when a node is killed or its DB erased or its state is deleted.
- Improve the process of killing a node by checking if it's still alive after receiving `SIGINT` and if so, send `SIGKILL`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
