### PR TITLE
Fetching all stakers from a validator

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -491,7 +491,7 @@ impl<N: Network> ConsensusProxy<N> {
                 .await?
         };
 
-        let mut sucess = false;
+        let mut success = false;
 
         // Subscribe to all peers that could provide the necessary services
         for peer_id in peers {
@@ -510,7 +510,7 @@ impl<N: Network> ConsensusProxy<N> {
                 Ok(response) => match response.result {
                     Ok(_) => {
                         // Done, we are subscribed at least to one peer, continue with the next one
-                        sucess = true;
+                        success = true;
                         continue;
                     }
                     Err(_) => {
@@ -525,7 +525,7 @@ impl<N: Network> ConsensusProxy<N> {
                 }
             }
         }
-        if sucess {
+        if success {
             Ok(())
         } else {
             Err(

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -40,6 +40,11 @@ impl Address {
     const CCODE: &'static str = "NQ";
     const NIMIQ_ALPHABET: &'static str = "0123456789ABCDEFGHJKLMNPQRSTUVXY";
 
+    /// The lexicographically first address.
+    pub const START_ADDRESS: Address = Address([0x00; 20]);
+    /// The lexicographically last address.
+    pub const END_ADDRESS: Address = Address([0xff; 20]);
+
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -6,7 +6,7 @@ use crate::account::staking_contract::validator::Tombstone;
 use crate::account::staking_contract::{Staker, Validator};
 #[cfg(feature = "interaction-traits")]
 use crate::data_store::DataStoreWrite;
-use crate::data_store_ops::DataStoreReadOps;
+use crate::data_store_ops::{DataStoreIterOps, DataStoreReadOps};
 
 // Fixme: This shouldn't be pub but for now it is needed for `RemoteDataStore`
 pub struct StakingContractStore {}
@@ -65,6 +65,15 @@ impl<'read, T: DataStoreReadOps> StakingContractStoreReadOps
 
     fn get_tombstone(&self, address: &Address) -> Option<Tombstone> {
         self.0.get(&StakingContractStore::tombstone_key(address))
+    }
+}
+
+impl<'read, T: DataStoreReadOps + DataStoreIterOps> StakingContractStoreRead<'read, T> {
+    pub(crate) fn iter_stakers(&self) -> impl Iterator<Item = Staker> {
+        self.0.iter(
+            &StakingContractStore::staker_key(&Address::START_ADDRESS),
+            &StakingContractStore::staker_key(&Address::END_ADDRESS),
+        )
     }
 }
 

--- a/primitives/account/src/data_store_ops.rs
+++ b/primitives/account/src/data_store_ops.rs
@@ -6,3 +6,12 @@ use nimiq_primitives::key_nibbles::KeyNibbles;
 pub trait DataStoreReadOps {
     fn get<T: Deserialize>(&self, key: &KeyNibbles) -> Option<T>;
 }
+
+/// Expensive iteration operations that a Data Store can implement
+/// for the Accounts Trie.
+pub trait DataStoreIterOps {
+    type Iter<T: Deserialize>: Iterator<Item = T>;
+
+    /// Returns an iterator over all items within a given range (inclusive).
+    fn iter<T: Deserialize>(&self, start_key: &KeyNibbles, end_key: &KeyNibbles) -> Self::Iter<T>;
+}

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -96,6 +96,22 @@ fn generate_contract_2() {
 }
 
 #[test]
+fn can_iter_stakers() {
+    let env = VolatileEnvironment::new(10).unwrap();
+    let accounts = Accounts::new(env.clone());
+    let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+    let mut db_txn = WriteTransaction::new(&env);
+
+    let staking_contract = make_sample_contract(data_store.write(&mut db_txn), true);
+
+    let stakers =
+        staking_contract.get_stakers_for_validator(&data_store.read(&db_txn), &validator_address());
+
+    assert_eq!(stakers.len(), 1);
+    assert_eq!(stakers[0].balance, Coin::from_u64_unchecked(150_000_000));
+}
+
+#[test]
 fn it_can_de_serialize_a_staking_contract() {
     let bytes_1: Vec<u8> = hex::decode(CONTRACT_1).unwrap();
     let contract_1: StakingContract = Deserialize::deserialize(&mut &bytes_1[..]).unwrap();

--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -1,10 +1,13 @@
-use std::cmp::Ordering;
-use std::{borrow::Cow, cmp, fmt, ops, str, usize};
+use std::{
+    borrow::Cow,
+    cmp::{self, Ordering},
+    fmt, io, ops, str, usize,
+};
 
 use log::error;
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
-use nimiq_database_value::AsDatabaseBytes;
+use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_keys::Address;
 
 /// A compact representation of a node's key. It stores the key in big endian. Each byte
@@ -357,6 +360,15 @@ impl AsDatabaseBytes for KeyNibbles {
         // TODO: Improve KeyNibbles, so that no serialization is needed.
         let v = Serialize::serialize_to_vec(&self);
         Cow::Owned(v)
+    }
+}
+
+impl FromDatabaseValue for KeyNibbles {
+    fn copy_from_database(bytes: &[u8]) -> io::Result<Self>
+    where
+        Self: Sized,
+    {
+        KeyNibbles::deserialize_from_vec(bytes).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 }
 

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -123,15 +123,17 @@ pub enum BlockchainCommand {
     /// Returns information about the currently parked validators.
     ParkedValidators {},
 
-    /// Tries to fetch a validator information given its address. It has an option to include a map
-    /// containing the addresses and stakes of all the stakers that are delegating to the validator.
+    /// Tries to fetch a validator information given its address.
     ValidatorByAddress {
         /// The address to query by.
         address: Address,
+    },
 
-        /// Include the stakers of the validator.
-        #[clap(short = 's')]
-        include_stakers: Option<bool>,
+    /// Tries to fetch all stakers of a given validator.
+    /// IMPORTANT: This is a very expensive operation, iterating over all existing stakers in the contract.
+    StakersByValidator {
+        /// The validator address to query by.
+        address: Address,
     },
 
     /// Tries to fetch a staker information given its address.
@@ -301,17 +303,18 @@ impl HandleSubcommand for BlockchainCommand {
             BlockchainCommand::ParkedValidators {} => {
                 println!("{:#?}", client.blockchain.get_parked_validators().await?)
             }
-            BlockchainCommand::ValidatorByAddress {
-                address,
-                include_stakers,
-            } => println!(
+            BlockchainCommand::ValidatorByAddress { address } => println!(
+                "{:#?}",
+                client.blockchain.get_validator_by_address(address).await?
+            ),
+
+            BlockchainCommand::StakersByValidator { address } => println!(
                 "{:#?}",
                 client
                     .blockchain
-                    .get_validator_by_address(address, include_stakers)
+                    .get_stakers_by_validator_address(address)
                     .await?
             ),
-
             BlockchainCommand::Staker { address } => {
                 println!(
                     "{:#?}",

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -104,8 +104,15 @@ pub trait BlockchainInterface {
     async fn get_validator_by_address(
         &mut self,
         address: Address,
-        include_stakers: Option<bool>,
     ) -> RPCResult<Validator, BlockchainState, Self::Error>;
+
+    /// Fetches all stakers for a given validator.
+    /// IMPORTANT: This operation iterates over all stakers of the staking contract
+    /// and thus is extremely computationally expensive.
+    async fn get_stakers_by_validator_address(
+        &mut self,
+        address: Address,
+    ) -> RPCResult<Vec<Staker>, BlockchainState, Self::Error>;
 
     async fn get_staker_by_address(
         &mut self,

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -727,15 +727,10 @@ pub struct Validator {
     pub num_stakers: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inactivity_flag: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stakers: Option<Vec<Staker>>,
 }
 
 impl Validator {
-    pub fn from_validator(
-        validator: &nimiq_account::Validator,
-        stakers: Option<Vec<Staker>>,
-    ) -> Self {
+    pub fn from_validator(validator: &nimiq_account::Validator) -> Self {
         Validator {
             address: validator.address.clone(),
             signing_key: validator.signing_key,
@@ -745,7 +740,6 @@ impl Validator {
             balance: validator.total_stake,
             num_stakers: validator.num_stakers,
             inactivity_flag: validator.inactive_since,
-            stakers,
         }
     }
 }

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -17,8 +17,7 @@ use nimiq_network_interface::{
     request::{MessageMarker, RequestCommon},
 };
 use nimiq_network_libp2p::Network;
-use nimiq_network_mock::{MockHub, MockNetwork};
-use nimiq_primitives::{coin::Coin, networks::NetworkId};
+use nimiq_network_mock::MockHub;
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     test_network::TestNetwork,
@@ -26,7 +25,6 @@ use nimiq_test_utils::{
         build_validator, build_validators, pop_validator_for_slot, seeded_rng, validator_for_slot,
     },
 };
-use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_validator::aggregation::skip_block::SignedSkipBlockMessage;
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## What's in this pull request?
With the accounts refactoring we no longer can query efficiently the stakers of a given validator. This PR adds the functionality for the rpc client to fetch all stakers of a validator through a computationally heavy database query.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
