### PR TITLE
Include hybrid values that are proven in trie proofs

### DIFF
--- a/primitives/src/trie/trie_proof_node.rs
+++ b/primitives/src/trie/trie_proof_node.rs
@@ -114,13 +114,6 @@ impl TrieProofNode {
     pub fn iter_children(&self) -> Iter {
         Iter::from_children(&self.children)
     }
-
-    pub fn value(&self) -> Option<&Vec<u8>> {
-        if let ProofValue::Value(value) = &self.value {
-            return Some(value);
-        }
-        None
-    }
 }
 
 impl SerializeContent for TrieProofNode {


### PR DESCRIPTION
This allows to use the proof to directly read values from the trie.