### PR TITLE
Added conditional serde serialization support for OutgoingStakingTransactionProof

### DIFF
--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -240,13 +240,16 @@ impl IncomingStakingTransactionData {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum OutgoingStakingTransactionProof {
     DeleteValidator {
+        #[cfg_attr(feature = "serde-derive", serde(skip))]
         // This proof is signed with the validator cold key.
         proof: SignatureProof,
     },
     RemoveStake {
+        #[cfg_attr(feature = "serde-derive", serde(skip))]
         proof: SignatureProof,
     },
 }


### PR DESCRIPTION
## What's in this pull request?

I am adding the same logic that it is already implemented for `IncomingStakingTransactionData`  [here](https://github.com/nimiq/core-rs-albatross/blob/1a51de367120bf66b82bcffb2f7d6a241f55a217/primitives/transaction/src/account/staking_contract/structs.rs#L38)

#### This fixes problem when working with WASM.

I am working with this tool https://github.com/onmax/albatross-util-wasm

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
