### PR TITLE
Fixing panic when calculating the upper bound

### DIFF
--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -171,6 +171,9 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                 .as_ref()
                 .map(|checkpoint| checkpoint.block_number)
                 .unwrap_or_else(|| {
+                    if epoch_ids.checkpoint_epoch_number() == 0 {
+                        return 0;
+                    }
                     Policy::first_block_of(epoch_ids.checkpoint_epoch_number() as u32)
                 })
                 + Policy::blocks_per_batch()


### PR DESCRIPTION
## What's in this pull request?
Fixing panic when calculating the upper bound.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
