### PR TITLE
Rename `include_transactions` to `include_body` in RPC server, interface and client

### DIFF
--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -39,9 +39,9 @@ pub enum BlockchainCommand {
         #[clap(long)]
         block_number: Option<u32>,
 
-        /// Include transactions
-        #[clap(short = 't', long)]
-        include_transactions: bool,
+        /// Whether to include the block body
+        #[clap(short = 'b', long)]
+        include_body: bool,
     },
 
     /// Query a transaction from the blockchain.
@@ -176,23 +176,20 @@ impl HandleSubcommand for BlockchainCommand {
             BlockchainCommand::Block {
                 block_hash,
                 block_number,
-                include_transactions,
+                include_body,
             } => {
                 let block = if let Some(block_hash) = block_hash {
                     client
                         .blockchain
-                        .get_block_by_hash(block_hash, Some(include_transactions))
+                        .get_block_by_hash(block_hash, Some(include_body))
                         .await
                 } else if let Some(block_number) = block_number {
                     client
                         .blockchain
-                        .get_block_by_number(block_number, Some(include_transactions))
+                        .get_block_by_number(block_number, Some(include_body))
                         .await
                 } else {
-                    client
-                        .blockchain
-                        .get_latest_block(Some(include_transactions))
-                        .await
+                    client.blockchain.get_latest_block(Some(include_body)).await
                 }?;
                 println!("{block:#?}")
             }

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -23,18 +23,18 @@ pub trait BlockchainInterface {
     async fn get_block_by_hash(
         &mut self,
         hash: Blake2bHash,
-        include_transactions: Option<bool>,
+        include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
     async fn get_block_by_number(
         &mut self,
         block_number: u32,
-        include_transactions: Option<bool>,
+        include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
     async fn get_latest_block(
         &mut self,
-        include_transactions: Option<bool>,
+        include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
     async fn get_slot_at(
@@ -115,7 +115,7 @@ pub trait BlockchainInterface {
     #[stream]
     async fn subscribe_for_head_block(
         &mut self,
-        include_transactions: Option<bool>,
+        include_body: Option<bool>,
     ) -> Result<BoxStream<'static, RPCData<Block, ()>>, Self::Error>;
 
     #[stream]

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -172,7 +172,7 @@ impl Block {
     pub fn from_block(
         blockchain: &BlockchainReadProxy,
         block: nimiq_block::Block,
-        include_transactions: bool,
+        include_body: bool,
     ) -> Self {
         let block_number = block.block_number();
         let timestamp = block.timestamp();
@@ -191,7 +191,7 @@ impl Block {
 
                 // Get the reward inherents and convert them to reward transactions.
                 let transactions = if let BlockchainReadProxy::Full(blockchain) = blockchain {
-                    if include_transactions {
+                    if include_body {
                         let ext_txs = blockchain
                             .history_store
                             .get_block_transactions(block_number, None);
@@ -256,7 +256,7 @@ impl Block {
                                 .map(Into::into)
                                 .collect(),
                         ),
-                        if include_transactions {
+                        if include_body {
                             let head_height = blockchain.head().block_number();
                             Some(
                                 body.transactions


### PR DESCRIPTION
## What's in this pull request?

Update `BlockchainDispatcher` to allow for excluding transactions from block responses when requested but keeping the rest of keys untouched.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.

### More details

```js
blockByNumber(/*block_number*/ 0, /*include_transactions */ false)
``` 

Given the following RCP request to `https://seed1.v2.nimiq-testnet.com:8648/?secret={SECRET}` and body as:
```{"jsonrpc":"2.0","method":"getBlockByNumber","params":[0,false],"id":1}```

<details><summary> Previously the response was</summary>

```json
{
    "jsonrpc": "2.0",
    "result": {
        "data": {
            "hash": "1ea0fe2c0b2004c046e8d5f386359de51ded1d2a8c4c8eb49d253305c12e51d5",
            "size": 278,
            "batch": 0,
            "epoch": 0,
            "version": 1,
            "number": 0,
            "timestamp": 1678838400,
            "parentHash": "0000000000000000000000000000000000000000000000000000000000000000",
            "seed": {
                "signature": [ "blah blah blah" ]
            },
            "extraData": "",
            "stateHash": "35106825436098c59fa582f973a5f1497b78f35fd0e0852ff381b2e21957f379",
            "bodyHash": "c9279c5fde51032adc643e825d9efeb5f23aee83ea0d396093300937517d035f",
            "historyHash": "0000000000000000000000000000000000000000000000000000000000000000",
            "type": "macro",
            "isElectionBlock": true,
            "parentElectionHash": "0000000000000000000000000000000000000000000000000000000000000000"
        },
        "metadata": null
    },
    "id": 1
}
```
</details> 

<details><summary> With this PR, the response is </summary>

```json
{
    "jsonrpc": "2.0",
    "result": {
        "data": {
            "hash": "b542d3744e6adef801ad230004366a80279a3814cc8a53598187c3902af498e9",
            "size": 1650,
            "batch": 0,
            "epoch": 0,
            "version": 1,
            "number": 0,
            "timestamp": 1626307200,
            "parentHash": "0000000000000000000000000000000000000000000000000000000000000000",
            "seed": {
                "signature": [ "blah blah blah" ]
            },
            "extraData": "",
            "stateHash": "b52c86b31d61def7e7b5be4109dafcb30a4d924363cbed2b6953eb2427889d1b",
            "bodyHash": "c066df2adf1847645851d9475022619ce69c937d37a21c0148b888d6a3adda30",
            "historyHash": "0000000000000000000000000000000000000000000000000000000000000000",
            "type": "macro",
            "isElectionBlock": true,
            "parentElectionHash": "0000000000000000000000000000000000000000000000000000000000000000",
            "slots": [ "slots distribution" ],
            "lostRewardSet": [],
            "disabledSet": []
        },
        "metadata": null
    },
    "id": 1
}
```
</details> 

## What did it change?

The new response include: `slots`, `lostRewardSet` and `disabledSet`


