### PR TITLE
RPC: Obtain mempool transaction

### DIFF
--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -1,26 +1,38 @@
 use crate::types::{HashOrTx, MempoolInfo, RPCResult};
 use async_trait::async_trait;
 use nimiq_hash::Blake2bHash;
+use nimiq_transaction::Transaction;
 
 #[nimiq_jsonrpc_derive::proxy(name = "MempoolProxy", rename_all = "camelCase")]
 #[async_trait]
 pub trait MempoolInterface {
     type Error;
 
+    /// Pushes a raw transaction into the mempool, it will be assigned a default priority
     async fn push_transaction(&mut self, raw_tx: String)
         -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Pushes a raw transaction into the mempool with high priority
     async fn push_high_priority_transaction(
         &mut self,
         raw_tx: String,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Obtains the list of transactions that are currently in the mempool
     async fn mempool_content(
         &mut self,
         include_transactions: bool,
     ) -> RPCResult<Vec<HashOrTx>, (), Self::Error>;
 
+    /// Obtains the mempool content in fee per byte buckets
     async fn mempool(&mut self) -> RPCResult<MempoolInfo, (), Self::Error>;
 
+    /// Obtains the minimum fee per byte as per mempool configuration
     async fn get_min_fee_per_byte(&mut self) -> RPCResult<f64, (), Self::Error>;
+
+    /// Tries to obtain the given transaction (using its hash) from the mempool
+    async fn get_transaction_from_mempool(
+        &mut self,
+        hash: Blake2bHash,
+    ) -> RPCResult<Transaction, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/mempool.rs
+++ b/rpc-server/src/dispatchers/mempool.rs
@@ -10,6 +10,7 @@ use nimiq_mempool::mempool_transactions::TxPriority;
 use nimiq_rpc_interface::mempool::MempoolInterface;
 use nimiq_rpc_interface::types::RPCResult;
 use nimiq_rpc_interface::types::{HashOrTx, MempoolInfo};
+use nimiq_transaction::Transaction;
 
 use crate::error::Error;
 
@@ -91,5 +92,16 @@ impl MempoolInterface for MempoolDispatcher {
 
     async fn get_min_fee_per_byte(&mut self) -> RPCResult<f64, (), Self::Error> {
         Ok(self.mempool.get_rules().tx_fee_per_byte.into())
+    }
+
+    async fn get_transaction_from_mempool(
+        &mut self,
+        hash: Blake2bHash,
+    ) -> RPCResult<Transaction, (), Self::Error> {
+        if let Some(tx) = self.mempool.get_transaction_by_hash(&hash) {
+            return Ok(tx.into());
+        } else {
+            return Err(Error::TransactionNotFound(hash));
+        }
     }
 }


### PR DESCRIPTION
Add the ability to obtain a transaction, by hash, from the mempool.
Closes #858

...
#### This fixes #858 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
