### PR TITLE
Add signer to proposal signature

### DIFF
--- a/validator/src/aggregation/tendermint/proposal.rs
+++ b/validator/src/aggregation/tendermint/proposal.rs
@@ -44,6 +44,7 @@ pub struct SignedProposal {
     pub(crate) round: u32,
     pub(crate) valid_round: Option<u32>,
     pub(crate) signature: SchnorrSignature,
+    pub(crate) signer: u16,
 }
 
 impl SignedProposal {
@@ -53,9 +54,9 @@ impl SignedProposal {
     pub fn into_tendermint_signed_message<Id>(
         self,
         id: Option<Id>,
-    ) -> SignedProposalMessage<Header<Id>, SchnorrSignature> {
+    ) -> SignedProposalMessage<Header<Id>, (SchnorrSignature, u16)> {
         SignedProposalMessage {
-            signature: self.signature,
+            signature: (self.signature, self.signer),
             message: ProposalMessage {
                 proposal: Header(self.proposal, id),
                 round: self.round,
@@ -65,13 +66,14 @@ impl SignedProposal {
     }
 }
 
-impl<Id> From<SignedProposalMessage<Header<Id>, SchnorrSignature>> for SignedProposal {
-    fn from(value: SignedProposalMessage<Header<Id>, SchnorrSignature>) -> Self {
+impl<Id> From<SignedProposalMessage<Header<Id>, (SchnorrSignature, u16)>> for SignedProposal {
+    fn from(value: SignedProposalMessage<Header<Id>, (SchnorrSignature, u16)>) -> Self {
         Self {
             proposal: value.message.proposal.0,
             valid_round: value.message.valid_round,
             round: value.message.round,
-            signature: value.signature,
+            signature: value.signature.0,
+            signer: value.signature.1,
         }
     }
 }

--- a/validator/src/aggregation/tendermint/state.rs
+++ b/validator/src/aggregation/tendermint/state.rs
@@ -21,7 +21,7 @@ pub struct MacroState {
     round_number: u32,
     step: Step,
     known_proposals: BTreeMap<Blake2sHash, MacroHeader>,
-    round_proposals: BTreeMap<u32, BTreeMap<Blake2sHash, (Option<u32>, SchnorrSignature)>>,
+    round_proposals: BTreeMap<u32, BTreeMap<Blake2sHash, (Option<u32>, (SchnorrSignature, u16))>>,
     votes: BTreeMap<(u32, Step), Option<Blake2sHash>>,
     best_votes: BTreeMap<(u32, Step), TendermintContribution>,
     inherents: BTreeMap<Blake2bHash, MacroBody>,
@@ -123,7 +123,8 @@ impl MacroState {
             proposal,
             round: round_number,
             valid_round,
-            signature,
+            signature: signature.0,
+            signer: signature.1,
         })
     }
 }

--- a/validator/src/macro.rs
+++ b/validator/src/macro.rs
@@ -35,9 +35,15 @@ where
 {
     Update(MacroState),
     Decision(MacroBlock),
-    ProposalAccepted(SignedProposalMessage<Header<TValidatorNetwork::PubsubId>, SchnorrSignature>),
-    ProposalIgnored(SignedProposalMessage<Header<TValidatorNetwork::PubsubId>, SchnorrSignature>),
-    ProposalRejected(SignedProposalMessage<Header<TValidatorNetwork::PubsubId>, SchnorrSignature>),
+    ProposalAccepted(
+        SignedProposalMessage<Header<TValidatorNetwork::PubsubId>, (SchnorrSignature, u16)>,
+    ),
+    ProposalIgnored(
+        SignedProposalMessage<Header<TValidatorNetwork::PubsubId>, (SchnorrSignature, u16)>,
+    ),
+    ProposalRejected(
+        SignedProposalMessage<Header<TValidatorNetwork::PubsubId>, (SchnorrSignature, u16)>,
+    ),
 }
 
 pub struct ProposalTopic<TValidatorNetwork> {
@@ -79,7 +85,7 @@ where
             'static,
             SignedProposalMessage<
                 Header<<TValidatorNetwork as ValidatorNetwork>::PubsubId>,
-                SchnorrSignature,
+                (SchnorrSignature, u16),
             >,
         >,
     ) -> Self {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -155,7 +155,7 @@ where
     ///
     /// This hash is NOT suited to be signed for BLS Aggregated signatures for the macro blocks, as those need to include the pk_tree_root.
     /// See MacroBlock::zkp_hash for more details.
-    fn hash_proposal(proposal_msg: &ProposalMessage<<Self as Protocol>::Proposal>) -> &[u8] {
+    fn hash_proposal(proposal_msg: &ProposalMessage<<Self as Protocol>::Proposal>) -> Vec<u8> {
         let mut h = Blake2sHasher::new();
 
         h.write_u8(Self::PROPOSAL_PREFIX)
@@ -179,8 +179,7 @@ where
             .serialize(&mut v)
             .expect("Must be able to serialize the hash.");
 
-        v.as_slice();
-        &[]
+        v
     }
 }
 
@@ -315,7 +314,7 @@ where
 
                     let data = Self::hash_proposal(&msg.message);
 
-                    if proposer.verify(&msg.signature.0, data) {
+                    if proposer.verify(&msg.signature.0, data.as_slice()) {
                         return Some(msg);
                     }
                 }
@@ -363,7 +362,7 @@ where
             .signing_key;
 
         // Verify the signature. The proposal is signed by the proposer of the round the proposal is used in
-        if !proposer.verify(&proposal.signature.0, data) {
+        if !proposer.verify(&proposal.signature.0, data.as_slice()) {
             return Err(ProposalError::InvalidSignature);
         }
 
@@ -448,7 +447,7 @@ where
     ) -> Self::ProposalSignature {
         let data = Self::hash_proposal(proposal_message);
         (
-            self.block_producer.signing_key.sign(data),
+            self.block_producer.signing_key.sign(data.as_slice()),
             self.validator_slot_band,
         )
     }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -958,7 +958,7 @@ where
 {
     type Item = SignedProposalMessage<
         Header<<TValidatorNetwork as ValidatorNetwork>::PubsubId>,
-        SchnorrSignature,
+        (SchnorrSignature, u16),
     >;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {


### PR DESCRIPTION
Currently the proposal messages signature can only be verified once the proposer is known. In a case where e.g. the preceding block is unknown that is not the case.
With this PR the message does contain the validators id that signed the proposal, making it possible to verify it only knowing the validator set.