### PR TITLE
Limit Tendermint proof verification to available CPU parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,6 +4497,7 @@ dependencies = [
  "nimiq-vrf",
  "parking_lot 0.12.1",
  "rand 0.8.5",
+ "rayon",
  "tokio",
  "tokio-metrics",
  "tokio-stream",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -20,6 +20,7 @@ linked-hash-map = "0.5.6"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 rand = "0.8"
+rayon = "1.7"
 tokio = { version = "1.26", features = ["rt", "time", "tracing"] }
 tokio-metrics = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }


### PR DESCRIPTION
The `tokio::spawn_blocking` docs suggest to use `rayon` to do that, we also get aborts on the first failed verification for free.