### PR TITLE
validator-network: Use `RwLock` instead of `Mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,6 +4525,7 @@ dependencies = [
  "nimiq-bls",
  "nimiq-network-interface",
  "nimiq-utils",
+ "parking_lot 0.12.1",
  "thiserror",
  "tokio",
  "tracing",

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -22,6 +22,7 @@ beserial = { path = "../beserial", features = ["derive", "libp2p"] }
 futures = { package = "futures-util", version = "0.3" }
 thiserror = "1.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
+parking_lot = "0.12"
 tokio = { version = "1.26", features = ["rt"] }
 
 nimiq-network-interface = { path = "../network-interface" }

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -27,18 +27,20 @@ pub trait ValidatorNetwork: Send + Sync {
     type NetworkType: Network;
     type PubsubId: PubsubId<<Self::NetworkType as Network>::PeerId> + Send;
 
-    /// Tells the validator network the validator keys for the current set of active validators. The keys must be
-    /// ordered, such that the k-th entry is the validator with ID k.
+    /// Tells the validator network the validator keys for the current set of active validators.
+    /// The keys must be ordered, such that the k-th entry is the validator with ID k.
     async fn set_validators(&self, validator_keys: Vec<LazyPublicKey>);
 
-    /// must make a reasonable effort to establish a connection to the peer denoted with `validator_address`
+    /// Sends a message to a validator identified by its ID (position) in the `validator keys`.
+    /// It must make a reasonable effort to establish a connection to the peer denoted with `validator_id`
     /// before returning a connection not established error.
     async fn send_to<M: Message + Clone>(
         &self,
-        validator_ids: &[usize],
+        validator_id: usize,
         msg: M,
-    ) -> Vec<Result<(), Self::Error>>;
+    ) -> Result<(), Self::Error>;
 
+    /// Performs a request to a validator identified by its ID.
     async fn request<TRequest: Request>(
         &self,
         request: TRequest,
@@ -48,29 +50,33 @@ pub trait ValidatorNetwork: Send + Sync {
         NetworkError<<Self::NetworkType as Network>::Error>,
     >;
 
-    /// Will receive from all connected peers
+    /// Returns a stream to receive certain types of messages from every peer.
     fn receive<M>(&self) -> MessageStream<M, <Self::NetworkType as Network>::PeerId>
     where
         M: Message + Clone;
 
+    /// Publishes an item into a Gossipsub topic.
     async fn publish<TTopic: Topic + Sync>(&self, item: TTopic::Item) -> Result<(), Self::Error>;
 
+    /// Subscribes to a specific Gossipsub topic.
     async fn subscribe<'a, TTopic: Topic + Sync>(
         &self,
     ) -> Result<BoxStream<'a, (TTopic::Item, Self::PubsubId)>, Self::Error>;
 
-    /// registers a cache for the specified message type.
-    /// Incoming messages of this type should be held in a FIFO queue of total size `buffer_size`, each with a lifetime of `lifetime`
+    /// Registers a cache for the specified message type.
+    /// Incoming messages of this type should be held in a FIFO queue of total size `buffer_size`,
+    /// each with a lifetime of `lifetime`.
     /// `lifetime` or `buffer_size` of 0 should disable the cache.
     fn cache<M: Message>(&self, buffer_size: usize, lifetime: Duration);
 
+    /// Sets this node peer ID using its secret key and public key.
     async fn set_public_key(
         &self,
         public_key: &CompressedPublicKey,
         secret_key: &SecretKey,
     ) -> Result<(), Self::Error>;
 
-    /// Signals that a Gossipsup'd message with `id` was verified successfully and can be relayed
+    /// Signals that a Gossipsup'd message with `id` was verified successfully and can be relayed.
     fn validate_message<TTopic>(&self, id: Self::PubsubId, acceptance: MsgAcceptance)
     where
         TTopic: Topic + Sync;

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -111,7 +111,9 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
 
         // create the send future and return it.
         async move {
-            nw.send_to(&[recipient], update_message).await;
+            if let Err(error) = nw.send_to(recipient, update_message).await {
+                log::error!(?error, recipient, "Failed to send message");
+            }
         }
         .boxed()
     }

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -89,7 +89,9 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
 
         // create the send future and return it.
         async move {
-            nw.send_to(&[recipient], update_message).await;
+            if let Err(error) = nw.send_to(recipient, update_message).await {
+                log::error!(?error, recipient, "Failed to send message");
+            }
         }
         .boxed()
     }


### PR DESCRIPTION
- Use `parking_lot`'s `RwLock` instead of `future`'s `Mutex` to lock the state in the validator network. This is necessary since the       validator network is this unique instance for example in `Tendermint` where all messages goes to. In the case of `Tendermint` this means multiple handel aggregations will use this network for sending multiple concurrent messages and a `Mutex` will block other send opetations to complete only for the sake of reading (most of the time) the validator network internal cache. So this change replaces the `Mutex` for a `RwLock` such that we only block when we need to change the state which will be mostly once at       the beggining of the epoch (calling `set_validators`) or when resolving for the first time a `validator_id` to a `peer_id`.
- Make the `send_to` function in the validator network to only receive one recipient since callers always pass a single element array.
- Add some `rustdoc` to the `ValidatorNetwork` trait.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
