### PR TITLE
consensus: Add a way of getting staking contract elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,6 +3584,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "beserial",
+ "futures-executor",
  "futures-util",
  "gloo-timers",
  "hex",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-trait = "0.1"
 futures = { package = "futures-util", version = "0.3" }
+futures-executor = { version = "0.3" }
 gloo-timers = { version = "0.2.6", features = [ "futures" ]}
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 lazy_static = "1.4.0"

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -6,8 +6,7 @@ use futures::stream::BoxStream;
 use tokio::sync::broadcast::Sender as BroadcastSender;
 use tokio_stream::wrappers::BroadcastStream;
 
-use beserial::Deserialize;
-use nimiq_account::Account;
+use nimiq_account::{Account, Staker, Validator};
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -24,12 +23,15 @@ use nimiq_transaction::{
     TransactionTopic,
 };
 
-use crate::messages::{
-    AddressNotification, AddressSubscriptionOperation, AddressSubscriptionTopic,
-    RequestBlocksProof, RequestSubscribeToAddress, RequestTransactionReceiptsByAddress,
-    RequestTransactionsProof, RequestTrieProof, ResponseBlocksProof,
+use crate::{
+    consensus::remote_data_store::RemoteDataStore,
+    messages::{
+        AddressNotification, AddressSubscriptionOperation, AddressSubscriptionTopic,
+        RequestBlocksProof, RequestSubscribeToAddress, RequestTransactionReceiptsByAddress,
+        RequestTransactionsProof, ResponseBlocksProof,
+    },
+    ConsensusEvent,
 };
-use crate::ConsensusEvent;
 
 pub struct ConsensusProxy<N: Network> {
     pub blockchain: BlockchainProxy,
@@ -355,96 +357,70 @@ impl<N: Network> ConsensusProxy<N> {
         Ok(transactions)
     }
 
+    /// Gets a set of accounts given their addresses. The returned type is a
+    /// BTreeMap of addresses to an optional `Account`. If an account was not
+    /// found, then `None` is returned in its corresponding entry.
     pub async fn request_accounts_by_addresses(
         &self,
         addresses: Vec<Address>,
         min_peers: usize,
     ) -> Result<BTreeMap<Address, Option<Account>>, RequestError> {
-        // First we tell the network to provide us with a vector that contains all the connected peers that support such services
-        // Note: If the network could not provide enough peers that satisfies our requirement, then an error would be returned
-        let peers = self
-            .network
-            .get_peers_by_services(Services::ACCOUNTS_PROOF, min_peers)
-            .await
-            .map_err(|error| {
-                log::error!(
-                    err = %error,
-                    "Request accounts by addresses couldn't be fulfilled"
-                );
+        let mut keys = HashMap::<KeyNibbles, Address>::from_iter(
+            addresses
+                .iter()
+                .map(|address| (KeyNibbles::from(address), address.clone())),
+        );
+        let accounts: BTreeMap<KeyNibbles, Option<Account>> = RemoteDataStore::get_trie(
+            Arc::clone(&self.network),
+            self.blockchain.clone(),
+            &keys.keys().cloned().collect::<Vec<KeyNibbles>>(),
+            min_peers,
+        )
+        .await?;
 
-                RequestError::OutboundRequest(OutboundRequestError::SendError)
-            })?;
+        let accounts = accounts
+            .iter()
+            .map(|(key, account)| {
+                (
+                    keys.remove(key)
+                        .expect("Key must be in the proven accounts"),
+                    account.clone(),
+                )
+            })
+            .collect();
+        Ok(accounts)
+    }
 
-        let keys: Vec<KeyNibbles> = addresses.iter().map(Into::into).collect();
+    /// Gets a set of validators given their addresses. The returned type is a
+    /// BTreeMap of addresses to an optional `Validator`. If a validator was not
+    /// found, then `None` is returned in its corresponding entry.
+    pub async fn request_validators_by_addresses(
+        &self,
+        addresses: Vec<Address>,
+        min_peers: usize,
+    ) -> Result<BTreeMap<Address, Option<Validator>>, RequestError> {
+        let remote_ds = RemoteDataStore {
+            network: Arc::clone(&self.network),
+            blockchain: self.blockchain.clone(),
+            min_peers,
+        };
+        remote_ds.get_validators(addresses).await
+    }
 
-        for peer_id in peers {
-            log::debug!(
-                peer_id = %peer_id,
-                "Performing accounts by address request to peer",
-            );
-            let response = self
-                .network
-                .request::<RequestTrieProof>(RequestTrieProof { keys: keys.clone() }, peer_id)
-                .await;
-
-            match response {
-                Ok(response) => {
-                    if let Some(proof) = response.proof {
-                        if let Some(block_hash) = response.block_hash {
-                            let blockchain = self.blockchain.read();
-                            // First try to obtain, from our chain store, the block that was used to generate the proof
-                            let block = blockchain.get_block(&block_hash, false).ok();
-
-                            if let Some(block) = block {
-                                // Now we need to verify the proof
-                                if let Ok(values) = proof.verify_values(
-                                    block.state_root(),
-                                    &keys.iter().collect::<Vec<_>>(),
-                                ) {
-                                    return Ok(values
-                                        .into_iter()
-                                        .map(|(key, value)| {
-                                            (
-                                                key.to_address().unwrap(),
-                                                value.map(|v| {
-                                                    Account::deserialize_from_vec(&v).unwrap()
-                                                }),
-                                            )
-                                        })
-                                        .collect());
-                                } else {
-                                    // If the proof does not verify, we disconnect from the peer
-                                    log::debug!(peer=%peer_id, "Disconnecting from peer because the accounts proof didn't verify");
-                                    self.network
-                                        .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
-                                        .await;
-                                }
-                            } else {
-                                // If we couldn't find the block, then we cannot verify the proof
-                                log::debug!(block_hash=%block_hash, "Received an accounts proof, but we could not find the block that was used to generate the proof");
-                            }
-                        } else {
-                            // The peer provided a proof but did not provide the block hash, this is considered malicious
-                            log::debug!(peer=%peer_id, "Disconnecting from peer because of mailicious behaviour during accounts proof");
-                            self.network
-                                .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
-                                .await;
-                        }
-                    } else {
-                        // If there is no proof, then we just continue with the next peer
-                        log::debug!(peer=%peer_id, "We requested an accounts proof but the peer didn't provide any");
-                    }
-                }
-                Err(error) => {
-                    // If there was a request error with this peer we log an error
-                    log::error!(peer=%peer_id, err=%error, "There was an error requesting accounts proof from peer");
-                }
-            }
-        }
-
-        Err(RequestError::OutboundRequest(
-            OutboundRequestError::NoResponse,
-        ))
+    /// Gets a set of stakers given their addresses. The returned type is a
+    /// BTreeMap of addresses to an optional `Staker`. If a staker was not
+    /// found, then `None` is returned in its corresponding entry.
+    pub async fn request_stakers_by_addresses(
+        &self,
+        addresses: Vec<Address>,
+        min_peers: usize,
+    ) -> Result<BTreeMap<Address, Option<Staker>>, RequestError> {
+        let remote_ds = RemoteDataStore {
+            network: Arc::clone(&self.network),
+            blockchain: self.blockchain.clone(),
+            min_peers,
+        };
+        remote_ds.get_stakers(addresses).await
     }
 
     pub async fn subscribe_to_addresses(

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -37,6 +37,7 @@ use self::remote_event_dispatcher::RemoteEventDispatcher;
 
 pub mod consensus_proxy;
 mod head_requests;
+mod remote_data_store;
 #[cfg(feature = "full")]
 mod remote_event_dispatcher;
 

--- a/consensus/src/consensus/remote_data_store.rs
+++ b/consensus/src/consensus/remote_data_store.rs
@@ -1,0 +1,332 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use beserial::Deserialize;
+use nimiq_account::{
+    Account, DataStoreReadOps, Staker, StakingContract, StakingContractStore, Tombstone, Validator,
+};
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_keys::Address;
+use nimiq_network_interface::{
+    network::{CloseReason, Network},
+    peer_info::Services,
+    request::{OutboundRequestError, RequestError},
+};
+use nimiq_primitives::{key_nibbles::KeyNibbles, policy::Policy};
+
+use crate::messages::RequestTrieProof;
+
+/// The Remote Data Store is a component to remotely request data from the staking
+/// contract such as:
+/// - Validators
+/// - Stakers
+/// - Tombstones
+/// It also serves as an utility function to extract any type from the Accounts Trie
+/// remotely.
+pub(crate) struct RemoteDataStore<N: Network> {
+    /// An Arc of the network to make requests.
+    pub(crate) network: Arc<N>,
+    /// A blockchain proxy for verifying proofs of data received.
+    pub(crate) blockchain: BlockchainProxy,
+    /// Minimum set of peers that request should be made to.
+    pub(crate) min_peers: usize,
+}
+
+/// Internal Remote operations the Remote Data Store can perform over addresses on
+/// wasm
+enum RemoteDataStoreOps {
+    /// Gets a set of validators by their addresses
+    Validator(Vec<Address>),
+    /// Gets a set of stakers by their addresses
+    Staker(Vec<Address>),
+    /// Gets a set of tombstones by their addresses
+    Tombstone(Vec<Address>),
+}
+
+impl<N: Network> RemoteDataStore<N> {
+    /// Gets a proof for an deserializable item in a remote accounts trie and returns
+    /// the item if a valid proof was obtained or `None` if not.
+    pub(crate) async fn get_trie<T: Deserialize>(
+        network: Arc<N>,
+        blockchain: BlockchainProxy,
+        keys: &[KeyNibbles],
+        min_peers: usize,
+    ) -> Result<BTreeMap<KeyNibbles, Option<T>>, RequestError> {
+        // First we tell the network to provide us with a vector that contains all the connected peers that support such services
+        // Note: If the network could not provide enough peers that satisfies our requirement, then an error would be returned
+        let peers = network
+            .get_peers_by_services(Services::ACCOUNTS_PROOF, min_peers)
+            .await
+            .map_err(|error| {
+                log::error!(
+                    err = %error,
+                    "Request items by trie keys couldn't be fulfilled"
+                );
+                RequestError::OutboundRequest(OutboundRequestError::SendError)
+            })?;
+
+        for peer_id in peers {
+            log::debug!(
+                peer_id = %peer_id,
+                "Performing accounts by address request to peer",
+            );
+            log::debug!("Getting accounts for {:?}", keys.iter());
+            let response = network
+                .request::<RequestTrieProof>(
+                    RequestTrieProof {
+                        keys: keys.to_vec(),
+                    },
+                    peer_id,
+                )
+                .await;
+
+            match response {
+                Ok(response) => {
+                    if let Some(proof) = response.proof {
+                        if let Some(block_hash) = response.block_hash {
+                            let blockchain = blockchain.read();
+                            // First try to obtain, from our chain store, the block that was used to generate the proof
+                            let block = blockchain.get_block(&block_hash, false).ok();
+
+                            if let Some(block) = block {
+                                // Now we need to verify the proof
+                                if let Ok(values) = proof.verify_values(
+                                    block.state_root(),
+                                    &keys.iter().collect::<Vec<_>>(),
+                                ) {
+                                    return Ok(values
+                                        .into_iter()
+                                        .map(|(key, value)| {
+                                            (
+                                                key,
+                                                value.map(|v| T::deserialize_from_vec(&v).unwrap()),
+                                            )
+                                        })
+                                        .collect());
+                                } else {
+                                    // If the proof does not verify, we disconnect from the peer
+                                    log::debug!(peer=%peer_id, "Disconnecting from peer because the accounts proof didn't verify");
+                                    network
+                                        .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                                        .await;
+                                    break;
+                                }
+                            } else {
+                                // If we couldn't find the block, then we cannot verify the proof
+                                log::debug!(block_hash=%block_hash, "Received an accounts proof, but we could not find the block that was used to generate the proof");
+                            }
+                        } else {
+                            // The peer provided a proof but did not provide the block hash, this is considered malicious
+                            log::debug!(peer=%peer_id, "Disconnecting from peer because of malicious behaviour during accounts proof");
+                            network
+                                .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                                .await;
+                        }
+                    } else {
+                        // If there is no proof, then we just continue with the next peer
+                        log::debug!(peer=%peer_id, "We requested an accounts proof but the peer didn't provide any");
+                    }
+                }
+                Err(error) => {
+                    // If there was a request error with this peer we log an error
+                    log::error!(peer=%peer_id, err=%error, "There was an error requesting accounts proof from peer");
+                }
+            }
+        }
+
+        Err(RequestError::OutboundRequest(
+            OutboundRequestError::NoResponse,
+        ))
+    }
+
+    async fn get_staking_contract(&self) -> Result<StakingContract, RequestError> {
+        let key = KeyNibbles::from(&Policy::STAKING_CONTRACT_ADDRESS);
+        let accounts = Self::get_trie(
+            Arc::clone(&self.network),
+            self.blockchain.clone(),
+            &[key.clone()],
+            self.min_peers,
+        )
+        .await?;
+
+        if accounts.len() != 1 {
+            log::error!(
+                len = accounts.len(),
+                "Expected only one account for the staking contract"
+            );
+            return Err(RequestError::OutboundRequest(
+                OutboundRequestError::SendError,
+            ));
+        }
+
+        if let Some(account) = accounts.get(&key) {
+            if let Some(account) = account {
+                match account {
+                    Account::Staking(account) => Ok(account.clone()),
+                    _ => {
+                        log::error!(
+                            "Requested a staking contract account and received another account type"
+                        );
+                        Err(RequestError::OutboundRequest(
+                            OutboundRequestError::SendError,
+                        ))
+                    }
+                }
+            } else {
+                log::error!("No proof was provided for the staking contract");
+                Err(RequestError::OutboundRequest(
+                    OutboundRequestError::SendError,
+                ))
+            }
+        } else {
+            log::error!("Returned accounts do not include staking contract");
+            Err(RequestError::OutboundRequest(
+                OutboundRequestError::SendError,
+            ))
+        }
+    }
+
+    /// Gets a set of validators given their addresses. The returned type is a
+    /// BTreeMap of addresses to an optional `Validator`. If a validator was not
+    /// found, then `None` is returned in its corresponding entry.
+    pub(crate) async fn get_validators(
+        &self,
+        addresses: Vec<Address>,
+    ) -> Result<BTreeMap<Address, Option<Validator>>, RequestError> {
+        if cfg!(target_family = "wasm") {
+            self.wasm_exec(RemoteDataStoreOps::Validator(addresses))
+                .await
+        } else {
+            let staking_contract = self.get_staking_contract().await?;
+            let mut validators = BTreeMap::new();
+            for address in addresses {
+                validators.insert(
+                    address.clone(),
+                    staking_contract.get_validator(self, &address),
+                );
+            }
+            Ok(validators)
+        }
+    }
+
+    /// Gets a set of stakers given their addresses. The returned type is a
+    /// BTreeMap of addresses to an optional `Staker`. If a staker was not
+    /// found, then `None` is returned in its corresponding entry.
+    pub(crate) async fn get_stakers(
+        &self,
+        addresses: Vec<Address>,
+    ) -> Result<BTreeMap<Address, Option<Staker>>, RequestError> {
+        if cfg!(target_family = "wasm") {
+            self.wasm_exec(RemoteDataStoreOps::Staker(addresses)).await
+        } else {
+            let staking_contract = self.get_staking_contract().await?;
+            let mut stakers = BTreeMap::new();
+            for address in addresses {
+                stakers.insert(address.clone(), staking_contract.get_staker(self, &address));
+            }
+            Ok(stakers)
+        }
+    }
+
+    /// Gets a set of tombstones given their addresses. The returned type is a
+    /// BTreeMap of addresses to an optional `Tombstone`. If a tombstone was not
+    /// found, then `None` is returned in its corresponding entry.
+    #[allow(dead_code)]
+    pub(crate) async fn get_tombstones(
+        &self,
+        addresses: Vec<Address>,
+    ) -> Result<BTreeMap<Address, Option<Tombstone>>, RequestError> {
+        if cfg!(target_family = "wasm") {
+            self.wasm_exec(RemoteDataStoreOps::Tombstone(addresses))
+                .await
+        } else {
+            let staking_contract = self.get_staking_contract().await?;
+            let mut tombstones = BTreeMap::new();
+            for address in addresses {
+                tombstones.insert(
+                    address.clone(),
+                    staking_contract.get_tombstone(self, &address),
+                );
+            }
+            Ok(tombstones)
+        }
+    }
+
+    async fn wasm_exec<T: Deserialize + Clone>(
+        &self,
+        op: RemoteDataStoreOps,
+    ) -> Result<BTreeMap<Address, Option<T>>, RequestError> {
+        let staking_contract_key = KeyNibbles::from(&Policy::STAKING_CONTRACT_ADDRESS);
+        let mut keys_to_address: HashMap<KeyNibbles, Address> = match op {
+            RemoteDataStoreOps::Validator(addresses) => {
+                HashMap::from_iter(addresses.iter().map(|address| {
+                    (
+                        &staking_contract_key + &StakingContractStore::validator_key(address),
+                        address.clone(),
+                    )
+                }))
+            }
+            RemoteDataStoreOps::Staker(addresses) => {
+                HashMap::from_iter(addresses.iter().map(|address| {
+                    (
+                        &staking_contract_key + &StakingContractStore::staker_key(address),
+                        address.clone(),
+                    )
+                }))
+            }
+            RemoteDataStoreOps::Tombstone(addresses) => {
+                HashMap::from_iter(addresses.iter().map(|address| {
+                    (
+                        &staking_contract_key + &StakingContractStore::tombstone_key(address),
+                        address.clone(),
+                    )
+                }))
+            }
+        };
+
+        let keys: Vec<KeyNibbles> = keys_to_address.keys().cloned().collect();
+
+        let items = Self::get_trie::<T>(
+            Arc::clone(&self.network),
+            self.blockchain.clone(),
+            &keys,
+            self.min_peers,
+        )
+        .await?;
+
+        Ok(items
+            .iter()
+            .map(|(key, item)| {
+                (
+                    keys_to_address
+                        .remove(key)
+                        .expect("Key should have an address"),
+                    item.clone(),
+                )
+            })
+            .collect())
+    }
+}
+
+impl<N: Network> DataStoreReadOps for RemoteDataStore<N> {
+    fn get<T: Deserialize>(&self, key: &KeyNibbles) -> Option<T> {
+        let proof = futures_executor::block_on(Self::get_trie(
+            Arc::clone(&self.network),
+            self.blockchain.clone(),
+            &[key.clone()],
+            self.min_peers,
+        ))
+        .ok();
+        if let Some(mut proof) = proof {
+            if proof.len() != 1 {
+                log::error!(len = proof.len(), "Unexpected amount of proved items");
+                None
+            } else {
+                proof.remove(key).flatten()
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 
 pub use receipts::*;
 pub use staker::Staker;
+pub use store::StakingContractStore;
 #[cfg(feature = "interaction-traits")]
 pub use store::StakingContractStoreWrite;
 pub use validator::{Tombstone, Validator};

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -8,22 +8,23 @@ use crate::account::staking_contract::{Staker, Validator};
 use crate::data_store::DataStoreWrite;
 use crate::data_store_ops::DataStoreReadOps;
 
-struct StakingContractStore {}
+// Fixme: This shouldn't be pub but for now it is needed for `RemoteDataStore`
+pub struct StakingContractStore {}
 
 impl StakingContractStore {
     const PREFIX_VALIDATOR: u8 = 0;
     const PREFIX_STAKER: u8 = 1;
     const PREFIX_TOMBSTONE: u8 = 2;
 
-    fn validator_key(address: &Address) -> KeyNibbles {
+    pub fn validator_key(address: &Address) -> KeyNibbles {
         Self::prefixed_address(Self::PREFIX_VALIDATOR, address)
     }
 
-    fn staker_key(address: &Address) -> KeyNibbles {
+    pub fn staker_key(address: &Address) -> KeyNibbles {
         Self::prefixed_address(Self::PREFIX_STAKER, address)
     }
 
-    fn tombstone_key(address: &Address) -> KeyNibbles {
+    pub fn tombstone_key(address: &Address) -> KeyNibbles {
         Self::prefixed_address(Self::PREFIX_TOMBSTONE, address)
     }
 

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::account::{
 pub use crate::accounts::{Accounts, AccountsTrie};
 #[cfg(feature = "interaction-traits")]
 pub use crate::data_store::{DataStore, DataStoreRead, DataStoreWrite};
+pub use crate::data_store_ops::DataStoreReadOps;
 #[cfg(feature = "interaction-traits")]
 pub use crate::interaction_traits::*;
 pub use crate::logs::*;


### PR DESCRIPTION
Add a way of getting staking contract elements to a remote endpoint. For this `RemoteDataStore` was implemented in consensus such that it builds the appropriate `TrieProofRequest` to then verify the received proofs and then deserialize the data appropriately. The implementation differs for now on `wasm` and non `wasm` targets since in `wasm` right now everything runs in a single thread and we can't block it. Therefore, in `wasm` the implementation is for now leaking the `StakingContractStore` instead of just using sync interface of `RemoteDataStore` for the staking contract.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
