### PR TITLE
Fix #1271

### DIFF
--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -183,6 +183,15 @@ impl PolicyInterface for PolicyDispatcher {
         genesis_time: u64,
         current_time: u64,
     ) -> RPCResult<u64, (), Self::Error> {
+        if genesis_time > current_time {
+            log::error!(
+                current_time,
+                genesis_time,
+                "The supplied time must be equal or greater than the genesis time"
+            );
+            return Err(Error::InvalidArgument(current_time.to_string()));
+        }
+
         Ok(Policy::supply_at(genesis_supply, genesis_time, current_time).into())
     }
 }


### PR DESCRIPTION
Fix panic in RPC server due to current_time >= genesis_time


...
#### This fixes #1271 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
