### PR TITLE
Fix duplicate message IDs and check for them in CI

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -32,6 +32,8 @@ jobs:
     - name: "Free up disk space"
       run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - uses: actions/checkout@v3
+    - name: "Check for duplicate message IDs"
+      run: "! grep -rEoh --exclude-dir tests --exclude-dir target 'TYPE_ID: u16 = [^;]+;' | sort | uniq -d | grep '^'"
     - uses: actions/cache@v3
       with:
         path: |

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -290,7 +290,7 @@ pub struct ResponseBlocksProof {
 
 impl RequestCommon for RequestBlocksProof {
     type Kind = RequestMarker;
-    const TYPE_ID: u16 = 215;
+    const TYPE_ID: u16 = 216;
     type Response = ResponseBlocksProof;
     const MAX_REQUESTS: u32 = MAX_REQUEST_BLOCKS_PROOF;
 }


### PR DESCRIPTION
Fix `RequestTrieProof` and `RequestBlocksProof` sharing IDs and add a quick grep to the CI that shows duplicate message IDs and fails the run if there are any.