### PR TITLE
Fix timestamp of genesis block to be in milliseconds

### DIFF
--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate log;
 
-use std::convert::TryFrom;
 use std::fs::{read_to_string, OpenOptions};
 use std::io::Error as IoError;
 use std::path::Path;
@@ -33,8 +32,6 @@ mod config;
 pub enum GenesisBuilderError {
     #[error("No VRF seed to generate genesis block")]
     NoVrfSeed,
-    #[error("Invalid timestamp: {0}")]
-    InvalidTimestamp(OffsetDateTime),
     #[error("Serialization failed")]
     SerializingError(#[from] SerializingError),
     #[error("I/O error")]
@@ -238,8 +235,7 @@ impl GenesisBuilder {
             version: 1,
             block_number: 0,
             round: 0,
-            timestamp: u64::try_from(timestamp.unix_timestamp())
-                .map_err(|_| GenesisBuilderError::InvalidTimestamp(timestamp))?,
+            timestamp: timestamp.unix_timestamp() as u64 * 1000,
             parent_hash: [0u8; 32].into(),
             parent_election_hash: [0u8; 32].into(),
             interlink: Some(vec![]),


### PR DESCRIPTION
## What's in this pull request?

The genesis timestamp was set as a UNIX timestamp in seconds. However, block header timestamps are supposed to be in milliseconds. This timestamp being in seconds but being interpreted in milliseconds, led to wrong rewards being paid out because the supply calculation was shifted forward in time.

Additionally, I removed the `u64::try_from` and subsequent error mapping, as the method `unix_timestamp()` returns an `i64`, not a result, and converting from i64 to u64 cannot fail.

> **Note**
> This fix only applies to newly generated genesis blocks, thus requiring a chain reset to apply to the testnet.

#### This fixes #1569.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
