### PR TITLE
Encode genesis supply in genesis block

### DIFF
--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -229,6 +229,17 @@ impl GenesisBuilder {
         // State root
         let state_root = accounts.get_root_hash_assert(Some(&txn));
         debug!("State root: {}", &state_root);
+
+        // Supply
+        let supply = accounts
+            .tree
+            .iter_nodes::<Account>(
+                &txn,
+                &KeyNibbles::from(&Address::START_ADDRESS),
+                &KeyNibbles::from(&Address::END_ADDRESS),
+            )
+            .fold(Coin::ZERO, |sum, account| sum + account.balance());
+
         txn.abort();
 
         // The header
@@ -241,7 +252,7 @@ impl GenesisBuilder {
             parent_election_hash: [0u8; 32].into(),
             interlink: Some(vec![]),
             seed,
-            extra_data: vec![],
+            extra_data: supply.serialize_to_vec(),
             state_root,
             body_root,
             history_root: Blake2bHash::default(),


### PR DESCRIPTION
## What's in this pull request?

Calculates and encodes the genesis supply from the config into the genesis block.

#### This fixes #1506.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
