### PR TITLE
Improve mempool behaviour during and after consensus loss

### DIFF
--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -130,8 +130,13 @@ impl Blockchain {
         self.state.accounts.size()
     }
 
-    pub fn get_account(&self, address: &Address) -> Account {
-        self.state.accounts.get_complete(address, None)
+    pub fn get_account_if_complete(&self, address: &Address) -> Option<Account> {
+        if let Ok(account) = self.state.accounts.get(address, None) {
+            Some(account)
+        } else {
+            warn!("Could not get account for address");
+            None
+        }
     }
 
     pub fn reserve_balance(

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -402,9 +402,14 @@ impl Mempool {
         self.prune_expired_transactions(&blockchain, &mut mempool_state);
 
         // Check for all transactions whether they have been included already.
-        for (tx_hash, _) in &mempool_state.regular_transactions.transactions.clone() {
-            if blockchain.contains_tx_in_validity_window(&tx_hash, None) {
-                mempool_state.remove(&blockchain, &tx_hash, EvictionReason::AlreadyIncluded);
+        for tx_hash in mempool_state
+            .regular_transactions
+            .transactions
+            .clone()
+            .keys()
+        {
+            if blockchain.contains_tx_in_validity_window(tx_hash, None) {
+                mempool_state.remove(&blockchain, tx_hash, EvictionReason::AlreadyIncluded);
             }
         }
 
@@ -452,7 +457,7 @@ impl Mempool {
                     .reserve_balance(&sender_account, tx, &mut sender_state.reserved_balance)
                     .is_ok();
                 if !still_valid {
-                    mempool_state.remove(&blockchain, tx_hash, EvictionReason::Invalid);
+                    mempool_state.remove(blockchain, tx_hash, EvictionReason::Invalid);
                 }
                 still_valid
             });
@@ -472,7 +477,7 @@ impl Mempool {
         let next_block_number = blockchain.block_number() + 1;
         let expired_txns = mempool_state.get_expired_txns(next_block_number);
         for tx_hash in expired_txns {
-            mempool_state.remove(&blockchain, &tx_hash, EvictionReason::Expired);
+            mempool_state.remove(blockchain, &tx_hash, EvictionReason::Expired);
         }
     }
 

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -30,6 +30,8 @@ pub enum VerifyErr {
     Known,
     #[error("Transaction is filtered")]
     Filtered,
+    #[error("Can't verify transaction without consensus")]
+    NoConsensus,
 }
 
 /// Verifies a transaction and adds it to the mempool.

--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -82,6 +82,9 @@ pub enum Error {
     #[error("Invalid argument: {0}")]
     InvalidArgument(String),
 
+    #[error("No consensus")]
+    NoConsensus,
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -426,6 +426,9 @@ where
             #[cfg(not(feature = "metrics"))]
             tokio::spawn({
                 async move {
+                    // The mempool is not updated while consensus is lost.
+                    // Thus, we need to check all transactions if they are still valid.
+                    mempool.mempool_update_full();
                     mempool.start_executors(network, None, None).await;
                 }
             });
@@ -434,6 +437,10 @@ where
                 let mempool_monitor = self.mempool_monitor.clone();
                 let ctrl_mempool_monitor = self.control_mempool_monitor.clone();
                 async move {
+                    // The mempool is not updated while consensus is lost.
+                    // Thus, we need to check all transactions if they are still valid.
+                    mempool.mempool_update_full();
+
                     mempool
                         .start_executors(network, Some(mempool_monitor), Some(ctrl_mempool_monitor))
                         .await;

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -17,7 +17,8 @@ use nimiq_network_interface::{
     request::{MessageMarker, RequestCommon},
 };
 use nimiq_network_libp2p::Network;
-use nimiq_network_mock::MockHub;
+use nimiq_network_mock::{MockHub, MockNetwork};
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     test_network::TestNetwork,
@@ -25,6 +26,7 @@ use nimiq_test_utils::{
         build_validator, build_validators, pop_validator_for_slot, seeded_rng, validator_for_slot,
     },
 };
+use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_validator::aggregation::skip_block::SignedSkipBlockMessage;
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Currently, the mempool assumes to always work on a complete accounts tree and expect()s it to be there. However, there can be a short timespan after we had consensus and lost it, where the mempool is not yet deactivated (since the validator and the consensus run on different threads). This PR fixes the potential crash by not expect()ing the account anymore.

Also, the state of the mempool might be outdated after the consensus is regained, since it doesn't get any updates in that time. Also, the state might be inconsistent if we ran into a partial accountstree and had to abort the current action. This PR rechecks all transactions in the mempool and rebuilds the reserved balance.