### PR TITLE
Increase default buffer size in block queue

### DIFF
--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -103,7 +103,7 @@ pub struct QueueConfig {
 impl Default for QueueConfig {
     fn default() -> Self {
         Self {
-            buffer_max: 4 * Policy::blocks_per_batch() as usize,
+            buffer_max: 10 * Policy::blocks_per_batch() as usize,
             window_ahead_max: 2 * Policy::blocks_per_batch(),
             tolerate_past_max: Policy::blocks_per_batch(),
             include_micro_bodies: true,

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -103,6 +103,7 @@ impl<N: Network> SyncerProxy<N> {
     ) -> Self {
         let mut queue_config = QueueConfig::default();
         queue_config.window_ahead_max = max(full_sync_threshold, queue_config.window_ahead_max);
+        queue_config.buffer_max = max(full_sync_threshold as usize, queue_config.buffer_max);
 
         let block_queue = BlockQueue::new(
             Arc::clone(&network),


### PR DESCRIPTION
## What's in this pull request?
We temporarily increase the default max buffer size in the block queue until #1514 is implemented.
We also set the max buffer size to the macro sync threshold for the full sync.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
