### PR TITLE
tendermint: Fix the message dispatcher for future contributions

### DIFF
--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -409,6 +409,9 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                     self.state.current_step = Step::Propose;
                     self.future_contributions
                         .retain(|round, _contributors| round > &self.state.current_round);
+
+                    // Return to account the state change
+                    return None;
                 }
             } else if let Some(sender) = self.aggregation_senders.get(&id) {
                 match sender.try_send(message.aggregation) {


### PR DESCRIPTION
Fix the message dispatcher for future contributions when the number of contributions is more than `f+1` and we advance the state to the round of the receive contribution.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
