### PR TITLE
Cleanup proofs cache if necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,6 +4719,7 @@ dependencies = [
  "ark-std",
  "beserial",
  "nimiq-bls",
+ "nimiq-log",
  "nimiq-primitives",
  "nimiq-test-log",
  "nimiq-test-utils",

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -37,6 +37,7 @@ nimiq-zkp-primitives = { path = "../zkp-primitives" }
 rand_chacha = "0.3.1"
 tracing-subscriber = { version = "0.3" }
 
+nimiq-log = { path = "../log" }
 nimiq-test-log = { path = "../test-log" }
 nimiq-test-utils = { path = "../test-utils" }
 nimiq-zkp-circuits = { path = "../zkp-circuits", features = ["zkp-prover"] }

--- a/zkp/examples/prover/prove.rs
+++ b/zkp/examples/prover/prove.rs
@@ -4,10 +4,13 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use ark_groth16::Proof;
-use ark_relations::r1cs::{ConstraintLayer, TracingMode};
 use ark_serialize::CanonicalSerialize;
+use log::level_filters::LevelFilter;
+use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
+use nimiq_log::TargetsExt;
 use nimiq_zkp::prove::prove;
 use nimiq_zkp_circuits::utils::create_test_blocks;
 
@@ -29,10 +32,15 @@ fn main() {
 
     println!("====== Proof generation for Nano Sync initiated ======");
 
-    let mut layer = ConstraintLayer::default();
-    layer.mode = TracingMode::OnlyConstraints;
-    let subscriber = tracing_subscriber::Registry::default().with(layer);
-    let _guard = log::subscriber::set_default(subscriber);
+    tracing_subscriber::registry()
+        .with(
+            Targets::new()
+                .with_default(LevelFilter::INFO)
+                .with_nimiq_targets(LevelFilter::DEBUG)
+                .with_target("r1cs", LevelFilter::WARN)
+                .with_env(),
+        )
+        .init();
 
     let start = Instant::now();
 


### PR DESCRIPTION
## What's in this pull request?
Checks whether cached proofs are compatible with the current proof.
If not, it clears the folder and creates a new metadata file.
The metadata file stores the current header hash.

This also fixes compilation issues with the newest cargo version.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
