### PR TITLE
Prove transaction by hash

### DIFF
--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -441,7 +441,6 @@ fn prove_transaction(
     let mut verifier_state = None;
     let election_head = blockchain.election_head().block_number();
     let macro_head = blockchain.macro_head().block_number();
-    let current_head = blockchain.head().block_number();
 
     // Get the extended transaction from the history store
     let mut extended_transactions = blockchain

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -233,7 +233,7 @@ pub struct ResponseTransactionsProof {
 pub struct RequestTransactionsProof {
     #[beserial(len_type(u16, limit = 128))]
     pub hashes: Vec<Blake2bHash>,
-    pub block_number: u32,
+    pub block_number: Option<u32>,
 }
 
 impl RequestCommon for RequestTransactionsProof {

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -906,8 +906,14 @@ impl Client {
                     }
                 }
 
+                let receipts = notification
+                    .receipts
+                    .into_iter()
+                    .map(|(hash, block_number)| (hash, Some(block_number)))
+                    .collect();
+
                 if let Ok(ext_txs) = consensus
-                    .prove_transactions_from_receipts(notification.receipts, 1)
+                    .prove_transactions_from_receipts(receipts, 1)
                     .await
                     .map_err(|e| {
                         log::error!("Failed to prove transactions from receipts: {}", e);


### PR DESCRIPTION
Currently, we have the possibility to request a transaction proof by hash and block number. In this PR a new variant is introduced, which adds the possibility to request a proof by providing only the transaction hash. In other words, the proving block is determined from the server side and not the client side.
