### PR TITLE
Fix TOCTOU in selecting next peer in sync queue

### DIFF
--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -124,10 +124,11 @@ where
     }
 
     fn get_next_peer(&mut self, start_index: usize) -> Option<TNetwork::PeerId> {
-        if !self.peers.read().is_empty() {
-            let index = start_index % self.peers.read().len();
+        let peers = self.peers.read();
+        if !peers.is_empty() {
+            let index = start_index % peers.len();
             // TODO: Maybe check if the peer connection is closed.
-            return Some(self.peers.read()[index]);
+            return Some(peers[index]);
         }
         None
     }


### PR DESCRIPTION
A read lock wasn't held until its data was used completely, possible making the data available for others to modify in the meanwhile.

(TOCTOU is "time of check vs time of use", in this case the length might be changed by the time we read an element from the vector.)
