### PR TITLE
handel: Allow empty levels and avoid invalid IDs in levels

### DIFF
--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -167,6 +167,11 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
             level.num_peers()
         };
 
+        if num_peers == 0 {
+            trace!("Level {} is empty and thus complete", level_id);
+            return;
+        }
+
         // first get the current contributor count for this level. Release the lock as soon as possible
         // to continue working on todos.
         let num_contributors = {
@@ -268,14 +273,10 @@ impl<P: Protocol, N: Network<Contribution = P::Contribution>> NextAggregation<P,
         for level_id in 1..self.levels.len() {
             let (receive_complete, next_peers) = {
                 let level = self.levels.get(level_id).unwrap();
-                if level.active() {
-                    (
-                        level.receive_complete(),
-                        level.select_next_peers(self.config.peer_count),
-                    )
-                } else {
-                    return;
-                }
+                (
+                    level.receive_complete(),
+                    level.select_next_peers(self.config.peer_count),
+                )
             };
 
             // Get the current best aggregate from store (no clone() needed as that already happens within the store)

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -200,6 +200,11 @@ impl<
         if level == self.partitioner.levels() {
             return true;
         }
-        self.partitioner.range(level).unwrap().contains(&id)
+        let range = self.partitioner.range(level);
+        if let Ok(range) = range {
+            range.contains(&id)
+        } else {
+            false
+        }
     }
 }

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -59,6 +59,11 @@ impl Level {
         self.peer_ids.len()
     }
 
+    /// Returns wether this level is empty
+    pub fn is_empty(&self) -> bool {
+        self.peer_ids.len() == 0
+    }
+
     /// Creates a set of levels given a partitioner
     pub fn create_levels<P: Partitioner>(partitioner: Arc<P>) -> Vec<Level> {
         let mut levels: Vec<Level> = Vec::new();
@@ -109,7 +114,7 @@ impl Level {
 
     /// Selects the set of next peers to send an update to for this level given a count of them
     pub fn select_next_peers(&self, count: usize) -> Vec<usize> {
-        if self.id == 0 {
+        if self.id == 0 || self.is_empty() {
             vec![]
         } else {
             let size = min(count, self.peer_ids.len());


### PR DESCRIPTION
Allow empty levels and avoid invalid IDs in levels. This is useful to account for level complete appropriately instead of waiting for aggregations from peers that will never arrive. Also this avoid accounting internal state for peers that doesn't exist such as the state in the `Level` code for selecting the next peers for sending updates.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
