### PR TITLE
Reintroduce Block Logs

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -694,7 +694,7 @@ fn it_can_revert_failed_vesting_contract_transaction() {
 
     let bc = blockchain.upgradable_read();
 
-    //Now we create a redeem funds transaction that will fail
+    // Now we create a redeem funds transaction that will fail
     let redeem_tx = TransactionBuilder::new_redeem_vesting(
         &key_pair,
         tx.contract_creation_address(),

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -82,8 +82,8 @@ impl Blockchain {
                         block_logger,
                     )
                 } else {
+                    // We should not emit logs when syncing.
                     accounts.commit_incomplete(txn, &body.transactions, &inherents, &block_state)
-                    // PITODO we cannot emit logs when syncing
                 };
 
                 // Check if the receipts contain an error.

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -204,14 +204,12 @@ impl Blockchain {
 
             // Commit block to AccountsTree and create the receipts.
             let block_state = BlockState::new(block_numbers[i], block_timestamps[i]);
-            let mut block_log =
-                BlockLogger::new_applied(Default::default(), block_numbers[i], block_timestamps[i]); // PITODO: Potentially integrate but fix hash
             let receipts = this.state.accounts.commit_batch(
                 &mut txn,
                 &txns,
                 &block_inherents[i],
                 &block_state,
-                &mut block_log,
+                &mut BlockLogger::empty(),
             );
 
             // Check if the receipts contain an error.

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -1,4 +1,4 @@
-use nimiq_account::BlockState;
+use nimiq_account::{BlockLogger, BlockState};
 use nimiq_block::{MacroBlock, MacroBody, MacroHeader};
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_database::volatile::VolatileEnvironment;
@@ -102,6 +102,7 @@ fn it_can_create_batch_finalization_inherents() {
             &[],
             &[slash_inherent],
             &BlockState::new(Policy::blocks_per_batch() + 1, 1),
+            &mut BlockLogger::empty()
         )
         .is_ok());
     txn.commit();

--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -11,7 +11,9 @@ use time::OffsetDateTime;
 use toml::de::Error as TomlError;
 
 use beserial::{Serialize, SerializeWithLength, SerializingError};
-use nimiq_account::{Account, Accounts, BasicAccount, StakingContract, StakingContractStoreWrite};
+use nimiq_account::{
+    Account, Accounts, BasicAccount, StakingContract, StakingContractStoreWrite, TransactionLog,
+};
 use nimiq_block::{Block, MacroBlock, MacroBody, MacroHeader};
 use nimiq_bls::PublicKey as BlsPublicKey;
 use nimiq_database::{Environment, WriteTransaction};
@@ -290,6 +292,7 @@ impl GenesisBuilder {
                 validator.reward_address.clone(),
                 None,
                 deposit,
+                &mut TransactionLog::empty(),
             )?;
         }
 
@@ -299,6 +302,7 @@ impl GenesisBuilder {
                 &staker.staker_address,
                 staker.balance,
                 Some(staker.delegation.clone()),
+                &mut TransactionLog::empty(),
             )?;
         }
 

