### PR TITLE
Fix compilation error and comment

### DIFF
--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -199,7 +199,6 @@ pub fn initialize_logging(
     }
     #[cfg(not(feature = "loki"))]
     tracing_subscriber::registry()
-        .with(rotating_layer)
         .with(tokio_console_layer)
         .with(
             tracing_subscriber::fmt::layer()

--- a/rpc-server/src/dispatchers/zkp_component.rs
+++ b/rpc-server/src/dispatchers/zkp_component.rs
@@ -23,7 +23,7 @@ impl ZKPComponentDispatcher {
 impl ZKPComponentInterface for ZKPComponentDispatcher {
     type Error = Error;
 
-    /// Returns the peer ID for our local peer.
+    /// Returns the current ZKP state (proof with its related block hash and block number).
     async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error> {
         Ok(ZKPState::with_zkp_state(&self.zkp_component.get_zkp_state()).into())
     }


### PR DESCRIPTION
- Fix compilation error in the `lib` crate when enabling the `loki` feature.
- Fix copy/pasted comment on the `get_zkp_state` RPC function implementation.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
