### PR TITLE
handel: Add documentation, fix typos and make the aggregation test more generic

### DIFF
--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -32,3 +32,5 @@ nimiq-primitives = { path = "../primitives", features = ["policy"] }
 nimiq-network-interface = { path = "../network-interface" }
 nimiq-network-mock = { path = "../network-mock" }
 nimiq-test-log = { path = "../test-log" }
+
+tokio = { version = "1.26", features = ["rt", "time", "macros"] }

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -263,6 +263,7 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
 
     /// Send updates for every level to every peer accordingly.
     fn automatic_update(&mut self) {
+        // Skip level 0 since it only contains this node
         for level_id in 1..self.levels.len() {
             let (receive_complete, next_peers) = {
                 let level = self.levels.get(level_id).unwrap();

--- a/handel/src/contribution.rs
+++ b/handel/src/contribution.rs
@@ -20,9 +20,9 @@ pub trait AggregatableContribution:
     /// A BitSet signaling which contributors have contributed in this Contribution
     fn contributors(&self) -> BitSet;
 
-    /// returns the id of the single contributor
+    /// Returns the id of the single contributor
     ///
-    /// panics if there is more than one contributor
+    /// Panics if there is more than one contributor
     fn contributor(&self) -> usize {
         assert_eq!(self.num_contributors(), 1);
         self.contributors().iter().next().unwrap()
@@ -33,11 +33,12 @@ pub trait AggregatableContribution:
         self.contributors().len()
     }
 
+    /// Returns whether the contributors is empty
     fn is_empty(&self) -> bool {
         self.contributors().len() == 0
     }
 
-    /// combines this contribution with `other_contribution` to create the aggregate of the two.
+    /// Combines this contribution with `other_contribution` to create the aggregate of the two.
     ///
     /// The combining contributions must be disjoint.
     fn combine(&mut self, other_contribution: &Self) -> Result<(), ContributionError>;

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -38,6 +38,7 @@ pub trait ContributionStore: Send + Sync {
 }
 
 #[derive(Clone, Debug)]
+/// An implementation of the `ContributionStore` trait
 pub struct ReplaceStore<P: Partitioner, C: AggregatableContribution> {
     /// The Partitioner used to create the Aggregation Tree.
     partitioner: Arc<P>,
@@ -188,17 +189,12 @@ impl<P: Partitioner, C: AggregatableContribution> ContributionStore for ReplaceS
         self.best_contribution.get(&level).map(|(c, _)| c)
     }
 
-    fn combined(&self, mut level: usize) -> Option<Self::Contribution> {
+    fn combined(&self, level: usize) -> Option<Self::Contribution> {
         // TODO: Cache this?
 
         let mut signatures = Vec::new();
         for (_, (signature, _)) in self.best_contribution.range(0..=level) {
             signatures.push(signature)
-        }
-
-        // ???
-        if level < self.partitioner.levels() - 1 {
-            level += 1;
         }
 
         self.partitioner.combine(signatures, level)

--- a/handel/src/todo.rs
+++ b/handel/src/todo.rs
@@ -32,8 +32,8 @@ impl<C: AggregatableContribution> fmt::Debug for TodoItem<C> {
 }
 
 impl<C: AggregatableContribution> TodoItem<C> {
-    /// Evaluated the contribution of the tTdoItem. It returns a score representing how useful
-    /// the contribution is, with `0` meaning not useful at all -> can be discarded and `>0`
+    /// Evaluated the contribution of the TodoItem. It returns a score representing how useful
+    /// the contribution is, with `0` meaning not useful at all -> can be discarded and `> 0`
     /// meaning more useful the higher the number.
     ///
     /// * `evaluator` - The evaluator used for the score computation

--- a/handel/src/update.rs
+++ b/handel/src/update.rs
@@ -24,7 +24,7 @@ pub struct LevelUpdate<C: AggregatableContribution> {
 }
 
 impl<C: AggregatableContribution> LevelUpdate<C> {
-    /// crate a new LevelUpdate
+    /// Create a new LevelUpdate
     /// * `aggregate` - The aggregated contribution
     /// * `individual` - The contribution of the sender, or none. Must have `individual.num_contributors() == 1`
     /// * `level` - The level this update belongs to
@@ -43,7 +43,7 @@ impl<C: AggregatableContribution> LevelUpdate<C> {
         self.origin as usize
     }
 
-    /// return the level this update is for
+    /// Returns the level this update is for
     pub fn level(&self) -> usize {
         self.level as usize
     }

--- a/handel/src/verifier.rs
+++ b/handel/src/verifier.rs
@@ -20,7 +20,7 @@ impl VerificationResult {
 pub trait Verifier: Send + Sync {
     type Contribution: AggregatableContribution;
 
-    /// Verifies the correectness of `contribution`
+    /// Verifies the correctness of `contribution`
     /// * `contribution` - The contribution to verify
     async fn verify(&self, contribution: &Self::Contribution) -> VerificationResult;
 }


### PR DESCRIPTION
- Make the `it_can_aggregate` test more generic since it was hardwired for a number of contributors of 7.
- Remove some dead code from the handel store in the `combined` method.
- Add some documentation for some `structs` and methods and fix some typos.
- Add missing `tokio` `macros` feature for `dev-dependencies`.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
