### PR TITLE
Conflicting default ports in `client.example.toml`

### DIFF
--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -21,7 +21,7 @@
 [network]
 
 listen_addresses = [
-        "/ip4/0.0.0.0/tcp/9100/ws",
+        "/ip4/0.0.0.0/tcp/8443/ws",
 ]
 
 seed_nodes = [


### PR DESCRIPTION
The default setup of the `client.example.toml` have conflicting port values. It will have the least impact to change the host listing port rather then the `metrics server` port.

**edit** When giving it a second thought, it can break Docker configurations when the listening port is exposed in the container. Thus have more impact.

## What's in this pull request?

...

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
