### PR TITLE
consensus: Use the block number to generate a transaction proof

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -322,11 +322,11 @@ impl<N: Network> ConsensusProxy<N> {
                                 } else if block.block_number() <= checkpoint_head.block_number() {
                                     // Check that the transaction inclusion proof actually proofs inclusion in the block we know
                                     if block.hash() != checkpoint_head.hash() {
-                                        log::debug!(peer=%peer_id,"BlockProof does not correspond to expected block");
+                                        log::debug!(peer=%peer_id, "BlockProof does not correspond to expected checkpoint block");
                                         continue;
                                     }
                                 } else if block.hash() != current_head.hash() {
-                                    log::debug!(peer=%peer_id,"BlockProof does not correspond to expected block");
+                                    log::debug!(block_number=%block.block_number(), peer=%peer_id, "BlockProof does not correspond to expected block");
                                     continue;
                                 }
 
@@ -336,7 +336,7 @@ impl<N: Network> ConsensusProxy<N> {
                                     }
                                 } else {
                                     // The proof didn't verify so we disconnect from this peer
-                                    log::debug!(peer=%peer_id,"Disconnecting from peer because the transaction proof didn't verify");
+                                    log::debug!(peer=%peer_id, "Disconnecting from peer because the transaction proof didn't verify");
                                     self.network
                                         .disconnect_peer(peer_id, CloseReason::Other)
                                         .await;
@@ -344,7 +344,7 @@ impl<N: Network> ConsensusProxy<N> {
                                 }
                             } else {
                                 // If we receive a proof but we do not receive a block, we disconnect from the peer
-                                log::debug!(peer=%peer_id,"Disconnecting from peer due to an inconsistency in the transaction proof response");
+                                log::debug!(peer=%peer_id, "Disconnecting from peer due to an inconsistency in the transaction proof response");
                                 self.network
                                     .disconnect_peer(peer_id, CloseReason::Other)
                                     .await;
@@ -356,7 +356,7 @@ impl<N: Network> ConsensusProxy<N> {
                     }
                     Err(error) => {
                         // If there was a request error with this peer we don't request anymore proofs from it
-                        log::error!(peer=%peer_id, err=%error,"There was an error requesting transaction proof from peer");
+                        log::error!(peer=%peer_id, err=%error, "There was an error requesting transaction proof from peer");
                         break;
                     }
                 }

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -393,7 +393,7 @@ impl<N: Network> Handle<N, ResponseTransactionsProof, Arc<RwLock<Blockchain>>>
                 let history_tree_len = chain_info.unwrap().history_tree_len;
                 verifier_state = Some(history_tree_len as usize);
             } else {
-                //If we could not find a block, we cannot fulfil the request
+                // If we could not find the block, we cannot fullfil the request
                 log::info!("Could not find the desired block to create the txn proof");
                 return ResponseTransactionsProof {
                     proof: None,

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -97,6 +97,9 @@ pub enum OutboundRequestError {
     /// No response after asking a couple of peers.
     #[error("No response after asking a couple of peers")]
     NoResponse,
+    /// Error that doesn't match any of the other error causes
+    #[error("Other: {0}")]
+    Other(String),
 }
 
 #[repr(u8)]


### PR DESCRIPTION
- Use the block number in the handler of `RequestTransactionsProof` to generate the proof. This avoids race conditions where the client is behind and can't verify the proof for a block that is still unknown to it.
- Allow transaction proof requests of micro blocks that are within a batch of difference of the current block number in the handler of `RequestTransactionsProof`.
- Make `prove_transactions_from_receipts` fail if the block number that is passed to generate the proof is in the future.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
