### PR TITLE
Various fixes for recent transaction proving

### DIFF
--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -396,10 +396,8 @@ fn prove_txns_with_block_number(
         .ok();
 
     if let Some(ref block) = block {
-        // We have some extra work for a macro block
-        if Policy::is_macro_block_at(proving_block_number)
-            && !Policy::is_election_block_at(proving_block_number)
-        {
+        // We have some extra work in the current epoch, if the block we are proving is not our current head
+        if block.block_number() > election_head && block.block_number() < current_head {
             let chain_info = blockchain.get_chain_info(&block.hash(), false, None);
             let history_tree_len = chain_info.unwrap().history_tree_len;
             verifier_state = Some(history_tree_len as usize);

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -465,7 +465,7 @@ fn prove_transaction(
 
         let block = blockchain
             .chain_store
-            .get_block_at(election_head, false, None)
+            .get_block_at(proving_block_number, false, None)
             .ok();
 
         if let Some(ref block) = block {

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -413,7 +413,7 @@ fn prove_txns_with_block_number(
     }
 
     let proof = blockchain.history_store.prove(
-        Policy::epoch_at(block_number),
+        Policy::epoch_at(proving_block_number),
         hashes,
         verifier_state,
         None,
@@ -487,7 +487,7 @@ fn prove_transaction(
 
         // Prove the transaction
         let proof = blockchain.history_store.prove(
-            Policy::epoch_at(block_number),
+            Policy::epoch_at(proving_block_number),
             vec![transaction],
             verifier_state,
             None,

--- a/primitives/transaction/src/history_proof.rs
+++ b/primitives/transaction/src/history_proof.rs
@@ -25,7 +25,14 @@ impl HistoryTreeProof {
             .copied()
             .zip(self.history.iter())
             .collect();
-        self.proof.verify(&expected_root, &zipped).ok()
+        let result = self.proof.verify(&expected_root, &zipped);
+        match result {
+            Ok(res) => Some(res),
+            Err(error) => {
+                log::error!("{:?}", error);
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What's in this pull request?

Together with @jsdanielh we finally figured out why fetching recent transactions doesn't work reliably. It's again because of a mismatch of current head block between the browser client and the history nodes it requests from.

When we changed which block the full node is using to answer a tx-proof request from its current head to the block requested by the client in 058a9ec09e815d720fb201fa892ffa5374d0a538, we failed to see that this also affects micro blocks in the current batch that are older than the node's head block.

Closes #1515.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
