### PR TITLE
Fix generation of devnet keys in prover

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -3,8 +3,6 @@ use parking_lot::{Mutex, RwLock};
 use rand::SeedableRng;
 #[cfg(feature = "zkp-prover")]
 use rand_chacha::ChaCha20Rng;
-#[cfg(feature = "zkp-prover")]
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use nimiq_block::Block;
@@ -43,9 +41,8 @@ use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
 use nimiq_wallet::WalletStore;
 use nimiq_zkp::ZKP_VERIFYING_KEY;
 #[cfg(feature = "zkp-prover")]
-use nimiq_zkp_circuits::{
-    setup::{all_files_created, load_verifying_key_from_file, setup, DEVELOPMENT_SEED},
-    DEFAULT_KEYS_PATH,
+use nimiq_zkp_circuits::setup::{
+    all_files_created, load_verifying_key_from_file, setup, DEVELOPMENT_SEED,
 };
 #[cfg(feature = "database-storage")]
 use nimiq_zkp_component::proof_store::{DBProofStore, ProofStore};
@@ -161,7 +158,7 @@ impl ClientInner {
             );
             setup(
                 ChaCha20Rng::from_seed(DEVELOPMENT_SEED),
-                &PathBuf::from(DEFAULT_KEYS_PATH),
+                &config.zkp.prover_keys_path,
                 config.network_id,
                 config.zkp.prover_active,
             )?;

--- a/zkp/src/proof_system/prove.rs
+++ b/zkp/src/proof_system/prove.rs
@@ -984,7 +984,7 @@ fn proof_to_file<T: Pairing>(
 ) -> Result<(), NanoZKPError> {
     let proofs = path.join("proofs");
     if !proofs.is_dir() {
-        DirBuilder::new().create(&proofs)?;
+        DirBuilder::new().recursive(true).create(&proofs)?;
     }
 
     let suffix = match number {


### PR DESCRIPTION
## What's in this pull request?
The client was ignoring the configured path during setup.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
