### PR TITLE
Handel Identity and logging identifier

### DIFF
--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -12,7 +12,7 @@ fn index_and_mask(value: usize) -> (usize, u64) {
     (value >> 6, 1u64 << (value & 63))
 }
 
-#[derive(Clone, Eq)]
+#[derive(Clone, Eq, PartialOrd, Ord)]
 pub struct BitSet {
     store: Vec<u64>,
     count: usize,

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -357,7 +357,7 @@ impl<T: Debug + Clone + 'static, P: Protocol<T>, N: Network<Contribution = P::Co
                                     store.put(
                                         todo.contribution.clone(),
                                         todo.level,
-                                        self.protocol.registry().signers_identity(&todo.contribution.contributors()),
+                                        self.protocol.registry(),
                                         self.protocol.identify(),
                                     );
                                 }

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -2,13 +2,12 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::identity::WeightRegistry;
-use crate::partitioner::Partitioner;
-use crate::protocol::Protocol;
-use crate::store::ContributionStore;
 use crate::{
     contribution::AggregatableContribution,
-    identity::{Identity, IdentityRegistry},
+    identity::{IdentityRegistry, WeightRegistry},
+    partitioner::Partitioner,
+    protocol::Protocol,
+    store::ContributionStore,
 };
 
 pub trait Evaluator<TId, TProtocol>: Send + Sync
@@ -16,7 +15,7 @@ where
     TId: Clone + std::fmt::Debug + 'static,
     TProtocol: Protocol<TId>,
 {
-    fn evaluate(&self, signature: &TProtocol::Contribution, level: usize) -> usize;
+    fn evaluate(&self, signature: &TProtocol::Contribution, level: usize, id: TId) -> usize;
     fn is_final(&self, signature: &TProtocol::Contribution) -> bool;
     fn level_contains_id(&self, level: usize, id: usize) -> bool;
 }
