### PR TITLE
lib: Add an optional `advertised_addresses` for `NetworkSettings`

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -201,10 +201,17 @@ impl ClientInner {
             provided_services |= Services::VALIDATOR;
         }
 
-        // Generate my peer contact from identity keypair and my provided services
+        // Generate my peer contact from identity keypair, our own addresses
+        // (which could be the advertised addresses from the configuration file
+        // if they were passed or the listen addresses if not) and my provided services
         // Filter out unspecified IP addresses since those are not addresses suitable
         // for the contact book (for others to contact ourself).
-        let mut peer_contact_addresses = config.network.listen_addresses.clone();
+        let mut peer_contact_addresses = config
+            .network
+            .advertised_addresses
+            .as_ref()
+            .unwrap_or(&config.network.listen_addresses)
+            .clone();
         peer_contact_addresses.retain(|address| {
             let mut protocols = address.iter();
             match protocols.next() {
@@ -239,7 +246,13 @@ impl ClientInner {
             required_services,
         );
 
-        log::debug!("listen_addresses = {:?}", config.network.listen_addresses);
+        log::debug!(
+            addresses = ?config.network.listen_addresses,
+            "Listen addresses");
+        log::debug!(
+            addresses = ?config.network.advertised_addresses,
+            "Advertised addresses",
+        );
 
         let network =
             Arc::new(Network::new(Arc::clone(&time), network_config, executor.clone()).await);

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -101,6 +101,9 @@ pub struct NetworkConfig {
     #[builder(default)]
     pub listen_addresses: Vec<Multiaddr>,
 
+    #[builder(default)]
+    pub advertised_addresses: Option<Vec<Multiaddr>>,
+
     /// The user agent is a custom string that is sent during the handshake. Usually it contains
     /// the kind of node, Nimiq version, processor architecture and operating system. This enable
     /// gathering information on which Nimiq versions are being run on the network. A typical
@@ -674,6 +677,19 @@ impl ClientConfigBuilder {
                 .iter()
                 .map(|addr| addr.parse())
                 .collect::<Result<Vec<Multiaddr>, _>>()?,
+
+            advertised_addresses: if let Some(advertised_addresses) =
+                &config_file.network.advertised_addresses
+            {
+                Some(
+                    advertised_addresses
+                        .iter()
+                        .map(|addr| addr.parse())
+                        .collect::<Result<Vec<Multiaddr>, _>>()?,
+                )
+            } else {
+                None
+            },
 
             user_agent: config_file
                 .network

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -28,6 +28,15 @@ seed_nodes = [
         { address = "/dns4/seed1.v2.nimiq-testnet.com/tcp/8443/ws" }
 ]
 
+# Optionally specify address(es) that will be advertised to peers instead of the ones in `listen_addresses`
+#
+# This can be used to advertise the public URL and port that peers should connect to, while
+# `listen_addresses` contains the loopback IP and port that this nodes listens on, which may
+# not be publicly reachable.
+#advertised_addresses = [
+#        "/dns4/my.public.domain.com/tcp/8443/wss",
+#]
+
 # User Agent
 #
 # String that describes what kind of node is running.

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -132,6 +132,9 @@ pub struct NetworkSettings {
     pub listen_addresses: Vec<String>,
 
     #[serde(default)]
+    pub advertised_addresses: Option<Vec<String>>,
+
+    #[serde(default)]
     pub seed_nodes: Vec<Seed>,
     #[serde(default)]
     pub user_agent: Option<String>,


### PR DESCRIPTION
Add an optional `advertised_addresses` for `NetworkSettings` in the configuration file  such that the client can use them as the addresses in the `PeerContact` which end up being advertised to other peers.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
