### PR TITLE
Increase max databases in tests to 20

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -45,7 +45,7 @@ const VOLATILE_ENV: bool = true;
 #[test]
 fn it_can_produce_micro_blocks() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -156,7 +156,7 @@ fn it_can_produce_micro_blocks() {
 #[test]
 fn it_can_produce_macro_blocks() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -190,7 +190,7 @@ fn it_can_produce_macro_blocks() {
 #[test]
 fn it_can_produce_election_blocks() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -229,7 +229,7 @@ fn it_can_produce_election_blocks() {
 fn it_can_produce_a_chain_with_txns() {
     let time = Arc::new(OffsetTime::new());
     let env = if VOLATILE_ENV {
-        VolatileDatabase::new(10).unwrap()
+        VolatileDatabase::new(20).unwrap()
     } else {
         let tmp_dir = tempdir().expect("Could not create temporal directory");
         let tmp_dir = tmp_dir.path().to_str().unwrap();
@@ -276,7 +276,7 @@ fn it_can_produce_a_chain_with_txns() {
 #[test]
 fn it_can_revert_unpark_transactions() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -380,7 +380,7 @@ fn it_can_revert_unpark_transactions() {
 #[test]
 fn it_can_revert_create_staker_transaction() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -477,7 +477,7 @@ fn it_can_revert_create_staker_transaction() {
 #[test]
 fn it_can_revert_failed_transactions() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -622,7 +622,7 @@ fn it_can_revert_failed_transactions() {
 #[test]
 fn it_can_revert_failed_vesting_contract_transaction() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -784,7 +784,7 @@ fn it_can_revert_failed_vesting_contract_transaction() {
 #[test]
 fn it_can_revert_reactivate_transaction() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -885,7 +885,7 @@ fn it_can_revert_reactivate_transaction() {
 #[test]
 fn it_can_consume_all_validator_deposit() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -1091,7 +1091,7 @@ fn it_can_consume_all_validator_deposit() {
 #[test]
 fn it_can_revert_failed_delete_validator() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -1254,7 +1254,7 @@ fn it_can_revert_failed_delete_validator() {
 fn it_can_revert_basic_and_create_contracts_txns() {
     let mut rng = test_rng(false);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1111,7 +1111,7 @@ mod tests {
     #[test]
     fn length_at_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1139,7 +1139,7 @@ mod tests {
     #[test]
     fn get_root_from_ext_txs_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1165,7 +1165,7 @@ mod tests {
     #[test]
     fn get_ext_tx_by_hash_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1205,7 +1205,7 @@ mod tests {
     #[test]
     fn get_block_transactions_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1319,7 +1319,7 @@ mod tests {
     #[test]
     fn get_epoch_transactions_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1438,7 +1438,7 @@ mod tests {
     #[test]
     fn get_num_extended_transactions_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1466,7 +1466,7 @@ mod tests {
     #[test]
     fn get_tx_hashes_by_address_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1524,7 +1524,7 @@ mod tests {
     #[test]
     fn prove_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         // Create extended transactions.
@@ -1588,7 +1588,7 @@ mod tests {
     #[test]
     fn prove_empty_tree_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
 
         let txn = env.write_transaction();
@@ -1607,7 +1607,7 @@ mod tests {
     #[test]
     fn get_indexes_for_block_works() {
         // Initialize History Store.
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let history_store = HistoryStore::new(env.clone());
         let mut txn = env.write_transaction();
 

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -26,7 +26,7 @@ fn history_sync_works() {
     let time = Arc::new(OffsetTime::new());
 
     // Create a blockchain to produce the macro blocks.
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
@@ -110,7 +110,7 @@ fn history_sync_works() {
 
     let time = Arc::new(OffsetTime::new());
     // Create a second blockchain to push these blocks.
-    let env2 = VolatileDatabase::new(10).unwrap();
+    let env2 = VolatileDatabase::new(20).unwrap();
 
     let blockchain2 = Arc::new(RwLock::new(
         Blockchain::new(
@@ -180,7 +180,7 @@ fn history_sync_works_with_micro_blocks() {
     let time = Arc::new(OffsetTime::new());
 
     // Create a blockchain to produce the macro blocks.
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
@@ -273,7 +273,7 @@ fn history_sync_works_with_micro_blocks() {
 
     let time = Arc::new(OffsetTime::new());
     // Create a second blockchain to push these blocks.
-    let env2 = VolatileDatabase::new(10).unwrap();
+    let env2 = VolatileDatabase::new(20).unwrap();
 
     let blockchain2 = Arc::new(RwLock::new(
         Blockchain::new(
@@ -346,7 +346,7 @@ fn history_sync_works_with_micro_blocks() {
 #[test]
 fn history_sync_works_with_diverging_history() {
     // Produce macro blocks to complete one epoch in blockchain1.
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let time = Arc::new(OffsetTime::new());
     let blockchain1 = Arc::new(RwLock::new(
         Blockchain::new(
@@ -367,7 +367,7 @@ fn history_sync_works_with_diverging_history() {
     );
 
     // Produce some micro blocks (with a different history) in blockchain2.
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let time = Arc::new(OffsetTime::new());
     let blockchain2 = Arc::new(RwLock::new(
         Blockchain::new(

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -15,7 +15,7 @@ use nimiq_vrf::VrfSeed;
 #[test]
 fn it_can_create_batch_finalization_inherents() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(
         Blockchain::new(
             env,
@@ -154,7 +154,7 @@ fn it_can_create_batch_finalization_inherents() {
 #[test]
 fn it_can_penalize_delayed_batch() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(
         Blockchain::new(
             env,

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -69,7 +69,7 @@ fn test_skip_block_single_signature() {
 fn test_replay() {
     let time = Arc::new(OffsetTime::new());
     // Create a blockchain to have access to the validator slots.
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(
         Blockchain::new(
             env,

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -663,7 +663,7 @@ mod tests {
     #[test(tokio::test)]
     async fn it_can_cluster_epoch_ids() {
         let time = Arc::new(OffsetTime::new());
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let blockchain = Arc::new(RwLock::new(
             Blockchain::new(
                 env,
@@ -823,7 +823,7 @@ mod tests {
     #[test(tokio::test)]
     async fn it_can_cluster_checkpoint_ids() {
         let time = Arc::new(OffsetTime::new());
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let blockchain = Arc::new(RwLock::new(
             Blockchain::new(
                 env,
@@ -1111,7 +1111,7 @@ mod tests {
     #[test(tokio::test)]
     async fn it_splits_clusters_correctly() {
         let time = Arc::new(OffsetTime::new());
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let blockchain = Arc::new(RwLock::new(
             Blockchain::new(
                 env,

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -267,7 +267,7 @@ mod tests {
 
     fn blockchain() -> Arc<RwLock<Blockchain>> {
         let time = Arc::new(OffsetTime::new());
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         Arc::new(RwLock::new(
             Blockchain::new(
                 env,

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -446,7 +446,7 @@ mod tests {
 
     fn blockchain() -> BlockchainProxy {
         let time = Arc::new(OffsetTime::new());
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         BlockchainProxy::Full(Arc::new(RwLock::new(
             Blockchain::new(
                 env,

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -28,7 +28,7 @@ async fn test_request_transactions_by_address() {
 
     let blockchain1 = Arc::new(RwLock::new(
         Blockchain::new(
-            VolatileDatabase::new(11).unwrap(),
+            VolatileDatabase::new(20).unwrap(),
             BlockchainConfig::default(),
             NetworkId::UnitAlbatross,
             Arc::new(OffsetTime::new()),

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -64,7 +64,7 @@ impl MacroSync<MockPeerId> for MockHistorySyncStream {
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     Arc::new(RwLock::new(
         Blockchain::new(
             env,

--- a/consensus/tests/history_sync.rs
+++ b/consensus/tests/history_sync.rs
@@ -172,7 +172,7 @@ async fn sync_ingredients() {
 
     // Setup first peer.
     let time = Arc::new(OffsetTime::new());
-    let env1 = VolatileDatabase::new(11).unwrap();
+    let env1 = VolatileDatabase::new(20).unwrap();
     let blockchain1 = Arc::new(RwLock::new(
         Blockchain::new(
             env1.clone(),
@@ -223,7 +223,7 @@ async fn sync_ingredients() {
     );
 
     // Setup second peer (not synced yet).
-    let env2 = VolatileDatabase::new(11).unwrap();
+    let env2 = VolatileDatabase::new(20).unwrap();
     let time = Arc::new(OffsetTime::new());
     let blockchain2 = Arc::new(RwLock::new(
         Blockchain::new(

--- a/consensus/tests/request_component.rs
+++ b/consensus/tests/request_component.rs
@@ -18,7 +18,7 @@ use nimiq_test_utils::{
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
 async fn test_request_component() {
     let mut hub = Some(MockHub::default());
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     // Generate genesis block.
     let key = KeyPair::generate(&mut seeded_rng(0));

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -46,7 +46,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 fn blockchain(complete: bool) -> Blockchain {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Blockchain::new(
         env.clone(),
         BlockchainConfig::default(),

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -93,7 +93,7 @@ pub async fn sync_two_peers(
     let mut networks = vec![];
 
     // Setup first peer.
-    let env1 = VolatileDatabase::new(11).unwrap();
+    let env1 = VolatileDatabase::new(20).unwrap();
     let time = Arc::new(OffsetTime::new());
     let blockchain1 = Arc::new(RwLock::new(
         Blockchain::new(
@@ -144,7 +144,7 @@ pub async fn sync_two_peers(
 
     // Setup second peer (not synced yet).
     let time = Arc::new(OffsetTime::new());
-    let env2 = VolatileDatabase::new(11).unwrap();
+    let env2 = VolatileDatabase::new(20).unwrap();
 
     let blockchain2_proxy = match sync_mode {
         SyncMode::History | SyncMode::Full => {

--- a/genesis-builder/src/main.rs
+++ b/genesis-builder/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
     let args = env::args().collect::<Vec<String>>();
 
     if let Some(file) = args.get(1) {

--- a/genesis/build.rs
+++ b/genesis/build.rs
@@ -25,7 +25,7 @@ fn generate_albatross(name: &str, out_dir: &Path, src_dir: &Path) {
     let genesis_config = src_dir.join(format!("{name}.toml"));
     log::info!("genesis source file: {}", genesis_config.display());
 
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
     let builder = GenesisBuilder::from_config_file(genesis_config).unwrap();
     let genesis_hash = builder.write_to_files(env, &directory).unwrap();
     write_genesis_rs(&directory, name, &genesis_hash);

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -68,7 +68,7 @@ impl NetworkInfo {
 
 #[cfg(feature = "genesis-override")]
 fn read_genesis_config(config: &Path) -> Result<GenesisData, GenesisBuilderError> {
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     let GenesisInfo {
         block,

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -307,7 +307,7 @@ async fn push_same_tx_twice() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator
     genesis_builder.with_genesis_validator(
@@ -368,7 +368,7 @@ async fn valid_tx_not_in_blockchain() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Create an empty blockchain
     let blockchain = Arc::new(RwLock::new(
@@ -415,7 +415,7 @@ async fn push_tx_with_wrong_signature() {
     txns[0].proof = hex::decode("0222666efadc937148a6d61589ce6d4aeecca97fda4c32348d294eab582f14a0003fecb82d3aef4be76853d5c5b263754b7d495d9838f6ae5df60cf3addd3512a82988db0056059c7a52ae15285983ef0db8229ae446c004559147686d28f0a30b").unwrap();
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator
     genesis_builder.with_genesis_validator(
@@ -476,7 +476,7 @@ async fn mempool_get_txn_max_size() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator to genesis
     genesis_builder.with_genesis_validator(
@@ -547,7 +547,7 @@ async fn mempool_get_txn_ordered() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator to genesis
     genesis_builder.with_genesis_validator(
@@ -619,7 +619,7 @@ async fn push_tx_with_insufficient_balance() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator to genesis
     genesis_builder.with_genesis_validator(
@@ -681,7 +681,7 @@ async fn multiple_transactions_multiple_senders() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator to genesis
     genesis_builder.with_genesis_validator(
@@ -725,7 +725,7 @@ async fn multiple_transactions_multiple_senders() {
 async fn mempool_tps() {
     let mut rng = test_rng(true);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     // Generate and sign transaction from address_a using a balance that will be used to create the account later
@@ -802,7 +802,7 @@ async fn mempool_tps() {
 async fn multiple_start_stop() {
     let mut rng = test_rng(true);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     log::debug!("Generating transactions and accounts");
@@ -863,7 +863,7 @@ async fn multiple_start_stop() {
 async fn mempool_update() {
     let mut rng = test_rng(true);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     // Generate and sign transactions
@@ -1049,7 +1049,7 @@ async fn mempool_update() {
 async fn mempool_update_aged_transaction() {
     let mut rng = test_rng(true);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     // Generate and sign transactions
@@ -1163,7 +1163,7 @@ async fn mempool_update_aged_transaction() {
 async fn mempool_update_not_enough_balance() {
     let mut rng = test_rng(true);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     // Generate and sign transactions
@@ -1314,7 +1314,7 @@ async fn mempool_update_not_enough_balance() {
 async fn mempool_update_pruned_account() {
     let mut rng = test_rng(true);
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     // Generate and sign transactions
@@ -1463,7 +1463,7 @@ async fn mempool_update_pruned_account() {
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 10))]
 async fn mempool_basic_prioritization_control_tx() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     let key_pair = ed25519_key_pair(ACCOUNT_SECRET_KEY);
     let validator_signing_key = ed25519_key_pair(VALIDATOR_SECRET_KEY);
@@ -1576,7 +1576,7 @@ async fn mempool_regular_and_control_tx() {
     log::debug!("Done generating transactions and accounts");
 
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
 
     // Add a validator to genesis
     genesis_builder.with_genesis_validator(
@@ -1678,7 +1678,7 @@ async fn mempool_regular_and_control_tx() {
 
 #[tokio::test]
 async fn applies_total_tx_size_limits() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let mut genesis_builder = GenesisBuilder::default();
 
     // Generate transactions
@@ -1754,7 +1754,7 @@ async fn applies_total_tx_size_limits() {
 #[tokio::test]
 async fn it_can_reject_invalid_vesting_contract_transaction() {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let blockchain = Arc::new(RwLock::new(
         Blockchain::new(
             env,

--- a/primitives/account/src/data_store.rs
+++ b/primitives/account/src/data_store.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn data_store_works() {
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let tree = AccountsTrie::new(env.clone(), "accounts_trie");
         let store = DataStore::new(&tree, &Policy::STAKING_CONTRACT_ADDRESS);
 

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -396,7 +396,7 @@ fn it_checks_for_sufficient_funds() {
 fn accounts_performance() {
     let (env, num_txns) = if VOLATILE_ENV {
         let num_txns = 1_000;
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
 
         (env, num_txns)
     } else {
@@ -508,7 +508,7 @@ fn accounts_performance_history_sync_batches_single_sender() {
 
     let (env, num_txns) = if VOLATILE_ENV {
         let num_txns = 25;
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
 
         (env, num_txns)
     } else {
@@ -633,7 +633,7 @@ fn accounts_performance_history_sync_batches_many_to_many() {
 
     let (env, num_txns) = if VOLATILE_ENV {
         let num_txns = 25;
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
 
         (env, num_txns)
     } else {

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -100,7 +100,7 @@ fn generate_contract_2() {
 
 #[test]
 fn can_iter_stakers() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let mut db_txn = env.write_transaction();
@@ -153,7 +153,7 @@ fn it_can_de_serialize_a_staking_contract() {
 
 #[test]
 fn can_get_it() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let mut db_txn = env.write_transaction();
@@ -183,7 +183,7 @@ fn can_get_it() {
 
 #[test]
 fn create_validator_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(1, 1);
@@ -310,7 +310,7 @@ fn create_validator_works() {
 #[test]
 fn update_validator_works() {
     let mut rng = test_rng(false);
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -463,7 +463,7 @@ fn update_validator_works() {
 
 #[test]
 fn unpark_validator_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -599,7 +599,7 @@ fn unpark_validator_works() {
 
 #[test]
 fn deactivate_validator_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -768,7 +768,7 @@ fn deactivate_validator_works() {
 
 #[test]
 fn reactivate_validator_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -980,7 +980,7 @@ fn reactivate_validator_works() {
 
 #[test]
 fn retire_validator_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -1086,7 +1086,7 @@ fn retire_validator_works() {
 
 #[test]
 fn delete_validator_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -1365,7 +1365,7 @@ fn delete_validator_works() {
 
 #[test]
 fn create_staker_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -1499,7 +1499,7 @@ fn create_staker_works() {
 
 #[test]
 fn stake_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -1622,7 +1622,7 @@ fn stake_works() {
 
 #[test]
 fn update_staker_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -1878,7 +1878,7 @@ fn update_staker_works() {
 
 #[test]
 fn unstake_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -2102,7 +2102,7 @@ fn unstake_works() {
 
 #[test]
 fn reward_inherents_not_allowed() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -2130,7 +2130,7 @@ fn reward_inherents_not_allowed() {
 
 #[test]
 fn slash_inherents_work() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(2, 2);
@@ -2341,7 +2341,7 @@ fn slash_inherents_work() {
 
 #[test]
 fn finalize_batch_inherents_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(Policy::blocks_per_batch(), 500);
@@ -2391,7 +2391,7 @@ fn finalize_batch_inherents_works() {
 
 #[test]
 fn finalize_epoch_inherents_works() {
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     let accounts = Accounts::new(env.clone());
     let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
     let block_state = BlockState::new(Policy::blocks_per_epoch(), 1000);

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -1513,7 +1513,7 @@ mod tests {
         let key_3 = "413b397fa".parse().unwrap();
         let key_4 = "cfb986f5a".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let trie = MerkleRadixTrie::new(env.clone(), "database");
         let mut txn = env.write_transaction();
 
@@ -1576,7 +1576,7 @@ mod tests {
         let key_3 = "cfb98e0f6".parse().unwrap();
         let key_4 = "cfb98e0f5".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let trie = MerkleRadixTrie::new(env.clone(), "database");
         let mut txn = env.write_transaction();
 
@@ -1635,7 +1635,7 @@ mod tests {
         let key_6 = "ca".parse().unwrap();
         let key_7 = "b".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let trie = MerkleRadixTrie::new(env.clone(), "database");
         let mut txn = env.write_transaction();
 
@@ -1737,7 +1737,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let trie = MerkleRadixTrie::new(env.clone(), "database");
         let mut txn = env.write_transaction();
 
@@ -1806,7 +1806,7 @@ mod tests {
         let key_6 = "413f227fb".parse().unwrap();
         let key_7 = "413f227fa0".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let trie = MerkleRadixTrie::new(env.clone(), "database");
         let mut txn = env.write_transaction();
 
@@ -1842,7 +1842,7 @@ mod tests {
             .put_child(&proof_value_2.key, proof_value_2.hash_assert())
             .unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let trie = MerkleRadixTrie::new_incomplete(env.clone(), "database");
         let mut txn = env.write_transaction();
         assert!(!trie.is_complete(&txn));
@@ -1918,7 +1918,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5: KeyNibbles = "412324".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let mut txn = env.write_transaction();
 
@@ -1942,7 +1942,7 @@ mod tests {
 
     #[test]
     fn complete_tree_does_not_accept_chunks() {
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let trie = MerkleRadixTrie::new(env.clone(), "copy");
         let mut txn = env.write_transaction();
@@ -1964,7 +1964,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let trie = MerkleRadixTrie::new_incomplete(env.clone(), "copy");
         let mut txn = env.write_transaction();
@@ -2031,7 +2031,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let tries: Vec<_> = (1..5)
             .map(|i| {
@@ -2087,7 +2087,7 @@ mod tests {
         let key_4 = "1c".parse().unwrap();
         let key_5 = "81".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let tries: Vec<_> = (1..5)
             .map(|i| {
@@ -2144,7 +2144,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
         let tries: Vec<_> = (1..5)
             .map(|i| {
@@ -2225,7 +2225,7 @@ mod tests {
         let key_3 = "413f227fa".parse().unwrap();
         let key_4 = "413b391".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
 
         let mut txn = env.write_transaction();
@@ -2267,7 +2267,7 @@ mod tests {
         let key_3 = "413f227fa".parse().unwrap();
         let key_4 = "413b391".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
 
         let mut txn = env.write_transaction();
@@ -2301,7 +2301,7 @@ mod tests {
     fn remove_chunk_on_empty_tree() {
         let key_1 = "413f22".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
 
         let mut txn = env.write_transaction();
@@ -2318,7 +2318,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5: KeyNibbles = "415324".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
 
         let mut txn = env.write_transaction();
@@ -2353,7 +2353,7 @@ mod tests {
         let key_3 = "413f227fa".parse().unwrap();
         let key_4 = "413b391".parse().unwrap();
 
-        let env = nimiq_database::volatile::VolatileDatabase::new(10).unwrap();
+        let env = nimiq_database::volatile::VolatileDatabase::new(20).unwrap();
         let original = MerkleRadixTrie::new(env.clone(), "original");
 
         let mut txn = env.write_transaction();

--- a/test-utils/src/accounts_revert.rs
+++ b/test-utils/src/accounts_revert.rs
@@ -96,7 +96,7 @@ impl TestCommitRevert {
     impl_accounts_trait!(inherent, target, Inherent, InherentLogger);
 
     pub fn new() -> Self {
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let accounts = Accounts::new(env);
         TestCommitRevert { accounts }
     }

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -61,7 +61,7 @@ impl TemporaryBlockProducer {
 
     pub fn new() -> Self {
         let time = Arc::new(OffsetTime::new());
-        let env = VolatileDatabase::new(10).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let blockchain = Arc::new(RwLock::new(
             Blockchain::new(
                 env,

--- a/test-utils/src/mock_node.rs
+++ b/test-utils/src/mock_node.rs
@@ -134,7 +134,7 @@ impl<N: NetworkInterface + TestNetwork> MockNode<N> {
         hub: &mut Option<MockHub>,
     ) -> Self {
         let network = N::build_network(peer_id, block.hash(), hub).await;
-        let env = VolatileDatabase::new(14).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let clock = Arc::new(OffsetTime::new());
 
         let blockchain = Arc::new(RwLock::new(

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -56,7 +56,7 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
         is_prover_active: bool,
     ) -> Self {
         let block_hash = block.hash();
-        let env = VolatileDatabase::new(14).unwrap();
+        let env = VolatileDatabase::new(20).unwrap();
         let clock = Arc::new(OffsetTime::new());
         let blockchain = Arc::new(RwLock::new(
             Blockchain::with_genesis(

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -10,7 +10,7 @@ use nimiq_test_utils::validator::build_validators;
 #[test(tokio::test(flavor = "multi_thread"))]
 #[ignore]
 async fn four_validators_can_create_an_epoch() {
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     let validators =
         build_validators::<Network>(env, &(1u64..=4u64).collect::<Vec<_>>(), &mut None, false)

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -40,7 +40,7 @@ impl RequestCommon for SkipBlockMessage {
 #[test(tokio::test)]
 async fn one_validator_can_create_micro_blocks() {
     let hub = MockHub::default();
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     let voting_key = BlsKeyPair::generate(&mut seeded_rng(0));
     let validator_key = KeyPair::generate(&mut seeded_rng(0));
@@ -87,7 +87,7 @@ async fn one_validator_can_create_micro_blocks() {
 #[test(tokio::test)]
 async fn four_validators_can_create_micro_blocks() {
     let hub = MockHub::default();
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     let validators = build_validators::<Network>(
         env,
@@ -115,7 +115,7 @@ async fn four_validators_can_create_micro_blocks() {
 #[test(tokio::test)]
 async fn four_validators_can_do_skip_block() {
     let hub = MockHub::default();
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     let mut validators = build_validators::<Network>(
         env,
@@ -196,7 +196,7 @@ async fn validator_can_catch_up() {
     // third block producer needs to be disconnected as well and then reconnected to catch up to the second's skip blocks while not having seen the first one,
     // resulting in him producing the first block.
     let hub = MockHub::default();
-    let env = VolatileDatabase::new(10).expect("Could not open a volatile database");
+    let env = VolatileDatabase::new(20).expect("Could not open a volatile database");
 
     // In total 8 validator are registered. after 3 validators are taken offline the remaining 5 should not be able to progress on their own
     let mut validators = build_validators::<Network>(

--- a/zkp-component/tests/proof_utils.rs
+++ b/zkp-component/tests/proof_utils.rs
@@ -23,7 +23,7 @@ use parking_lot::RwLock;
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     Arc::new(RwLock::new(
         Blockchain::new(
             env,

--- a/zkp-component/tests/zkp_component.rs
+++ b/zkp-component/tests/zkp_component.rs
@@ -24,7 +24,7 @@ use parking_lot::RwLock;
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     Arc::new(RwLock::new(
         Blockchain::new(
             env,

--- a/zkp-component/tests/zkp_requests.rs
+++ b/zkp-component/tests/zkp_requests.rs
@@ -26,7 +26,7 @@ use parking_lot::RwLock;
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     Arc::new(RwLock::new(
         Blockchain::new(
             env,
@@ -92,8 +92,8 @@ async fn peers_reply_with_valid_proof() {
     network.dial_address(network3.address()).await.unwrap();
     network.dial_address(network2.address()).await.unwrap();
 
-    let env2 = VolatileDatabase::new(10).unwrap();
-    let env3 = VolatileDatabase::new(10).unwrap();
+    let env2 = VolatileDatabase::new(20).unwrap();
+    let env3 = VolatileDatabase::new(20).unwrap();
     let store2 = DBProofStore::new(env2.clone());
     let store3 = DBProofStore::new(env3.clone());
     let producer = BlockProducer::new(signing_key(), voting_key());
@@ -176,8 +176,8 @@ async fn peers_reply_with_valid_proof_and_election_block() {
     network.dial_address(network3.address()).await.unwrap();
     network.dial_address(network2.address()).await.unwrap();
 
-    let env2 = VolatileDatabase::new(10).unwrap();
-    let env3 = VolatileDatabase::new(10).unwrap();
+    let env2 = VolatileDatabase::new(20).unwrap();
+    let env3 = VolatileDatabase::new(20).unwrap();
     let store2 = DBProofStore::new(env2.clone());
     let store3 = DBProofStore::new(env3.clone());
     let producer = BlockProducer::new(signing_key(), voting_key());

--- a/zkp-component/zkp-test-gen/src/main.rs
+++ b/zkp-component/zkp-test-gen/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), NanoZKPError> {
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());
-    let env = VolatileDatabase::new(10).unwrap();
+    let env = VolatileDatabase::new(20).unwrap();
     Arc::new(RwLock::new(
         Blockchain::new(
             env,


### PR DESCRIPTION
This fixes the problem that we're currently at the maximum of 10 DBs in the volatile environment, adding any more will cause `DbsFull` errors.
