### PR TITLE
Use subscriptions to detect tx inclusion when sending txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,7 @@ name = "nimiq-web-client"
 version = "0.1.0"
 dependencies = [
  "beserial",
+ "futures",
  "futures-util",
  "hex",
  "js-sys",

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -139,7 +139,7 @@ impl<N: Network> ConsensusProxy<N> {
         min_peers: usize,
         max: Option<u16>,
     ) -> Result<Vec<ExtendedTransaction>, RequestError> {
-        let receipts = self
+        let receipts: Vec<_> = self
             .request_transaction_receipts_by_address(address, min_peers, max)
             .await?
             .into_iter()
@@ -148,6 +148,10 @@ impl<N: Network> ConsensusProxy<N> {
             })
             .map(|(hash, block_number)| (hash, Some(block_number)))
             .collect();
+
+        if receipts.is_empty() {
+            return Ok(vec![]);
+        }
 
         self.prove_transactions_from_receipts(receipts, min_peers)
             .await

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -21,7 +21,8 @@ maintenance = { status = "experimental" }
 crate-type = ["cdylib"]
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = "0.3"
+futures-util = "0.3"
 hex = "0.4"
 js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -431,13 +431,13 @@ impl Transaction {
 }
 
 /// Placeholder struct to serialize data of transactions as hex strings in the style of the Nimiq 1.0 library.
-#[derive(serde::Serialize, serde::Deserialize, Tsify)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Tsify)]
 pub struct PlainTransactionData {
     pub raw: String,
 }
 
 /// Placeholder struct to serialize proofs of transactions as hex strings in the style of the Nimiq 1.0 library.
-#[derive(serde::Serialize, serde::Deserialize, Tsify)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Tsify)]
 pub struct PlainTransactionProof {
     pub raw: String,
 }
@@ -445,7 +445,7 @@ pub struct PlainTransactionProof {
 /// JSON-compatible and human-readable format of transactions. E.g. addresses are presented in their human-readable
 /// format and address types and the network are represented as strings. Data and proof are serialized as an object
 /// describing their contents (not yet implemented, only the `{ raw: string }` fallback is available).
-#[derive(serde::Serialize, serde::Deserialize, Tsify)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 pub struct PlainTransaction {
     /// The transaction's unique hash, used as its identifier. Sometimes also called `txId`.
@@ -501,7 +501,7 @@ pub struct PlainTransaction {
 }
 
 /// Describes the state of a transaction as known by the client.
-#[derive(serde::Serialize, serde::Deserialize, Tsify)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Tsify)]
 #[serde(rename_all = "lowercase")]
 pub enum TransactionState {
     /// The transaction only exists locally and has not been broadcast or accepted by any peers.
@@ -526,7 +526,7 @@ pub enum TransactionState {
 /// JSON-compatible and human-readable format of transactions, including details about its state in the
 /// blockchain. Contains all fields from {@link PlainTransaction}, plus additional fields such as
 /// `blockHeight` and `timestamp` if the transaction is included in the blockchain.
-#[derive(serde::Deserialize, Tsify)]
+#[derive(Clone, serde::Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 pub struct PlainTransactionDetails {
     #[serde(flatten)]


### PR DESCRIPTION
## What's in this pull request?

Change transaction-awaiting in `client.sendTransaction` from an inefficient polling mechanism to re-use the client's address-event subscriptions introduced in #1437.

Also includes a small performance optimization in `client.getTransactionsByAddress` that returns early when there are no transactions to get.

#### This relates to #1339.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
