### PR TITLE
Re request missing blocks after receiving incomplete response

### DIFF
--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -241,7 +241,7 @@ impl<N: Network> ZKPComponent<N> {
                     log::info!("The zk proof was successfully load from disk");
                 }
             } else {
-                log::trace!("No zk proof found on the db");
+                log::info!("No zk proof found on the db");
             }
         }
     }


### PR DESCRIPTION
## What's in this pull request?
Before, the block queue would automatically request the next set of missing blocks because we would return blocks from newest to oldest. When we reversed the order, the response would no longer trigger a new missing blocks request and we would get stuck.

#### This fixes #1529.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
