### PR TITLE
Add additional conditions to omit block proof

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -336,9 +336,16 @@ impl<N: Network> ConsensusProxy<N> {
 
                                 // Verify that the transaction proof fits to the chain
                                 if block.block_number() <= election_head.block_number() {
+                                    let block_hash = block.hash();
                                     let mut already_proven = false;
-                                    if let Some(ref interlink) = election_head.header.interlink {
-                                        already_proven = interlink.contains(&block.hash());
+                                    if election_head.hash() == block_hash
+                                        || election_head.header.parent_election_hash == block_hash
+                                    {
+                                        already_proven = true;
+                                    } else if let Some(ref interlink) =
+                                        election_head.header.interlink
+                                    {
+                                        already_proven = interlink.contains(&block_hash);
                                     }
 
                                     if !already_proven {


### PR DESCRIPTION
## What's in this pull request?

https://github.com/nimiq/core-rs-albatross/pull/1526 added a condition to omit network request roundtrips if the block we are trying to prove is already proven by the election head's interlink. But as @fiaxh pointed out (privately), the check was missing the condition when the block to prove is the parent election block, which is referenced by hash in our election head already. I then also added a check for when the block to be proven is the same as our election head (which can happen, as the block number comparison above is `<=`).

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
