### PR TITLE
Optimize ZKP verification and rely on result of ZKP component

### DIFF
--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -17,10 +17,14 @@ impl Blockchain {
     /// a valid chain between the genesis block and that block.
     /// This brings the node from the genesis block all the way to the most recent election block.
     /// It is the default way to sync for a full node.
+    ///
+    /// When we get a ZKP from the ZKP component, it is already verified.
+    /// We can then set the `trusted_proof` flag to avoid the additional verification.
     pub fn push_zkp(
         this: RwLockUpgradableReadGuard<Self>,
         block: Block,
         proof: NanoProof,
+        trusted_proof: bool,
     ) -> Result<PushResult, PushError> {
         // Must be an election block.
         assert!(block.is_election());
@@ -68,19 +72,21 @@ impl Blockchain {
             .ok_or(PushError::InvalidBlock(BlockError::InvalidPkTreeRoot))?;
 
         // Verify the zk proof.
-        let verify_result = verify(
-            genesis_block.block_number(),
-            genesis_header_hash,
-            &genesis_pk_tree_root,
-            final_block_number,
-            final_header_hash,
-            &final_pk_tree_root,
-            proof,
-            &ZKP_VERIFYING_KEY,
-        );
+        if !trusted_proof {
+            let verify_result = verify(
+                genesis_block.block_number(),
+                genesis_header_hash,
+                &genesis_pk_tree_root,
+                final_block_number,
+                final_header_hash,
+                &final_pk_tree_root,
+                proof,
+                &ZKP_VERIFYING_KEY,
+            );
 
-        if verify_result.is_err() || !verify_result.unwrap() {
-            return Err(PushError::InvalidZKP);
+            if verify_result.is_err() || !verify_result.unwrap() {
+                return Err(PushError::InvalidZKP);
+            }
         }
 
         // At this point we know that the block is correct. We just have to push it.

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -94,6 +94,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                     blockchain_urg,
                                     Block::Macro(block),
                                     proof.proof.expect("Expected a zkp proof"),
+                                    true,
                                 )
                             }
                             BlockchainProxy::Light(ref light_blockchain) => {
@@ -101,6 +102,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                     light_blockchain.upgradable_read(),
                                     Block::Macro(block),
                                     proof.proof.expect("Expected a zkp proof"),
+                                    true,
                                 )
                             }
                         };


### PR DESCRIPTION
## What's in this pull request?
This is a tiny optimization preventing us from verifying ZKPs twice.
The ZKP component always verifies the proofs before forwarding them to the syncer.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
