### PR TITLE
Accept various formats for addresses and transactions in client API

### DIFF
--- a/web-client/src/address.rs
+++ b/web-client/src/address.rs
@@ -1,32 +1,64 @@
+use std::str::FromStr;
+
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_derive::TryFromJsValue;
 
 /// An object representing a Nimiq address.
 /// Offers methods to parse and format addresses from and to strings.
+#[derive(TryFromJsValue)]
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct Address {
     inner: nimiq_keys::Address,
 }
 
 #[wasm_bindgen]
 impl Address {
-    /// Parse an address from a string representation, either user-friendly or hex format.
+    /// Parses an address from an {@link Address} instance or a string representation.
+    ///
+    /// Throws when an address cannot be parsed from the argument.
+    #[wasm_bindgen(js_name = fromAny)]
+    pub fn from_any(addr: &AddressAnyType) -> Result<Address, JsError> {
+        let js_value: &JsValue = addr.unchecked_ref();
+
+        Address::try_from(js_value).or_else(|_| {
+            Address::from_string(&serde_wasm_bindgen::from_value::<String>(
+                js_value.to_owned(),
+            )?)
+        })
+    }
+
+    /// Parses an address from a string representation, either user-friendly or hex format.
     ///
     /// Throws when an address cannot be parsed from the string.
     #[wasm_bindgen(js_name = fromString)]
-    pub fn from_string(string: &str) -> Result<Address, JsError> {
-        match nimiq_keys::Address::from_any_str(string) {
-            Ok(address) => Ok(Address::from_native(address)),
-            Err(err) => Err(JsError::from(err)),
-        }
+    pub fn from_string(str: &str) -> Result<Address, JsError> {
+        Ok(Address::from_native(nimiq_keys::Address::from_str(str)?))
     }
 
-    /// Format the address in user-friendly IBAN format
+    /// Parses an address from its user-friendly string representation.
+    ///
+    /// Throws when an address cannot be parsed from the string.
+    #[wasm_bindgen(js_name = fromUserFriendlyAddress)]
+    pub fn from_user_friendly_address(str: &str) -> Result<Address, JsError> {
+        Ok(Address::from_native(
+            nimiq_keys::Address::from_user_friendly_address(str)?,
+        ))
+    }
+
+    /// Formats the address into a plain string format.
+    #[wasm_bindgen(js_name = toPlain)]
+    pub fn to_plain(&self) -> String {
+        self.to_user_friendly_address()
+    }
+
+    /// Formats the address into user-friendly IBAN format.
     #[wasm_bindgen(js_name = toUserFriendlyAddress)]
     pub fn to_user_friendly_address(&self) -> String {
         self.inner.to_user_friendly_address()
     }
 
-    /// Format the address in hex format
+    /// Formats the address into hex format.
     #[wasm_bindgen(js_name = toHex)]
     pub fn to_hex(&self) -> String {
         self.inner.to_hex()
@@ -45,4 +77,14 @@ impl Address {
     pub fn native(&self) -> nimiq_keys::Address {
         self.inner.clone()
     }
+
+    pub fn take_native(self) -> nimiq_keys::Address {
+        self.inner
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "Address | string")]
+    pub type AddressAnyType;
 }

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -28,7 +28,7 @@ use nimiq_network_interface::{
 };
 use nimiq_primitives::networks::NetworkId;
 
-use crate::address::Address;
+use crate::address::{Address, AddressAnyType};
 use crate::block::{PlainBlock, PlainBlockType};
 use crate::peer_info::PeerInfo;
 use crate::transaction::{
@@ -722,7 +722,7 @@ impl Client {
     #[wasm_bindgen(js_name = getTransactionReceiptsByAddress)]
     pub async fn get_transaction_receipts_by_address(
         &self,
-        address: Address,
+        address: &AddressAnyType,
         limit: Option<u16>,
         min_peers: Option<usize>,
     ) -> Result<PlainTransactionReceiptArrayType, JsError> {
@@ -738,7 +738,7 @@ impl Client {
             .inner
             .consensus_proxy()
             .request_transaction_receipts_by_address(
-                address.native(),
+                Address::from_any(address)?.take_native(),
                 min_peers.unwrap_or(1),
                 limit,
             )
@@ -762,7 +762,7 @@ impl Client {
     #[wasm_bindgen(js_name = getTransactionsByAddress)]
     pub async fn get_transactions_by_address(
         &self,
-        address: Address,
+        address: &AddressAnyType,
         since_block_height: Option<u32>,
         known_transaction_details: Option<PlainTransactionDetailsArrayType>,
         limit: Option<u16>,
@@ -798,7 +798,7 @@ impl Client {
             .inner
             .consensus_proxy()
             .request_transactions_by_address(
-                address.native(),
+                Address::from_any(address)?.take_native(),
                 since_block_height.unwrap_or(0),
                 known_hashes,
                 min_peers.unwrap_or(1),


### PR DESCRIPTION
## What's in this pull request?

Implement `Address.fromAny` and `Transaction.fromAny` methods, mirroring 1.0 client methods, to accept various formats for addresses and transactions in the client API.

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
