### PR TITLE
network-libp2p: Add support for websocket TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,6 +3881,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rustls-pemfile 1.0.2",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5813,6 +5814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7220,7 +7230,7 @@ dependencies = [
  "multipart",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
+ "rustls-pemfile 0.2.1",
  "scoped-tls",
  "serde",
  "serde_json",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,6 +30,7 @@ log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
 parking_lot = "0.12"
 rand = "0.8"
 rand_chacha = "0.3.1"
+rustls-pemfile = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -127,9 +127,9 @@ pub struct NetworkConfig {
 /// Configuration for setting TLS for secure WebSocket
 #[derive(Debug, Clone, Default)]
 pub struct TlsConfig {
-    /// Path to a file containing the private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
+    /// Path to a file containing the private key (PEM-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
     pub private_key: String,
-    /// Path to a file containing the certificates (in DER-encoded X.509 format). In this file several certificates
+    /// Path to a file containing the certificates (in PEM-encoded X.509 format). In this file several certificates
     /// could be added for certificate chaining.
     pub certificates: String,
 }

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -48,12 +48,14 @@ seed_nodes = [
 
 ##############################################################################
 #
-# Identity file (PCKS#12) and password for private key
+# TLS network configuration:
+# - Identity file (DER-encoded X.509 format)
+# - private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format)
 #
 ##############################################################################
 #[network.tls]
-#identity_file = "./my.domain.p12"
-#identity_password = "secret"
+#private_key = "./my_private_key.der"
+#certificate = "./my_certificate.der"
 
 
 

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -49,13 +49,15 @@ seed_nodes = [
 ##############################################################################
 #
 # TLS network configuration:
-# - Identity file (DER-encoded X.509 format)
-# - private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format)
+# - Path to private key file (PEM-encoded ASN.1 in either PKCS#8 or PKCS#1 format)
+# - Path to a certificate or fullchain file (PEM-encoded X.509 format)
+#
+# Ususally, PEM files from SSL providers like Let's Encrypt can be used as-is.
 #
 ##############################################################################
 #[network.tls]
-#private_key = "./my_private_key.der"
-#certificate = "./my_certificate.der"
+#private_key = "./my_private_key.pem"
+#certificates = "./my_certificate.pem"
 
 
 

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -148,11 +148,15 @@ pub struct Seed {
     pub address: Multiaddr,
 }
 
+/// Settings for configuring TLS for secure WebSocket
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TlsSettings {
-    pub identity_file: String,
-    pub identity_password: String,
+    /// Path to a file containing the private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
+    pub private_key: String,
+    /// Path to a file containing the certificates (in DER-encoded X.509 format). In this file several certificates
+    /// could be added for certificate chaining.
+    pub certificates: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -152,9 +152,9 @@ pub struct Seed {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TlsSettings {
-    /// Path to a file containing the private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
+    /// Path to a file containing the private key (PEM-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
     pub private_key: String,
-    /// Path to a file containing the certificates (in DER-encoded X.509 format). In this file several certificates
+    /// Path to a file containing the certificates (in PEM-encoded X.509 format). In this file several certificates
     /// could be added for certificate chaining.
     pub certificates: String,
 }

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -15,6 +15,16 @@ use nimiq_network_interface::peer_info::Services;
 
 use crate::discovery::{behaviour::DiscoveryConfig, peer_contacts::PeerContact};
 
+/// TLS settings for configuring a secure WebSocket
+pub struct TlsConfig {
+    /// Private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
+    pub private_key: Vec<u8>,
+    /// Certificates (in DER-encoded X.509 format). In this array one or more certificates could be encoded for
+    /// certificate chaining.
+    pub certificates: Vec<u8>,
+}
+
+/// LibP2P network configuration
 pub struct Config {
     pub keypair: Keypair,
     pub peer_contact: PeerContact,
@@ -24,6 +34,7 @@ pub struct Config {
     pub gossipsub: GossipsubConfig,
     pub memory_transport: bool,
     pub required_services: Services,
+    pub tls: Option<TlsConfig>,
 }
 
 impl Config {
@@ -34,6 +45,7 @@ impl Config {
         genesis_hash: Blake2bHash,
         memory_transport: bool,
         required_services: Services,
+        tls_settings: Option<TlsConfig>,
     ) -> Self {
         // Hardcoding the minimum number of peers in mesh network before adding more
         // TODO: Maybe change this to a mesh limits configuration argument of this function
@@ -71,6 +83,7 @@ impl Config {
             gossipsub,
             memory_transport,
             required_services,
+            tls: tls_settings,
         }
     }
 }

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -19,9 +19,9 @@ use crate::discovery::{behaviour::DiscoveryConfig, peer_contacts::PeerContact};
 pub struct TlsConfig {
     /// Private key (DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format).
     pub private_key: Vec<u8>,
-    /// Certificates (in DER-encoded X.509 format). In this array one or more certificates could be encoded for
-    /// certificate chaining.
-    pub certificates: Vec<u8>,
+    /// Certificates (in DER-encoded X.509 format). Each of the entries of the vector is a certificate
+    /// represented in a `Vec<u8>`.
+    pub certificates: Vec<Vec<u8>>,
 }
 
 /// LibP2P network configuration

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -18,6 +18,6 @@ pub const DISCOVERY_PROTOCOL: &[u8] = b"/nimiq/discovery/0.0.1";
 
 pub use libp2p::{self, identity::Keypair, swarm::NetworkInfo, PeerId};
 
-pub use config::Config;
+pub use config::{Config, TlsConfig};
 pub use error::NetworkError;
 pub use network::Network;

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -319,9 +319,14 @@ impl Network {
             #[cfg(feature = "tokio-websocket")]
             if let Some(tls) = tls {
                 let priv_key = websocket::tls::PrivateKey::new(tls.private_key.clone());
-                let cert = websocket::tls::Certificate::new(tls.certificates.clone());
+                let certificates: Vec<_> = tls
+                    .certificates
+                    .clone()
+                    .into_iter()
+                    .map(websocket::tls::Certificate::new)
+                    .collect();
                 transport
-                    .set_tls_config(websocket::tls::Config::new(priv_key, vec![cert]).unwrap());
+                    .set_tls_config(websocket::tls::Config::new(priv_key, certificates).unwrap());
             }
 
             #[cfg(feature = "tokio-websocket")]
@@ -354,9 +359,14 @@ impl Network {
             #[cfg(feature = "tokio-websocket")]
             if let Some(tls) = tls {
                 let priv_key = websocket::tls::PrivateKey::new(tls.private_key.clone());
-                let cert = websocket::tls::Certificate::new(tls.certificates.clone());
+                let certificates: Vec<_> = tls
+                    .certificates
+                    .clone()
+                    .into_iter()
+                    .map(websocket::tls::Certificate::new)
+                    .collect();
                 transport
-                    .set_tls_config(websocket::tls::Config::new(priv_key, vec![cert]).unwrap());
+                    .set_tls_config(websocket::tls::Config::new(priv_key, certificates).unwrap());
             }
 
             #[cfg(all(feature = "wasm-websocket", not(feature = "tokio-websocket")))]

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -57,6 +57,7 @@ fn network_config(address: Multiaddr) -> Config {
         gossipsub,
         memory_transport: true,
         required_services: Services::all(),
+        tls: None,
     }
 }
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -322,6 +322,7 @@ fn network_config(address: Multiaddr) -> Config {
         gossipsub,
         memory_transport: true,
         required_services: Services::all(),
+        tls: None,
     }
 }
 

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -71,6 +71,7 @@ impl TestNetwork for Network {
             genesis_hash.clone(),
             true,
             Services::all(),
+            None,
         );
         let network = Arc::new(
             Network::new(


### PR DESCRIPTION
- Add support for websocket TLS for the libp2p implementation of the network.
- Add an optional network configuration for receiving TLS parameters.
- Use rustls_pemfile to parse PEM files into DER directly
  - Use rustls_pemfile to parse PEM files into DER.
  - Change the network to receive a list of certificates.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
