### PR TITLE
Query full nodes for recent transaction proofs

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -300,6 +300,10 @@ impl<N: Network> ConsensusProxy<N> {
                 }
             }
 
+            if hashes_by_block.is_empty() {
+                break;
+            }
+
             // Now we request proofs for each block and its hashes, according to its classification
             for (block_number, hashes) in hashes_by_block {
                 if let Some(block_number) = block_number {


### PR DESCRIPTION
## What's in this pull request?

For recent transactions (especially proving received notification events), it makes sense to also include full nodes in the queried peers, as they usually have the transactions from the current and last epoch.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
