### PR TITLE
Compat for WASM PrivateKey, PublicKey & KeyPair APIs

### DIFF
--- a/web-client/src/key_pair.rs
+++ b/web-client/src/key_pair.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
-use beserial::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+use beserial::{Deserialize, Serialize};
 use nimiq_keys::SecureGenerate;
 
 use crate::address::Address;

--- a/web-client/src/private_key.rs
+++ b/web-client/src/private_key.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
-use beserial::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+use beserial::{Deserialize, Serialize};
 use nimiq_keys::SecureGenerate;
 
 /// The secret (private) part of an asymmetric key pair that is typically used to digitally sign or decrypt data.

--- a/web-client/src/public_key.rs
+++ b/web-client/src/public_key.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
-use beserial::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
+
+use beserial::{Deserialize, Serialize};
 
 use crate::address::Address;
 use crate::private_key::PrivateKey;


### PR DESCRIPTION
## What's in this pull request?

Update methods names and implement new methods to increase compat with the 1.0 client API for `PrivateKey`, `PublicKey` & `KeyPair`.

#### This relates to #1339.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
