### PR TITLE
web-client: Fix `package.json` contributors

### DIFF
--- a/web-client/dist/package.json
+++ b/web-client/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/core-web",
-  "collaborators": [
+  "contributors": [
     "The Nimiq Core Development Team <info@nimiq.com>"
   ],
   "description": "Nimiq's Rust-to-WASM web client",


### PR DESCRIPTION
Fix `package.json` contributors as it was incorrectly named per [the spec](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#people-fields-author-contributors).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
