### PR TITLE
web-client: Upgrade the `wasm-bindgen-derive` dependency

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -67,25 +67,30 @@ jobs:
         components: llvm-tools-preview
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler
-    - name: Install cargo-llvm-cov
-      run: cargo install cargo-llvm-cov
-    - name: Remove possible stale artifacts
-      run: cargo llvm-cov clean --workspace
-    - name: Run test with coverage instrumentation
-      run: cargo llvm-cov --all-features
+    - name: Install cargo-nextest
+      run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+    # Coverage is disabled for now since at the moment it has a considerable performance impact in the CI
+    #- name: Install cargo-llvm-cov
+    #  run: cargo install cargo-llvm-cov
+    #- name: Remove possible stale artifacts
+    #  run: cargo llvm-cov clean --workspace
+    #- name: Run test with coverage instrumentation
+    #  run: cargo llvm-cov nextest --all-features
       # Fixme: --doctest is not supported in stable. See:
       # https://github.com/taiki-e/cargo-llvm-cov/tree/7448e48b438797efb446a98ebd8ff22d3fae5ebe#known-limitations
       # run: cargo llvm-cov --all-features --doctests
-    - name: Generate coverage report
-      run: cargo llvm-cov report --lcov --output-path coverage.lcov
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: coverage.lcov
-        fail_ci_if_error: false
-        flags: unittests
-        name: Nimiq code coverage
-        verbose: true
+    #- name: Generate coverage report
+    #  run: cargo llvm-cov report --lcov --output-path coverage.lcov
+    #- name: Upload coverage to Codecov
+    #  uses: codecov/codecov-action@v3
+    #  with:
+    #    files: coverage.lcov
+    #    fail_ci_if_error: false
+    #    flags: unittests
+    #    name: Nimiq code coverage
+    #    verbose: true
+    - name: Run tests
+      run: cargo nextest run --all-features
 
   clippy:
     if: github.event_name != 'push' || github.event.pusher.name != 'dependabot[bot]'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7302,15 +7302,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-derive"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7301886930edaa72b7d102655ea395774aa9f0614c1a491393648a5fec34435"
+checksum = "c1ab6c8bffb3f89584781211283fb57337d6902faab6eaee38f336977bdf177d"
 dependencies = [
  "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-derive-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-derive-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87c28b31d27616bc69a891700ef0445d2cbaa0340fdacb145145256d5f5fcbb"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -29,7 +29,7 @@ serde-wasm-bindgen = "0.5"
 tsify = { version = "0.4", features= ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-wasm-bindgen-derive = { version = "0.1.1", optional = true }
+wasm-bindgen-derive = { version = "0.2", optional = true }
 wasm-timer = "0.2"
 web-sys = { version = "0.3.22", features = ["MessageEvent"]}
 


### PR DESCRIPTION
Upgrade the `wasm-bindgen-derive` dependency for the `web-client` crate from version 0.1.1 to version 0.2.1 to address compilation issues while compiling wasm tests.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
