### PR TITLE
Allow to prove the non-existence of keys

### DIFF
--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -201,9 +201,9 @@ impl Blockchain {
         }
     }
 
-    pub fn get_accounts_proof(&self, keys: &[KeyNibbles]) -> Option<TrieProof> {
+    pub fn get_accounts_proof(&self, keys: Vec<&KeyNibbles>) -> Option<TrieProof> {
         let txn = ReadTransaction::new(&self.env);
 
-        self.state().accounts.tree.get_proof(&txn, keys.to_vec())
+        self.state().accounts.tree.get_proof(&txn, keys).ok()
     }
 }

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -499,7 +499,7 @@ impl<N: Network> Handle<N, ResponseTrieProof, Arc<RwLock<Blockchain>>> for Reque
         let blockchain = blockchain.read();
 
         // We only prove accounts that exist in our current state
-        let proof = blockchain.get_accounts_proof(&self.keys);
+        let proof = blockchain.get_accounts_proof(self.keys.iter().collect());
 
         if proof.is_none() {
             // If we could not generate a proof we respond with an empty result

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -94,6 +94,9 @@ pub enum OutboundRequestError {
     /// The remote supports none of the requested protocols.
     #[error("Remote doesn't support requested protocol")]
     UnsupportedProtocols,
+    /// No response after asking a couple of peers.
+    #[error("No response after asking a couple of peers")]
+    NoResponse,
 }
 
 #[repr(u8)]

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -635,7 +635,7 @@ impl ConnectionHandler for DiscoveryHandler {
                                     }
                                 }
                             }
-                            Poll::Ready(None) => todo!("Interval terminated"),
+                            Poll::Ready(None) => unreachable!("Interval terminated"),
                             Poll::Pending => break,
                         }
                     }


### PR DESCRIPTION
This is done by including the last existing node on the path to the missing key. In order to make verifying cheap, the mapping from the missing key to the last existing node's key is included in the proof.

Includes the commits from #1455, because it would conflict otherwise.