@@ -41,6 +40,23 @@ where
     TId: Clone + std::fmt::Debug + 'static,
     TProtocol: Protocol<TId>,
 {
+    /// If a todo completes a level this is the base score
+    const COMPLETES_LEVEL_BASE_SCORE: usize = 1_000_000;
+
+    /// For todos which complete a level this is a penalty multiplied with the level, resulting
+    /// in higher levels having lower scores.
+    const COMPLETES_LEVEL_LEVEL_PENALTY: usize = 10;
+
+    /// If a todo improves the best score on its level this is the base score
+    const IMPROVEMENT_BASE_SCORE: usize = 100_000;
+
+    /// For a todo which improves the best score this is the penalty per level, resulting
+    /// in higher levels having a lower score.
+    const IMPROVEMENT_LEVEL_PENALTY: usize = 100;
+
+    /// For a todo which improves the best score this is a bonus added to th score per signature added.
+    const IMPROVEMENT_ADDED_SIG_BONUS: usize = 10;
+
     pub fn new(
         store: Arc<RwLock<TProtocol::Store>>,
         weights: Arc<TProtocol::Registry>,
@@ -66,9 +82,7 @@ where
     /// `0` being not useful at all, can be discarded.
     ///
     /// `>0` being more useful the bigger the number.
-    fn evaluate(&self, contribution: &TProtocol::Contribution, level: usize) -> usize {
-        // TODO: Consider weight
-
+    fn evaluate(&self, contribution: &TProtocol::Contribution, level: usize, id: TId) -> usize {
         // Special case for final aggregations
         if level == self.partitioner.levels() {
             // Only available to full aggregations
@@ -86,108 +100,133 @@ where
 
         let store = self.store.read();
 
-        // check if we already know this individual signature
-        // signers_identity returns None if it is not a single identity (also no identity at all)
+        // Calculate the identity represented in the contribution.
         let identity = self.weights.signers_identity(&contribution.contributors());
-        if let Identity::Single(identity) = identity {
-            if store.individual_signature(level, identity).is_some() {
-                // If we already know it for this level, score it as 0
-                return 0;
-            }
+
+        // Empty or faulty signatures get a score of 0
+        if identity.is_empty() {
+            return 0;
         }
 
-        // number of identities at `level`, sort of maximum receivable contributions
-        let to_receive = self.partitioner.level_size(level);
+        // For contributions with a single signer, check if it is already known.
+        if identity.len() == 1 && store.individual_signature(level, &identity).is_some() {
+            // If we already know it for this level, score it as 0
+            return 0;
+        }
+
+        // Number of identities at `level`, sort of maximum receivable individual contributions
+        let level_identity_count = self.partitioner.level_size(level);
+
+        // The current best contribution stored for `level`.
         let best_contribution = store.best(level);
 
         if let Some(best_contribution) = best_contribution {
-            let best_contributors_num = match self
+            let best_contributors = self
                 .weights
-                .signers_identity(&best_contribution.contributors())
-            {
-                Identity::None => 0,
-                Identity::Single(_) => 1,
-                Identity::Multiple(ids) => ids.len(),
-            };
+                .signers_identity(&best_contribution.contributors());
 
-            // check if the best signature for that level is already complete
-            if to_receive == best_contributors_num {
+            // Check if the best signature for that level is already complete
+            if level_identity_count == best_contributors.len() {
                 return 0;
             }
 
-            // check if the best signature is better than the new one
-            if best_contribution
-                .contributors()
-                .is_superset(&contribution.contributors())
-            {
+            // Check if the best signature is strictly better than the new one
+            if best_contributors.is_superset_of(&identity) {
                 return 0;
             }
         }
 
-        // the signers of the signature
-        // NOTE: This is a little bit more efficient than `signature.signers().collect()`, since
-        // `signers()` returns a boxed iterator.
-        // NOTE: We compute the full `BitSet` (also for individual signatures), since we need it in
-        // a few places here
-        let signers = if let Identity::Single(identity) = identity {
-            let mut individuals = store.individual_verified(level).clone();
-            individuals.insert(identity);
-            individuals
-        } else {
-            contribution.contributors()
-        };
-
-        // compute bitset of signers combined with all (verified) individual signatures that we have
-        let with_individuals = &signers | store.individual_verified(level);
+        // Compute bitset of signers combined with all (verified) individual signatures that we have.
+        // Allow intersection here as all individual signatures are stored individually.
+        let mut with_individuals = identity.clone();
+        with_individuals.combine(store.individual_verified(level), true);
 
         // ---------------------------------------------
 
         let (new_total, added_sigs, combined_sigs) = if let Some(best_signature) = best_contribution
         {
-            let best_contributors_num = match self
+            let best_contributors = self
                 .weights
-                .signers_identity(&best_signature.contributors())
-            {
-                Identity::None => 0,
-                Identity::Single(_) => 1,
-                Identity::Multiple(ids) => ids.len(),
-            };
-            // TODO weights!
-            if signers.intersection_size(&best_signature.contributors()) > 0 {
-                // can't merge
+                .signers_identity(&best_signature.contributors());
+
+            if identity.intersection_size(&best_contributors) > 0 {
+                // The contribution we got cannot be merged into the best one we already have, as they overlap.
+                // Best thing we can do is merge individual contributions into it.
                 let new_total = with_individuals.len();
                 (
+                    // The new contribution combined with all already verified individuals not yet present in the new one.
                     new_total,
-                    new_total.saturating_sub(best_contributors_num),
-                    new_total - signers.len(),
+                    (new_total as isize) - best_contributors.len() as isize,
+                    new_total - identity.len(),
                 )
             } else {
-                let final_sig = &with_individuals | &best_signature.contributors();
+                // The signatures can be combined, so the resulting signature will have the signers of both,
+                // as well as individual signatures.
+
+                let mut final_sig = with_individuals.clone();
+                // Intersections must be allowed as individuals are already present on the left side, and potentially
+                // part of the right side.
+                final_sig.combine(&best_contributors, true);
+
+                // Needed to find out how many individuals are present in final_sig
+                let mut without_individuals = best_contributors.clone();
+                without_individuals.combine(&identity, false);
+
                 let new_total = final_sig.len();
-                let combined_sigs = (final_sig ^ (&best_signature.contributors() | &signers)).len();
-                (new_total, new_total - best_contributors_num, combined_sigs)
+                let combined_sigs = (final_sig ^ without_individuals).len();
+                (
+                    new_total,
+                    new_total as isize - best_contributors.len() as isize,
+                    combined_sigs,
+                )
             }
         } else {
-            // best is the new signature with the individual signatures
+            // Currently there is no best signature for this level. The new signature will become the best.
+            // Best is the new signature with the individual signatures. However, if there are individual
+            // signatures for this level there should also be a best signature.
+            if with_individuals.len() != identity.len() {
+                log::warn!(
+                    ?id,
+                    ?level,
+                    ?identity,
+                    individuals = ?store.individual_verified(level),
+                    "No best contribution found, even though there are individuals",
+                );
+            }
             let new_total = with_individuals.len();
-            (new_total, new_total, new_total - signers.len())
+
+            (
+                new_total,                  // this should be identical to identity.len()
+                new_total as isize,         // This will be a positive number
+                new_total - identity.len(), // This should be 0
+            )
         };
 
-        // compute score
-        // TODO: Remove magic numbers! What do they mean? I don't think this is discussed in the paper.
-        if added_sigs == 0 {
-            // return signature_weight for an individual signature, otherwise 0
-            if let Identity::Single(_) = self.weights.signers_identity(&contribution.contributors())
-            {
-                self.weights.signature_weight(contribution).unwrap_or(0)
-            } else {
-                0
+        // Compute score
+        if added_sigs <= 0 {
+            // return `signature_weight` for an individual signature, otherwise 0 as the signature is useless
+            if identity.len() == 1 {
+                return self.weights.signature_weight(contribution).unwrap_or(0);
             }
-        } else if new_total == to_receive {
-            1_000_000 - level * 10 - combined_sigs
-        } else {
-            100_000 - level * 100 + added_sigs * 10 - combined_sigs
+            return 0;
         }
+
+        if new_total == level_identity_count {
+            // The signature will complete the level it is on.
+            // These signatures are the most valuable, with early levels being more valuable than later ones.
+            // The less signatures are added by combining with individual ones, the better.
+            return Self::COMPLETES_LEVEL_BASE_SCORE
+                - level * Self::COMPLETES_LEVEL_LEVEL_PENALTY
+                - combined_sigs;
+        }
+
+        // The signature makes the best signature better, but does not complete a level.
+        // Make it so it will be better than in individual but worse than those which complete a level.
+        // Favor earlier levels over later levels.
+        // Favor those which add more signatures but out of them favor those with less individual merges.
+        Self::IMPROVEMENT_BASE_SCORE - level * Self::IMPROVEMENT_LEVEL_PENALTY
+            + added_sigs as usize * Self::IMPROVEMENT_ADDED_SIG_BONUS
+            - combined_sigs
     }
 
     fn is_final(&self, signature: &TProtocol::Contribution) -> bool {

--- a/handel/src/identity.rs
+++ b/handel/src/identity.rs
@@ -1,52 +1,113 @@
+use std::ops::{BitXor, BitXorAssign};
+
 use nimiq_bls::PublicKey;
 use nimiq_collections::bitset::BitSet;
 
 use crate::contribution::AggregatableContribution;
 
-#[derive(Clone, std::fmt::Debug)]
-pub enum Identity {
-    Single(usize),
-    Multiple(Vec<usize>),
-    None,
+/// Struct that defines an identity.
+/// An identity is composed of zero, one or more signers of a contribution.
+#[derive(Clone, std::fmt::Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Identity {
+    signers: BitSet,
 }
 
 impl Identity {
-    pub fn as_bitset(&self) -> BitSet {
-        let mut bitset = BitSet::new();
-        match self {
-            Self::Single(id) => bitset.insert(*id),
-            Self::Multiple(ids) => ids.iter().for_each(|id| bitset.insert(*id)),
-            Self::None => {}
-        }
-        bitset
+    /// Creates a new identity given a bitset of signers of a contribution.
+    pub fn new(signers: BitSet) -> Self {
+        Self { signers }
     }
 
+    /// Returns the number of signers in this identity.
     pub fn len(&self) -> usize {
-        match self {
-            Identity::None => 0,
-            Identity::Single(_) => 1,
-            Identity::Multiple(ids) => ids.len(),
+        self.signers.len()
+    }
+
+    /// Returns whether this identity is empty.
+    pub fn is_empty(&self) -> bool {
+        self.signers.is_empty()
+    }
+
+    /// Returns whether this identity is a superset of another identity.
+    pub fn is_superset_of(&self, other: &Self) -> bool {
+        self.signers.is_superset(&other.signers)
+    }
+
+    /// Returns the complement signers from another identity.
+    pub fn complement(&self, other: &Self) -> Self {
+        Self {
+            signers: &(&self.signers & &other.signers) ^ &other.signers,
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    /// Returns the identity as a vector of signers.
+    pub fn as_vec(&self) -> Vec<usize> {
+        self.signers.iter().collect()
+    }
+
+    /// Returns the intersection size with another identity.
+    pub fn intersection_size(&self, other: &Self) -> usize {
+        self.signers.intersection_size(&other.signers)
+    }
+
+    /// Perform bitwise or. Panics if overlap exists when flag is set.
+    pub fn combine(&mut self, other: &Self, allow_intersection: bool) {
+        if !allow_intersection && self.signers.intersection_size(&other.signers) > 0 {
+            panic!("Identities overlap");
+        }
+        self.signers = &self.signers | &other.signers;
+    }
+
+    /// Returns an iterator for this identity.
+    pub fn iter(&self) -> impl Iterator<Item = Identity> + '_ {
+        self.signers.iter().map(|id| Identity {
+            signers: BitSet::from_iter([id]),
+        })
+    }
+}
+
+impl BitXor for Identity {
+    type Output = Identity;
+
+    fn bitxor(self, other: Self) -> Self::Output {
+        Identity {
+            signers: self.signers ^ other.signers,
+        }
+    }
+}
+
+impl BitXor for &Identity {
+    type Output = Identity;
+
+    fn bitxor(self, other: Self) -> Self::Output {
+        Identity {
+            signers: &self.signers ^ &other.signers,
+        }
+    }
+}
+
+impl BitXorAssign for Identity {
+    fn bitxor_assign(&mut self, other: Self) {
+        self.signers ^= other.signers;
     }
 }
 
 pub trait IdentityRegistry: Send + Sync {
+    /// Maps form Slot to PublicKey, returns None if the Slot does not exist.
     fn public_key(&self, id: usize) -> Option<PublicKey>;
 
-    fn signers_identity(&self, signers: &BitSet) -> Identity;
+    /// For a Set of Slots returns the Identity represented by those Slots.
+    fn signers_identity(&self, slots: &BitSet) -> Identity;
 }
 
 pub trait WeightRegistry: Send + Sync {
+    /// Given a Slot, returns the weight of that Slot.
     fn weight(&self, id: usize) -> Option<usize>;
 
-    fn signers_weight(&self, signers: &BitSet) -> Option<usize> {
+    fn signers_weight(&self, slots: &BitSet) -> Option<usize> {
         let mut votes = 0;
-        for signer in signers.iter() {
-            votes += self.weight(signer)?;
+        for slot in slots.iter() {
+            votes += self.weight(slot)?;
         }
         Some(votes)
     }

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -65,7 +65,10 @@ impl Level {
     }
 
     /// Creates a set of levels given a partitioner
-    pub fn create_levels<P: Partitioner>(partitioner: Arc<P>) -> Vec<Level> {
+    pub fn create_levels<P: Partitioner, TId: std::fmt::Debug>(
+        partitioner: Arc<P>,
+        id: TId,
+    ) -> Vec<Level> {
         let mut levels: Vec<Level> = Vec::new();
         let mut first_active = false;
         let mut send_expected_full_size: usize = 1;
@@ -78,7 +81,12 @@ impl Level {
                     ids.shuffle(&mut rng);
 
                     let size = ids.len();
-                    trace!("Level {} peers: {:?}", i, ids);
+                    trace!(
+                        ?id,
+                        level = i,
+                        peers_on_level = ?ids,
+                        "Peers on Level",
+                    );
                     let level = Level::new(i, ids, send_expected_full_size);
 
                     if !first_active {

--- a/handel/src/protocol.rs
+++ b/handel/src/protocol.rs
@@ -5,21 +5,21 @@ use parking_lot::RwLock;
 
 use crate::contribution::AggregatableContribution;
 use crate::evaluator::Evaluator;
-use crate::identity::IdentityRegistry;
+use crate::identity::{IdentityRegistry, WeightRegistry};
 use crate::partitioner::Partitioner;
 use crate::store::ContributionStore;
 use crate::verifier::{VerificationResult, Verifier};
 
 #[async_trait]
-pub trait Protocol: Send + Sync + 'static {
-    /// The type foor individual as well as aggregated contributions.
+pub trait Protocol<TId: Clone + std::fmt::Debug + 'static>: Send + Sync + Sized + 'static {
+    /// The type for individual as well as aggregated contributions.
     type Contribution: AggregatableContribution;
     // TODO: Some of those traits can be directly move into `Protocol`. Others should not be part of
     // the protocol (i.e. `Verifier`).
-    type Registry: IdentityRegistry;
+    type Registry: IdentityRegistry + WeightRegistry;
     type Verifier: Verifier<Contribution = Self::Contribution>;
-    type Store: ContributionStore<Contribution = Self::Contribution>;
-    type Evaluator: Evaluator<Self::Contribution>;
+    type Store: ContributionStore<TId, Self>;
+    type Evaluator: Evaluator<TId, Self>;
     type Partitioner: Partitioner;
 
     fn registry(&self) -> Arc<Self::Registry>;
@@ -28,6 +28,7 @@ pub trait Protocol: Send + Sync + 'static {
     fn evaluator(&self) -> Arc<Self::Evaluator>;
     fn partitioner(&self) -> Arc<Self::Partitioner>;
 
+    fn identify(&self) -> TId;
     fn node_id(&self) -> usize;
 
     // TODO: not strictly necessary as it does the same as protocol.verifier().verify(contribution).

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -72,14 +72,8 @@ impl IdentityRegistry for Registry {
         None
     }
 
-    fn signers_identity(&self, signers: &BitSet) -> Identity {
-        if signers.len() == 1 {
-            Identity::Single(signers.iter().next().unwrap())
-        } else if !signers.is_empty() {
-            Identity::Multiple(signers.iter().collect())
-        } else {
-            Identity::None
-        }
+    fn signers_identity(&self, slots: &BitSet) -> Identity {
+        Identity::new(slots.clone())
     }
 }
 

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -494,6 +494,7 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                             }
                             Step::Precommit => {
                                 // The proposal exists and is valid. 2f+1 precommits have been seen.
+                                log::debug!(?round_and_step, "Aggregation produced decision value",);
 
                                 // Get the inherent
                                 let inherent = self

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -432,6 +432,11 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                         return Some(message);
                     }
                 }
+            } else {
+                log::debug!(
+                    ?message,
+                    "received level update for non running aggregation",
+                );
             }
         }
         None

--- a/validator/src/aggregation/tendermint/state.rs
+++ b/validator/src/aggregation/tendermint/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io};
+use std::{collections::BTreeMap, fmt::Debug, io};
 
 use beserial::{Deserialize, DeserializeWithLength, Serialize, SerializeWithLength};
 use nimiq_block::{MacroBody, MacroHeader};
@@ -27,6 +27,20 @@ pub struct MacroState {
     inherents: BTreeMap<Blake2bHash, MacroBody>,
     locked: Option<(u32, Blake2sHash)>,
     valid: Option<(u32, Blake2sHash)>,
+}
+
+impl Debug for MacroState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("MacroState");
+        dbg.field("round", &self.round_number);
+        dbg.field("step", &self.step);
+        dbg.field("locked", &self.locked);
+        dbg.field("valid", &self.valid);
+        dbg.field("best_votes", &self.best_votes);
+        dbg.field("votes", &self.votes);
+
+        dbg.finish()
+    }
 }
 
 impl MacroState {

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -612,7 +612,7 @@ where
                 // In case of a new state update we need to store the new version of it disregarding
                 // any old state which potentially still lingers.
                 MappedReturn::Update(update) => {
-                    // trace!("Tendermint state update {:?}", update);
+                    trace!(?update, "Tendermint state update",);
                     let mut write_transaction = WriteTransaction::new(&self.env);
                     let expected_height = self.blockchain.read().block_number() + 1;
                     if expected_height != update.block_number {


### PR DESCRIPTION
Reworks Identity. It is now no longer an Enum but a struct exposing necessary functionalities to not having to expose the underlying Bitset. This is done to facilitate a strict separation between Slots and Identities, which previously both used BitSets.

Also adds an identifier to Handel which is used to attribute log messages to a specific ongoing aggregation. Tendermint specifically can have multiple aggregations ongoing which makes this identifier necessary.
