### PR TITLE
ci: Make sure code is built before running it

### DIFF
--- a/scripts/devnet/node.py
+++ b/scripts/devnet/node.py
@@ -153,6 +153,22 @@ class Node:
         """
         return self.get_state_dir() + "/" + "devalbatross-history-consensus"
 
+    def build(self):
+        """
+        Builds the code for the current node
+        """
+        # Prepare the build command.
+        # Note: Use the `run` for the client since this will assure that
+        # when we call it later, it won't compile the code again.
+        # To exit the client, we will call it with `--help`
+        command = ["cargo", "run", "--bin", self.nimiq_exec]
+        if self.topology_settings.get_release():
+            command.append("--release")
+        command.extend(["--", "--help"])
+        subprocess.run(
+            command, cwd=self.topology_settings.get_nimiq_dir(), check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
     def run(self):
         """
         Runs the process for the current node

--- a/scripts/devnet/topology.py
+++ b/scripts/devnet/topology.py
@@ -261,6 +261,11 @@ class Topology:
         # Register a handler for SIGINT (CTRL-c)
         signal.signal(signal.SIGINT, self.__sigint_handler)
 
+        # Continue with the rest of the nodes
+        for node in all_nodes:
+            logging.info(f"Building {node.get_name()}")
+            node.build()
+
         # Start all nodes, starting first with seeds
         for seed in self.seed_nodes:
             logging.info(f"Starting {seed.get_name()}")


### PR DESCRIPTION
Make sure code is built before running it.
For building it, the script will use run the client with the `--help` argument to make sure code doesn't need a recompilation when later it runs the client again.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
