### PR TITLE
handel: Fix hashing of `AggregatableContribution`

### DIFF
--- a/handel/src/todo.rs
+++ b/handel/src/todo.rs
@@ -54,6 +54,7 @@ impl<C: AggregatableContribution> Eq for TodoItem<C> {}
 impl<C: AggregatableContribution> std::hash::Hash for TodoItem<C> {
     // TODO
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&self.level, state);
         std::hash::Hash::hash(&self.contribution.contributors().to_string(), state);
     }
 }


### PR DESCRIPTION
Fix hashing of `AggregatableContribution` in the `handel` code to be the same as the implementation of `eq` by taking also the `level`. This change shouldn't impact the functionality but for the sake of correctness it is nice to have it.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
