### PR TITLE
handel: Invert `send_individual` logic and fix typos

### DIFF
--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -130,7 +130,7 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
                     self.send_update(
                         best,
                         level.id,
-                        level.receive_complete(),
+                        !level.receive_complete(),
                         level.select_next_peers(self.config.peer_count),
                     );
                 }
@@ -214,7 +214,7 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
                     self.send_update(
                         multisig,
                         level.id,
-                        level.receive_complete(),
+                        !level.receive_complete(),
                         level.select_next_peers(self.config.peer_count),
                     );
                 }
@@ -224,7 +224,8 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
 
     /// Send updated `contribution` for `level` to `count` peers
     ///
-    /// for incomplete levels the contribution containing solely this nodes contribution is sent alongside the aggregate
+    /// If the `send_individual` flag is set, the contribution containing solely
+    /// this node contribution is sent alongside the aggregate.
     fn send_update(
         &mut self,
         contribution: P::Contribution,
@@ -234,11 +235,11 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
     ) {
         // If there are peers to send the update to send them
         if !peer_ids.is_empty() {
-            // If the send_individual flag is set the individual contribution is send alongside the aggregate.
+            // If the send_individual flag is set the individual contribution is sent alongside the aggregate.
             let individual = if send_individual {
-                None
-            } else {
                 Some(self.contribution.clone())
+            } else {
+                None
             };
 
             // Create the LevelUpdate
@@ -287,7 +288,7 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
 
             // For an existing aggregate for this level send it around to the respective peers.
             if let Some(aggregate) = aggregate {
-                self.send_update(aggregate, level_id, receive_complete, next_peers);
+                self.send_update(aggregate, level_id, !receive_complete, next_peers);
             }
         }
     }

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -33,7 +33,7 @@ pub trait ContributionStore: Send + Sync {
     /// Panics if `level` is invalid.
     fn best(&self, level: usize) -> Option<&Self::Contribution>;
 
-    /// Returns the best combined multi-signature for all levels upto `level`.
+    /// Returns the best combined multi-signature for all levels up to `level`.
     fn combined(&self, level: usize) -> Option<Self::Contribution>;
 }
 
@@ -119,7 +119,7 @@ impl<P: Partitioner, C: AggregatableContribution> ReplaceStore<P, C> {
                         })
                         .get(&id)
                         .unwrap_or_else(|| {
-                            panic!("Individual contributioon {id} missing for level {level}")
+                            panic!("Individual contribution {id} missing for level {level}")
                         });
 
                     // merge individual signature into multisig
@@ -318,7 +318,7 @@ mod tests {
         }
 
         // Now try to insert a contribution using the same identity (1)
-        // Note that since we are using a previous identity, then we need to substract
+        // Note that since we are using a previous identity, then we need to subtract
         // the previous contribution from this identity to the value to be aggregated
         let mut third_contributors = BitSet::new();
         // Note that we are using a different contributor number

--- a/handel/src/todo.rs
+++ b/handel/src/todo.rs
@@ -152,8 +152,8 @@ impl<C: AggregatableContribution, E: Evaluator<C>> Stream for TodoList<C, E> {
         while let Poll::Ready(Some(msg)) = self.input_stream.poll_next_unpin(cx) {
             // TODO the case where the msg is None is not being handled which could mean that:
             // The input has ended, i.e. there is no producer left.
-            // In testcases that could mean the other instances have completed their aggregations and droped their network instances.
-            // In reality this should never happen as the network should not terminate those streams, but try to aquire new Peers in this situation.
+            // In testcases that could mean the other instances have completed their aggregations and dropped their network instances.
+            // In reality this should never happen as the network should not terminate those streams, but try to acquire new Peers in this situation.
             // Panic here is viable, but makes testing a bit harder.
             // TODO more robust handling of this case, as the aggregation might not be able to finish here (depending on what todos are left).
 

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -291,9 +291,11 @@ async fn it_can_aggregate() {
         NetworkWrapper(Arc::clone(&net)),
     );
 
-    // aggregating should not take more than 300 ms
+    // aggregating should not take more than 300 ms per each 7 contributors
+    let timeout_ms = 300u64 * (contributor_num / 7 + 1) as u64;
+
     let deadline = tokio::time::Instant::now()
-        .checked_add(tokio::time::Duration::from_millis(300))
+        .checked_add(tokio::time::Duration::from_millis(timeout_ms))
         .unwrap();
 
     // The final value needs to be the sum of all contributions.


### PR DESCRIPTION
- Invert the `send_individual` logic of `send_update` to send the update when this argument is set to `true` and to be consistent with the variable name. This doesn't change the behavior since on the calling side the flag was inverted too.
- Fix some typos in the `store` and `todo` code.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
