### PR TITLE
Change read interface for the staking contract and remove database dependency from account crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,7 +3648,6 @@ dependencies = [
  "bitflags",
  "hex",
  "lazy_static",
- "nimiq-account",
  "nimiq-block",
  "nimiq-bls",
  "nimiq-database",

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -24,7 +24,6 @@ lazy_static = "1.2"
 url = "2.3"
 
 beserial = { path = "../beserial", features = ["derive", "net"] }
-nimiq-account = { path = "../primitives/account", optional = true }
 nimiq-block = { path = "../primitives/block" }
 nimiq-bls = { path = "../bls" }
 nimiq-database = { path = "../database", optional = true }
@@ -47,6 +46,5 @@ nimiq-hash = { path = "../hash" }
 nimiq-keys = { path = "../keys" }
 
 [features]
-accounts = ["nimiq-account"]
-default = ["accounts", "genesis-override"]
-genesis-override = ["accounts", "nimiq-database", "nimiq-genesis-builder"]
+default = ["genesis-override"]
+genesis-override = ["nimiq-database", "nimiq-genesis-builder"]

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -5,9 +5,9 @@ use std::path::Path;
 
 use lazy_static::lazy_static;
 
+use beserial::Deserialize;
 #[cfg(feature = "genesis-override")]
-use beserial::Serialize;
-use beserial::{Deserialize, SerializeWithLength};
+use beserial::{Serialize, SerializeWithLength};
 use nimiq_block::Block;
 #[cfg(feature = "genesis-override")]
 use nimiq_database::volatile::VolatileEnvironment;
@@ -15,7 +15,6 @@ use nimiq_database::volatile::VolatileEnvironment;
 use nimiq_genesis_builder::{GenesisBuilder, GenesisBuilderError, GenesisInfo};
 use nimiq_hash::Blake2bHash;
 pub use nimiq_primitives::networks::NetworkId;
-#[cfg(feature = "accounts")]
 use nimiq_primitives::trie::TrieItem;
 
 #[derive(Clone, Debug)]
@@ -54,7 +53,6 @@ impl NetworkInfo {
         &self.genesis.hash
     }
 
-    #[cfg(feature = "accounts")]
     #[inline]
     pub fn genesis_accounts(&self) -> Vec<TrieItem> {
         use beserial::DeserializeWithLength;
@@ -81,7 +79,6 @@ fn read_genesis_config(config: &Path) -> Result<GenesisData, GenesisBuilderError
     } = GenesisBuilder::from_config_file(config)?.generate(env)?;
 
     let block = block.serialize_to_vec();
-    #[cfg(feature = "accounts")]
     let accounts = accounts.serialize_to_vec::<u32>();
 
     Ok(GenesisData {

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -17,7 +17,9 @@ use nimiq_consensus::{
     sync::syncer_proxy::SyncerProxy, Consensus as AbstractConsensus,
     ConsensusProxy as AbstractConsensusProxy,
 };
-use nimiq_genesis::{NetworkId, NetworkInfo};
+#[cfg(feature = "zkp-prover")]
+use nimiq_genesis::NetworkId;
+use nimiq_genesis::NetworkInfo;
 use nimiq_light_blockchain::LightBlockchain;
 #[cfg(feature = "validator")]
 use nimiq_mempool::mempool::Mempool;

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -27,6 +27,8 @@ use nimiq_utils::file_store::FileStore;
 use nimiq_utils::key_rng::SecureGenerate;
 use nimiq_zkp_circuits::DEFAULT_KEYS_PATH;
 
+#[cfg(feature = "database-storage")]
+use crate::config::config_file::DatabaseSettings;
 #[cfg(any(feature = "rpc-server", feature = "metrics-server"))]
 use crate::config::consts;
 #[cfg(feature = "metrics-server")]
@@ -34,7 +36,7 @@ use crate::config::consts::default_bind;
 use crate::{
     config::{
         command_line::CommandLine,
-        config_file::{self, ConfigFile, Seed},
+        config_file::{ConfigFile, Seed},
         paths,
         user_agent::UserAgent,
     },
@@ -225,8 +227,8 @@ impl Default for DatabaseConfig {
     }
 }
 #[cfg(feature = "database-storage")]
-impl From<Option<config_file::DatabaseSettings>> for DatabaseConfig {
-    fn from(db_settings: Option<config_file::DatabaseSettings>) -> Self {
+impl From<Option<DatabaseSettings>> for DatabaseConfig {
+    fn from(db_settings: Option<DatabaseSettings>) -> Self {
         let default = DatabaseConfig::default();
 
         if let Some(db_settings) = db_settings {

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -23,14 +23,14 @@ thiserror = "1.0"
 beserial = { path = "../../beserial", features = ["derive"] }
 nimiq-bls = { path = "../../bls" }
 nimiq-collections = { path = "../../collections" }
-nimiq-database = { path = "../../database" }
+nimiq-database = { path = "../../database", optional = true }
 nimiq-database-value = { path = "../../database/database-value" }
 nimiq-hash = { path = "../../hash" }
 nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
 nimiq-macros = { path = "../../macros" }
 nimiq-primitives = { path = "..", features = ["coin", "policy", "serde-derive", "slots", "trie"] }
 nimiq-transaction = { path = "../transaction", features = ["serde-derive"] }
-nimiq-trie = { path = "../trie" }
+nimiq-trie = { path = "../trie", optional = true }
 nimiq-utils = { path = "../../utils", features = ["key-rng"] }
 nimiq-vrf = { path = "../../vrf" }
 
@@ -43,4 +43,7 @@ nimiq-test-log = { path = "../../test-log" }
 nimiq-test-utils = { path = "../../test-utils" }
 
 [features]
+accounts = ["interaction-traits", "nimiq-database", "nimiq-trie"]
+default = ["accounts", "interaction-traits"]
+interaction-traits = ["nimiq-database"]
 serde-derive = ["serde"]

--- a/primitives/account/src/account/basic_account.rs
+++ b/primitives/account/src/account/basic_account.rs
@@ -1,14 +1,19 @@
 use beserial::{Deserialize, Serialize};
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::{account::AccountError, coin::Coin};
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::account::{AccountError, AccountType};
+use nimiq_primitives::coin::Coin;
+#[cfg(feature = "interaction-traits")]
 use nimiq_transaction::{inherent::Inherent, Transaction};
 
-use crate::data_store::{DataStoreRead, DataStoreWrite};
-use crate::interaction_traits::{AccountPruningInteraction, AccountTransactionInteraction};
-use crate::reserved_balance::ReservedBalance;
+#[cfg(feature = "interaction-traits")]
 use crate::{
-    Account, AccountInherentInteraction, AccountReceipt, BlockState, InherentLogger, Log,
-    TransactionLog,
+    data_store::{DataStoreRead, DataStoreWrite},
+    interaction_traits::{
+        AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
+        BlockState,
+    },
+    reserved_balance::ReservedBalance,
+    Account, AccountReceipt, InherentLogger, Log, TransactionLog,
 };
 
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Default, Serialize, Deserialize)]
@@ -17,6 +22,7 @@ pub struct BasicAccount {
     pub balance: Coin,
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountTransactionInteraction for BasicAccount {
     fn create_new_contract(
         _transaction: &Transaction,
@@ -142,6 +148,7 @@ impl AccountTransactionInteraction for BasicAccount {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountInherentInteraction for BasicAccount {
     fn commit_inherent(
         &mut self,
@@ -189,6 +196,7 @@ impl AccountInherentInteraction for BasicAccount {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountPruningInteraction for BasicAccount {
     fn can_be_pruned(&self) -> bool {
         self.balance.is_zero()

--- a/primitives/account/src/account/htlc_contract.rs
+++ b/primitives/account/src/account/htlc_contract.rs
@@ -1,19 +1,25 @@
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::Address;
-use nimiq_primitives::account::{AccountError, AccountType};
+use nimiq_primitives::account::AccountError;
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
-use nimiq_transaction::account::htlc_contract::{
-    AnyHash, CreationTransactionData, HashAlgorithm, ProofType,
-};
+use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
+#[cfg(feature = "interaction-traits")]
+use nimiq_transaction::account::htlc_contract::{CreationTransactionData, ProofType};
+#[cfg(feature = "interaction-traits")]
 use nimiq_transaction::{inherent::Inherent, SignatureProof, Transaction};
 
-use crate::data_store::{DataStoreRead, DataStoreWrite};
-use crate::interaction_traits::{
-    AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
-};
-use crate::reserved_balance::ReservedBalance;
+use crate::{convert_receipt, AccountReceipt};
+#[cfg(feature = "interaction-traits")]
 use crate::{
-    convert_receipt, Account, AccountReceipt, BlockState, InherentLogger, Log, TransactionLog,
+    data_store::{DataStoreRead, DataStoreWrite},
+    interaction_traits::{
+        AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
+        BlockState,
+    },
+    reserved_balance::ReservedBalance,
+    Account, InherentLogger, Log, TransactionLog,
 };
 
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
@@ -30,6 +36,7 @@ pub struct HashedTimeLockedContract {
     pub total_amount: Coin,
 }
 
+#[cfg(feature = "interaction-traits")]
 impl HashedTimeLockedContract {
     fn can_change_balance(
         &self,
@@ -137,6 +144,7 @@ impl HashedTimeLockedContract {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountTransactionInteraction for HashedTimeLockedContract {
     fn create_new_contract(
         transaction: &Transaction,
@@ -348,6 +356,7 @@ impl AccountTransactionInteraction for HashedTimeLockedContract {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountInherentInteraction for HashedTimeLockedContract {
     fn commit_inherent(
         &mut self,
@@ -371,6 +380,7 @@ impl AccountInherentInteraction for HashedTimeLockedContract {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountPruningInteraction for HashedTimeLockedContract {
     fn can_be_pruned(&self) -> bool {
         self.balance.is_zero()

--- a/primitives/account/src/account/mod.rs
+++ b/primitives/account/src/account/mod.rs
@@ -1,24 +1,32 @@
 use beserial::{Deserialize, Serialize};
-use nimiq_primitives::account::{AccountError, AccountType};
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::account::AccountError;
+use nimiq_primitives::account::AccountType;
 use nimiq_primitives::coin::Coin;
+#[cfg(feature = "interaction-traits")]
 use nimiq_transaction::{inherent::Inherent, Transaction, TransactionFlags};
 
 use crate::account::basic_account::BasicAccount;
 use crate::account::htlc_contract::HashedTimeLockedContract;
 use crate::account::staking_contract::StakingContract;
 use crate::account::vesting_contract::VestingContract;
-use crate::data_store::{DataStoreRead, DataStoreWrite};
-use crate::interaction_traits::{
-    AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
+#[cfg(feature = "interaction-traits")]
+use crate::{
+    data_store::{DataStoreRead, DataStoreWrite},
+    interaction_traits::{
+        AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
+        BlockState,
+    },
+    reserved_balance::ReservedBalance,
+    AccountReceipt, InherentLogger, TransactionLog,
 };
-use crate::reserved_balance::ReservedBalance;
-use crate::{AccountReceipt, BlockState, InherentLogger, TransactionLog};
 
 pub mod basic_account;
 pub mod htlc_contract;
 pub mod staking_contract;
 pub mod vesting_contract;
 
+#[cfg(feature = "interaction-traits")]
 macro_rules! gen_account_match {
     ($self: ident, $f: ident $(, $arg:expr )*) => {
         match $self {
@@ -30,6 +38,7 @@ macro_rules! gen_account_match {
     };
 }
 
+#[cfg(feature = "interaction-traits")]
 macro_rules! gen_account_type_match {
     ($self: expr, $f: ident $(, $arg:expr )*) => {
         match $self {
@@ -70,6 +79,7 @@ impl Account {
         }
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn default_with_balance(balance: Coin) -> Self {
         Account::Basic(BasicAccount { balance })
     }
@@ -81,6 +91,7 @@ impl Default for Account {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountTransactionInteraction for Account {
     fn create_new_contract(
         transaction: &Transaction,
@@ -261,6 +272,7 @@ impl AccountTransactionInteraction for Account {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountInherentInteraction for Account {
     fn commit_inherent(
         &mut self,
@@ -299,6 +311,7 @@ impl AccountInherentInteraction for Account {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountPruningInteraction for Account {
     fn can_be_pruned(&self) -> bool {
         gen_account_match!(self, can_be_pruned)

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -14,10 +14,10 @@ use nimiq_primitives::{
 };
 use nimiq_vrf::{AliasMethod, VrfSeed, VrfUseCase};
 
-use crate::account::staking_contract::store::{
-    StakingContractStoreRead, StakingContractStoreReadOps,
+use crate::{
+    account::staking_contract::store::{StakingContractStoreRead, StakingContractStoreReadOps},
+    data_store_ops::DataStoreReadOps,
 };
-use crate::data_store::DataStoreRead;
 
 pub use receipts::*;
 pub use staker::Staker;
@@ -86,32 +86,36 @@ pub struct StakingContract {
 
 impl StakingContract {
     /// Get a validator given its address, if it exists.
-    pub fn get_validator(
+    pub fn get_validator<T: DataStoreReadOps>(
         &self,
-        data_store: &DataStoreRead,
+        data_store: &T,
         address: &Address,
     ) -> Option<Validator> {
         StakingContractStoreRead::new(data_store).get_validator(address)
     }
 
     /// Get a staker given its address, if it exists.
-    pub fn get_staker(&self, data_store: &DataStoreRead, address: &Address) -> Option<Staker> {
+    pub fn get_staker<T: DataStoreReadOps>(
+        &self,
+        data_store: &T,
+        address: &Address,
+    ) -> Option<Staker> {
         StakingContractStoreRead::new(data_store).get_staker(address)
     }
 
     /// Get a tombstone given its address, if it exists.
-    pub fn get_tombstone(
+    pub fn get_tombstone<T: DataStoreReadOps>(
         &self,
-        data_store: &DataStoreRead,
+        data_store: &T,
         address: &Address,
     ) -> Option<Tombstone> {
         StakingContractStoreRead::new(data_store).get_tombstone(address)
     }
 
     /// Get a list containing the addresses of all stakers that are delegating for a given validator.
-    pub fn get_stakers_for_validator(
+    pub fn get_stakers_for_validator<T: DataStoreReadOps>(
         &self,
-        _data_store: &DataStoreRead,
+        _data_store: &T,
         _address: &Address,
     ) -> Vec<Address> {
         todo!()
@@ -119,7 +123,11 @@ impl StakingContract {
 
     /// Given a seed, it randomly distributes the validator slots across all validators. It is
     /// used to select the validators for the next epoch.
-    pub fn select_validators(&self, data_store: &DataStoreRead, seed: &VrfSeed) -> Validators {
+    pub fn select_validators<T: DataStoreReadOps>(
+        &self,
+        data_store: &T,
+        seed: &VrfSeed,
+    ) -> Validators {
         let mut validator_addresses = Vec::with_capacity(self.active_validators.len());
         let mut validator_stakes = Vec::with_capacity(self.active_validators.len());
 

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -21,12 +21,14 @@ use crate::{
 
 pub use receipts::*;
 pub use staker::Staker;
+#[cfg(feature = "interaction-traits")]
 pub use store::StakingContractStoreWrite;
 pub use validator::{Tombstone, Validator};
 
 mod receipts;
 mod staker;
 mod store;
+#[cfg(feature = "interaction-traits")]
 mod traits;
 mod validator;
 

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -1,12 +1,19 @@
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::Address;
-use nimiq_primitives::{account::AccountError, coin::Coin};
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::account::AccountError;
+use nimiq_primitives::coin::Coin;
 
-use crate::account::staking_contract::store::{
-    StakingContractStoreReadOps, StakingContractStoreReadOpsExt, StakingContractStoreWrite,
+#[cfg(feature = "interaction-traits")]
+use crate::{
+    account::staking_contract::{
+        store::{
+            StakingContractStoreReadOps, StakingContractStoreReadOpsExt, StakingContractStoreWrite,
+        },
+        StakerReceipt, StakingContract, Tombstone,
+    },
+    Log, TransactionLog,
 };
-use crate::account::staking_contract::{StakerReceipt, StakingContract};
-use crate::{Log, Tombstone, TransactionLog};
 
 /// Struct representing a staker in the staking contract.
 /// Actions concerning a staker are:
@@ -29,6 +36,7 @@ pub struct Staker {
     pub delegation: Option<Address>,
 }
 
+#[cfg(feature = "interaction-traits")]
 impl StakingContract {
     /// Creates a new staker. This function is public to fill the genesis staking contract.
     pub fn create_staker(

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -4,7 +4,8 @@ use nimiq_primitives::key_nibbles::KeyNibbles;
 
 use crate::account::staking_contract::validator::Tombstone;
 use crate::account::staking_contract::{Staker, Validator};
-use crate::data_store::{DataStoreRead, DataStoreWrite};
+use crate::data_store::DataStoreWrite;
+use crate::data_store_ops::DataStoreReadOps;
 
 struct StakingContractStore {}
 
@@ -41,18 +42,16 @@ pub trait StakingContractStoreReadOps {
     fn get_tombstone(&self, address: &Address) -> Option<Tombstone>;
 }
 
-pub(crate) struct StakingContractStoreRead<'read, 'store, 'tree, 'txn, 'env>(
-    &'read DataStoreRead<'store, 'tree, 'txn, 'env>,
-);
+pub(crate) struct StakingContractStoreRead<'read, T: DataStoreReadOps>(&'read T);
 
-impl<'read, 'store, 'tree, 'txn, 'env> StakingContractStoreRead<'read, 'store, 'tree, 'txn, 'env> {
-    pub fn new(data_store: &'read DataStoreRead<'store, 'tree, 'txn, 'env>) -> Self {
+impl<'read, T: DataStoreReadOps> StakingContractStoreRead<'read, T> {
+    pub fn new(data_store: &'read T) -> Self {
         StakingContractStoreRead(data_store)
     }
 }
 
-impl<'read, 'store, 'tree, 'txn, 'env> StakingContractStoreReadOps
-    for StakingContractStoreRead<'read, 'store, 'tree, 'txn, 'env>
+impl<'read, T: DataStoreReadOps> StakingContractStoreReadOps
+    for StakingContractStoreRead<'read, T>
 {
     fn get_validator(&self, address: &Address) -> Option<Validator> {
         self.0.get(&StakingContractStore::validator_key(address))

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -4,6 +4,7 @@ use nimiq_primitives::key_nibbles::KeyNibbles;
 
 use crate::account::staking_contract::validator::Tombstone;
 use crate::account::staking_contract::{Staker, Validator};
+#[cfg(feature = "interaction-traits")]
 use crate::data_store::DataStoreWrite;
 use crate::data_store_ops::DataStoreReadOps;
 
@@ -66,10 +67,12 @@ impl<'read, T: DataStoreReadOps> StakingContractStoreReadOps
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 pub struct StakingContractStoreWrite<'write, 'store, 'tree, 'txn, 'env>(
     &'write mut DataStoreWrite<'store, 'tree, 'txn, 'env>,
 );
 
+#[cfg(feature = "interaction-traits")]
 impl<'write, 'store, 'tree, 'txn, 'env>
     StakingContractStoreWrite<'write, 'store, 'tree, 'txn, 'env>
 {
@@ -105,6 +108,7 @@ impl<'write, 'store, 'tree, 'txn, 'env>
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl<'write, 'store, 'tree, 'txn, 'env> StakingContractStoreReadOps
     for StakingContractStoreWrite<'write, 'store, 'tree, 'txn, 'env>
 {

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -2,17 +2,24 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::CompressedPublicKey as BlsPublicKey;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
-use nimiq_primitives::{account::AccountError, coin::Coin, policy::Policy};
+use nimiq_primitives::coin::Coin;
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::{account::AccountError, policy::Policy};
 
-use crate::account::staking_contract::receipts::{
-    DeactivateValidatorReceipt, DeleteValidatorReceipt, ReactivateValidatorReceipt,
-    UnparkValidatorReceipt, UpdateValidatorReceipt,
+#[cfg(feature = "interaction-traits")]
+use crate::{
+    account::staking_contract::{
+        receipts::{
+            DeactivateValidatorReceipt, DeleteValidatorReceipt, ReactivateValidatorReceipt,
+            UnparkValidatorReceipt, UpdateValidatorReceipt,
+        },
+        store::{
+            StakingContractStoreReadOps, StakingContractStoreReadOpsExt, StakingContractStoreWrite,
+        },
+        StakingContract,
+    },
+    Log, RetireValidatorReceipt, TransactionLog,
 };
-use crate::account::staking_contract::store::{
-    StakingContractStoreReadOps, StakingContractStoreReadOpsExt, StakingContractStoreWrite,
-};
-use crate::account::staking_contract::StakingContract;
-use crate::{Log, RetireValidatorReceipt, TransactionLog};
 
 /// Struct representing a validator in the staking contract.
 /// Actions concerning a validator are:
@@ -87,6 +94,7 @@ pub struct Tombstone {
     pub num_remaining_stakers: u64,
 }
 
+#[cfg(feature = "interaction-traits")]
 impl StakingContract {
     /// Creates a new validator. The initial stake is always equal to the validator deposit
     /// and can only be retrieved by deleting the validator.

--- a/primitives/account/src/account/vesting_contract.rs
+++ b/primitives/account/src/account/vesting_contract.rs
@@ -1,23 +1,24 @@
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::Address;
-use nimiq_primitives::{
-    account::{AccountError, AccountType},
-    coin::Coin,
-};
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::account::AccountType;
+use nimiq_primitives::{account::AccountError, coin::Coin};
+#[cfg(feature = "interaction-traits")]
 use nimiq_transaction::{
     account::vesting_contract::CreationTransactionData, inherent::Inherent, SignatureProof,
     Transaction,
 };
 
+use crate::{convert_receipt, AccountReceipt};
+#[cfg(feature = "interaction-traits")]
 use crate::{
-    convert_receipt,
     data_store::{DataStoreRead, DataStoreWrite},
     interaction_traits::{
         AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
     },
-    Account, AccountReceipt, BlockState, InherentLogger,
+    reserved_balance::ReservedBalance,
+    Account, BlockState, InherentLogger, Log, TransactionLog,
 };
-use crate::{reserved_balance::ReservedBalance, Log, TransactionLog};
 
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
@@ -31,6 +32,7 @@ pub struct VestingContract {
     pub total_amount: Coin,
 }
 
+#[cfg(feature = "interaction-traits")]
 impl VestingContract {
     fn can_change_balance(
         &self,
@@ -72,6 +74,7 @@ impl VestingContract {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountTransactionInteraction for VestingContract {
     fn create_new_contract(
         transaction: &Transaction,
@@ -236,6 +239,7 @@ impl AccountTransactionInteraction for VestingContract {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountInherentInteraction for VestingContract {
     fn commit_inherent(
         &mut self,
@@ -259,6 +263,7 @@ impl AccountInherentInteraction for VestingContract {
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 impl AccountPruningInteraction for VestingContract {
     fn can_be_pruned(&self) -> bool {
         self.balance.is_zero()

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -13,12 +13,11 @@ use nimiq_primitives::{
 use nimiq_transaction::{inherent::Inherent, ExecutedTransaction, Transaction, TransactionFlags};
 use nimiq_trie::trie::{IncompleteTrie, MerkleRadixTrie};
 
-use crate::data_store::DataStore;
-use crate::interaction_traits::AccountPruningInteraction;
 use crate::{
-    Account, AccountInherentInteraction, AccountReceipt, AccountTransactionInteraction,
-    BlockLogger, BlockState, InherentLogger, InherentOperationReceipt, OperationReceipt, Receipts,
-    ReservedBalance, TransactionLog, TransactionOperationReceipt, TransactionReceipt,
+    Account, AccountInherentInteraction, AccountPruningInteraction, AccountReceipt,
+    AccountTransactionInteraction, BlockLogger, BlockState, DataStore, InherentLogger,
+    InherentOperationReceipt, OperationReceipt, Receipts, ReservedBalance, TransactionLog,
+    TransactionOperationReceipt, TransactionReceipt,
 };
 
 /// An alias for the accounts tree.

--- a/primitives/account/src/data_store.rs
+++ b/primitives/account/src/data_store.rs
@@ -3,7 +3,7 @@ use nimiq_database::{Transaction, WriteTransaction};
 use nimiq_keys::Address;
 use nimiq_primitives::key_nibbles::KeyNibbles;
 
-use crate::AccountsTrie;
+use crate::{data_store_ops::DataStoreReadOps, AccountsTrie};
 
 pub struct DataStore<'a> {
     tree: &'a AccountsTrie,
@@ -54,8 +54,8 @@ pub struct DataStoreRead<'store, 'tree, 'txn, 'env> {
     txn: &'txn Transaction<'env>,
 }
 
-impl<'store, 'tree, 'txn, 'env> DataStoreRead<'store, 'tree, 'txn, 'env> {
-    pub fn get<T: Deserialize>(&self, key: &KeyNibbles) -> Option<T> {
+impl<'store, 'tree, 'txn, 'env> DataStoreReadOps for DataStoreRead<'store, 'tree, 'txn, 'env> {
+    fn get<T: Deserialize>(&self, key: &KeyNibbles) -> Option<T> {
         self.store.get(self.txn, key)
     }
 }
@@ -82,6 +82,7 @@ impl<'store, 'tree, 'txn, 'env> DataStoreWrite<'store, 'tree, 'txn, 'env> {
 #[cfg(test)]
 mod tests {
     use crate::data_store::DataStore;
+    use crate::data_store_ops::DataStoreReadOps;
     use crate::AccountsTrie;
     use nimiq_database::volatile::VolatileEnvironment;
     use nimiq_database::{ReadTransaction, WriteTransaction};

--- a/primitives/account/src/data_store_ops.rs
+++ b/primitives/account/src/data_store_ops.rs
@@ -1,0 +1,8 @@
+use beserial::Deserialize;
+use nimiq_primitives::key_nibbles::KeyNibbles;
+
+/// Read Operations that a Data Store needs to implement to interact with
+/// contracts in the Accounts Trie.
+pub trait DataStoreReadOps {
+    fn get<T: Deserialize>(&self, key: &KeyNibbles) -> Option<T>;
+}

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::reserved_balance::ReservedBalance;
 mod account;
 mod accounts;
 mod data_store;
+mod data_store_ops;
 mod interaction_traits;
 mod logs;
 mod receipts;

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "accounts")]
 #[macro_use]
 extern crate log;
 
@@ -5,17 +6,23 @@ pub use crate::account::{
     basic_account::BasicAccount, htlc_contract::HashedTimeLockedContract, staking_contract::*,
     vesting_contract::VestingContract, Account,
 };
+#[cfg(feature = "accounts")]
 pub use crate::accounts::{Accounts, AccountsTrie};
+#[cfg(feature = "interaction-traits")]
 pub use crate::data_store::{DataStore, DataStoreRead, DataStoreWrite};
+#[cfg(feature = "interaction-traits")]
 pub use crate::interaction_traits::*;
 pub use crate::logs::*;
 pub use crate::receipts::*;
 pub use crate::reserved_balance::ReservedBalance;
 
 mod account;
+#[cfg(feature = "accounts")]
 mod accounts;
+#[cfg(feature = "interaction-traits")]
 mod data_store;
 mod data_store_ops;
+#[cfg(feature = "interaction-traits")]
 mod interaction_traits;
 mod logs;
 mod receipts;

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -330,10 +330,12 @@ impl TransactionLog {
         self.logs.push(log)
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn prepend_log(&mut self, log: Log) {
         self.logs.insert(0, log)
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn clear(&mut self) {
         self.logs.clear()
     }
@@ -355,12 +357,14 @@ impl<'a> InherentLogger<'a> {
         Self { inherents: None }
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn push_log(&mut self, log: Log) {
         if let Some(ref mut inherents) = self.inherents {
             inherents.push(log);
         }
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn prepend_log(&mut self, log: Log) {
         if let Some(ref mut inherents) = self.inherents {
             inherents.insert(0, log);
@@ -410,6 +414,7 @@ impl BlockLogger {
         })
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn inherent_logger(&mut self) -> InherentLogger {
         match self.block_log {
             BlockLog::RevertedBlock {
@@ -425,6 +430,7 @@ impl BlockLogger {
         }
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn new_tx_log(&mut self, tx_hash: Blake2bHash) -> &mut TransactionLog {
         let tx_log = TransactionLog::new(tx_hash, vec![]);
 

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -51,4 +51,4 @@ nimiq-test-log = { path = "../test-log" }
 [features]
 zkp-prover = ["ark-crypto-primitives/r1cs", "ark-mnt4-753/r1cs", "ark-mnt6-753/r1cs", "ark-groth16/r1cs", "nimiq-zkp-primitives/zkp-prover"]
 parallel = ["rayon", "ark-crypto-primitives/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel", "nimiq-zkp-primitives/parallel"]
-test-setup = ["ark-poly"]
+test-setup = ["ark-poly", "zkp-prover"]


### PR DESCRIPTION
- `account`: Change the interface of the staking contract
  - Change the interface of the staking contract to receive a type parameter that needs to implement the `DataStoreReadOps` trait.
  - Implement `DataStoreReadOps` for `DataStoreRead`.
- account: Add a couple of features to the crate:
  - `interaction-traits`
  - `accounts`  
  These features were added to remove the database dependency that the crate used to have even only for referencing the basic constructs of this crate.
- genesis: Remove unused `nimiq-account` dependency
  - Remove the unused `nimiq-account` dependency from the `genesis` crate dependencies.
  - Remove the `accounts` feature since it is no longer needed.
  - Fix compilation warnings when enabling only certain features.
- lib: Fix compilation warnings for certain features
  - Fix some compilation warnings in the `nimiq-lib` crate that are shown when certain features are enabled.
- zkp-circuits: Fix feature compilation
  - Fix feature compilation for the `zkp-circuits` crate when the `test-setup` feature is enabled.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
