### PR TITLE
Accept various argument types for sending a transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,6 +4589,7 @@ dependencies = [
  "tracing",
  "tsify",
  "wasm-bindgen",
+ "wasm-bindgen-derive",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
@@ -7172,6 +7173,19 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7301886930edaa72b7d102655ea395774aa9f0614c1a491393648a5fec34435"
+dependencies = [
+ "js-sys",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -30,6 +30,7 @@ serde-wasm-bindgen = "0.5"
 tsify = { version = "0.4", features= ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+wasm-bindgen-derive = "0.1.1"
 web-sys = { version = "0.3.22", features = ["EventTarget", "Window"]}
 
 beserial = { path = "../beserial", features = ["derive"] }

--- a/web-client/src/utils.rs
+++ b/web-client/src/utils.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::JsError;
 
 use nimiq_primitives::networks::NetworkId;
 
-/// Convert u8 to a NetworkId
+/// Convert a NetworkId to u8
 pub fn from_network_id(network_id: NetworkId) -> u8 {
     match network_id {
         NetworkId::Test => 1,
@@ -17,7 +17,7 @@ pub fn from_network_id(network_id: NetworkId) -> u8 {
     }
 }
 
-/// Convert a NetworkId to u8
+/// Convert u8 to a NetworkId
 pub fn to_network_id(network_id: u8) -> Result<NetworkId, JsError> {
     match network_id {
         1 => Ok(NetworkId::Test),


### PR DESCRIPTION
## What's in this pull request?

Make the `client.sendTransaction` method compatible with the 1.0 client by accepting instances of the `Transaction` class, a plain object following the `PlainTransaction` type, or a hex string of the serialized transaction. 

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
