### PR TITLE
Various WASM client updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,7 @@ dependencies = [
  "futures-util",
  "hex",
  "js-sys",
+ "nimiq-account",
  "nimiq-block",
  "nimiq-blockchain-interface",
  "nimiq-blockchain-proxy",

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -190,7 +190,7 @@ impl<N: Network> ConsensusProxy<N> {
             })
     }
 
-    async fn prove_transactions_from_receipts(
+    pub async fn prove_transactions_from_receipts(
         &self,
         receipts: Vec<(Blake2bHash, u32)>,
         min_peers: usize,

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -34,6 +34,7 @@ wasm-bindgen-derive = "0.1.1"
 web-sys = { version = "0.3.22", features = ["EventTarget", "Window"]}
 
 beserial = { path = "../beserial", features = ["derive"] }
+nimiq-account = { path = "../primitives/account", default-features = false }
 nimiq-block = { path = "../primitives/block" }
 nimiq-blockchain-interface = { path = "../blockchain-interface" }
 nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }

--- a/web-client/src/account.rs
+++ b/web-client/src/account.rs
@@ -1,0 +1,137 @@
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(serde::Serialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PlainBasicAccount {
+    balance: u64,
+}
+
+#[derive(serde::Serialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PlainVestingAccount {
+    balance: u64,
+    owner: String,
+    start_time: u64,
+    time_step: u64,
+    step_amount: u64,
+    total_amount: u64,
+}
+
+#[derive(serde::Serialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PlainHtlcAccount {
+    balance: u64,
+    sender: String,
+    recipient: String,
+    hash_algorithm: String,
+    hash_root: String,
+    hash_count: u8,
+    timeout: u64,
+    total_amount: u64,
+}
+
+#[derive(serde::Serialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PlainStakingAccount {
+    balance: u64,
+    active_validators: Vec<(String, u64)>,
+    parked_set: Vec<String>,
+    current_lost_rewards: String,
+    previous_lost_rewards: String,
+    current_disabled_slots: Vec<(String, Vec<u16>)>,
+    previous_disabled_slots: Vec<(String, Vec<u16>)>,
+}
+
+#[derive(serde::Serialize, Tsify)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum PlainAccount {
+    Basic(PlainBasicAccount),
+    Vesting(PlainVestingAccount),
+    Htlc(PlainHtlcAccount),
+    Staking(PlainStakingAccount),
+}
+
+impl PlainAccount {
+    pub fn from_native(account: &nimiq_account::Account) -> PlainAccount {
+        match account {
+            nimiq_account::Account::Basic(acc) => PlainAccount::Basic(PlainBasicAccount {
+                balance: acc.balance.into(),
+            }),
+            nimiq_account::Account::Vesting(acc) => PlainAccount::Vesting(PlainVestingAccount {
+                balance: acc.balance.into(),
+                owner: acc.owner.to_user_friendly_address(),
+                start_time: acc.start_time,
+                time_step: acc.time_step,
+                step_amount: acc.step_amount.into(),
+                total_amount: acc.total_amount.into(),
+            }),
+            nimiq_account::Account::HTLC(acc) => PlainAccount::Htlc(PlainHtlcAccount {
+                balance: acc.balance.into(),
+                sender: acc.sender.to_user_friendly_address(),
+                recipient: acc.recipient.to_user_friendly_address(),
+                hash_algorithm: match acc.hash_algorithm {
+                    nimiq_transaction::account::htlc_contract::HashAlgorithm::Blake2b => {
+                        "blake2b".to_string()
+                    }
+                    nimiq_transaction::account::htlc_contract::HashAlgorithm::Sha256 => {
+                        "sha256".to_string()
+                    }
+                },
+                hash_root: acc.hash_root.to_hex(),
+                hash_count: acc.hash_count,
+                timeout: acc.timeout,
+                total_amount: acc.total_amount.into(),
+            }),
+            nimiq_account::Account::Staking(acc) => PlainAccount::Staking(PlainStakingAccount {
+                balance: acc.balance.into(),
+                active_validators: acc
+                    .active_validators
+                    .iter()
+                    .map(|(address, balance)| {
+                        (
+                            address.to_user_friendly_address(),
+                            balance.to_owned().into(),
+                        )
+                    })
+                    .collect(),
+                parked_set: acc
+                    .parked_set
+                    .iter()
+                    .map(|address| address.to_user_friendly_address())
+                    .collect(),
+                current_lost_rewards: acc.current_lost_rewards.to_string(),
+                previous_lost_rewards: acc.previous_lost_rewards.to_string(),
+                current_disabled_slots: acc
+                    .current_disabled_slots
+                    .iter()
+                    .map(|(address, slots)| {
+                        (
+                            address.to_user_friendly_address(),
+                            slots.iter().cloned().collect(),
+                        )
+                    })
+                    .collect(),
+                previous_disabled_slots: acc
+                    .previous_disabled_slots
+                    .iter()
+                    .map(|(address, slots)| {
+                        (
+                            address.to_user_friendly_address(),
+                            slots.iter().cloned().collect(),
+                        )
+                    })
+                    .collect(),
+            }),
+        }
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "PlainAccount")]
+    pub type PlainAccountType;
+
+    #[wasm_bindgen(typescript_type = "PlainAccount[]")]
+    pub type PlainAccountArrayType;
+}

--- a/web-client/src/address.rs
+++ b/web-client/src/address.rs
@@ -87,4 +87,7 @@ impl Address {
 extern "C" {
     #[wasm_bindgen(typescript_type = "Address | string")]
     pub type AddressAnyType;
+
+    #[wasm_bindgen(typescript_type = "(Address | string)[]")]
+    pub type AddressAnyArrayType;
 }

--- a/web-client/src/address.rs
+++ b/web-client/src/address.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use beserial::Serialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_derive::TryFromJsValue;
 
@@ -62,6 +63,10 @@ impl Address {
     #[wasm_bindgen(js_name = toHex)]
     pub fn to_hex(&self) -> String {
         self.inner.to_hex()
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.serialize_to_vec()
     }
 }
 


### PR DESCRIPTION
## What's in this pull request?

- Fix `PlainBlock` generated Typescript types, which were invalid before
- Make all client methods `async`, like they have been in the 1.0 client and to be consistent (because the tx listener method must be async as it does network requests to subscribe at peers)
- Implement `getAccount` and `getAccounts` methods on the client (enabled by #1408 & #1484)
- Implement transaction listeners by subscribing to addresses (enabled by #1437)
- Add `serialize` method to Address for compatibility
- Avoid concurrent access locks by avoiding any `&mut self` methods
- Prevent `addTransactionListener` from failing when called without peers

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
