### PR TITLE
Add missing waker in tendermint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4286,6 +4286,7 @@ dependencies = [
  "nimiq-block",
  "nimiq-collections",
  "nimiq-hash",
+ "nimiq-macros",
  "nimiq-primitives",
  "nimiq-test-log",
  "thiserror",

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -23,6 +23,7 @@ beserial = { path = "../beserial", features = ["derive"] }
 nimiq-block = { path = "../primitives/block" }
 nimiq-collections = { path = "../collections" }
 nimiq-hash = { path = "../hash" }
+nimiq-macros = { path = "../macros" }
 nimiq-primitives = { path = "../primitives", features = ["policy"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Add a missing waker in tendermint related to a futures unordered struct. 


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