--- a/primitives/account/src/account/basic_account.rs
+++ b/primitives/account/src/account/basic_account.rs
@@ -148,7 +148,7 @@ impl AccountInherentInteraction for BasicAccount {
         inherent: &Inherent,
         _block_state: &BlockState,
         _data_store: DataStoreWrite,
-        mut inherent_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         match inherent {
             Inherent::Reward { value, target } => {
@@ -171,7 +171,7 @@ impl AccountInherentInteraction for BasicAccount {
         _block_state: &BlockState,
         _receipt: Option<AccountReceipt>,
         _data_store: DataStoreWrite,
-        mut inherent_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<(), AccountError> {
         match inherent {
             Inherent::Reward { value, target } => {

--- a/primitives/account/src/account/htlc_contract.rs
+++ b/primitives/account/src/account/htlc_contract.rs
@@ -354,7 +354,7 @@ impl AccountInherentInteraction for HashedTimeLockedContract {
         _inherent: &Inherent,
         _block_state: &BlockState,
         _data_store: DataStoreWrite,
-        _inherent_logger: InherentLogger,
+        _inherent_logger: &mut InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         Err(AccountError::InvalidForTarget)
     }
@@ -365,7 +365,7 @@ impl AccountInherentInteraction for HashedTimeLockedContract {
         _block_state: &BlockState,
         _receipt: Option<AccountReceipt>,
         _data_store: DataStoreWrite,
-        _inherent_logger: InherentLogger,
+        _inherent_logger: &mut InherentLogger,
     ) -> Result<(), AccountError> {
         Err(AccountError::InvalidForTarget)
     }

--- a/primitives/account/src/account/mod.rs
+++ b/primitives/account/src/account/mod.rs
@@ -267,7 +267,7 @@ impl AccountInherentInteraction for Account {
         inherent: &Inherent,
         block_state: &BlockState,
         data_store: DataStoreWrite,
-        inherent_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         gen_account_match!(
             self,
@@ -285,7 +285,7 @@ impl AccountInherentInteraction for Account {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
-        inherent_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<(), AccountError> {
         gen_account_match!(
             self,

--- a/primitives/account/src/account/mod.rs
+++ b/primitives/account/src/account/mod.rs
@@ -12,7 +12,7 @@ use crate::interaction_traits::{
     AccountInherentInteraction, AccountPruningInteraction, AccountTransactionInteraction,
 };
 use crate::reserved_balance::ReservedBalance;
-use crate::{AccountReceipt, BlockState};
+use crate::{AccountReceipt, BlockState, InherentLogger, TransactionLog};
 
 pub mod basic_account;
 pub mod htlc_contract;
@@ -87,6 +87,7 @@ impl AccountTransactionInteraction for Account {
         initial_balance: Coin,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Account, AccountError> {
         assert!(transaction
             .flags
@@ -97,7 +98,8 @@ impl AccountTransactionInteraction for Account {
             transaction,
             initial_balance,
             block_state,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -106,13 +108,15 @@ impl AccountTransactionInteraction for Account {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         gen_account_match!(
             self,
             revert_new_contract,
             transaction,
             block_state,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -121,13 +125,15 @@ impl AccountTransactionInteraction for Account {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         gen_account_match!(
             self,
             commit_incoming_transaction,
             transaction,
             block_state,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -137,6 +143,7 @@ impl AccountTransactionInteraction for Account {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         gen_account_match!(
             self,
@@ -144,7 +151,8 @@ impl AccountTransactionInteraction for Account {
             transaction,
             block_state,
             receipt,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -153,13 +161,15 @@ impl AccountTransactionInteraction for Account {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         gen_account_match!(
             self,
             commit_outgoing_transaction,
             transaction,
             block_state,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -169,6 +179,7 @@ impl AccountTransactionInteraction for Account {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         gen_account_match!(
             self,
@@ -176,7 +187,8 @@ impl AccountTransactionInteraction for Account {
             transaction,
             block_state,
             receipt,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -185,13 +197,15 @@ impl AccountTransactionInteraction for Account {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         gen_account_match!(
             self,
             commit_failed_transaction,
             transaction,
             block_state,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -201,6 +215,7 @@ impl AccountTransactionInteraction for Account {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         gen_account_match!(
             self,
@@ -208,7 +223,8 @@ impl AccountTransactionInteraction for Account {
             transaction,
             block_state,
             receipt,
-            data_store
+            data_store,
+            tx_logger
         )
     }
 
@@ -251,8 +267,16 @@ impl AccountInherentInteraction for Account {
         inherent: &Inherent,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        inherent_logger: InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError> {
-        gen_account_match!(self, commit_inherent, inherent, block_state, data_store)
+        gen_account_match!(
+            self,
+            commit_inherent,
+            inherent,
+            block_state,
+            data_store,
+            inherent_logger
+        )
     }
 
     fn revert_inherent(
@@ -261,6 +285,7 @@ impl AccountInherentInteraction for Account {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        inherent_logger: InherentLogger,
     ) -> Result<(), AccountError> {
         gen_account_match!(
             self,
@@ -268,7 +293,8 @@ impl AccountInherentInteraction for Account {
             inherent,
             block_state,
             receipt,
-            data_store
+            data_store,
+            inherent_logger
         )
     }
 }

--- a/primitives/account/src/account/vesting_contract.rs
+++ b/primitives/account/src/account/vesting_contract.rs
@@ -242,7 +242,7 @@ impl AccountInherentInteraction for VestingContract {
         _inherent: &Inherent,
         _block_state: &BlockState,
         _data_store: DataStoreWrite,
-        _inherent_logger: InherentLogger,
+        _inherent_logger: &mut InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError> {
         Err(AccountError::InvalidForTarget)
     }
@@ -253,7 +253,7 @@ impl AccountInherentInteraction for VestingContract {
         _block_state: &BlockState,
         _receipt: Option<AccountReceipt>,
         _data_store: DataStoreWrite,
-        _inherent_logger: InherentLogger,
+        _inherent_logger: &mut InherentLogger,
     ) -> Result<(), AccountError> {
         Err(AccountError::InvalidForTarget)
     }

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -326,8 +326,12 @@ impl Accounts {
         }
 
         for inherent in inherents {
-            let receipt =
-                self.commit_inherent(txn, inherent, block_state, block_logger.inherent_logger())?;
+            let receipt = self.commit_inherent(
+                txn,
+                inherent,
+                block_state,
+                &mut block_logger.inherent_logger(),
+            )?;
             receipts.inherents.push(receipt);
         }
 
@@ -350,7 +354,7 @@ impl Accounts {
 
         for inherent in inherents {
             let receipt =
-                self.commit_inherent(txn, inherent, block_state, InherentLogger::empty())?;
+                self.commit_inherent(txn, inherent, block_state, &mut InherentLogger::empty())?;
             receipts.inherents.push(receipt);
         }
 
@@ -607,7 +611,7 @@ impl Accounts {
         txn: &mut WriteTransaction,
         inherent: &Inherent,
         block_state: &BlockState,
-        inherent_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<InherentOperationReceipt, AccountError> {
         let address = inherent.target();
         if self.mark_changed_if_missing(txn, address) {
@@ -667,7 +671,7 @@ impl Accounts {
                 inherent,
                 block_state,
                 receipt,
-                block_logger.inherent_logger(),
+                &mut block_logger.inherent_logger(),
             )?;
         }
 
@@ -823,7 +827,7 @@ impl Accounts {
         inherent: &Inherent,
         block_state: &BlockState,
         receipt: InherentOperationReceipt,
-        inherent_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<(), AccountError> {
         // If the inherent operation failed, there is nothing to revert.
         let receipt = match receipt {

--- a/primitives/account/src/interaction_traits.rs
+++ b/primitives/account/src/interaction_traits.rs
@@ -4,7 +4,7 @@ use nimiq_transaction::{inherent::Inherent, Transaction};
 
 use crate::data_store::{DataStoreRead, DataStoreWrite};
 use crate::reserved_balance::ReservedBalance;
-use crate::{Account, AccountReceipt};
+use crate::{Account, AccountReceipt, InherentLogger, TransactionLog};
 
 pub struct BlockState {
     pub number: u32,
@@ -26,6 +26,7 @@ pub trait AccountTransactionInteraction: Sized {
         initial_balance: Coin,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Account, AccountError>;
 
     fn revert_new_contract(
@@ -33,6 +34,7 @@ pub trait AccountTransactionInteraction: Sized {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError>;
 
     fn commit_incoming_transaction(
@@ -40,6 +42,7 @@ pub trait AccountTransactionInteraction: Sized {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Option<AccountReceipt>, AccountError>;
 
     fn revert_incoming_transaction(
@@ -48,6 +51,7 @@ pub trait AccountTransactionInteraction: Sized {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError>;
 
     fn commit_outgoing_transaction(
@@ -55,6 +59,7 @@ pub trait AccountTransactionInteraction: Sized {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Option<AccountReceipt>, AccountError>;
 
     fn revert_outgoing_transaction(
@@ -63,6 +68,7 @@ pub trait AccountTransactionInteraction: Sized {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError>;
 
     fn commit_failed_transaction(
@@ -70,6 +76,7 @@ pub trait AccountTransactionInteraction: Sized {
         transaction: &Transaction,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<Option<AccountReceipt>, AccountError>;
 
     fn revert_failed_transaction(
@@ -78,6 +85,7 @@ pub trait AccountTransactionInteraction: Sized {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError>;
 
     fn reserve_balance(
@@ -102,6 +110,7 @@ pub trait AccountInherentInteraction: Sized {
         inherent: &Inherent,
         block_state: &BlockState,
         data_store: DataStoreWrite,
+        tx_logger: InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError>;
 
     fn revert_inherent(
@@ -110,6 +119,7 @@ pub trait AccountInherentInteraction: Sized {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
+        tx_logger: InherentLogger,
     ) -> Result<(), AccountError>;
 }
 

--- a/primitives/account/src/interaction_traits.rs
+++ b/primitives/account/src/interaction_traits.rs
@@ -110,7 +110,7 @@ pub trait AccountInherentInteraction: Sized {
         inherent: &Inherent,
         block_state: &BlockState,
         data_store: DataStoreWrite,
-        tx_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<Option<AccountReceipt>, AccountError>;
 
     fn revert_inherent(
@@ -119,7 +119,7 @@ pub trait AccountInherentInteraction: Sized {
         block_state: &BlockState,
         receipt: Option<AccountReceipt>,
         data_store: DataStoreWrite,
-        tx_logger: InherentLogger,
+        inherent_logger: &mut InherentLogger,
     ) -> Result<(), AccountError>;
 }
 

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -83,6 +83,12 @@ pub enum Log {
     },
 
     #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
+    ValidatorFeeDeduction {
+        validator_address: Address,
+        fee: Coin,
+    },
+
+    #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
     DeactivateValidator { validator_address: Address },
 
     #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
@@ -104,6 +110,9 @@ pub enum Log {
         validator_address: Option<Address>,
         value: Coin,
     },
+
+    #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
+    StakerFeeDeduction { staker_address: Address, fee: Coin },
 
     #[cfg_attr(feature = "serde-derive", serde(rename_all = "camelCase"))]
     UpdateStaker {
@@ -276,6 +285,10 @@ impl Log {
             } => validator_address == address,
             Log::RevertContract { contract_address } => contract_address == address,
             Log::FailedTransaction { from, to, .. } => from == address || to == address,
+            Log::ValidatorFeeDeduction {
+                validator_address, ..
+            } => validator_address == address,
+            Log::StakerFeeDeduction { staker_address, .. } => staker_address == address,
         }
     }
 }

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -300,11 +300,26 @@ pub struct TransactionLog {
     #[cfg_attr(feature = "serde-derive", serde(rename = "hash"))]
     pub tx_hash: Blake2bHash,
     pub logs: Vec<Log>,
+    pub failed: bool,
 }
 
 impl TransactionLog {
     pub fn new(tx_hash: Blake2bHash, logs: Vec<Log>) -> Self {
-        Self { tx_hash, logs }
+        Self {
+            tx_hash,
+            logs,
+            failed: false,
+        }
+    }
+
+    pub fn push_failed_log(&mut self, transaction: &Transaction, reason: String) {
+        self.failed = true;
+
+        self.push_log(Log::FailedTransaction {
+            from: transaction.sender.clone(),
+            to: transaction.recipient.clone(),
+            failure_reason: reason,
+        })
     }
 
     pub fn empty() -> Self {

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -2133,7 +2133,7 @@ fn reward_inherents_not_allowed() {
             &inherent,
             &block_state,
             data_store.write(&mut db_txn),
-            InherentLogger::empty()
+            &mut InherentLogger::empty()
         ),
         Err(AccountError::InvalidForTarget)
     );
@@ -2162,13 +2162,13 @@ fn slash_inherents_work() {
 
     // Works in current epoch, current batch case.
     let mut logs = vec![];
-    let inherent_logger = InherentLogger::new(&mut logs);
+    let mut inherent_logger = InherentLogger::new(&mut logs);
     let receipt = staking_contract
         .commit_inherent(
             &inherent,
             &block_state,
             data_store.write(&mut db_txn),
-            inherent_logger,
+            &mut inherent_logger,
         )
         .expect("Failed to commit inherent");
 
@@ -2226,13 +2226,13 @@ fn slash_inherents_work() {
     let block_state = BlockState::new(Policy::blocks_per_batch() + 1, 500);
 
     let mut logs = vec![];
-    let inherent_logger = InherentLogger::new(&mut logs);
+    let mut inherent_logger = InherentLogger::new(&mut logs);
     let receipt = staking_contract
         .commit_inherent(
             &inherent,
             &block_state,
             data_store.write(&mut db_txn),
-            inherent_logger,
+            &mut inherent_logger,
         )
         .expect("Failed to commit inherent");
 
@@ -2290,13 +2290,13 @@ fn slash_inherents_work() {
     let block_state = BlockState::new(Policy::blocks_per_epoch() + 1, 1000);
 
     let mut logs = vec![];
-    let inherent_logger = InherentLogger::new(&mut logs);
+    let mut inherent_logger = InherentLogger::new(&mut logs);
     let receipt = staking_contract
         .commit_inherent(
             &inherent,
             &block_state,
             data_store.write(&mut db_txn),
-            inherent_logger,
+            &mut inherent_logger,
         )
         .expect("Failed to commit inherent");
 
@@ -2368,13 +2368,13 @@ fn finalize_batch_inherents_works() {
     let inherent = Inherent::FinalizeBatch;
 
     let mut logs = vec![];
-    let inherent_logger = InherentLogger::new(&mut logs);
+    let mut inherent_logger = InherentLogger::new(&mut logs);
     let receipt = staking_contract
         .commit_inherent(
             &inherent,
             &block_state,
             data_store.write(&mut db_txn),
-            inherent_logger,
+            &mut inherent_logger,
         )
         .expect("Failed to commit inherent");
 
@@ -2394,7 +2394,7 @@ fn finalize_batch_inherents_works() {
             &block_state,
             None,
             data_store.write(&mut db_txn),
-            InherentLogger::empty()
+            &mut InherentLogger::empty()
         ),
         Err(AccountError::InvalidForTarget)
     );
@@ -2433,13 +2433,13 @@ fn finalize_epoch_inherents_works() {
     let inherent = Inherent::FinalizeEpoch;
 
     let mut logs = vec![];
-    let inherent_logger = InherentLogger::new(&mut logs);
+    let mut inherent_logger = InherentLogger::new(&mut logs);
     let receipt = staking_contract
         .commit_inherent(
             &inherent,
             &block_state,
             data_store.write(&mut db_txn),
-            inherent_logger,
+            &mut inherent_logger,
         )
         .expect("Failed to commit inherent");
 
@@ -2484,7 +2484,7 @@ fn finalize_epoch_inherents_works() {
             &block_state,
             None,
             data_store.write(&mut db_txn),
-            InherentLogger::empty()
+            &mut InherentLogger::empty()
         ),
         Err(AccountError::InvalidForTarget)
     );
@@ -2660,9 +2660,15 @@ fn revert_slash_inherent(
     slot: u16,
 ) {
     let mut logs = vec![];
-    let inherent_logger = InherentLogger::new(&mut logs);
+    let mut inherent_logger = InherentLogger::new(&mut logs);
     staking_contract
-        .revert_inherent(inherent, block_state, receipt, data_store, inherent_logger)
+        .revert_inherent(
+            inherent,
+            block_state,
+            receipt,
+            data_store,
+            &mut inherent_logger,
+        )
         .expect("Failed to revert inherent");
 
     let mut event_block = block_state.number;

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -527,12 +527,12 @@ fn unpark_validator_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::UnparkValidator {
-    //         validator_address: validator_address.clone()
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::UnparkValidator {
+            validator_address: validator_address.clone()
+        }]
+    );
 
     assert!(staking_contract.parked_set.contains(&validator_address));
     assert!(staking_contract
@@ -683,12 +683,12 @@ fn deactivate_validator_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::DeactivateValidator {
-    //         validator_address: validator_address.clone()
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::DeactivateValidator {
+            validator_address: validator_address.clone()
+        }]
+    );
 
     let validator = staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address)
@@ -868,12 +868,12 @@ fn reactivate_validator_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::ReactivateValidator {
-    //         validator_address: validator_address.clone()
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::ReactivateValidator {
+            validator_address: validator_address.clone()
+        }]
+    );
 
     let validator = staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address)
@@ -1036,12 +1036,12 @@ fn retire_validator_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::UnparkValidator {
-    //         validator_address: validator_address.clone()
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::DeactivateValidator {
+            validator_address: validator_address.clone()
+        }]
+    );
 
     assert!(staking_contract
         .active_validators
@@ -1300,25 +1300,25 @@ fn delete_validator_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![
-    //         Log::PayFee {
-    //             from: tx.sender.clone(),
-    //             fee: tx.fee,
-    //         },
-    //         Log::Transfer {
-    //             from: tx.sender.clone(),
-    //             to: tx.recipient.clone(),
-    //             amount: tx.value,
-    //             data: None,
-    //         },
-    //         Log::DeleteValidator {
-    //             validator_address: validator_address.clone(),
-    //             reward_address: reward_address.clone(),
-    //         }
-    //     ]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![
+            Log::PayFee {
+                from: tx.sender.clone(),
+                fee: tx.fee,
+            },
+            Log::Transfer {
+                from: tx.sender.clone(),
+                to: tx.recipient.clone(),
+                amount: tx.value,
+                data: None,
+            },
+            Log::DeleteValidator {
+                validator_address: validator_address.clone(),
+                reward_address: reward_address.clone(),
+            }
+        ]
+    );
 
     let validator = staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address)
@@ -1447,14 +1447,14 @@ fn create_staker_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::CreateStaker {
-    //         staker_address: staker_address.clone(),
-    //         validator_address: Some(validator_address.clone()),
-    //         value: tx.value,
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::CreateStaker {
+            staker_address: staker_address.clone(),
+            validator_address: Some(validator_address.clone()),
+            value: tx.value,
+        }]
+    );
 
     assert_eq!(
         staking_contract.get_staker(&data_store.read(&db_txn), &staker_address),
@@ -1566,14 +1566,14 @@ fn stake_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::Stake {
-    //         staker_address: staker_address.clone(),
-    //         validator_address: Some(validator_address.clone()),
-    //         value: tx.value,
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::Stake {
+            staker_address: staker_address.clone(),
+            validator_address: Some(validator_address.clone()),
+            value: tx.value,
+        }]
+    );
 
     let staker = staking_contract
         .get_staker(&data_store.read(&db_txn), &staker_address)
@@ -1808,14 +1808,14 @@ fn update_staker_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![Log::UpdateStaker {
-    //         staker_address: staker_address.clone(),
-    //         old_validator_address: Some(other_validator_address.clone()),
-    //         new_validator_address: None,
-    //     }]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::UpdateStaker {
+            staker_address: staker_address.clone(),
+            old_validator_address: Some(other_validator_address.clone()),
+            new_validator_address: None,
+        }]
+    );
 
     let validator = staking_contract
         .get_validator(&data_store.read(&db_txn), &other_validator_address)
@@ -2033,26 +2033,26 @@ fn unstake_works() {
         )
         .expect("Failed to revert transaction");
 
-    // assert_eq!(
-    //     logs,
-    //     vec![
-    //         Log::PayFee {
-    //             from: tx.sender.clone(),
-    //             fee: tx.fee,
-    //         },
-    //         Log::Transfer {
-    //             from: tx.sender.clone(),
-    //             to: tx.recipient.clone(),
-    //             amount: tx.value,
-    //             data: None,
-    //         },
-    //         Log::Unstake {
-    //             staker_address: staker_address.clone(),
-    //             validator_address: Some(validator_address.clone()),
-    //             value: Coin::from_u64_unchecked(50_000_000),
-    //         }
-    //     ]
-    // );
+    assert_eq!(
+        tx_logger.logs,
+        vec![
+            Log::PayFee {
+                from: tx.sender.clone(),
+                fee: tx.fee,
+            },
+            Log::Transfer {
+                from: tx.sender.clone(),
+                to: tx.recipient.clone(),
+                amount: tx.value,
+                data: None,
+            },
+            Log::Unstake {
+                staker_address: staker_address.clone(),
+                validator_address: Some(validator_address.clone()),
+                value: Coin::from_u64_unchecked(50_000_000),
+            }
+        ]
+    );
 
     let staker = staking_contract
         .get_staker(&data_store.read(&db_txn), &staker_address)
@@ -2084,32 +2084,6 @@ fn unstake_works() {
         ))
     );
 }
-
-// Not applicable anymore
-// #[test]
-// fn zero_value_inherents_not_allowed() {
-//     let env = VolatileEnvironment::new(10).unwrap();
-//     let accounts = Accounts::new(env.clone());
-//     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
-//     let block_state = BlockState::new(2, 2);
-//     let mut db_txn = WriteTransaction::new(&env);
-//
-//     let mut staking_contract = make_sample_contract(data_store.write(&mut db_txn), true);
-//
-//     let validator_address = validator_address();
-//
-//     let inherent = Inherent::Slash {
-//         ty: InherentType::Slash,
-//         target: validator_address,
-//         value: Coin::ZERO,
-//         data: vec![],
-//     };
-//
-//     assert_eq!(
-//         staking_contract.commit_inherent(&accounts_tree, &mut db_txn, &inherent, 2, 0),
-//         Err(AccountError::InvalidInherent)
-//     );
-// }
 
 #[test]
 fn reward_inherents_not_allowed() {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -855,12 +855,14 @@ pub enum LogType {
     VestingCreate,
     CreateValidator,
     UpdateValidator,
+    ValidatorFeeDeduction,
     DeactivateValidator,
     ReactivateValidator,
     UnparkValidator,
     CreateStaker,
     Stake,
     UpdateStaker,
+    StakerFeeDeduction,
     DeleteValidator,
     Unstake,
     PayoutReward,
@@ -916,6 +918,8 @@ impl LogType {
             Log::Slash { .. } => Self::Slash,
             Log::RevertContract { .. } => Self::RevertContract,
             Log::FailedTransaction { .. } => Self::FailedTransaction,
+            Log::ValidatorFeeDeduction { .. } => Self::ValidatorFeeDeduction,
+            Log::StakerFeeDeduction { .. } => Self::StakerFeeDeduction,
         }
     }
 }

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -7,6 +7,7 @@ use futures::{
 use parking_lot::RwLock;
 
 use beserial::{Serialize, WriteBytesExt};
+use nimiq_account::BlockLogger;
 use nimiq_block::{
     Block, MacroBlock, TendermintIdentifier, TendermintProof, TendermintStep, TendermintVote,
 };
@@ -416,7 +417,10 @@ where
 
             // Update our blockchain state using the received proposal. If we can't update the state, we
             // return a proposal timeout.
-            if blockchain.commit_accounts(state, &block, &mut txn).is_err() {
+            if blockchain
+                .commit_accounts(state, &block, &mut txn, &mut BlockLogger::empty())
+                .is_err()
+            {
                 txn.abort();
                 debug!("Tendermint - await_proposal: Can't update state");
                 return Err(ProposalError::InvalidProposal);


### PR DESCRIPTION
## What's in this pull request?
With the new accounts implementation, the block logs were temporarily removed.
This reintroduces them with a new builder pattern instead of returning them.

Additionally, it:
- adds further tests
- adds additional log structures for failing transactions

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
