### PR TITLE
Add a default way to format imports

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -27,7 +27,7 @@ jobs:
         key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
+        toolchain: nightly
         components: rustfmt
     - run: cargo fmt --all -- --check
 

--- a/beserial/src/lib.rs
+++ b/beserial/src/lib.rs
@@ -1,15 +1,16 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::BuildHasher;
-use std::ops;
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    hash::BuildHasher,
+    ops,
+    ops::Deref,
+    sync::Arc,
+};
 
 use arrayvec::ArrayVec;
 #[cfg(feature = "derive")]
 pub use beserial_derive::{Deserialize, Serialize};
 pub use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
 pub use num_traits::{FromPrimitive, ToPrimitive};
-
 use thiserror::Error;
 
 pub use crate::types::uvar;

--- a/beserial/src/net.rs
+++ b/beserial/src/net.rs
@@ -1,9 +1,9 @@
 //! This module generates `Serialize` and `Deserialize` implementations for the `std::net`
 //! IP address structs and enums.
 
-use crate::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
-
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+use crate::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 
 macro_rules! impl_serialize_ipaddr {
     ($name: ident, $bytes: expr) => {

--- a/beserial/src/types.rs
+++ b/beserial/src/types.rs
@@ -1,5 +1,6 @@
-use crate::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 use num_traits::{FromPrimitive, ToPrimitive};
+
+use crate::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 
 #[allow(non_camel_case_types)]
 #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone)]

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -1,4 +1,3 @@
-use crate::{BlsKeyPair, SchnorrKeyPair};
 use nimiq_account::BlockState;
 use nimiq_block::{
     Block, ForkProof, MacroBlock, MacroBody, MacroHeader, MicroBlock, MicroBody, MicroHeader,
@@ -17,6 +16,8 @@ use nimiq_transaction::{
     extended_transaction::ExtendedTransaction, inherent::Inherent, Transaction,
 };
 use nimiq_vrf::VrfSeed;
+
+use crate::{BlsKeyPair, SchnorrKeyPair};
 
 #[derive(Clone)]
 pub struct BlockConfig {

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -1,8 +1,4 @@
-use std::convert::TryInto;
-use std::sync::Arc;
-
-use parking_lot::RwLock;
-use tempfile::tempdir;
+use std::{convert::TryInto, sync::Arc};
 
 use beserial::Deserialize;
 use nimiq_block::{Block, ForkProof, MicroJustification};
@@ -32,6 +28,8 @@ use nimiq_test_utils::{
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
+use tempfile::tempdir;
 
 const ADDRESS: &str = "NQ20TSB0DFSMUH9C15GQGAGJTTE4D3MA859E";
 

--- a/blockchain-interface/src/abstract_blockchain.rs
+++ b/blockchain-interface/src/abstract_blockchain.rs
@@ -1,13 +1,16 @@
 use futures::stream::BoxStream;
-
 use nimiq_block::{Block, BlockType, MacroBlock};
 use nimiq_hash::Blake2bHash;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::{Validator, Validators};
+use nimiq_primitives::{
+    networks::NetworkId,
+    policy::Policy,
+    slots::{Validator, Validators},
+};
 
-use crate::error::{BlockchainError, BlockchainEvent, Direction};
-use crate::{ChainInfo, ForkEvent};
+use crate::{
+    error::{BlockchainError, BlockchainEvent, Direction},
+    ChainInfo, ForkEvent,
+};
 
 /// Defines several basic methods for blockchains.
 pub trait AbstractBlockchain {

--- a/blockchain-interface/src/chain_info.rs
+++ b/blockchain-interface/src/chain_info.rs
@@ -1,6 +1,4 @@
-use std::convert::TryInto;
-use std::io;
-use std::ops::RangeFrom;
+use std::{convert::TryInto, io, ops::RangeFrom};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 use nimiq_block::{

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -1,8 +1,7 @@
-use thiserror::Error;
-
 use nimiq_block::{Block, BlockError, ForkProof};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{account::AccountError, networks::NetworkId};
+use thiserror::Error;
 
 /// An enum used when a fork is detected.
 #[derive(Clone, Debug)]

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
 use futures::stream::BoxStream;
-use parking_lot::{RwLock, RwLockReadGuard};
-
 use nimiq_block::{Block, MacroBlock};
 #[cfg(feature = "full")]
 use nimiq_blockchain::Blockchain;
@@ -15,6 +13,7 @@ use nimiq_primitives::{
     networks::NetworkId,
     slots::{Validator, Validators},
 };
+use parking_lot::{RwLock, RwLockReadGuard};
 
 macro_rules! gen_blockchain_match {
     ($self: ident, $t: ident, $f: ident $(, $arg:expr )*) => {

--- a/blockchain/src/blockchain/abstract_blockchain.rs
+++ b/blockchain/src/blockchain/abstract_blockchain.rs
@@ -1,7 +1,4 @@
-use futures::future;
-use futures::stream::BoxStream;
-use futures::StreamExt;
-
+use futures::{future, stream::BoxStream, StreamExt};
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainError, BlockchainEvent, ChainInfo, Direction, ForkEvent,

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -1,11 +1,11 @@
-use crate::blockchain_state::BlockchainState;
-use crate::Blockchain;
 use nimiq_account::{Accounts, BlockLogger, BlockState, TransactionOperationReceipt};
 use nimiq_block::{Block, BlockError, SkipBlockInfo};
 use nimiq_blockchain_interface::PushError;
 use nimiq_database::{traits::Database, WriteTransactionProxy};
 use nimiq_primitives::{key_nibbles::KeyNibbles, trie::trie_proof::TrieProof};
 use nimiq_transaction::extended_transaction::ExtendedTransaction;
+
+use crate::{blockchain_state::BlockchainState, Blockchain};
 
 /// Implements methods to handle the accounts.
 impl Blockchain {

--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 
 use nimiq_account::{Accounts, BlockLog};
 use nimiq_block::Block;
@@ -14,6 +13,7 @@ use nimiq_primitives::{
     coin::Coin, networks::NetworkId, policy::Policy, slots::Validators, trie::TrieItem,
 };
 use nimiq_utils::time::OffsetTime;
+use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 
 #[cfg(feature = "metrics")]
 use crate::chain_metrics::BlockchainMetrics;

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -1,4 +1,3 @@
-use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 use std::error::Error;
 
 use beserial::Serialize;
@@ -8,13 +7,13 @@ use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, PushError, PushResult,
 };
 use nimiq_database::{traits::WriteTransaction, WriteTransactionProxy};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_transaction::{
     extended_transaction::{ExtTxData, ExtendedTransaction},
     inherent::Inherent,
     Transaction,
 };
+use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 
 use crate::Blockchain;
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -1,8 +1,4 @@
-use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
-use std::cmp;
-use std::error::Error;
-use std::ops::Deref;
-use tokio::sync::broadcast::Sender as BroadcastSender;
+use std::{cmp, error::Error, ops::Deref};
 
 use nimiq_account::{BlockLog, BlockLogger};
 use nimiq_block::{Block, ForkProof, MicroBlock};
@@ -20,6 +16,8 @@ use nimiq_primitives::{
     trie::trie_chunk::{TrieChunkPushResult, TrieChunkWithStart},
 };
 use nimiq_vrf::VrfSeed;
+use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
+use tokio::sync::broadcast::Sender as BroadcastSender;
 
 use crate::{blockchain_state::BlockchainState, Blockchain};
 

--- a/blockchain/src/blockchain/slots.rs
+++ b/blockchain/src/blockchain/slots.rs
@@ -1,8 +1,10 @@
 use nimiq_blockchain_interface::BlockchainError;
 use nimiq_collections::BitSet;
 use nimiq_database::TransactionProxy;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::{Validator, Validators};
+use nimiq_primitives::{
+    policy::Policy,
+    slots::{Validator, Validators},
+};
 use nimiq_vrf::{Rng, VrfEntropy, VrfSeed, VrfUseCase};
 
 use crate::Blockchain;

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -3,8 +3,7 @@ use nimiq_blockchain_interface::{AbstractBlockchain, PushError};
 use nimiq_database::TransactionProxy as DBTransaction;
 use nimiq_hash::{Blake2bHash, Hash};
 
-use crate::blockchain_state::BlockchainState;
-use crate::Blockchain;
+use crate::{blockchain_state::BlockchainState, Blockchain};
 
 /// Implements methods to verify the validity of blocks.
 impl Blockchain {

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -1,3 +1,4 @@
+use std::ops::RangeFrom;
 #[cfg(feature = "metrics")]
 use std::sync::Arc;
 
@@ -11,7 +12,6 @@ use nimiq_primitives::{
     account::AccountError, key_nibbles::KeyNibbles, policy::Policy, slots::Validator,
 };
 use nimiq_transaction::Transaction;
-use std::ops::RangeFrom;
 
 #[cfg(feature = "metrics")]
 use crate::chain_metrics::BlockchainMetrics;

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -1,7 +1,5 @@
 use std::{cmp, mem};
 
-use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
-
 use nimiq_block::{Block, BlockError};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, PushError, PushResult,
@@ -9,6 +7,7 @@ use nimiq_blockchain_interface::{
 use nimiq_database::traits::{ReadTransaction, WriteTransaction};
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp::{verify::verify, NanoProof, ZKP_VERIFYING_KEY};
+use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 
 use crate::Blockchain;
 

--- a/blockchain/src/chain_metrics.rs
+++ b/blockchain/src/chain_metrics.rs
@@ -1,5 +1,4 @@
-use nimiq_block::Block;
-use nimiq_block::BlockBody::Micro;
+use nimiq_block::{Block, BlockBody::Micro};
 use nimiq_blockchain_interface::{ChunksPushError, ChunksPushResult, PushError, PushResult};
 use nimiq_hash::Blake2bHash;
 use prometheus_client::{

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1,5 +1,7 @@
-use std::cmp;
-use std::collections::{HashSet, VecDeque};
+use std::{
+    cmp,
+    collections::{HashSet, VecDeque},
+};
 
 use beserial::Serialize;
 use nimiq_database::{
@@ -1098,8 +1100,7 @@ impl HistoryStore {
 #[cfg(test)]
 mod tests {
     use nimiq_database::volatile::VolatileDatabase;
-    use nimiq_primitives::coin::Coin;
-    use nimiq_primitives::networks::NetworkId;
+    use nimiq_primitives::{coin::Coin, networks::NetworkId};
     use nimiq_test_log::test;
     use nimiq_transaction::{
         inherent::Inherent, ExecutedTransaction, Transaction as BlockchainTransaction,

--- a/blockchain/src/history/mmr_store.rs
+++ b/blockchain/src/history/mmr_store.rs
@@ -1,5 +1,4 @@
-use std::cmp;
-use std::convert::TryInto;
+use std::{cmp, convert::TryInto};
 
 use nimiq_database::{
     traits::{ReadCursor, ReadTransaction, WriteTransaction},

--- a/blockchain/src/history/ordered_hash.rs
+++ b/blockchain/src/history/ordered_hash.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-use std::convert::TryInto;
-use std::io;
+use std::{borrow::Cow, convert::TryInto, io};
 
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_hash::{Blake2bHash, HashOutput};

--- a/blockchain/src/reward.rs
+++ b/blockchain/src/reward.rs
@@ -1,8 +1,7 @@
 use std::convert::TryInto;
 
 use nimiq_block::MacroHeader;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{coin::Coin, policy::Policy};
 
 /// Parses the genesis supply and timestamp from the genesis block. We require both values to
 /// calculate the block rewards.

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
@@ -14,6 +12,7 @@ use nimiq_test_utils::blockchain::{
     voting_key,
 };
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
 
 // Tests if the basic history sync works. It will try to push a succession of election and checkpoint
 // blocks. It does test if election blocks can be pushed after checkpoint blocks and vice-versa. It

--- a/blockchain/tests/mod.rs
+++ b/blockchain/tests/mod.rs
@@ -1,6 +1,4 @@
 use std::sync::Arc;
-use tokio_stream::wrappers::BroadcastStream;
-use tokio_stream::StreamExt;
 
 use nimiq_block::Block;
 use nimiq_blockchain::Blockchain;
@@ -10,6 +8,7 @@ use nimiq_test_log::test;
 use nimiq_test_utils::{
     block_production::TemporaryBlockProducer, blockchain::produce_macro_blocks,
 };
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 
 #[test]
 fn it_can_rebranch_skip_block() {

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -1,7 +1,7 @@
-use nimiq_block::Block;
-use nimiq_block::BlockError;
-use nimiq_block_production::test_custom_block::next_skip_block;
-use nimiq_block_production::test_custom_block::{next_macro_block, next_micro_block, BlockConfig};
+use nimiq_block::{Block, BlockError};
+use nimiq_block_production::test_custom_block::{
+    next_macro_block, next_micro_block, next_skip_block, BlockConfig,
+};
 use nimiq_blockchain_interface::{PushError, PushError::InvalidBlock, PushResult};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::policy::Policy;

--- a/bls/examples/gen_keys.rs
+++ b/bls/examples/gen_keys.rs
@@ -1,7 +1,6 @@
-use rand::thread_rng;
-
 use nimiq_bls::*;
 use nimiq_utils::key_rng::SecureGenerate;
+use rand::thread_rng;
 
 fn main() {
     let rng = &mut thread_rng();

--- a/bls/examples/gen_sig.rs
+++ b/bls/examples/gen_sig.rs
@@ -1,7 +1,6 @@
-use rand::thread_rng;
-
 use nimiq_bls::*;
 use nimiq_utils::key_rng::SecureGenerate;
+use rand::thread_rng;
 
 fn main() {
     let rng = &mut thread_rng();

--- a/bls/src/lazy.rs
+++ b/bls/src/lazy.rs
@@ -1,10 +1,9 @@
 use std::{cmp::Ordering, fmt};
 
+use nimiq_hash::Hash;
 use parking_lot::{
     MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard,
 };
-
-use nimiq_hash::Hash;
 
 use crate::{CompressedPublicKey, PublicKey, SigHash, Signature};
 

--- a/bls/src/serialization.rs
+++ b/bls/src/serialization.rs
@@ -2,7 +2,6 @@ use std::io;
 
 use ark_mnt6_753::Fr;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 use nimiq_hash::{Hash, SerializeContent};
 

--- a/bls/src/types/aggregate_public_key.rs
+++ b/bls/src/types/aggregate_public_key.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use ark_ff::Zero;
 use ark_mnt6_753::G2Projective;
-
 use nimiq_hash::Hash;
 
 use crate::{AggregateSignature, PublicKey, SigHash};

--- a/bls/src/types/compressed_public_key.rs
+++ b/bls/src/types/compressed_public_key.rs
@@ -9,7 +9,6 @@ use std::{
 use ark_ec::AffineRepr;
 use ark_mnt6_753::G2Affine;
 use ark_serialize::CanonicalDeserialize;
-
 #[cfg(feature = "beserial")]
 use beserial::Deserialize;
 

--- a/bls/src/types/compressed_signature.rs
+++ b/bls/src/types/compressed_signature.rs
@@ -8,7 +8,6 @@ use std::{
 
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_mnt6_753::{G1Affine, G1Projective};
-
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 #[cfg(feature = "beserial")]
 use beserial::Deserialize;

--- a/bls/src/types/keypair.rs
+++ b/bls/src/types/keypair.rs
@@ -4,8 +4,7 @@ use std::fmt;
 #[cfg(feature = "beserial")]
 use beserial::Serialize;
 use nimiq_hash::Hash;
-use nimiq_utils::key_rng::SecureGenerate;
-use nimiq_utils::key_rng::{CryptoRng, RngCore};
+use nimiq_utils::key_rng::{CryptoRng, RngCore, SecureGenerate};
 
 use crate::{PublicKey, SecretKey, SigHash, Signature};
 

--- a/bls/src/types/public_key.rs
+++ b/bls/src/types/public_key.rs
@@ -6,7 +6,6 @@ pub use ark_mnt6_753::G2Projective;
 use ark_mnt6_753::{G1Projective, MNT6_753};
 use ark_serialize::CanonicalSerialize;
 use log::error;
-
 use nimiq_hash::Hash;
 
 use crate::{CompressedPublicKey, SecretKey, SigHash, Signature};

--- a/bls/src/types/secret_key.rs
+++ b/bls/src/types/secret_key.rs
@@ -3,12 +3,10 @@ use std::fmt;
 
 use ark_ff::{UniformRand, Zero};
 use ark_mnt6_753::{Fr, G1Projective};
-
 #[cfg(feature = "beserial")]
 use beserial::Serialize;
 use nimiq_hash::Hash;
-use nimiq_utils::key_rng::SecureGenerate;
-use nimiq_utils::key_rng::{CryptoRng, RngCore};
+use nimiq_utils::key_rng::{CryptoRng, RngCore, SecureGenerate};
 
 use crate::{CompressedSignature, SigHash, Signature};
 

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -3,8 +3,7 @@ use std::fmt;
 use ark_ec::{AffineRepr, Group};
 use ark_ff::{One, PrimeField, ToConstraintField};
 use ark_mnt6_753::{Fq, G1Affine, G1Projective};
-use nimiq_hash::blake2s::Blake2sWithParameterBlock;
-use nimiq_hash::HashOutput;
+use nimiq_hash::{blake2s::Blake2sWithParameterBlock, HashOutput};
 
 use crate::{CompressedSignature, SigHash};
 

--- a/bls/tests/tests.rs
+++ b/bls/tests/tests.rs
@@ -1,5 +1,4 @@
 use ark_ec::CurveGroup;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_bls::*;
 use nimiq_test_log::test;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,14 +1,10 @@
 use std::time::Duration;
 
 use log::info;
-
 use nimiq::prover::prover_main;
-
 pub use nimiq::{
     client::{Client, Consensus},
-    config::command_line::CommandLine,
-    config::config::ClientConfig,
-    config::config_file::ConfigFile,
+    config::{command_line::CommandLine, config::ClientConfig, config_file::ConfigFile},
     error::Error,
     extras::{
         deadlock::initialize_deadlock_detection,

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -1,6 +1,8 @@
-use std::fmt;
-use std::iter::{repeat, FromIterator};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
+use std::{
+    fmt,
+    iter::{repeat, FromIterator},
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign},
+};
 
 use beserial::{
     uvar, Deserialize, FromPrimitive, ReadBytesExt, Serialize, SerializingError, ToPrimitive,
@@ -466,9 +468,10 @@ mod serde_derive {
 
 #[cfg(test)]
 mod tests {
-    use super::BitSet;
     use beserial::{Deserialize, Serialize};
     use nimiq_test_log::test;
+
+    use super::BitSet;
 
     fn sample_bitset() -> BitSet {
         let mut set = BitSet::new();

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -1,11 +1,12 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use futures::stream::BoxStream;
-use tokio::sync::broadcast::Sender as BroadcastSender;
-use tokio_stream::wrappers::BroadcastStream;
-
 use nimiq_account::{Account, Staker, Validator};
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
@@ -22,6 +23,8 @@ use nimiq_transaction::{
     extended_transaction::ExtendedTransaction, ControlTransactionTopic, Transaction,
     TransactionTopic,
 };
+use tokio::sync::broadcast::Sender as BroadcastSender;
+use tokio_stream::wrappers::BroadcastStream;
 
 use crate::{
     consensus::remote_data_store::RemoteDataStore,

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -1,12 +1,13 @@
-use std::collections::HashSet;
-use std::future::Future;
-use std::mem;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    collections::HashSet,
+    future::Future,
+    mem,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
-
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1,39 +1,42 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use futures::{FutureExt, StreamExt};
 use instant::Instant;
-use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
-#[cfg(not(target_family = "wasm"))]
-use tokio::time::{sleep, Sleep};
-use tokio_stream::wrappers::BroadcastStream;
-
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network, request::request_handler};
 use nimiq_primitives::task_executor::TaskExecutor;
 use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
+use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
+#[cfg(not(target_family = "wasm"))]
+use tokio::time::{sleep, Sleep};
+use tokio_stream::wrappers::BroadcastStream;
 
-use crate::consensus::head_requests::{HeadRequests, HeadRequestsResult};
+use self::consensus_proxy::ConsensusProxy;
+#[cfg(feature = "full")]
+use self::remote_event_dispatcher::RemoteEventDispatcher;
 #[cfg(feature = "full")]
 use crate::messages::{
     RequestBatchSet, RequestBlocksProof, RequestHistoryChunk, RequestTransactionReceiptsByAddress,
     RequestTransactionsProof, RequestTrieProof,
 };
-use crate::messages::{RequestBlock, RequestHead, RequestMacroChain, RequestMissingBlocks};
-
 #[cfg(feature = "full")]
 use crate::sync::live::state_queue::RequestChunk;
-use crate::sync::{syncer::LiveSyncPushEvent, syncer_proxy::SyncerProxy};
-
-use self::consensus_proxy::ConsensusProxy;
-#[cfg(feature = "full")]
-use self::remote_event_dispatcher::RemoteEventDispatcher;
+use crate::{
+    consensus::head_requests::{HeadRequests, HeadRequestsResult},
+    messages::{RequestBlock, RequestHead, RequestMacroChain, RequestMissingBlocks},
+    sync::{syncer::LiveSyncPushEvent, syncer_proxy::SyncerProxy},
+};
 
 pub mod consensus_proxy;
 mod head_requests;

--- a/consensus/src/consensus/remote_data_store.rs
+++ b/consensus/src/consensus/remote_data_store.rs
@@ -1,5 +1,7 @@
-use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use beserial::Deserialize;
 use nimiq_account::{

--- a/consensus/src/consensus/remote_event_dispatcher.rs
+++ b/consensus/src/consensus/remote_event_dispatcher.rs
@@ -7,8 +7,6 @@ use std::{
 };
 
 use futures::{stream::BoxStream, StreamExt};
-use parking_lot::RwLock;
-
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
 use nimiq_hash::{Blake2bHash, Hash};
@@ -19,12 +17,15 @@ use nimiq_network_interface::{
 };
 use nimiq_primitives::account::AccountType;
 use nimiq_transaction::account::staking_contract::IncomingStakingTransactionData;
+use parking_lot::RwLock;
 
-use crate::messages::{
-    AddressNotification, AddressSubscriptionOperation, AddressSubscriptionTopic, NotificationEvent,
-    RequestSubscribeToAddress, ResponseSubscribeToAddress,
+use crate::{
+    messages::{
+        AddressNotification, AddressSubscriptionOperation, AddressSubscriptionTopic,
+        NotificationEvent, RequestSubscribeToAddress, ResponseSubscribeToAddress,
+    },
+    SubscribeToAddressesError::*,
 };
-use crate::SubscribeToAddressesError::*;
 
 /// The max number of peers that can be subscribed.
 pub const MAX_SUBSCRIBED_PEERS: usize = 50;

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -1,7 +1,6 @@
-use thiserror::Error;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_blockchain_interface::BlockchainError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,8 +1,7 @@
 #[macro_use]
 extern crate log;
 
-pub use consensus::consensus_proxy::ConsensusProxy;
-pub use consensus::{Consensus, ConsensusEvent, RemoteEvent};
+pub use consensus::{consensus_proxy::ConsensusProxy, Consensus, ConsensusEvent, RemoteEvent};
 pub use error::{Error, SubscribeToAddressesError};
 
 pub mod consensus;

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -2,9 +2,6 @@ use std::cmp;
 #[cfg(feature = "full")]
 use std::sync::Arc;
 
-#[cfg(feature = "full")]
-use parking_lot::RwLock;
-
 use nimiq_block::Block;
 #[cfg(feature = "full")]
 use nimiq_block::BlockInclusionProof;
@@ -14,6 +11,8 @@ use nimiq_blockchain_interface::{AbstractBlockchain, Direction};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_network_interface::{network::Network, request::Handle};
 use nimiq_primitives::policy::Policy;
+#[cfg(feature = "full")]
+use parking_lot::RwLock;
 
 use crate::messages::*;
 #[cfg(feature = "full")]

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -1,15 +1,16 @@
-use std::collections::VecDeque;
-use std::fmt::Formatter;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    collections::VecDeque,
+    fmt::Formatter,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
 
 use futures::{FutureExt, Stream, StreamExt};
 use lazy_static::lazy_static;
-use parking_lot::RwLock;
-use thiserror::Error;
-
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::{Blockchain, HistoryTreeChunk, CHUNK_SIZE};
 use nimiq_blockchain_interface::{AbstractBlockchain, PushError, PushResult};
@@ -18,11 +19,12 @@ use nimiq_network_interface::{network::Network, request::RequestError};
 use nimiq_primitives::{policy::Policy, slots::Validators};
 use nimiq_transaction::extended_transaction::ExtendedTransaction;
 use nimiq_utils::math::CeilingDiv;
+use parking_lot::RwLock;
+use thiserror::Error;
 
-use crate::sync::peer_list::PeerList;
 use crate::{
     messages::{BatchSetInfo, HistoryChunk, RequestBatchSet, RequestHistoryChunk},
-    sync::sync_queue::SyncQueue,
+    sync::{peer_list::PeerList, sync_queue::SyncQueue},
 };
 
 /// Error enumeration for history sync request

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -1,17 +1,22 @@
-use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
-use std::task::Waker;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+    task::Waker,
+};
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
-use parking_lot::RwLock;
-
 use nimiq_blockchain::Blockchain;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
+use parking_lot::RwLock;
 
-use crate::messages::Checkpoint;
-use crate::sync::history::cluster::{SyncCluster, SyncClusterResult};
-use crate::sync::syncer::MacroSync;
+use crate::{
+    messages::Checkpoint,
+    sync::{
+        history::cluster::{SyncCluster, SyncClusterResult},
+        syncer::MacroSync,
+    },
+};
 
 #[derive(Clone)]
 pub(crate) struct EpochIds<T> {

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -1,7 +1,4 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
-
-use parking_lot::RwLock;
+use std::{collections::VecDeque, sync::Arc};
 
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
@@ -11,13 +8,20 @@ use nimiq_network_interface::{
     request::RequestError,
 };
 use nimiq_primitives::policy::Policy;
+use parking_lot::RwLock;
 
-use crate::messages::{MacroChain, RequestMacroChain};
-use crate::sync::history::cluster::{SyncCluster, SyncClusterResult};
-use crate::sync::history::sync::{EpochIds, Job};
-use crate::sync::history::HistoryMacroSync;
-use crate::sync::peer_list::PeerList;
-use crate::sync::syncer::MacroSync;
+use crate::{
+    messages::{MacroChain, RequestMacroChain},
+    sync::{
+        history::{
+            cluster::{SyncCluster, SyncClusterResult},
+            sync::{EpochIds, Job},
+            HistoryMacroSync,
+        },
+        peer_list::PeerList,
+        syncer::MacroSync,
+    },
+};
 
 impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
     pub(crate) async fn request_epoch_ids(
@@ -560,21 +564,20 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
 mod tests {
     use std::sync::Arc;
 
-    use parking_lot::RwLock;
-
     use nimiq_blockchain::{Blockchain, BlockchainConfig};
     use nimiq_database::volatile::VolatileDatabase;
     use nimiq_hash::Blake2bHash;
     use nimiq_network_interface::network::Network;
     use nimiq_network_mock::{MockHub, MockNetwork, MockPeerId};
-    use nimiq_primitives::networks::NetworkId;
-    use nimiq_primitives::policy::Policy;
+    use nimiq_primitives::{networks::NetworkId, policy::Policy};
     use nimiq_test_log::test;
     use nimiq_utils::time::OffsetTime;
+    use parking_lot::RwLock;
 
-    use crate::messages::Checkpoint;
-    use crate::sync::history::sync::EpochIds;
-    use crate::sync::history::HistoryMacroSync;
+    use crate::{
+        messages::Checkpoint,
+        sync::history::{sync::EpochIds, HistoryMacroSync},
+    };
 
     fn generate_epoch_ids(
         sender: MockPeerId,

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -1,19 +1,24 @@
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use futures::{FutureExt, Stream, StreamExt};
-use tokio::task::spawn_blocking;
-
 use nimiq_block::Block;
 use nimiq_blockchain::Blockchain;
 use nimiq_macros::store_waker;
 use nimiq_network_interface::network::{Network, NetworkEvent};
+use tokio::task::spawn_blocking;
 
-use crate::sync::history::cluster::{SyncCluster, SyncClusterResult};
-use crate::sync::history::sync::Job;
-use crate::sync::history::HistoryMacroSync;
-use crate::sync::syncer::{MacroSync, MacroSyncReturn};
+use crate::sync::{
+    history::{
+        cluster::{SyncCluster, SyncClusterResult},
+        sync::Job,
+        HistoryMacroSync,
+    },
+    syncer::{MacroSync, MacroSyncReturn},
+};
 
 impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
     fn poll_network_events(
@@ -239,28 +244,26 @@ impl<TNetwork: Network> Stream for HistoryMacroSync<TNetwork> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::task::Poll;
+    use std::{sync::Arc, task::Poll};
 
     use futures::{Stream, StreamExt};
     use nimiq_block_production::BlockProducer;
-    use nimiq_network_interface::request::request_handler;
-    use parking_lot::RwLock;
-
     use nimiq_blockchain::{Blockchain, BlockchainConfig};
     use nimiq_blockchain_interface::AbstractBlockchain;
     use nimiq_blockchain_proxy::BlockchainProxy;
     use nimiq_database::volatile::VolatileDatabase;
-    use nimiq_network_interface::network::Network;
+    use nimiq_network_interface::{network::Network, request::request_handler};
     use nimiq_network_mock::{MockHub, MockNetwork};
-    use nimiq_primitives::networks::NetworkId;
-    use nimiq_primitives::policy::Policy;
+    use nimiq_primitives::{networks::NetworkId, policy::Policy};
     use nimiq_test_log::test;
     use nimiq_test_utils::blockchain::{produce_macro_blocks_with_txns, signing_key, voting_key};
     use nimiq_utils::time::OffsetTime;
+    use parking_lot::RwLock;
 
-    use crate::messages::{RequestBatchSet, RequestHistoryChunk, RequestMacroChain};
-    use crate::sync::{history::HistoryMacroSync, syncer::MacroSyncReturn};
+    use crate::{
+        messages::{RequestBatchSet, RequestHistoryChunk, RequestMacroChain},
+        sync::{history::HistoryMacroSync, syncer::MacroSyncReturn},
+    };
 
     fn blockchain() -> Arc<RwLock<Blockchain>> {
         let time = Arc::new(OffsetTime::new());

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -1,9 +1,10 @@
-use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
-use std::task::Waker;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+    task::Waker,
+};
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
-
 use nimiq_block::Block;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use futures::FutureExt;
-
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -18,10 +17,12 @@ use nimiq_zkp_component::{
     zkp_component::ZKPComponentProxy,
 };
 
-use crate::messages::{MacroChain, RequestBlock, RequestMacroChain};
-use crate::sync::light::{
-    sync::{EpochIds, PeerMacroRequests},
-    LightMacroSync,
+use crate::{
+    messages::{MacroChain, RequestBlock, RequestMacroChain},
+    sync::light::{
+        sync::{EpochIds, PeerMacroRequests},
+        LightMacroSync,
+    },
 };
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -1,9 +1,10 @@
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use futures::{FutureExt, Stream, StreamExt};
-
 use nimiq_block::Block;
 #[cfg(feature = "full")]
 use nimiq_blockchain::Blockchain;
@@ -424,8 +425,6 @@ mod tests {
     use std::sync::Arc;
 
     use futures::StreamExt;
-    use parking_lot::RwLock;
-
     use nimiq_block_production::BlockProducer;
     use nimiq_blockchain::{Blockchain, BlockchainConfig};
     use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
@@ -438,10 +437,12 @@ mod tests {
     use nimiq_test_log::test;
     use nimiq_test_utils::blockchain::{produce_macro_blocks_with_txns, signing_key, voting_key};
     use nimiq_utils::time::OffsetTime;
+    use parking_lot::RwLock;
 
-    use crate::messages::{RequestBlock, RequestMacroChain};
-    use crate::sync::light::LightMacroSync;
-    use crate::sync::syncer::MacroSyncReturn;
+    use crate::{
+        messages::{RequestBlock, RequestMacroChain},
+        sync::{light::LightMacroSync, syncer::MacroSyncReturn},
+    };
 
     fn blockchain() -> BlockchainProxy {
         let time = Arc::new(OffsetTime::new());

--- a/consensus/src/sync/live/block_queue/block_request_component.rs
+++ b/consensus/src/sync/live/block_queue/block_request_component.rs
@@ -1,9 +1,10 @@
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use futures::{FutureExt, Stream, StreamExt};
-
 use nimiq_block::Block;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{

--- a/consensus/src/sync/live/block_queue/live_sync.rs
+++ b/consensus/src/sync/live/block_queue/live_sync.rs
@@ -6,11 +6,8 @@ use std::{
 
 use futures::{
     future::{self, BoxFuture},
-    FutureExt, Stream,
-};
-use futures::{
     stream::{empty, select},
-    StreamExt,
+    FutureExt, Stream, StreamExt,
 };
 use nimiq_block::Block;
 use nimiq_blockchain_interface::{PushError, PushResult};

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -8,9 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::stream::BoxStream;
-use futures::{Stream, StreamExt};
-
+use futures::{stream::BoxStream, Stream, StreamExt};
 use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction, ForkEvent};
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -19,7 +17,6 @@ use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
 use nimiq_primitives::policy::Policy;
 
 use self::block_request_component::BlockRequestComponent;
-
 use super::{
     block_queue::block_request_component::BlockRequestComponentEvent,
     queue::{LiveSyncQueue, QueueConfig},

--- a/consensus/src/sync/live/mod.rs
+++ b/consensus/src/sync/live/mod.rs
@@ -3,26 +3,25 @@ pub mod queue;
 #[cfg(feature = "full")]
 pub mod state_queue;
 
-use futures::{future::BoxFuture, Stream, StreamExt};
-use parking_lot::Mutex;
 use std::{
     collections::VecDeque,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
 };
-use tokio::sync::mpsc::{channel as mpsc, Sender as MpscSender};
-use tokio_stream::wrappers::ReceiverStream;
 
+use futures::{future::BoxFuture, Stream, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_network_interface::network::Network;
+use parking_lot::Mutex;
+use tokio::sync::mpsc::{channel as mpsc, Sender as MpscSender};
+use tokio_stream::wrappers::ReceiverStream;
 
 #[cfg(feature = "full")]
 use self::state_queue::StateQueue;
 use self::{block_queue::BlockQueue, queue::LiveSyncQueue};
-
 use super::syncer::{LiveSync, LiveSyncEvent};
 
 pub type BlockLiveSync<N> = LiveSyncer<N, BlockQueue<N>>;

--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -1,15 +1,9 @@
-use futures::{future::BoxFuture, FutureExt, Stream};
-use nimiq_light_blockchain::LightBlockchain;
-use nimiq_primitives::policy::Policy;
 use std::{
     collections::{HashSet, VecDeque},
     sync::Arc,
 };
-#[cfg(not(target_family = "wasm"))]
-use tokio::task::spawn_blocking;
 
-use parking_lot::Mutex;
-
+use futures::{future::BoxFuture, FutureExt, Stream};
 use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
 #[cfg(feature = "full")]
 use nimiq_blockchain::Blockchain;
@@ -19,11 +13,16 @@ use nimiq_blockchain_interface::{
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_hash::Blake2bHash;
+use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{MsgAcceptance, Network};
 use nimiq_primitives::{
     key_nibbles::KeyNibbles,
+    policy::Policy,
     trie::trie_chunk::{TrieChunk, TrieChunkWithStart},
 };
+use parking_lot::Mutex;
+#[cfg(not(target_family = "wasm"))]
+use tokio::task::spawn_blocking;
 
 use crate::sync::syncer::LiveSyncEvent;
 

--- a/consensus/src/sync/live/state_queue/chunk_request_component.rs
+++ b/consensus/src/sync/live/state_queue/chunk_request_component.rs
@@ -5,17 +5,15 @@ use std::{
 };
 
 use futures::{FutureExt, Stream, StreamExt};
-use parking_lot::RwLock;
-
 use nimiq_network_interface::{
     network::{Network, NetworkEvent, SubscribeEvents},
     request::RequestError,
 };
 use nimiq_primitives::key_nibbles::KeyNibbles;
-
-use crate::sync::{peer_list::PeerList, sync_queue::SyncQueue};
+use parking_lot::RwLock;
 
 use super::{RequestChunk, ResponseChunk};
+use crate::sync::{peer_list::PeerList, sync_queue::SyncQueue};
 
 /// Peer Tracking & Chunk Request Component.
 /// This component returns only the responses that respect the size limit specified on

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -1,21 +1,21 @@
-use std::cmp;
-use std::cmp::Ordering;
-use std::collections::binary_heap::PeekMut;
-use std::collections::{BinaryHeap, VecDeque};
-use std::fmt::Debug;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
+use std::{
+    cmp,
+    cmp::Ordering,
+    collections::{binary_heap::PeekMut, BinaryHeap, VecDeque},
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll, Waker},
+};
 
 use futures::{
     future, future::BoxFuture, ready, stream::FuturesUnordered, FutureExt, Stream, StreamExt,
 };
-use parking_lot::RwLock;
-use pin_project::pin_project;
-
 use nimiq_macros::store_waker;
 use nimiq_network_interface::network::Network;
+use parking_lot::RwLock;
+use pin_project::pin_project;
 
 use super::peer_list::PeerList;
 
@@ -336,11 +336,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::task::{Context, Poll};
+    use std::{
+        sync::Arc,
+        task::{Context, Poll},
+    };
 
     use futures::{future, task::noop_waker_ref, FutureExt, StreamExt};
-
     use nimiq_network_mock::MockHub;
 
     use crate::sync::sync_queue::SyncQueue;

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -1,11 +1,12 @@
-use std::collections::{HashMap, HashSet};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use futures::{Stream, StreamExt};
 use instant::Instant;
-
 use nimiq_block::Block;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::Network;

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -7,15 +7,14 @@ use std::{
 };
 
 use futures::{Stream, StreamExt};
-use parking_lot::Mutex;
-use pin_project::pin_project;
-
 use nimiq_block::Block;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
 use nimiq_primitives::task_executor::TaskExecutor;
 use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
+use parking_lot::Mutex;
+use pin_project::pin_project;
 
 #[cfg(feature = "full")]
 use crate::sync::{

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -1,28 +1,26 @@
+use std::{str::FromStr, sync::Arc};
+
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
-use nimiq_consensus::sync::syncer_proxy::SyncerProxy;
-use nimiq_consensus::Consensus;
+use nimiq_consensus::{sync::syncer_proxy::SyncerProxy, Consensus};
 use nimiq_database::volatile::VolatileDatabase;
 use nimiq_keys::{Address, KeyPair, PrivateKey};
 use nimiq_network_interface::network::Network;
 use nimiq_network_mock::MockHub;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
-use nimiq_test_utils::blockchain::{fill_micro_blocks_with_txns, UNIT_KEY};
 use nimiq_test_utils::{
-    blockchain::{produce_macro_blocks, signing_key, voting_key},
+    blockchain::{
+        fill_micro_blocks_with_txns, produce_macro_blocks, signing_key, voting_key, UNIT_KEY,
+    },
     node::TESTING_BLS_CACHE_MAX_CAPACITY,
 };
-use nimiq_transaction::extended_transaction::ExtTxData;
-use nimiq_transaction::{ExecutedTransaction, TransactionFormat};
+use nimiq_transaction::{extended_transaction::ExtTxData, ExecutedTransaction, TransactionFormat};
 use nimiq_utils::time::OffsetTime;
 use nimiq_zkp_component::ZKPComponent;
 use parking_lot::{Mutex, RwLock};
-use std::str::FromStr;
-use std::sync::Arc;
 
 #[test(tokio::test)]
 async fn test_request_transactions_by_address() {

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -5,25 +5,21 @@ use std::{
 };
 
 use futures::{poll, Stream, StreamExt};
-use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_bls::cache::PublicKeyCache;
-use nimiq_consensus::messages::{RequestMissingBlocks, ResponseBlocks};
-use nimiq_consensus::sync::live::queue::QueueConfig;
-use nimiq_network_interface::request::RequestCommon;
-use parking_lot::{Mutex, RwLock};
-use rand::Rng;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-
 use nimiq_block::Block;
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::{AbstractBlockchain, Direction};
-use nimiq_consensus::sync::live::block_queue::BlockQueue;
-use nimiq_consensus::sync::live::BlockLiveSync;
-use nimiq_consensus::sync::syncer::{LiveSync, MacroSync, MacroSyncReturn, Syncer};
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_bls::cache::PublicKeyCache;
+use nimiq_consensus::{
+    messages::{RequestMissingBlocks, ResponseBlocks},
+    sync::{
+        live::{block_queue::BlockQueue, queue::QueueConfig, BlockLiveSync},
+        syncer::{LiveSync, MacroSync, MacroSyncReturn, Syncer},
+    },
+};
 use nimiq_database::volatile::VolatileDatabase;
-use nimiq_network_interface::network::Network;
+use nimiq_network_interface::{network::Network, request::RequestCommon};
 use nimiq_network_mock::{MockHub, MockId, MockPeerId};
 use nimiq_primitives::networks::NetworkId;
 use nimiq_test_log::test;
@@ -36,6 +32,10 @@ use nimiq_test_utils::{
     test_rng::test_rng,
 };
 use nimiq_utils::time::OffsetTime;
+use parking_lot::{Mutex, RwLock};
+use rand::Rng;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
 #[derive(Default)]
 struct MockHistorySyncStream {

--- a/consensus/tests/history_sync.rs
+++ b/consensus/tests/history_sync.rs
@@ -1,33 +1,35 @@
 mod sync_utils;
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
-use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_bls::cache::PublicKeyCache;
-use nimiq_consensus::sync::syncer_proxy::SyncerProxy;
-use nimiq_test_log::test;
-use nimiq_test_utils::node::TESTING_BLS_CACHE_MAX_CAPACITY;
-use nimiq_zkp_component::ZKPComponent;
-use parking_lot::{Mutex, RwLock};
-
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::AbstractBlockchain;
-use nimiq_consensus::consensus::Consensus;
-use nimiq_consensus::sync::history::{cluster::SyncCluster, HistoryMacroSync};
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_bls::cache::PublicKeyCache;
+use nimiq_consensus::{
+    consensus::Consensus,
+    sync::{
+        history::{cluster::SyncCluster, HistoryMacroSync},
+        syncer_proxy::SyncerProxy,
+    },
+};
 use nimiq_database::volatile::VolatileDatabase;
 use nimiq_genesis::NetworkId;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::policy::Policy;
+use nimiq_test_log::test;
 use nimiq_test_utils::{
     blockchain::{produce_macro_blocks, signing_key, voting_key},
+    node::TESTING_BLS_CACHE_MAX_CAPACITY,
     test_network::TestNetwork,
 };
 use nimiq_utils::time::OffsetTime;
+use nimiq_zkp_component::ZKPComponent;
+use parking_lot::{Mutex, RwLock};
 
 use crate::sync_utils::{sync_two_peers, SyncMode};
 

--- a/consensus/tests/request_component.rs
+++ b/consensus/tests/request_component.rs
@@ -8,9 +8,11 @@ use nimiq_genesis_builder::GenesisBuilder;
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_test_log::test;
-use nimiq_test_utils::blockchain::{produce_macro_blocks, signing_key, voting_key};
-use nimiq_test_utils::node::Node;
-use nimiq_test_utils::validator::seeded_rng;
+use nimiq_test_utils::{
+    blockchain::{produce_macro_blocks, signing_key, voting_key},
+    node::Node,
+    validator::seeded_rng,
+};
 
 #[ignore]
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -1,12 +1,7 @@
-use std::sync::Arc;
-use std::task::Poll;
+use std::{sync::Arc, task::Poll};
 
 use futures::{join, poll, Future, FutureExt, StreamExt};
 use log::info;
-use parking_lot::{Mutex, RwLock};
-use tokio::sync::mpsc::{self, Sender};
-use tokio_stream::wrappers::ReceiverStream;
-
 use nimiq_block::Block;
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
@@ -45,6 +40,9 @@ use nimiq_test_utils::{
     node::TESTING_BLS_CACHE_MAX_CAPACITY,
 };
 use nimiq_utils::{math::CeilingDiv, time::OffsetTime};
+use parking_lot::{Mutex, RwLock};
+use tokio::sync::mpsc::{self, Sender};
+use tokio_stream::wrappers::ReceiverStream;
 
 fn blockchain(complete: bool) -> Blockchain {
     let time = Arc::new(OffsetTime::new());

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -2,30 +2,30 @@ use std::sync::Arc;
 
 use futures::{future, StreamExt};
 use nimiq_block::{BlockHeaderTopic, BlockTopic};
-use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_bls::cache::PublicKeyCache;
-use nimiq_consensus::sync::syncer::MacroSyncReturn;
-use nimiq_consensus::sync::syncer_proxy::SyncerProxy;
-use nimiq_light_blockchain::LightBlockchain;
-use nimiq_primitives::policy::Policy;
-use nimiq_test_utils::node::TESTING_BLS_CACHE_MAX_CAPACITY;
-use nimiq_zkp_component::ZKPComponent;
-use parking_lot::{Mutex, RwLock};
-
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction};
-use nimiq_consensus::consensus::Consensus;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_bls::cache::PublicKeyCache;
+use nimiq_consensus::{
+    consensus::Consensus,
+    sync::{syncer::MacroSyncReturn, syncer_proxy::SyncerProxy},
+};
 use nimiq_database::volatile::VolatileDatabase;
 use nimiq_genesis::NetworkId;
+use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::MockHub;
+use nimiq_primitives::policy::Policy;
 use nimiq_test_utils::{
     blockchain::{produce_macro_blocks_with_txns, signing_key, voting_key},
+    node::TESTING_BLS_CACHE_MAX_CAPACITY,
     test_network::TestNetwork,
 };
 use nimiq_utils::time::OffsetTime;
+use nimiq_zkp_component::ZKPComponent;
+use parking_lot::{Mutex, RwLock};
 use tokio::spawn;
 
 #[allow(dead_code)]

--- a/database/database-value/src/lib.rs
+++ b/database/database-value/src/lib.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-use std::ffi::CStr;
-use std::io;
-use std::mem;
-use std::slice;
+use std::{borrow::Cow, ffi::CStr, io, mem, slice};
 
 pub trait IntoDatabaseValue {
     fn database_byte_size(&self) -> usize;

--- a/database/src/mdbx/cursor.rs
+++ b/database/src/mdbx/cursor.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use libmdbx::{TransactionKind, WriteFlags, RO, RW};
-
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 
 use super::{DbKvPair, IntoIter};

--- a/database/src/mdbx/database.rs
+++ b/database/src/mdbx/database.rs
@@ -3,9 +3,8 @@ use std::{borrow::Cow, fs, path::Path, sync::Arc};
 use libmdbx::NoWriteMap;
 use log::info;
 
-use crate::{traits::Database, DatabaseProxy, Error, TableFlags};
-
 use super::{MdbxReadTransaction, MdbxWriteTransaction};
+use crate::{traits::Database, DatabaseProxy, Error, TableFlags};
 
 pub(super) type DbKvPair<'a> = (Cow<'a, [u8]>, Cow<'a, [u8]>);
 

--- a/database/src/mdbx/iterators.rs
+++ b/database/src/mdbx/iterators.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use libmdbx::TransactionKind;
-
 use nimiq_database_value::FromDatabaseValue;
 
 /// Iterates over database entries (key, value pairs).

--- a/database/src/mdbx/mod.rs
+++ b/database/src/mdbx/mod.rs
@@ -7,14 +7,14 @@ pub use self::{cursor::*, database::*, iterators::*, transaction::*};
 
 #[cfg(test)]
 mod tests {
+    use nimiq_test_log::test;
+    use tempfile::tempdir;
+
+    use super::*;
     use crate::{
         traits::{Database, ReadCursor, ReadTransaction, WriteTransaction},
         TableFlags,
     };
-
-    use super::*;
-    use nimiq_test_log::test;
-    use tempfile::tempdir;
 
     #[test]
     fn it_can_save_basic_objects() {

--- a/database/src/mdbx/transaction.rs
+++ b/database/src/mdbx/transaction.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use libmdbx::{NoWriteMap, TransactionKind, WriteFlags, RO, RW};
-
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue, IntoDatabaseValue};
 
 use super::{MdbxCursor, MdbxTable, MdbxWriteCursor};

--- a/database/src/proxy/cursor.rs
+++ b/database/src/proxy/cursor.rs
@@ -1,5 +1,4 @@
 use libmdbx::{RO, RW};
-
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 
 use crate::{

--- a/database/src/volatile.rs
+++ b/database/src/volatile.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use tempfile::TempDir;
 
-use super::mdbx::*;
-use super::*;
+use super::{mdbx::*, *};
 use crate::traits::Database;
 
 /// A database instantiation that is not permanently stored.
@@ -89,10 +88,10 @@ pub type VolatileWriteCursor<'txn> = MdbxWriteCursor<'txn>;
 
 #[cfg(test)]
 mod tests {
-    use crate::traits::{ReadCursor, ReadTransaction, WriteTransaction};
+    use nimiq_test_log::test;
 
     use super::*;
-    use nimiq_test_log::test;
+    use crate::traits::{ReadCursor, ReadTransaction, WriteTransaction};
 
     #[test]
     fn it_can_save_basic_objects() {

--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -1,14 +1,12 @@
 use std::convert::TryFrom;
 
-use serde::de::Error;
-use serde::{Deserialize, Deserializer};
-use time::OffsetDateTime;
-
 use beserial::Deserialize as BDeserialize;
 use nimiq_bls::PublicKey as BlsPublicKey;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
 use nimiq_primitives::coin::Coin;
 use nimiq_vrf::VrfSeed;
+use serde::{de::Error, Deserialize, Deserializer};
+use time::OffsetDateTime;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct GenesisConfig {

--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -1,13 +1,11 @@
 #[macro_use]
 extern crate log;
 
-use std::fs::{read_to_string, OpenOptions};
-use std::io::Error as IoError;
-use std::path::Path;
-
-use thiserror::Error;
-use time::OffsetDateTime;
-use toml::de::Error as TomlError;
+use std::{
+    fs::{read_to_string, OpenOptions},
+    io::Error as IoError,
+    path::Path,
+};
 
 use beserial::{Serialize, SerializeWithLength, SerializingError};
 use nimiq_account::{
@@ -25,6 +23,9 @@ use nimiq_primitives::{
     account::AccountError, coin::Coin, key_nibbles::KeyNibbles, policy::Policy, trie::TrieItem,
 };
 use nimiq_vrf::VrfSeed;
+use thiserror::Error;
+use time::OffsetDateTime;
+use toml::de::Error as TomlError;
 
 mod config;
 

--- a/genesis-builder/src/main.rs
+++ b/genesis-builder/src/main.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::process::exit;
+use std::{env, process::exit};
 
 use nimiq_database::volatile::VolatileDatabase;
 use nimiq_genesis_builder::{GenesisBuilder, GenesisInfo};

--- a/genesis/build.rs
+++ b/genesis/build.rs
@@ -1,6 +1,4 @@
-use std::env;
-use std::fs;
-use std::path::Path;
+use std::{env, fs, path::Path};
 
 use nimiq_database::volatile::VolatileDatabase;
 use nimiq_genesis_builder::GenesisBuilder;

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -1,13 +1,11 @@
-use std::collections::HashMap;
-use std::env;
 #[cfg(feature = "genesis-override")]
 use std::path::Path;
-
-use lazy_static::lazy_static;
+use std::{collections::HashMap, env};
 
 use beserial::Deserialize;
 #[cfg(feature = "genesis-override")]
 use beserial::{Serialize, SerializeWithLength};
+use lazy_static::lazy_static;
 use nimiq_block::Block;
 #[cfg(feature = "genesis-override")]
 use nimiq_database::volatile::VolatileDatabase;

--- a/handel/src/contribution.rs
+++ b/handel/src/contribution.rs
@@ -1,6 +1,5 @@
-use thiserror::Error;
-
 use nimiq_collections::bitset::BitSet;
+use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
 pub enum ContributionError {

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -1,5 +1,4 @@
-use std::cmp::min;
-use std::sync::Arc;
+use std::{cmp::min, sync::Arc};
 
 use parking_lot::RwLock;
 use rand::{seq::SliceRandom, thread_rng};
@@ -179,11 +178,10 @@ impl Level {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
-
     use beserial::{Deserialize, Serialize};
     use nimiq_collections::bitset::BitSet;
     use nimiq_test_log::test;
+    use rand::Rng;
 
     use super::*;
     use crate::contribution::ContributionError;

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -8,7 +8,6 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     Stream,
 };
-
 use nimiq_macros::store_waker;
 
 use crate::{contribution::AggregatableContribution, update::LevelUpdate};
@@ -162,13 +161,12 @@ impl<TNetwork: Network + Unpin> Stream for LevelUpdateSender<TNetwork> {
 mod test {
     use std::{sync::Arc, task::Context};
 
-    use futures::{FutureExt, StreamExt};
-    use parking_lot::Mutex;
-    use tokio::time;
-
     use beserial::{Deserialize, Serialize};
+    use futures::{FutureExt, StreamExt};
     use nimiq_collections::BitSet;
     use nimiq_test_log::test;
+    use parking_lot::Mutex;
+    use tokio::time;
 
     use crate::{
         contribution::{AggregatableContribution, ContributionError},

--- a/handel/src/partitioner.rs
+++ b/handel/src/partitioner.rs
@@ -1,8 +1,7 @@
 use std::ops::RangeInclusive;
 
-use thiserror::Error;
-
 use nimiq_utils::math::log2;
+use thiserror::Error;
 
 use crate::contribution::AggregatableContribution;
 
@@ -122,9 +121,10 @@ impl Partitioner for BinomialPartitioner {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nimiq_test_log::test;
     use rand::Rng;
+
+    use super::*;
 
     #[test]
     fn test_partitioner() {

--- a/handel/src/protocol.rs
+++ b/handel/src/protocol.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use parking_lot::RwLock;
 
-use crate::contribution::AggregatableContribution;
-use crate::evaluator::Evaluator;
-use crate::identity::{IdentityRegistry, WeightRegistry};
-use crate::partitioner::Partitioner;
-use crate::store::ContributionStore;
-use crate::verifier::{VerificationResult, Verifier};
+use crate::{
+    contribution::AggregatableContribution,
+    evaluator::Evaluator,
+    identity::{IdentityRegistry, WeightRegistry},
+    partitioner::Partitioner,
+    store::ContributionStore,
+    verifier::{VerificationResult, Verifier},
+};
 
 #[async_trait]
 pub trait Protocol<TId: Clone + std::fmt::Debug + 'static>: Send + Sync + Sized + 'static {

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
-use crate::identity::IdentityRegistry;
-use crate::partitioner::Partitioner;
-use crate::protocol::Protocol;
-use crate::{contribution::AggregatableContribution, identity::Identity};
+use crate::{
+    contribution::AggregatableContribution,
+    identity::{Identity, IdentityRegistry},
+    partitioner::Partitioner,
+    protocol::Protocol,
+};
 
 /// Trait that needs to be implemented to support the storage of contributions
 /// and the selection of the best contributions seen.
@@ -304,12 +305,11 @@ where
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use parking_lot::RwLock;
-    use rand::Rng;
-
     use beserial::{Deserialize, Serialize};
     use nimiq_collections::BitSet;
     use nimiq_test_log::test;
+    use parking_lot::RwLock;
+    use rand::Rng;
 
     use super::*;
     use crate::{

--- a/handel/src/todo.rs
+++ b/handel/src/todo.rs
@@ -1,18 +1,16 @@
-use core::pin::Pin;
-use core::task::{Context, Poll};
-use std::collections::HashSet;
-use std::fmt;
-use std::sync::Arc;
-use std::task::Waker;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::{collections::HashSet, fmt, sync::Arc, task::Waker};
 
 use futures::{stream::BoxStream, Stream, StreamExt};
-
 use nimiq_macros::store_waker;
 
-use crate::contribution::AggregatableContribution;
-use crate::evaluator::Evaluator;
-use crate::protocol::Protocol;
-use crate::update::LevelUpdate;
+use crate::{
+    contribution::AggregatableContribution, evaluator::Evaluator, protocol::Protocol,
+    update::LevelUpdate,
+};
 
 /// A TodoItem represents a contribution which has not yet been aggregated into the store.
 #[derive(Clone)]

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -1,14 +1,11 @@
 use std::{fmt::Formatter, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use beserial::{Deserialize, Serialize};
 use futures::{
     future::{BoxFuture, FutureExt},
     stream::StreamExt,
 };
-use parking_lot::RwLock;
-use rand::{thread_rng, Rng};
-
-use beserial::{Deserialize, Serialize};
 use nimiq_bls::PublicKey;
 use nimiq_collections::bitset::BitSet;
 use nimiq_handel::{
@@ -30,6 +27,8 @@ use nimiq_network_interface::{
 };
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_test_log::test;
+use parking_lot::RwLock;
+use rand::{thread_rng, Rng};
 
 /// Dump Aggregate adding numbers.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -1,20 +1,19 @@
-use std::cmp::Ordering;
-use std::fmt::{Debug, Error, Formatter};
-use std::io;
-use std::str;
-
-use blake2_rfc::blake2b::Blake2b;
-use blake2_rfc::blake2s::Blake2s;
-use hex::FromHex;
-use sha2::{Digest, Sha256, Sha512};
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    fmt::{Debug, Error, Formatter},
+    io, str,
+};
 
 use beserial::{Deserialize, Serialize};
+use blake2_rfc::{blake2b::Blake2b, blake2s::Blake2s};
+use hex::FromHex;
+use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_macros::{add_hex_io_fns_typed_arr, create_typed_array};
+use nimiq_mmr::hash::Merge;
+use sha2::{Digest, Sha256, Sha512};
 
 pub use self::sha512::*;
-use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
-use nimiq_mmr::hash::Merge;
-use std::borrow::Cow;
 
 pub mod argon2kdf;
 pub mod blake2s;

--- a/hash/src/pbkdf2.rs
+++ b/hash/src/pbkdf2.rs
@@ -2,8 +2,7 @@ use std::io::{Error, Write};
 
 use byteorder::{BigEndian, WriteBytesExt};
 
-use super::hmac::compute_hmac_sha512;
-use super::{Sha512Hash, SHA512_LENGTH};
+use super::{hmac::compute_hmac_sha512, Sha512Hash, SHA512_LENGTH};
 
 #[derive(Debug)]
 pub enum Pbkdf2Error {

--- a/hash/tests/hmac.rs
+++ b/hash/tests/hmac.rs
@@ -1,7 +1,5 @@
 use hex::FromHex;
-
-use nimiq_hash::hmac::*;
-use nimiq_hash::Sha512Hash;
+use nimiq_hash::{hmac::*, Sha512Hash};
 use nimiq_test_log::test;
 
 struct TestVector {

--- a/hash/tests/pbkdf2.rs
+++ b/hash/tests/pbkdf2.rs
@@ -1,5 +1,4 @@
 use hex::FromHex;
-
 use nimiq_hash::pbkdf2::*;
 use nimiq_test_log::test;
 

--- a/key-derivation/src/lib.rs
+++ b/key-derivation/src/lib.rs
@@ -1,13 +1,10 @@
 use std::borrow::Cow;
 
-use byteorder::{BigEndian, WriteBytesExt};
-use regex::Regex;
-
 use beserial::Serialize;
-use nimiq_hash::hmac::*;
-use nimiq_hash::Sha512Hash;
-use nimiq_keys::Address;
-use nimiq_keys::{PrivateKey, PublicKey};
+use byteorder::{BigEndian, WriteBytesExt};
+use nimiq_hash::{hmac::*, Sha512Hash};
+use nimiq_keys::{Address, PrivateKey, PublicKey};
+use regex::Regex;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExtendedPrivateKey {

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -1,20 +1,12 @@
-use std::borrow::Cow;
-use std::char;
-use std::convert::From;
-use std::fmt;
-use std::io;
-use std::iter::Iterator;
-use std::str::FromStr;
+use std::{borrow::Cow, char, convert::From, fmt, io, iter::Iterator, str::FromStr};
 
 use hex::FromHex;
-use thiserror::Error;
-
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_hash::{hash_typed_array, Blake2bHash, Blake2bHasher, Hasher};
 use nimiq_macros::create_typed_array;
+use thiserror::Error;
 
-use crate::key_pair::KeyPair;
-use crate::PublicKey;
+use crate::{key_pair::KeyPair, PublicKey};
 
 create_typed_array!(Address, u8, 20);
 hash_typed_array!(Address);

--- a/keys/src/key_pair.rs
+++ b/keys/src/key_pair.rs
@@ -1,8 +1,7 @@
-use ed25519_zebra::{SigningKey, VerificationKeyBytes};
-use rand_core::{CryptoRng, RngCore};
-
 use beserial::{Deserialize, Serialize};
+use ed25519_zebra::{SigningKey, VerificationKeyBytes};
 use nimiq_utils::key_rng::SecureGenerate;
+use rand_core::{CryptoRng, RngCore};
 
 use crate::{PrivateKey, PublicKey, Signature};
 

--- a/keys/src/lib.rs
+++ b/keys/src/lib.rs
@@ -1,11 +1,6 @@
 pub use nimiq_utils::key_rng::{SecureGenerate, SecureRng};
 
-pub use self::address::*;
-pub use self::errors::*;
-pub use self::key_pair::*;
-pub use self::private_key::*;
-pub use self::public_key::*;
-pub use self::signature::*;
+pub use self::{address::*, errors::*, key_pair::*, private_key::*, public_key::*, signature::*};
 
 #[macro_export]
 macro_rules! implement_simple_add_sum_traits {

--- a/keys/src/multisig.rs
+++ b/keys/src/multisig.rs
@@ -1,17 +1,14 @@
-use std::borrow::Borrow;
-use std::error;
-use std::fmt;
-use std::iter::Sum;
-use std::ops::Add;
+use std::{borrow::Borrow, error, fmt, iter::Sum, ops::Add};
 
-use curve25519_dalek::constants;
-use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
-use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::Identity;
+use curve25519_dalek::{
+    constants,
+    edwards::{CompressedEdwardsY, EdwardsPoint},
+    scalar::Scalar,
+    traits::Identity,
+};
+use nimiq_utils::key_rng::{CryptoRng, RngCore, SecureGenerate};
 use rand::Rng;
 use sha2::{self, Digest, Sha512};
-
-use nimiq_utils::key_rng::{CryptoRng, RngCore, SecureGenerate};
 
 use crate::{KeyPair, PublicKey, Signature};
 

--- a/keys/src/private_key.rs
+++ b/keys/src/private_key.rs
@@ -1,16 +1,17 @@
-use std::convert::{TryFrom, TryInto};
-use std::fmt::{Debug, Error, Formatter};
-use std::io;
-use std::str::FromStr;
-
-use curve25519_dalek::scalar::Scalar;
-use hex::FromHex;
-use rand_core::{CryptoRng, RngCore};
-use sha2::{Digest as _, Sha512};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt::{Debug, Error, Formatter},
+    io,
+    str::FromStr,
+};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use curve25519_dalek::scalar::Scalar;
+use hex::FromHex;
 use nimiq_hash::{Hash, SerializeContent};
 use nimiq_utils::key_rng::SecureGenerate;
+use rand_core::{CryptoRng, RngCore};
+use sha2::{Digest as _, Sha512};
 
 use crate::errors::{KeysError, ParseError};
 

--- a/keys/src/public_key.rs
+++ b/keys/src/public_key.rs
@@ -1,17 +1,18 @@
-use std::cmp::Ordering;
-use std::convert::TryFrom;
-use std::convert::TryInto;
-use std::fmt;
-use std::io;
-use std::str::FromStr;
-
-use hex::FromHex;
+use std::{
+    cmp::Ordering,
+    convert::{TryFrom, TryInto},
+    fmt, io,
+    str::FromStr,
+};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use hex::FromHex;
 use nimiq_hash::{Hash, SerializeContent};
 
-use crate::errors::{KeysError, ParseError};
-use crate::{PrivateKey, Signature};
+use crate::{
+    errors::{KeysError, ParseError},
+    PrivateKey, Signature,
+};
 
 #[derive(Clone, Copy)]
 pub struct PublicKey(pub ed25519_zebra::VerificationKeyBytes);

--- a/keys/src/signature.rs
+++ b/keys/src/signature.rs
@@ -1,10 +1,7 @@
-use std::convert::TryFrom;
-use std::fmt;
-use std::str::FromStr;
-
-use hex::FromHex;
+use std::{convert::TryFrom, fmt, str::FromStr};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use hex::FromHex;
 
 use crate::errors::{KeysError, ParseError};
 

--- a/keys/tests/multisig.rs
+++ b/keys/tests/multisig.rs
@@ -1,11 +1,13 @@
-use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
-use curve25519_dalek::scalar::Scalar;
-use sha2::Digest;
-
-use nimiq_keys::multisig::*;
-use nimiq_keys::multisig::{Commitment, PartialSignature, RandomSecret};
-use nimiq_keys::{KeyPair, PrivateKey, PublicKey, Signature};
+use curve25519_dalek::{
+    edwards::{CompressedEdwardsY, EdwardsPoint},
+    scalar::Scalar,
+};
+use nimiq_keys::{
+    multisig::{Commitment, PartialSignature, RandomSecret, *},
+    KeyPair, PrivateKey, PublicKey, Signature,
+};
 use nimiq_test_log::test;
+use sha2::Digest;
 
 struct StrTestVector {
     priv_keys: &'static [&'static str],

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -1,12 +1,5 @@
 use std::{fs, io, sync::Arc};
 
-use parking_lot::{Mutex, RwLock};
-#[cfg(feature = "zkp-prover")]
-use rand::SeedableRng;
-#[cfg(feature = "zkp-prover")]
-use rand_chacha::ChaCha20Rng;
-use rustls_pemfile::Item;
-
 use nimiq_block::Block;
 #[cfg(feature = "full-consensus")]
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
@@ -53,9 +46,17 @@ use nimiq_zkp_component::zkp_component::{
     ZKPComponent as AbstractZKPComponent, ZKPComponentProxy as AbstractZKPComponentProxy,
 };
 use nimiq_zkp_primitives::NanoZKPError;
+use parking_lot::{Mutex, RwLock};
+#[cfg(feature = "zkp-prover")]
+use rand::SeedableRng;
+#[cfg(feature = "zkp-prover")]
+use rand_chacha::ChaCha20Rng;
+use rustls_pemfile::Item;
 
-use crate::config::config::{ClientConfig, SyncMode};
-use crate::error::Error;
+use crate::{
+    config::config::{ClientConfig, SyncMode},
+    error::Error,
+};
 
 /// Alias for the Consensus and Validator specialized over libp2p network
 pub type Consensus = AbstractConsensus<Network>;

--- a/lib/src/config/command_line.rs
+++ b/lib/src/config/command_line.rs
@@ -2,9 +2,8 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use log::level_filters::{LevelFilter, ParseLevelFilterError};
-use thiserror::Error;
-
 use nimiq_primitives::networks::NetworkId;
+use thiserror::Error;
 
 use crate::config::config_file::SyncMode;
 

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -7,10 +7,8 @@ use std::{
     string::ToString,
 };
 
-use derive_builder::Builder;
-use strum_macros::Display;
-
 use beserial::Deserialize;
+use derive_builder::Builder;
 #[cfg(feature = "validator")]
 use nimiq_bls::{KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
 #[cfg(feature = "database-storage")]
@@ -26,6 +24,7 @@ use nimiq_utils::file_store::FileStore;
 #[cfg(feature = "validator")]
 use nimiq_utils::key_rng::SecureGenerate;
 use nimiq_zkp_circuits::DEFAULT_KEYS_PATH;
+use strum_macros::Display;
 
 #[cfg(feature = "database-storage")]
 use crate::config::config_file::DatabaseSettings;

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -1,13 +1,6 @@
-use std::collections::HashMap;
-use std::fs::read_to_string;
-use std::path::Path;
-use std::str::FromStr;
+use std::{collections::HashMap, fs::read_to_string, path::Path, str::FromStr};
 
 use log::level_filters::LevelFilter;
-use serde_derive::Deserialize;
-use thiserror::Error;
-use url::Url;
-
 #[cfg(feature = "nimiq-mempool")]
 use nimiq_mempool::{
     config::MempoolConfig,
@@ -16,6 +9,9 @@ use nimiq_mempool::{
 };
 use nimiq_network_interface::Multiaddr;
 use nimiq_primitives::{coin::Coin, networks::NetworkId};
+use serde_derive::Deserialize;
+use thiserror::Error;
+use url::Url;
 
 use crate::{
     config::{command_line::CommandLine, config, config_file::serialization::*, paths},

--- a/lib/src/config/config_file/serialization.rs
+++ b/lib/src/config/config_file/serialization.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, convert::TryFrom, fmt::Display, str::FromStr};
 
-use serde::{de::Error, Deserialize, Deserializer};
-
 use nimiq_primitives::coin::Coin;
+use serde::{de::Error, Deserialize, Deserializer};
 
 pub(crate) fn deserialize_coin<'de, D>(deserializer: D) -> Result<Coin, D::Error>
 where

--- a/lib/src/config/user_agent.rs
+++ b/lib/src/config/user_agent.rs
@@ -1,6 +1,4 @@
-use std::env;
-use std::fmt;
-use std::str::FromStr;
+use std::{env, fmt, str::FromStr};
 
 /// A user agent string.
 ///

--- a/lib/src/extras/deadlock.rs
+++ b/lib/src/extras/deadlock.rs
@@ -1,5 +1,4 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 use parking_lot::deadlock;
 

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -1,10 +1,14 @@
-use log::{level_filters::LevelFilter, Level, Subscriber};
-use std::env;
-use std::fs::{self, File};
-use std::io;
 #[cfg(all(tokio_unstable, feature = "tokio-console"))]
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
+use std::{
+    env,
+    fs::{self, File},
+    io,
+    sync::Arc,
+};
+
+use log::{level_filters::LevelFilter, Level, Subscriber};
+use nimiq_log::{Formatting, MaybeSystemTime, TargetsExt};
 use tracing_subscriber::{
     filter::Targets, layer::SubscriberExt, registry::LookupSpan, util::SubscriberInitExt, Layer,
 };
@@ -13,7 +17,6 @@ use crate::{
     config::{command_line::CommandLine, config_file::LogSettings},
     error::Error,
 };
-use nimiq_log::{Formatting, MaybeSystemTime, TargetsExt};
 
 pub const DEFAULT_LEVEL: LevelFilter = LevelFilter::INFO;
 

--- a/lib/src/extras/metrics_server.rs
+++ b/lib/src/extras/metrics_server.rs
@@ -1,13 +1,11 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_consensus::ConsensusProxy;
 #[cfg(feature = "nimiq-mempool")]
 use nimiq_mempool::mempool::Mempool;
-use nimiq_network_interface::network::Network;
-
 pub use nimiq_metrics_server::NimiqTaskMonitor;
+use nimiq_network_interface::network::Network;
 
 pub fn start_metrics_server<TNetwork: Network>(
     addr: SocketAddr,

--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -1,17 +1,13 @@
 use std::{collections::HashSet, iter::FromIterator, sync::Arc};
 
-use nimiq_rpc_server::dispatchers::*;
-
 use nimiq_jsonrpc_core::Credentials;
 use nimiq_jsonrpc_server::{AllowListDispatcher, Config, ModularDispatcher, Server as _Server};
-
+use nimiq_rpc_server::dispatchers::*;
 use nimiq_wallet::WalletStore;
 
-use crate::client::Client;
 #[cfg(feature = "rpc-server")]
 use crate::config::config::RpcServerConfig;
-use crate::config::consts::default_bind;
-use crate::error::Error;
+use crate::{client::Client, config::consts::default_bind, error::Error};
 
 pub type Server = _Server<AllowListDispatcher<ModularDispatcher>>;
 

--- a/lib/src/extras/web_logging.rs
+++ b/lib/src/extras/web_logging.rs
@@ -1,11 +1,11 @@
 use log::{level_filters::LevelFilter, Level};
+use nimiq_log::{Formatting, MaybeSystemTime, TargetsExt};
 use tracing_subscriber::{
     filter::Targets, fmt::format::Pretty, layer::SubscriberExt, util::SubscriberInitExt, Layer,
 };
 use tracing_web::{performance_layer, MakeConsoleWriter};
 
 use crate::{config::config_file::LogSettings, error::Error};
-use nimiq_log::{Formatting, MaybeSystemTime, TargetsExt};
 
 pub const DEFAULT_LEVEL: LevelFilter = LevelFilter::INFO;
 

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -1,5 +1,4 @@
 use futures::{future, stream::BoxStream, StreamExt};
-
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainError, BlockchainEvent, ChainInfo, Direction, ForkEvent,

--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
-
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainError, BlockchainEvent, ChainInfo, ForkEvent,
@@ -15,6 +13,7 @@ use nimiq_primitives::{
 };
 use nimiq_utils::time::OffsetTime;
 use nimiq_vrf::{Rng, VrfEntropy, VrfUseCase};
+use tokio::sync::broadcast::{channel as broadcast, Sender as BroadcastSender};
 
 use crate::chain_store::ChainStore;
 

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -352,7 +352,6 @@ mod tests {
     use nimiq_block::{MicroBlock, MicroHeader, MicroJustification};
     use nimiq_test_log::test;
     use nimiq_test_utils::test_rng::test_rng;
-
     use rand::{Rng, RngCore};
 
     use super::*;

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -1,7 +1,5 @@
 use std::ops::Deref;
 
-use parking_lot::RwLockUpgradableReadGuard;
-
 use nimiq_block::{Block, BlockError, ForkProof, MacroHeader, MicroBlock};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, ChainOrdering, ForkEvent, PushError, PushResult,
@@ -9,6 +7,7 @@ use nimiq_blockchain_interface::{
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_primitives::policy::Policy;
 use nimiq_vrf::VrfSeed;
+use parking_lot::RwLockUpgradableReadGuard;
 
 use crate::blockchain::LightBlockchain;
 

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -1,10 +1,9 @@
-use parking_lot::RwLockUpgradableReadGuard;
-
 use nimiq_block::{Block, BlockError};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, PushError, PushResult,
 };
 use nimiq_zkp::{verify::verify, NanoProof, ZKP_VERIFYING_KEY};
+use parking_lot::RwLockUpgradableReadGuard;
 
 use crate::blockchain::LightBlockchain;
 

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -1,13 +1,18 @@
+use std::{env, fmt};
+
 use ansi_term::{Color, Style};
 use log::{level_filters::LevelFilter, Event, Level, Subscriber};
-use std::{env, fmt};
 use time::format_description::well_known::Iso8601;
 use tracing_log::NormalizeEvent;
-use tracing_subscriber::filter::Targets;
-use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::fmt::time::{FormatTime, UtcTime};
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
-use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{
+    filter::Targets,
+    fmt::{
+        format::Writer,
+        time::{FormatTime, UtcTime},
+        FmtContext, FormatEvent, FormatFields, FormattedFields,
+    },
+    registry::LookupSpan,
+};
 
 pub static NIMIQ_MODULES: &[&str] = &[
     "beserial",

--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -1,5 +1,7 @@
-use crate::filter::{MempoolFilter, MempoolRules};
-use crate::mempool::Mempool;
+use crate::{
+    filter::{MempoolFilter, MempoolRules},
+    mempool::Mempool,
+};
 
 /// Struct defining a Mempool configuration
 #[derive(Debug, Clone)]

--- a/mempool/src/executor.rs
+++ b/mempool/src/executor.rs
@@ -1,22 +1,27 @@
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU32, Ordering as AtomicOrdering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
 
 use futures::{ready, stream::BoxStream, StreamExt};
-use parking_lot::RwLock;
-
 use nimiq_blockchain::Blockchain;
 use nimiq_network_interface::network::{MsgAcceptance, Network, Topic};
 use nimiq_primitives::networks::NetworkId;
 use nimiq_transaction::Transaction;
+use parking_lot::RwLock;
 
-use crate::filter::MempoolFilter;
-use crate::mempool_state::MempoolState;
-use crate::mempool_transactions::TxPriority;
-use crate::verify::{verify_tx, VerifyErr};
+use crate::{
+    filter::MempoolFilter,
+    mempool_state::MempoolState,
+    mempool_transactions::TxPriority,
+    verify::{verify_tx, VerifyErr},
+};
 
 const CONCURRENT_VERIF_TASKS: u32 = 1000;
 

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -1,13 +1,14 @@
-use futures::future::{AbortHandle, Abortable};
-use futures::lock::{Mutex, MutexGuard};
-use futures::stream::BoxStream;
-use parking_lot::RwLock;
-use std::collections::HashSet;
-use std::sync::atomic::AtomicU32;
-use std::sync::Arc;
-use tokio_metrics::TaskMonitor;
+use std::{
+    collections::HashSet,
+    sync::{atomic::AtomicU32, Arc},
+};
 
 use beserial::Serialize;
+use futures::{
+    future::{AbortHandle, Abortable},
+    lock::{Mutex, MutexGuard},
+    stream::BoxStream,
+};
 use nimiq_account::ReservedBalance;
 use nimiq_block::Block;
 use nimiq_blockchain::{Blockchain, TransactionVerificationCache};
@@ -16,15 +17,19 @@ use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::Address;
 use nimiq_network_interface::network::{Network, Topic};
 use nimiq_transaction::{ControlTransactionTopic, Transaction, TransactionTopic};
+use parking_lot::RwLock;
+use tokio_metrics::TaskMonitor;
 
-use crate::config::MempoolConfig;
-use crate::executor::MempoolExecutor;
-use crate::filter::{MempoolFilter, MempoolRules};
 #[cfg(feature = "metrics")]
 use crate::mempool_metrics::MempoolMetrics;
-use crate::mempool_state::{EvictionReason, MempoolState};
-use crate::mempool_transactions::{MempoolTransactions, TxPriority};
-use crate::verify::{verify_tx, VerifyErr};
+use crate::{
+    config::MempoolConfig,
+    executor::MempoolExecutor,
+    filter::{MempoolFilter, MempoolRules},
+    mempool_state::{EvictionReason, MempoolState},
+    mempool_transactions::{MempoolTransactions, TxPriority},
+    verify::{verify_tx, VerifyErr},
+};
 
 /// Struct defining the Mempool
 pub struct Mempool {

--- a/mempool/src/mempool_metrics.rs
+++ b/mempool/src/mempool_metrics.rs
@@ -1,9 +1,10 @@
-use crate::mempool_state::EvictionReason;
 use prometheus_client::{
     encoding::{EncodeLabelSet, EncodeLabelValue},
     metrics::{counter::Counter, family::Family},
     registry::Registry,
 };
+
+use crate::mempool_state::EvictionReason;
 
 #[derive(Default, Clone)]
 pub struct MempoolMetrics {

--- a/mempool/src/mempool_state.rs
+++ b/mempool/src/mempool_state.rs
@@ -1,17 +1,20 @@
-use nimiq_account::ReservedBalance;
-use nimiq_blockchain::Blockchain;
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "metrics")]
 use std::sync::Arc;
 
-#[cfg(feature = "metrics")]
-use crate::mempool_metrics::MempoolMetrics;
-use crate::mempool_transactions::{MempoolTransactions, TxPriority};
-use crate::verify::VerifyErr;
+use nimiq_account::ReservedBalance;
+use nimiq_blockchain::Blockchain;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::Address;
 use nimiq_primitives::account::AccountType;
 use nimiq_transaction::Transaction;
+
+#[cfg(feature = "metrics")]
+use crate::mempool_metrics::MempoolMetrics;
+use crate::{
+    mempool_transactions::{MempoolTransactions, TxPriority},
+    verify::VerifyErr,
+};
 
 pub(crate) struct MempoolState {
     // Container where the regular transactions are stored

--- a/mempool/src/mempool_transactions.rs
+++ b/mempool/src/mempool_transactions.rs
@@ -5,7 +5,6 @@ use std::{
 
 use beserial::Serialize;
 use keyed_priority_queue::KeyedPriorityQueue;
-
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_transaction::Transaction;
 

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -1,18 +1,14 @@
-use parking_lot::RwLock;
 use std::sync::Arc;
-use thiserror::Error;
 
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_hash::Hash;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::transaction::TransactionError;
-
+use nimiq_primitives::{networks::NetworkId, transaction::TransactionError};
 use nimiq_transaction::Transaction;
+use parking_lot::RwLock;
+use thiserror::Error;
 
-use crate::filter::MempoolFilter;
-use crate::mempool_state::MempoolState;
-use crate::mempool_transactions::TxPriority;
+use crate::{filter::MempoolFilter, mempool_state::MempoolState, mempool_transactions::TxPriority};
 
 /// Error codes for the transaction verification
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/mempool/tests/filter.rs
+++ b/mempool/tests/filter.rs
@@ -3,8 +3,7 @@ use std::convert::TryFrom;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::Address;
 use nimiq_mempool::filter::{MempoolFilter, MempoolRules};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_test_log::test;
 use nimiq_transaction::Transaction;
 

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1,9 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_block::{Block, MicroBlock, MicroBody, MicroHeader};
 use nimiq_block_production::BlockProducer;
@@ -30,6 +26,9 @@ use nimiq_transaction::{ExecutedTransaction, Transaction};
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_utils::time::OffsetTime;
 use nimiq_vrf::VrfSeed;
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
 const NUM_TXNS_START_STOP: usize = 100;
 

--- a/metrics-server/src/chain.rs
+++ b/metrics-server/src/chain.rs
@@ -1,12 +1,12 @@
-use prometheus_client::registry::Registry;
+use std::sync::Arc;
 
-use parking_lot::RwLock;
-
-use crate::NumericClosureMetric;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
-use std::sync::Arc;
+use parking_lot::RwLock;
+use prometheus_client::registry::Registry;
+
+use crate::NumericClosureMetric;
 
 pub struct BlockMetrics {}
 

--- a/metrics-server/src/consensus.rs
+++ b/metrics-server/src/consensus.rs
@@ -1,7 +1,8 @@
-use crate::NumericClosureMetric;
 use nimiq_consensus::ConsensusProxy;
 use nimiq_network_interface::network::Network;
 use prometheus_client::registry::Registry;
+
+use crate::NumericClosureMetric;
 
 pub struct ConsensusMetrics {}
 

--- a/metrics-server/src/lib.rs
+++ b/metrics-server/src/lib.rs
@@ -1,28 +1,25 @@
-use std::fmt::Debug;
-use std::net::SocketAddr;
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 
-use prometheus_client::encoding::{EncodeGaugeValue, EncodeMetric, MetricEncoder};
-use prometheus_client::registry::Registry;
-
-use parking_lot::RwLock;
-use tokio_metrics::TaskMonitor;
-
-use crate::chain::BlockMetrics;
-use crate::consensus::ConsensusMetrics;
-use crate::mempool::MempoolMetrics;
-use crate::network::NetworkMetrics;
-use crate::server::metrics_server;
-#[cfg(tokio_unstable)]
-use crate::tokio_runtime::TokioRuntimeMetrics;
-use crate::tokio_task::TokioTaskMetrics;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_consensus::ConsensusProxy;
 use nimiq_mempool::mempool::Mempool;
 use nimiq_network_interface::network::Network;
-use prometheus_client::metrics::MetricType;
-use std::sync::Arc;
+use parking_lot::RwLock;
+use prometheus_client::{
+    encoding::{EncodeGaugeValue, EncodeMetric, MetricEncoder},
+    metrics::MetricType,
+    registry::Registry,
+};
 #[cfg(tokio_unstable)]
 use tokio_metrics::RuntimeMonitor;
+use tokio_metrics::TaskMonitor;
+
+#[cfg(tokio_unstable)]
+use crate::tokio_runtime::TokioRuntimeMetrics;
+use crate::{
+    chain::BlockMetrics, consensus::ConsensusMetrics, mempool::MempoolMetrics,
+    network::NetworkMetrics, server::metrics_server, tokio_task::TokioTaskMetrics,
+};
 
 mod chain;
 mod consensus;

--- a/metrics-server/src/mempool.rs
+++ b/metrics-server/src/mempool.rs
@@ -1,8 +1,9 @@
+use std::sync::Arc;
+
+use nimiq_mempool::mempool::Mempool;
 use prometheus_client::registry::Registry;
 
 use crate::NumericClosureMetric;
-use nimiq_mempool::mempool::Mempool;
-use std::sync::Arc;
 
 pub struct MempoolMetrics {}
 

--- a/metrics-server/src/network.rs
+++ b/metrics-server/src/network.rs
@@ -1,8 +1,9 @@
+use std::sync::Arc;
+
+use nimiq_network_libp2p::Network;
 use prometheus_client::registry::Registry;
 
 use crate::NumericClosureMetric;
-use nimiq_network_libp2p::Network;
-use std::sync::Arc;
 
 pub struct NetworkMetrics {}
 

--- a/metrics-server/src/server.rs
+++ b/metrics-server/src/server.rs
@@ -1,18 +1,15 @@
-use prometheus_client::encoding::text::encode;
-use prometheus_client::registry::Registry;
+use std::{
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
-use hyper::http::StatusCode;
-use hyper::service::Service;
-use hyper::{Body, Method, Request, Response, Server};
-
+use hyper::{http::StatusCode, service::Service, Body, Method, Request, Response, Server};
 use log::{error, info};
-
 use parking_lot::RwLock;
-use std::future::Future;
-use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use prometheus_client::{encoding::text::encode, registry::Registry};
 
 pub async fn metrics_server(addr: SocketAddr, registry: Registry) -> Result<(), std::io::Error> {
     let server = Server::bind(&addr).serve(MakeMetricService::new(registry));

--- a/mnemonic/src/lib.rs
+++ b/mnemonic/src/lib.rs
@@ -1,14 +1,13 @@
-use std::fmt;
-use std::str;
-use std::str::FromStr;
+use std::{fmt, str, str::FromStr};
 
 use bitvec::{field::BitField, order::Msb0, slice::BitSlice, vec::BitVec, view::BitView};
-use unicode_normalization::UnicodeNormalization;
-
-use nimiq_hash::pbkdf2::{compute_pbkdf2_sha512, Pbkdf2Error};
-use nimiq_hash::{HashOutput, Hasher, Sha256Hasher};
+use nimiq_hash::{
+    pbkdf2::{compute_pbkdf2_sha512, Pbkdf2Error},
+    HashOutput, Hasher, Sha256Hasher,
+};
 use nimiq_macros::{add_hex_io_fns_typed_arr, create_typed_array};
 use nimiq_utils::crc::Crc8Computer;
+use unicode_normalization::UnicodeNormalization;
 
 #[cfg(feature = "key-derivation")]
 pub mod key_derivation;

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -1,12 +1,13 @@
-use std::fmt::{Debug, Display};
-use std::hash::Hash;
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
 
 use async_trait::async_trait;
+use beserial::{Deserialize, Serialize, SerializingError};
 use futures::stream::BoxStream;
 use thiserror::Error;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-
-use beserial::{Deserialize, Serialize, SerializingError};
 
 use crate::{
     peer_info::*,

--- a/network-interface/src/peer_info.rs
+++ b/network-interface/src/peer_info.rs
@@ -1,7 +1,6 @@
+use beserial::{Deserialize, Serialize};
 use bitflags::bitflags;
 use libp2p::Multiaddr;
-
-use beserial::{Deserialize, Serialize};
 
 bitflags! {
     /// Bitmask of services

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -1,14 +1,8 @@
-use std::fmt;
-use std::io;
-use std::sync::Arc;
-use std::time::Duration;
-
-use futures::stream::BoxStream;
-use futures::Future;
-use futures::StreamExt;
-use thiserror::Error;
+use std::{fmt, io, sync::Arc, time::Duration};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use futures::{stream::BoxStream, Future, StreamExt};
+use thiserror::Error;
 
 // The max number of request to be processed per peerID and per request type.
 

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -1,5 +1,4 @@
-use std::iter;
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 use libp2p::{
     core::either::EitherError,
@@ -20,9 +19,8 @@ use libp2p::{
     swarm::{ConnectionHandlerUpgrErr, NetworkBehaviour},
     Multiaddr, PeerId,
 };
-use parking_lot::RwLock;
-
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
 
 use crate::{
     connection_pool::{

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,15 +1,15 @@
-use libp2p::{
-    gossipsub::{GossipsubConfig, GossipsubConfigBuilder, MessageId},
-    identity::Keypair,
-    kad::{KademliaBucketInserts, KademliaConfig, KademliaStoreInserts},
-    Multiaddr,
-};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     time::Duration,
 };
 
+use libp2p::{
+    gossipsub::{GossipsubConfig, GossipsubConfigBuilder, MessageId},
+    identity::Keypair,
+    kad::{KademliaBucketInserts, KademliaConfig, KademliaStoreInserts},
+    Multiaddr,
+};
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
 

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -8,26 +8,23 @@ use std::{
 use futures::StreamExt;
 use instant::Instant;
 use ip_network::IpNetwork;
-use libp2p::swarm::{dial_opts::PeerCondition, NotifyHandler};
 use libp2p::{
     core::{connection::ConnectionId, multiaddr::Protocol, ConnectedPoint},
     swarm::{
-        dial_opts::DialOpts, ConnectionHandler, DialError, IntoConnectionHandler, NetworkBehaviour,
-        NetworkBehaviourAction, PollParameters,
+        dial_opts::{DialOpts, PeerCondition},
+        ConnectionHandler, DialError, IntoConnectionHandler, NetworkBehaviour,
+        NetworkBehaviourAction, NotifyHandler, PollParameters,
     },
     Multiaddr, PeerId,
 };
-use parking_lot::RwLock;
-use rand::seq::IteratorRandom;
-use rand::thread_rng;
-use wasm_timer::Interval;
-
 use nimiq_macros::store_waker;
 use nimiq_network_interface::{network::CloseReason, peer_info::Services};
-
-use crate::discovery::peer_contacts::PeerContactBook;
+use parking_lot::RwLock;
+use rand::{seq::IteratorRandom, thread_rng};
+use wasm_timer::Interval;
 
 use super::handler::{ConnectionPoolHandler, ConnectionPoolHandlerError};
+use crate::discovery::peer_contacts::PeerContactBook;
 
 #[derive(Clone, Debug)]
 struct ConnectionPoolLimits {

--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -1,3 +1,5 @@
+use std::task::{Context, Poll};
+
 use libp2p::{
     core::upgrade::{DeniedUpgrade, InboundUpgrade, OutboundUpgrade},
     swarm::{
@@ -5,10 +7,8 @@ use libp2p::{
         NegotiatedSubstream, SubstreamProtocol,
     },
 };
-use std::task::{Context, Poll};
-use thiserror::Error;
-
 use nimiq_network_interface::network::CloseReason;
+use thiserror::Error;
 
 #[derive(Default)]
 pub struct ConnectionPoolHandler {

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -15,12 +15,11 @@ use libp2p::{
     },
     Multiaddr, PeerId,
 };
-use parking_lot::RwLock;
-use wasm_timer::Interval;
-
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
+use wasm_timer::Interval;
 
 use super::{
     handler::{DiscoveryHandler, HandlerInEvent, HandlerOutEvent},

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use beserial::SerializingError;
 use futures::{Sink, SinkExt, StreamExt};
 use instant::Instant;
 use libp2p::{
@@ -15,15 +16,13 @@ use libp2p::{
     },
     Multiaddr,
 };
+use nimiq_hash::Blake2bHash;
+use nimiq_network_interface::peer_info::Services;
+use nimiq_utils::tagged_signing::TaggedKeypair;
 use parking_lot::RwLock;
 use rand::{seq::IteratorRandom, thread_rng};
 use thiserror::Error;
 use wasm_timer::Interval;
-
-use beserial::SerializingError;
-use nimiq_hash::Blake2bHash;
-use nimiq_network_interface::peer_info::Services;
-use nimiq_utils::tagged_signing::TaggedKeypair;
 
 use super::{
     behaviour::DiscoveryConfig,

--- a/network-libp2p/src/discovery/message_codec/mod.rs
+++ b/network-libp2p/src/discovery/message_codec/mod.rs
@@ -8,16 +8,15 @@ mod header;
 mod reader;
 mod writer;
 
-pub use self::reader::MessageReader;
-pub use self::writer::MessageWriter;
+pub use self::{reader::MessageReader, writer::MessageWriter};
 
 #[cfg(test)]
 mod tests {
     use beserial::{Deserialize, Serialize};
     use futures::{io::Cursor, SinkExt, StreamExt};
+    use nimiq_test_log::test;
 
     use super::{MessageReader, MessageWriter};
-    use nimiq_test_log::test;
 
     #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     struct TestMessage {

--- a/network-libp2p/src/discovery/message_codec/reader.rs
+++ b/network-libp2p/src/discovery/message_codec/reader.rs
@@ -1,12 +1,13 @@
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
+use beserial::{Deserialize, SerializingError};
 use bytes::{Buf, BytesMut};
 use futures::{AsyncRead, Stream};
 use pin_project::pin_project;
-
-use beserial::{Deserialize, SerializingError};
 
 use super::header::Header;
 
@@ -227,14 +228,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    use beserial::{Deserialize, Serialize};
     use bytes::{BufMut, BytesMut};
     use futures::{io::Cursor, StreamExt};
-
-    use beserial::{Deserialize, Serialize};
-
-    use super::Header;
-    use super::MessageReader;
     use nimiq_test_log::test;
+
+    use super::{Header, MessageReader};
 
     #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     struct TestMessage {

--- a/network-libp2p/src/discovery/message_codec/writer.rs
+++ b/network-libp2p/src/discovery/message_codec/writer.rs
@@ -1,12 +1,13 @@
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
+use beserial::{Serialize, SerializingError};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::{ready, AsyncWrite, Sink};
 use pin_project::pin_project;
-
-use beserial::{Serialize, SerializingError};
 
 use super::header::Header;
 
@@ -147,12 +148,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::SinkExt;
-
     use beserial::{Deserialize, Serialize};
+    use futures::SinkExt;
+    use nimiq_test_log::test;
 
     use super::{Header, MessageWriter};
-    use nimiq_test_log::test;
 
     #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     struct TestMessage {

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -4,17 +4,16 @@ use std::{
     time::Duration,
 };
 
+use beserial::{Deserialize, Serialize};
 use instant::SystemTime;
 use libp2p::{
     gossipsub::Gossipsub,
     identity::{Keypair, PublicKey},
     Multiaddr, PeerId,
 };
-use parking_lot::RwLock;
-
-use beserial::{Deserialize, Serialize};
 use nimiq_network_interface::peer_info::Services;
 use nimiq_utils::tagged_signing::{TaggedKeypair, TaggedSignable, TaggedSignature};
+use parking_lot::RwLock;
 
 /// A plain peer contact. This contains:
 ///

--- a/network-libp2p/src/discovery/protocol.rs
+++ b/network-libp2p/src/discovery/protocol.rs
@@ -1,12 +1,11 @@
+use beserial::{Deserialize, Serialize, SerializingError};
 use futures::{future, AsyncRead, AsyncWrite};
 use libp2p::{core::UpgradeInfo, identity::Keypair, InboundUpgrade, Multiaddr, OutboundUpgrade};
-use rand::{thread_rng, RngCore};
-
-use beserial::{Deserialize, Serialize, SerializingError};
 use nimiq_hash::Blake2bHash;
 use nimiq_macros::{add_hex_io_fns_typed_arr, create_typed_array};
 use nimiq_network_interface::peer_info::Services;
 use nimiq_utils::tagged_signing::{TaggedSignable, TaggedSignature};
+use rand::{thread_rng, RngCore};
 
 use super::{
     message_codec::{MessageReader, MessageWriter},

--- a/network-libp2p/src/dispatch/codecs/typed.rs
+++ b/network-libp2p/src/dispatch/codecs/typed.rs
@@ -6,12 +6,13 @@
 //! message, extracting the type ID and performing consistency checks.
 //!
 
-use std::fmt::Debug;
-use std::io;
+use std::{fmt::Debug, io};
 
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use libp2p::core::{upgrade, ProtocolName};
-use libp2p::request_response::RequestResponseCodec;
+use libp2p::{
+    core::{upgrade, ProtocolName},
+    request_response::RequestResponseCodec,
+};
 
 use crate::REQRES_PROTOCOL;
 

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -1,7 +1,6 @@
 use thiserror::Error;
 
-use crate::behaviour::NimiqNetworkBehaviourError;
-use crate::dispatch::codecs::typed::MessageCodec;
+use crate::{behaviour::NimiqNetworkBehaviourError, dispatch::codecs::typed::MessageCodec};
 
 #[derive(Debug, Error)]
 pub enum NetworkError {

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -16,8 +16,7 @@ pub const REQRES_PROTOCOL: &[u8] = b"/nimiq/reqres/0.0.1";
 pub const MESSAGE_PROTOCOL: &[u8] = b"/nimiq/message/0.0.1";
 pub const DISCOVERY_PROTOCOL: &[u8] = b"/nimiq/discovery/0.0.1";
 
-pub use libp2p::{self, identity::Keypair, swarm::NetworkInfo, PeerId};
-
 pub use config::{Config, TlsConfig};
 pub use error::NetworkError;
+pub use libp2p::{self, identity::Keypair, swarm::NetworkInfo, PeerId};
 pub use network::Network;

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1,11 +1,14 @@
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use async_trait::async_trait;
 use base64::Engine;
+use beserial::{Deserialize, Serialize};
 use bytes::{Buf, Bytes};
 use futures::{ready, stream::BoxStream, Stream, StreamExt};
 #[cfg(not(feature = "tokio-time"))]
@@ -40,15 +43,6 @@ use libp2p::{dns, tcp, websocket};
 #[cfg(all(feature = "wasm-websocket", not(feature = "tokio-websocket")))]
 use libp2p_websys_transport::WebsocketTransport;
 use log::Instrument;
-use parking_lot::{Mutex, RwLock};
-use tokio::sync::{broadcast, mpsc, oneshot};
-#[cfg(feature = "tokio-time")]
-use tokio::time::{Instant, Interval};
-use tokio_stream::wrappers::{BroadcastStream, ReceiverStream};
-#[cfg(not(feature = "tokio-time"))]
-use wasm_timer::Interval;
-
-use beserial::{Deserialize, Serialize};
 use nimiq_bls::CompressedPublicKey;
 use nimiq_network_interface::{
     network::{
@@ -64,6 +58,13 @@ use nimiq_network_interface::{
 use nimiq_primitives::task_executor::TaskExecutor;
 use nimiq_utils::time::OffsetTime;
 use nimiq_validator_network::validator_record::SignedValidatorRecord;
+use parking_lot::{Mutex, RwLock};
+use tokio::sync::{broadcast, mpsc, oneshot};
+#[cfg(feature = "tokio-time")]
+use tokio::time::{Instant, Interval};
+use tokio_stream::wrappers::{BroadcastStream, ReceiverStream};
+#[cfg(not(feature = "tokio-time"))]
+use wasm_timer::Interval;
 
 #[cfg(feature = "metrics")]
 use crate::network_metrics::NetworkMetrics;

--- a/network-libp2p/src/network_metrics.rs
+++ b/network-libp2p/src/network_metrics.rs
@@ -1,10 +1,11 @@
+use std::time::Duration;
+
 use libp2p::gossipsub::TopicHash;
 use prometheus_client::{
     encoding::EncodeLabelSet,
     metrics::{counter::Counter, family::Family, histogram::Histogram},
     registry::Registry,
 };
-use std::time::Duration;
 
 pub struct NetworkMetrics {
     gossipsub_messages_received: Family<TopicLabels, Counter>,

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -16,18 +16,16 @@ use libp2p::{
     yamux::YamuxConfig,
     PeerId, Transport,
 };
-use parking_lot::RwLock;
-use rand::{thread_rng, Rng};
-
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
 use nimiq_network_libp2p::discovery::{
     behaviour::{DiscoveryBehaviour, DiscoveryConfig, DiscoveryEvent},
-    peer_contacts::PeerContact,
-    peer_contacts::{PeerContactBook, SignedPeerContact},
+    peer_contacts::{PeerContact, PeerContactBook, SignedPeerContact},
 };
 use nimiq_test_log::test;
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
+use rand::{thread_rng, Rng};
 
 struct TestNode {
     peer_id: PeerId,

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
+use beserial::{Deserialize, Serialize};
 use futures::{Stream, StreamExt};
 use libp2p::{
     gossipsub::GossipsubConfigBuilder,
@@ -8,10 +9,6 @@ use libp2p::{
     swarm::KeepAlive,
     PeerId,
 };
-use rand::{thread_rng, Rng};
-use tokio::time::timeout;
-
-use beserial::{Deserialize, Serialize};
 use nimiq_network_interface::{
     network::{CloseReason, MsgAcceptance, Network as NetworkInterface, NetworkEvent, Topic},
     peer_info::Services,
@@ -22,6 +19,8 @@ use nimiq_network_libp2p::{
 };
 use nimiq_test_log::test;
 use nimiq_utils::time::OffsetTime;
+use rand::{thread_rng, Rng};
+use tokio::time::timeout;
 
 fn network_config(address: Multiaddr) -> Config {
     let keypair = Keypair::generate_ed25519();

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use beserial::{Deserialize, Serialize};
 use futures::{future::join_all, StreamExt};
 use libp2p::{
     core::multiaddr::{multiaddr, Multiaddr},
@@ -7,12 +8,6 @@ use libp2p::{
     identity::Keypair,
     swarm::KeepAlive,
 };
-use rand::{thread_rng, Rng};
-use tokio::time::Duration;
-#[cfg(feature = "tokio-time")]
-use tokio::time::Instant;
-
-use beserial::{Deserialize, Serialize};
 #[cfg(feature = "tokio-time")]
 use nimiq_network_interface::network::CloseReason;
 use nimiq_network_interface::{
@@ -29,6 +24,10 @@ use nimiq_network_libp2p::{
 };
 use nimiq_test_log::test;
 use nimiq_utils::time::OffsetTime;
+use rand::{thread_rng, Rng};
+use tokio::time::Duration;
+#[cfg(feature = "tokio-time")]
+use tokio::time::Instant;
 
 /// The max number of TestRequests per peer (used for regular tests only).
 const MAX_REQUEST_RESPONSE_TEST_REQUEST: u32 = 1000;

--- a/network-mock/src/hub.rs
+++ b/network-mock/src/hub.rs
@@ -4,13 +4,14 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
+use nimiq_network_interface::{peer_info::PeerInfo, request::RequestType};
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::{broadcast, mpsc, oneshot};
 
-use nimiq_network_interface::{peer_info::PeerInfo, request::RequestType};
-
-use crate::network::{MockNetwork, MockRequestId};
-use crate::{MockAddress, MockPeerId, ObservableHashMap};
+use crate::{
+    network::{MockNetwork, MockRequestId},
+    MockAddress, MockPeerId, ObservableHashMap,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct SenderKey {

--- a/network-mock/src/lib.rs
+++ b/network-mock/src/lib.rs
@@ -2,13 +2,11 @@ mod hub;
 mod network;
 mod observable_hash_map;
 
-use derive_more::{Display, From, Into};
-
 use beserial::{Deserialize, Serialize};
-use nimiq_network_interface::{multiaddr, Multiaddr};
-
+use derive_more::{Display, From, Into};
 pub use hub::MockHub;
 pub use network::{MockId, MockNetwork};
+use nimiq_network_interface::{multiaddr, Multiaddr};
 pub use observable_hash_map::ObservableHashMap;
 
 /// The address of a MockNetwork or a peer thereof. Peer IDs are always equal to their respective address, thus these
@@ -72,14 +70,12 @@ pub async fn create_mock_validator_network(n: usize, dial: bool) -> Vec<MockNetw
 
 #[cfg(test)]
 pub mod tests {
-    use futures::{Stream, StreamExt};
-
     use beserial::{Deserialize, Serialize};
+    use futures::{Stream, StreamExt};
     use nimiq_network_interface::network::{Network, NetworkEvent, SubscribeEvents, Topic};
     use nimiq_test_log::test;
 
-    use super::network::MockNetworkError;
-    use super::{MockHub, MockPeerId};
+    use super::{network::MockNetworkError, MockHub, MockPeerId};
 
     pub async fn assert_peer_joined(
         events: &mut SubscribeEvents<MockPeerId>,

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -1,17 +1,14 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
-use std::time::Duration;
 
 use async_trait::async_trait;
-use futures::{stream::BoxStream, StreamExt};
-use parking_lot::{Mutex, RwLock};
-use thiserror::Error;
-use tokio::sync::{broadcast, mpsc, oneshot};
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream, ReceiverStream};
-
 use beserial::{Deserialize, Serialize};
+use futures::{stream::BoxStream, StreamExt};
 use nimiq_network_interface::{
     network::{
         CloseReason, MsgAcceptance, Network, NetworkEvent, PubsubId, SubscribeEvents, Topic,
@@ -22,9 +19,15 @@ use nimiq_network_interface::{
         RequestKind, RequestType,
     },
 };
+use parking_lot::{Mutex, RwLock};
+use thiserror::Error;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream, ReceiverStream};
 
-use crate::hub::{MockHubInner, RequestKey, ResponseSender};
-use crate::{observable_hash_map, MockAddress, MockPeerId, ObservableHashMap};
+use crate::{
+    hub::{MockHubInner, RequestKey, ResponseSender},
+    observable_hash_map, MockAddress, MockPeerId, ObservableHashMap,
+};
 
 #[derive(Debug, Error, Eq, PartialEq)]
 pub enum MockNetworkError {

--- a/network-mock/src/observable_hash_map.rs
+++ b/network-mock/src/observable_hash_map.rs
@@ -1,6 +1,9 @@
-use std::collections::{hash_map, HashMap};
-use std::fmt;
-use std::hash::Hash;
+use std::{
+    collections::{hash_map, HashMap},
+    fmt,
+    hash::Hash,
+};
+
 use tokio::sync::broadcast;
 
 #[derive(Clone)]

--- a/primitives/account/src/account/htlc_contract.rs
+++ b/primitives/account/src/account/htlc_contract.rs
@@ -1,9 +1,8 @@
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::Address;
-use nimiq_primitives::account::AccountError;
 #[cfg(feature = "interaction-traits")]
 use nimiq_primitives::account::AccountType;
-use nimiq_primitives::coin::Coin;
+use nimiq_primitives::{account::AccountError, coin::Coin};
 #[cfg(feature = "interaction-traits")]
 use nimiq_transaction::account::htlc_contract::CreationTransactionData;
 use nimiq_transaction::account::htlc_contract::{

--- a/primitives/account/src/account/mod.rs
+++ b/primitives/account/src/account/mod.rs
@@ -1,15 +1,14 @@
 use beserial::{Deserialize, Serialize};
 #[cfg(feature = "interaction-traits")]
 use nimiq_primitives::account::AccountError;
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::coin::Coin;
+use nimiq_primitives::{account::AccountType, coin::Coin};
 #[cfg(feature = "interaction-traits")]
 use nimiq_transaction::{inherent::Inherent, Transaction, TransactionFlags};
 
-use crate::account::basic_account::BasicAccount;
-use crate::account::htlc_contract::HashedTimeLockedContract;
-use crate::account::staking_contract::StakingContract;
-use crate::account::vesting_contract::VestingContract;
+use crate::account::{
+    basic_account::BasicAccount, htlc_contract::HashedTimeLockedContract,
+    staking_contract::StakingContract, vesting_contract::VestingContract,
+};
 #[cfg(feature = "interaction-traits")]
 use crate::{
     data_store::{DataStoreRead, DataStoreWrite},

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -1,5 +1,4 @@
-use std::collections::btree_set::BTreeSet;
-use std::collections::BTreeMap;
+use std::collections::{btree_set::BTreeSet, BTreeMap};
 
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
@@ -13,18 +12,17 @@ use nimiq_primitives::{
     slots::{Validators, ValidatorsBuilder},
 };
 use nimiq_vrf::{AliasMethod, VrfSeed, VrfUseCase};
-
-use crate::{
-    account::staking_contract::store::{StakingContractStoreRead, StakingContractStoreReadOps},
-    data_store_ops::{DataStoreIterOps, DataStoreReadOps},
-};
-
 pub use receipts::*;
 pub use staker::Staker;
 pub use store::StakingContractStore;
 #[cfg(feature = "interaction-traits")]
 pub use store::StakingContractStoreWrite;
 pub use validator::{Tombstone, Validator};
+
+use crate::{
+    account::staking_contract::store::{StakingContractStoreRead, StakingContractStoreReadOps},
+    data_store_ops::{DataStoreIterOps, DataStoreReadOps},
+};
 
 mod receipts;
 mod staker;

--- a/primitives/account/src/account/staking_contract/receipts.rs
+++ b/primitives/account/src/account/staking_contract/receipts.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeSet;
 
-use crate::{convert_receipt, AccountReceipt};
 use beserial::{Deserialize, Serialize};
 use nimiq_bls::CompressedPublicKey as BlsPublicKey;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
 use nimiq_primitives::account::AccountError;
+
+use crate::{convert_receipt, AccountReceipt};
 
 /// A collection of receipts for inherents/transactions. This is necessary to be able to revert
 /// those inherents/transactions.

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -1,12 +1,12 @@
 use nimiq_keys::Address;
-use nimiq_primitives::account::AccountError;
-use nimiq_primitives::key_nibbles::KeyNibbles;
+use nimiq_primitives::{account::AccountError, key_nibbles::KeyNibbles};
 
-use crate::account::staking_contract::validator::Tombstone;
-use crate::account::staking_contract::{Staker, Validator};
 #[cfg(feature = "interaction-traits")]
 use crate::data_store::DataStoreWrite;
-use crate::data_store_ops::{DataStoreIterOps, DataStoreReadOps};
+use crate::{
+    account::staking_contract::{validator::Tombstone, Staker, Validator},
+    data_store_ops::{DataStoreIterOps, DataStoreReadOps},
+};
 
 // Fixme: This shouldn't be pub but for now it is needed for `RemoteDataStore`
 pub struct StakingContractStore {}

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -1,25 +1,31 @@
-use std::collections::BTreeSet;
-use std::mem;
+use std::{collections::BTreeSet, mem};
 
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::{account::AccountError, coin::Coin, policy::Policy};
-use nimiq_transaction::account::staking_contract::{
-    IncomingStakingTransactionData, OutgoingStakingTransactionProof,
+use nimiq_primitives::{
+    account::{AccountError, AccountType},
+    coin::Coin,
+    policy::Policy,
 };
-use nimiq_transaction::{inherent::Inherent, Transaction};
+use nimiq_transaction::{
+    account::staking_contract::{IncomingStakingTransactionData, OutgoingStakingTransactionProof},
+    inherent::Inherent,
+    Transaction,
+};
 
-use crate::account::staking_contract::store::{
-    StakingContractStoreRead, StakingContractStoreReadOps, StakingContractStoreReadOpsExt,
-    StakingContractStoreWrite,
-};
-use crate::reserved_balance::ReservedBalance;
 use crate::{
-    account::staking_contract::{receipts::SlashReceipt, StakingContract},
+    account::staking_contract::{
+        receipts::SlashReceipt,
+        store::{
+            StakingContractStoreRead, StakingContractStoreReadOps, StakingContractStoreReadOpsExt,
+            StakingContractStoreWrite,
+        },
+        StakingContract,
+    },
     data_store::{DataStoreRead, DataStoreWrite},
     interaction_traits::{AccountInherentInteraction, AccountTransactionInteraction},
-    Account, AccountPruningInteraction, AccountReceipt, BlockState,
+    reserved_balance::ReservedBalance,
+    Account, AccountPruningInteraction, AccountReceipt, BlockState, InherentLogger, Log,
+    TransactionLog,
 };
-use crate::{InherentLogger, Log, TransactionLog};
 
 impl AccountTransactionInteraction for StakingContract {
     fn create_new_contract(

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -7,8 +7,10 @@ use nimiq_keys::Address;
 use nimiq_primitives::{
     account::{AccountError, AccountType, FailReason},
     key_nibbles::KeyNibbles,
-    trie::trie_chunk::{TrieChunk, TrieChunkPushResult},
-    trie::TrieItem,
+    trie::{
+        trie_chunk::{TrieChunk, TrieChunkPushResult},
+        TrieItem,
+    },
 };
 use nimiq_transaction::{inherent::Inherent, ExecutedTransaction, Transaction, TransactionFlags};
 use nimiq_trie::trie::{IncompleteTrie, MerkleRadixTrie};

--- a/primitives/account/src/interaction_traits.rs
+++ b/primitives/account/src/interaction_traits.rs
@@ -1,10 +1,14 @@
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::{account::AccountError, coin::Coin};
+use nimiq_primitives::{
+    account::{AccountError, AccountType},
+    coin::Coin,
+};
 use nimiq_transaction::{inherent::Inherent, Transaction};
 
-use crate::data_store::{DataStoreRead, DataStoreWrite};
-use crate::reserved_balance::ReservedBalance;
-use crate::{Account, AccountReceipt, InherentLogger, TransactionLog};
+use crate::{
+    data_store::{DataStoreRead, DataStoreWrite},
+    reserved_balance::ReservedBalance,
+    Account, AccountReceipt, InherentLogger, TransactionLog,
+};
 
 #[derive(Default, Debug)]
 pub struct BlockState {

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -2,20 +2,22 @@
 #[macro_use]
 extern crate log;
 
-pub use crate::account::{
-    basic_account::BasicAccount, htlc_contract::HashedTimeLockedContract, staking_contract::*,
-    vesting_contract::VestingContract, Account,
-};
 #[cfg(feature = "accounts")]
 pub use crate::accounts::{Accounts, AccountsTrie};
 #[cfg(feature = "interaction-traits")]
 pub use crate::data_store::{DataStore, DataStoreRead, DataStoreWrite};
-pub use crate::data_store_ops::DataStoreReadOps;
 #[cfg(feature = "interaction-traits")]
 pub use crate::interaction_traits::*;
-pub use crate::logs::*;
-pub use crate::receipts::*;
-pub use crate::reserved_balance::ReservedBalance;
+pub use crate::{
+    account::{
+        basic_account::BasicAccount, htlc_contract::HashedTimeLockedContract, staking_contract::*,
+        vesting_contract::VestingContract, Account,
+    },
+    data_store_ops::DataStoreReadOps,
+    logs::*,
+    receipts::*,
+    reserved_balance::ReservedBalance,
+};
 
 mod account;
 #[cfg(feature = "accounts")]

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -1,4 +1,3 @@
-use crate::TransactionOperationReceipt;
 use beserial::Serialize as BeSerialize;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
@@ -10,6 +9,8 @@ use nimiq_transaction::{
     account::htlc_contract::{AnyHash, HashAlgorithm},
     Transaction,
 };
+
+use crate::TransactionOperationReceipt;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]

--- a/primitives/account/src/receipts.rs
+++ b/primitives/account/src/receipts.rs
@@ -1,5 +1,4 @@
-use std::fmt::Debug;
-use std::io;
+use std::{fmt::Debug, io};
 
 use beserial::{Deserialize, Serialize};
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};

--- a/primitives/account/src/reserved_balance.rs
+++ b/primitives/account/src/reserved_balance.rs
@@ -1,7 +1,7 @@
-use nimiq_keys::Address;
-use nimiq_primitives::account::AccountError;
-use nimiq_primitives::coin::Coin;
 use std::collections::BTreeMap;
+
+use nimiq_keys::Address;
+use nimiq_primitives::{account::AccountError, coin::Coin};
 
 #[derive(Clone)]
 pub struct ReservedBalance {

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -1,8 +1,7 @@
-use log::info;
 use std::{convert::TryFrom, time::Instant};
-use tempfile::tempdir;
 
 use beserial::{Deserialize, Serialize};
+use log::info;
 use nimiq_account::{
     Account, Accounts, BasicAccount, BlockLogger, BlockState, InherentOperationReceipt, Log,
     OperationReceipt, TransactionOperationReceipt, TransactionReceipt, VestingContract,
@@ -31,6 +30,7 @@ use nimiq_test_utils::{
 };
 use nimiq_transaction::{inherent::Inherent, SignatureProof, Transaction};
 use rand::Rng;
+use tempfile::tempdir;
 
 const VOLATILE_ENV: bool = true;
 

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -1,5 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryInto;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryInto,
+};
 
 use beserial::{Deserialize, Serialize};
 use nimiq_account::*;

--- a/primitives/account/tests/vesting_contract.rs
+++ b/primitives/account/tests/vesting_contract.rs
@@ -1,9 +1,5 @@
 use std::convert::{TryFrom, TryInto};
 
-use nimiq_test_utils::{
-    accounts_revert::TestCommitRevert, test_rng::test_rng, transactions::TransactionsGenerator,
-};
-
 use beserial::{Deserialize, Serialize};
 use nimiq_account::{
     Account, Accounts, BasicAccount, BlockState, Log, TransactionLog, VestingContract,
@@ -16,6 +12,9 @@ use nimiq_primitives::{
     transaction::TransactionError,
 };
 use nimiq_test_log::test;
+use nimiq_test_utils::{
+    accounts_revert::TestCommitRevert, test_rng::test_rng, transactions::TransactionsGenerator,
+};
 use nimiq_transaction::{SignatureProof, Transaction};
 use nimiq_utils::key_rng::SecureGenerate;
 

--- a/primitives/block/benches/pk_tree.rs
+++ b/primitives/block/benches/pk_tree.rs
@@ -3,11 +3,12 @@ extern crate bencher;
 
 use bencher::Bencher;
 use nimiq_block::MacroBlock;
-use nimiq_bls::lazy::LazyPublicKey;
-use nimiq_bls::KeyPair as BlsKeyPair;
+use nimiq_bls::{lazy::LazyPublicKey, KeyPair as BlsKeyPair};
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::{Validators, ValidatorsBuilder};
+use nimiq_primitives::{
+    policy::Policy,
+    slots::{Validators, ValidatorsBuilder},
+};
 use nimiq_test_utils::zkp_test_data::get_base_seed;
 
 // Benchmarks for the pk tree root computation.

--- a/primitives/block/examples/pk_tree.rs
+++ b/primitives/block/examples/pk_tree.rs
@@ -1,8 +1,10 @@
 use nimiq_block::MacroBlock;
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::{Validators, ValidatorsBuilder};
+use nimiq_primitives::{
+    policy::Policy,
+    slots::{Validators, ValidatorsBuilder},
+};
 use nimiq_test_utils::zkp_test_data::get_base_seed;
 
 // Benchmarks for the pk tree root computation.

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -1,24 +1,22 @@
-use std::convert::TryFrom;
-use std::{fmt, io};
-
-use bitflags::bitflags;
+use std::{convert::TryFrom, fmt, io};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use bitflags::bitflags;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_keys::PublicKey;
 use nimiq_network_interface::network::Topic;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
+use nimiq_primitives::{coin::Coin, policy::Policy, slots::Validators};
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_vrf::VrfSeed;
 
-use crate::macro_block::{MacroBlock, MacroHeader};
-use crate::micro_block::{MicroBlock, MicroHeader};
-use crate::{BlockError, MacroBody, MicroBody, MicroJustification, TendermintProof};
+use crate::{
+    macro_block::{MacroBlock, MacroHeader},
+    micro_block::{MicroBlock, MicroHeader},
+    BlockError, MacroBody, MicroBody, MicroJustification, TendermintProof,
+};
 
 /// These network topics are used to subscribe and request Blocks and Block Headers respectively
 #[derive(Clone, Debug, Default)]

--- a/primitives/block/src/block_proof.rs
+++ b/primitives/block/src/block_proof.rs
@@ -1,8 +1,10 @@
-use crate::MacroBlock;
+use std::collections::HashMap;
+
 use beserial::{Deserialize, Serialize};
 use nimiq_primitives::policy::Policy;
 use nimiq_utils::math::log2;
-use std::collections::HashMap;
+
+use crate::MacroBlock;
 
 // Block inclusion proofs proof that a block is part of the blockchain.
 // The proof consists of an interlink chain from the current election head down to the target block.

--- a/primitives/block/src/fork_proof.rs
+++ b/primitives/block/src/fork_proof.rs
@@ -1,5 +1,4 @@
-use std::cmp::Ordering;
-use std::io;
+use std::{cmp::Ordering, io};
 
 use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Blake2bHash, Hash, HashOutput, SerializeContent};

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -1,19 +1,17 @@
 #[macro_use]
 extern crate log;
 
-use thiserror::Error;
-
-use nimiq_primitives::transaction::TransactionError;
-
 pub use block::*;
 pub use block_proof::*;
 pub use fork_proof::*;
 pub use macro_block::*;
 pub use micro_block::*;
 pub use multisig::*;
+use nimiq_primitives::transaction::TransactionError;
 pub use signed::*;
 pub use skip_block::*;
 pub use tendermint::*;
+use thiserror::Error;
 
 mod block;
 mod block_proof;

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -1,21 +1,20 @@
 use std::fmt;
 
-use nimiq_transaction::reward::RewardTransaction;
-use thiserror::Error;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_collections::bitset::BitSet;
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
+use nimiq_primitives::{policy::Policy, slots::Validators};
+use nimiq_transaction::reward::RewardTransaction;
 use nimiq_vrf::VrfSeed;
-use nimiq_zkp_primitives::MacroBlock as ZKPMacroBlock;
-use nimiq_zkp_primitives::{pk_tree_construct, PK_TREE_BREADTH};
+use nimiq_zkp_primitives::{pk_tree_construct, MacroBlock as ZKPMacroBlock, PK_TREE_BREADTH};
+use thiserror::Error;
 
-use crate::signed::{Message, PREFIX_TENDERMINT_PROPOSAL};
-use crate::tendermint::TendermintProof;
-use crate::BlockError;
+use crate::{
+    signed::{Message, PREFIX_TENDERMINT_PROPOSAL},
+    tendermint::TendermintProof,
+    BlockError,
+};
 
 /// The struct representing a Macro block (can be either checkpoint or election).
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -1,22 +1,15 @@
-use std::cmp::Ordering;
-use std::collections::HashSet;
-use std::fmt::Debug;
-use std::{fmt, io};
+use std::{cmp::Ordering, collections::HashSet, fmt, fmt::Debug, io};
 
-use crate::{BlockError, SkipBlockInfo};
 use beserial::{Deserialize, Serialize};
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_keys::{PublicKey, Signature};
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
-use nimiq_transaction::ExecutedTransaction;
-use nimiq_transaction::Transaction;
+use nimiq_primitives::{policy::Policy, slots::Validators};
+use nimiq_transaction::{ExecutedTransaction, Transaction};
 use nimiq_vrf::VrfSeed;
 
-use crate::fork_proof::ForkProof;
-use crate::skip_block::SkipBlockProof;
+use crate::{fork_proof::ForkProof, skip_block::SkipBlockProof, BlockError, SkipBlockInfo};
 
 /// The struct representing a Micro block.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/primitives/block/src/skip_block.rs
+++ b/primitives/block/src/skip_block.rs
@@ -4,8 +4,7 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
+use nimiq_primitives::{policy::Policy, slots::Validators};
 use nimiq_vrf::VrfEntropy;
 
 use crate::{Message, MicroBlock, MultiSignature, SignedMessage, PREFIX_SKIP_BLOCK_INFO};

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -1,16 +1,15 @@
-use log::error;
 use std::io;
 
 use beserial::{Deserialize, Serialize};
+use log::error;
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash::{Blake2sHash, Hash, SerializeContent};
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
+use nimiq_primitives::{policy::Policy, slots::Validators};
 
-use crate::signed::{
-    PREFIX_TENDERMINT_COMMIT, PREFIX_TENDERMINT_PREPARE, PREFIX_TENDERMINT_PROPOSAL,
+use crate::{
+    signed::{PREFIX_TENDERMINT_COMMIT, PREFIX_TENDERMINT_PREPARE, PREFIX_TENDERMINT_PROPOSAL},
+    MacroBlock, MultiSignature,
 };
-use crate::{MacroBlock, MultiSignature};
 
 /// The proof for a block produced by Tendermint.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/primitives/block/tests/block_proof.rs
+++ b/primitives/block/tests/block_proof.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use nimiq_block::{BlockInclusionProof, MacroBlock, MacroHeader};
 use nimiq_primitives::policy::Policy;
-use std::collections::HashMap;
 
 #[test]
 fn test_interlink_hops_to_block() {

--- a/primitives/mmr/src/mmr/mod.rs
+++ b/primitives/mmr/src/mmr/mod.rs
@@ -1,18 +1,17 @@
-use std::collections::VecDeque;
-use std::marker::PhantomData;
-use std::ops::RangeBounds;
+use std::{collections::VecDeque, marker::PhantomData, ops::RangeBounds};
 
-use crate::error::Error;
-use crate::hash::{Hash, Merge};
-use crate::mmr::peaks::{PeakIterator, RevPeakIterator};
-use crate::mmr::position::{index_to_height, leaf_number_to_index, Position};
-use crate::mmr::proof::{Proof, RangeProof};
-use crate::mmr::utils::bagging;
-use crate::store::memory::MemoryTransaction;
-use crate::store::Store;
-
-use self::proof::SizeProof;
-use self::utils::prove_num_leaves;
+use self::{proof::SizeProof, utils::prove_num_leaves};
+use crate::{
+    error::Error,
+    hash::{Hash, Merge},
+    mmr::{
+        peaks::{PeakIterator, RevPeakIterator},
+        position::{index_to_height, leaf_number_to_index, Position},
+        proof::{Proof, RangeProof},
+        utils::bagging,
+    },
+    store::{memory::MemoryTransaction, Store},
+};
 
 pub mod partial;
 pub mod peaks;
@@ -456,11 +455,13 @@ impl<H: Merge + Clone + PartialEq, S: Store<H>> MerkleMountainRange<H, S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::mmr::utils::test_utils::{hash_mmr, TestHash};
-    use crate::store::memory::MemoryStore;
+    use nimiq_test_log::test;
 
     use super::*;
-    use nimiq_test_log::test;
+    use crate::{
+        mmr::utils::test_utils::{hash_mmr, TestHash},
+        store::memory::MemoryStore,
+    };
 
     #[test]
     fn it_correctly_constructs_trees() {

--- a/primitives/mmr/src/mmr/partial.rs
+++ b/primitives/mmr/src/mmr/partial.rs
@@ -1,16 +1,17 @@
-use std::collections::VecDeque;
-use std::marker::PhantomData;
-use std::ops::Range;
+use std::{collections::VecDeque, marker::PhantomData, ops::Range};
 
-use crate::error::Error;
-use crate::hash::{Hash, Merge};
-use crate::mmr::peaks::PeakIterator;
-use crate::mmr::position::{leaf_number_to_index, Position};
-use crate::mmr::proof::RangeProof;
-use crate::mmr::utils::bagging;
-use crate::mmr::MerkleMountainRange;
-use crate::store::memory::MemoryTransaction;
-use crate::store::Store;
+use crate::{
+    error::Error,
+    hash::{Hash, Merge},
+    mmr::{
+        peaks::PeakIterator,
+        position::{leaf_number_to_index, Position},
+        proof::RangeProof,
+        utils::bagging,
+        MerkleMountainRange,
+    },
+    store::{memory::MemoryTransaction, Store},
+};
 
 /// A struct that holds part of a MMR. Its main use is to construct a full MMR from a series of proofs.
 pub struct PartialMerkleMountainRange<H, S: Store<H>> {
@@ -302,14 +303,14 @@ impl<H: Merge + PartialEq + Clone, S: Store<H>> PartialMerkleMountainRange<H, S>
 mod tests {
     use std::cmp;
 
-    use crate::error::Error;
-    use crate::mmr::utils::test_utils::TestHash;
-    use crate::mmr::MerkleMountainRange;
-    use crate::store::memory::MemoryStore;
-    use crate::store::Store;
+    use nimiq_test_log::test;
 
     use super::*;
-    use nimiq_test_log::test;
+    use crate::{
+        error::Error,
+        mmr::{utils::test_utils::TestHash, MerkleMountainRange},
+        store::{memory::MemoryStore, Store},
+    };
 
     #[test]
     fn it_correctly_verifies_range_proofs() {

--- a/primitives/mmr/src/mmr/peaks.rs
+++ b/primitives/mmr/src/mmr/peaks.rs
@@ -112,8 +112,9 @@ impl Iterator for RevPeakIterator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nimiq_test_log::test;
+
+    use super::*;
 
     #[test]
     fn it_correctly_iterates_peaks() {

--- a/primitives/mmr/src/mmr/position.rs
+++ b/primitives/mmr/src/mmr/position.rs
@@ -184,8 +184,9 @@ pub fn leaf_number_to_index(leaf_number: usize) -> usize {
 mod tests {
     use std::collections::HashSet;
 
-    use super::*;
     use nimiq_test_log::test;
+
+    use super::*;
 
     #[test]
     fn it_correctly_computes_positions() {

--- a/primitives/mmr/src/mmr/proof.rs
+++ b/primitives/mmr/src/mmr/proof.rs
@@ -1,10 +1,14 @@
 use std::collections::VecDeque;
 
-use crate::error::Error;
-use crate::hash::{Hash, Merge};
-use crate::mmr::peaks::PeakIterator;
-use crate::mmr::position::{leaf_number_to_index, Position};
-use crate::mmr::utils::bagging;
+use crate::{
+    error::Error,
+    hash::{Hash, Merge},
+    mmr::{
+        peaks::PeakIterator,
+        position::{leaf_number_to_index, Position},
+        utils::bagging,
+    },
+};
 
 #[derive(Clone, Debug)]
 pub enum SizeProof<H: Merge, T: Hash<H>> {
@@ -294,14 +298,14 @@ impl<H: Merge + Clone + Eq> RangeProof<H> {
 mod tests {
     use std::ops::RangeInclusive;
 
-    use crate::error::Error;
-    use crate::mmr::utils::test_utils::TestHash;
-    use crate::mmr::MerkleMountainRange;
-    use crate::store::memory::MemoryStore;
-    use crate::store::Store;
+    use nimiq_test_log::test;
 
     use super::*;
-    use nimiq_test_log::test;
+    use crate::{
+        error::Error,
+        mmr::{utils::test_utils::TestHash, MerkleMountainRange},
+        store::{memory::MemoryStore, Store},
+    };
 
     #[test]
     fn it_correctly_constructs_proofs() {

--- a/primitives/mmr/src/mmr/utils.rs
+++ b/primitives/mmr/src/mmr/utils.rs
@@ -1,7 +1,8 @@
-use crate::error::Error;
-use crate::hash::{Hash, Merge};
-
 use super::proof::SizeProof;
+use crate::{
+    error::Error,
+    hash::{Hash, Merge},
+};
 
 const USIZE_BITS: u32 = 0usize.count_zeros();
 
@@ -76,10 +77,10 @@ pub fn prove_num_leaves<
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::hash::{Hash, Merge};
+    use nimiq_test_log::test;
 
     use super::*;
-    use nimiq_test_log::test;
+    use crate::hash::{Hash, Merge};
 
     pub(crate) fn hash_perfect_tree<H: Merge, T: Hash<H>>(values: &[T]) -> Option<H> {
         let len = values.len();
@@ -185,9 +186,8 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use crate::mmr::utils::test_utils::TestHash;
-
     use super::*;
+    use crate::mmr::utils::test_utils::TestHash;
 
     #[test]
     fn it_correctly_compute_bit_length() {

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -1,14 +1,12 @@
 use std::convert::TryFrom;
 
+use beserial::{Deserialize, Serialize, SerializingError};
+use nimiq_keys::Address;
 use strum_macros::Display;
 use thiserror::Error;
 
-use beserial::{Deserialize, Serialize, SerializingError};
-use nimiq_keys::Address;
-
-use crate::coin::CoinUnderflowError;
 use crate::{
-    coin::{Coin, CoinConvertError, CoinParseError},
+    coin::{Coin, CoinConvertError, CoinParseError, CoinUnderflowError},
     transaction::TransactionError,
     trie::error::MerkleRadixTrieError,
 };

--- a/primitives/src/coin.rs
+++ b/primitives/src/coin.rs
@@ -1,17 +1,16 @@
-use std::convert::TryFrom;
-use std::fmt;
-use std::io;
-use std::iter::Sum;
-use std::ops::{Add, AddAssign, Div, Rem, Sub, SubAssign};
-use std::str::FromStr;
-
-use lazy_static::lazy_static;
-use num_traits::identities::Zero;
-use num_traits::{SaturatingAdd, SaturatingSub};
-use regex::Regex;
-use thiserror::Error;
+use std::{
+    convert::TryFrom,
+    fmt, io,
+    iter::Sum,
+    ops::{Add, AddAssign, Div, Rem, Sub, SubAssign},
+    str::FromStr,
+};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use lazy_static::lazy_static;
+use num_traits::{identities::Zero, SaturatingAdd, SaturatingSub};
+use regex::Regex;
+use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Default, Hash)]
 #[cfg_attr(

--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -4,9 +4,8 @@ use std::{
     fmt, io, ops, str, usize,
 };
 
-use log::error;
-
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
+use log::error;
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_keys::Address;
 
@@ -404,8 +403,9 @@ impl Deserialize for KeyNibbles {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nimiq_test_log::test;
+
+    use super::*;
 
     #[test]
     fn to_from_str_works() {

--- a/primitives/src/networks.rs
+++ b/primitives/src/networks.rs
@@ -1,9 +1,10 @@
-use std::fmt::{Display, Error, Formatter};
-use std::str::FromStr;
-
-use thiserror::Error;
+use std::{
+    fmt::{Display, Error, Formatter},
+    str::FromStr,
+};
 
 use beserial::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -1,8 +1,7 @@
 use std::cmp;
 
-use once_cell::sync::OnceCell;
-
 use nimiq_keys::Address;
+use once_cell::sync::OnceCell;
 
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
@@ -367,8 +366,9 @@ pub const TEST_POLICY: Policy = Policy {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nimiq_test_log::test;
+
+    use super::*;
 
     fn initialize_policy() {
         let _ = Policy::get_or_init(TEST_POLICY);

--- a/primitives/src/slots.rs
+++ b/primitives/src/slots.rs
@@ -14,9 +14,7 @@
 //!                      |             SlotBand                      |    SlotBand       |
 //!                      +-------------------------------------------+-------------------+
 //! ```
-use std::cmp::max;
-use std::collections::BTreeMap;
-use std::slice::Iter;
+use std::{cmp::max, collections::BTreeMap, slice::Iter};
 
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,

--- a/primitives/src/trie/trie_node.rs
+++ b/primitives/src/trie/trie_node.rs
@@ -1,14 +1,10 @@
-use std::io;
-use std::ops;
-use std::ops::RangeFrom;
-use std::slice;
-
-use log::error;
+use std::{io, ops, ops::RangeFrom, slice};
 
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
     SerializingError, WriteBytesExt,
 };
+use log::error;
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash, HashOutput, Hasher};
 

--- a/primitives/src/trie/trie_proof.rs
+++ b/primitives/src/trie/trie_proof.rs
@@ -1,12 +1,10 @@
-use log::error;
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::{cmp::Ordering, collections::BTreeMap};
 
 use beserial::{Deserialize, Serialize};
+use log::error;
 use nimiq_hash::{Blake2bHash, Hash};
 
-use crate::key_nibbles::KeyNibbles;
-use crate::trie::trie_proof_node::TrieProofNode;
+use crate::{key_nibbles::KeyNibbles, trie::trie_proof_node::TrieProofNode};
 
 /// A Merkle proof of the inclusion of some leaf nodes in the Merkle Radix
 /// Trie.
@@ -213,10 +211,11 @@ impl TrieProof {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::trie::trie_node::TrieNode;
     use nimiq_hash::Hash;
     use nimiq_test_log::test;
+
+    use super::*;
+    use crate::trie::trie_node::TrieNode;
 
     // We're going to construct proofs based on this tree:
     //

--- a/primitives/src/trie/trie_proof_node.rs
+++ b/primitives/src/trie/trie_proof_node.rs
@@ -1,9 +1,8 @@
-use log::error;
+use std::io;
 
 use beserial::{Deserialize, Serialize, SerializeWithLength, WriteBytesExt};
+use log::error;
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
-
-use std::io;
 
 use crate::{
     key_nibbles::KeyNibbles,
@@ -141,10 +140,12 @@ impl Hash for TrieProofNode {}
 
 #[cfg(test)]
 mod test {
-    use crate::key_nibbles::KeyNibbles;
-    use crate::trie::trie_node::TrieNode;
-    use crate::trie::trie_proof_node::TrieProofNode;
     use nimiq_hash::{Blake2bHash, Hash};
+
+    use crate::{
+        key_nibbles::KeyNibbles,
+        trie::{trie_node::TrieNode, trie_proof_node::TrieProofNode},
+    };
 
     #[test]
     fn hash_works() {

--- a/primitives/tests/coin/mod.rs
+++ b/primitives/tests/coin/mod.rs
@@ -1,9 +1,10 @@
-use std::convert::{TryFrom, TryInto};
-use std::str::FromStr;
-
-use lazy_static::lazy_static;
+use std::{
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+};
 
 use beserial::{Deserialize, Serialize, SerializingError};
+use lazy_static::lazy_static;
 use nimiq_primitives::coin::Coin;
 use nimiq_test_log::test;
 

--- a/primitives/transaction/src/account/basic_account.rs
+++ b/primitives/transaction/src/account/basic_account.rs
@@ -1,11 +1,11 @@
-use log::error;
-
 use beserial::Deserialize;
+use log::error;
 use nimiq_primitives::account::AccountType;
 
-use crate::account::AccountTransactionVerification;
-use crate::SignatureProof;
-use crate::{Transaction, TransactionError, TransactionFlags};
+use crate::{
+    account::AccountTransactionVerification, SignatureProof, Transaction, TransactionError,
+    TransactionFlags,
+};
 
 /// The verifier trait for a basic account. This only uses data available in the transaction.
 pub struct BasicAccountVerifier {}

--- a/primitives/transaction/src/account/htlc_contract.rs
+++ b/primitives/transaction/src/account/htlc_contract.rs
@@ -1,15 +1,15 @@
-use beserial::ReadBytesExt;
+use beserial::{Deserialize, ReadBytesExt, Serialize};
 use log::error;
-use strum_macros::Display;
-
-use crate::account::AccountTransactionVerification;
-use crate::SignatureProof;
-use crate::{Transaction, TransactionError, TransactionFlags};
-use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Blake2bHasher, Hasher, Sha256Hasher};
 use nimiq_keys::Address;
 use nimiq_macros::{add_hex_io_fns_typed_arr, create_typed_array};
 use nimiq_primitives::account::AccountType;
+use strum_macros::Display;
+
+use crate::{
+    account::AccountTransactionVerification, SignatureProof, Transaction, TransactionError,
+    TransactionFlags,
+};
 
 /// The verifier trait for a hash time locked contract. This only uses data available in the transaction.
 pub struct HashedTimeLockedContractVerifier {}

--- a/primitives/transaction/src/account/mod.rs
+++ b/primitives/transaction/src/account/mod.rs
@@ -1,10 +1,12 @@
 use nimiq_primitives::account::AccountType;
 
-use crate::account::basic_account::BasicAccountVerifier;
-use crate::account::htlc_contract::HashedTimeLockedContractVerifier;
-use crate::account::staking_contract::StakingContractVerifier;
-use crate::account::vesting_contract::VestingContractVerifier;
-use crate::{Transaction, TransactionError};
+use crate::{
+    account::{
+        basic_account::BasicAccountVerifier, htlc_contract::HashedTimeLockedContractVerifier,
+        staking_contract::StakingContractVerifier, vesting_contract::VestingContractVerifier,
+    },
+    Transaction, TransactionError,
+};
 
 pub mod basic_account;
 pub mod htlc_contract;

--- a/primitives/transaction/src/account/staking_contract/mod.rs
+++ b/primitives/transaction/src/account/staking_contract/mod.rs
@@ -1,11 +1,10 @@
 use log::error;
-
 use nimiq_primitives::account::AccountType;
 
-use crate::account::AccountTransactionVerification;
-use crate::{Transaction, TransactionError, TransactionFlags};
-
 pub use self::structs::*;
+use crate::{
+    account::AccountTransactionVerification, Transaction, TransactionError, TransactionFlags,
+};
 
 pub mod structs;
 

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -1,14 +1,11 @@
-use log::error;
-
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError};
+use log::error;
 use nimiq_bls::{CompressedPublicKey as BlsPublicKey, CompressedSignature as BlsSignature};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{coin::Coin, policy::Policy};
 
-use crate::SignatureProof;
-use crate::{Transaction, TransactionError};
+use crate::{SignatureProof, Transaction, TransactionError};
 
 /// We need to distinguish two types of transactions:
 /// 1. Incoming transactions, which include:

--- a/primitives/transaction/src/account/vesting_contract.rs
+++ b/primitives/transaction/src/account/vesting_contract.rs
@@ -1,13 +1,12 @@
-use log::error;
-
 use beserial::{Deserialize, Serialize, SerializingError, WriteBytesExt};
+use log::error;
 use nimiq_keys::Address;
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::coin::Coin;
+use nimiq_primitives::{account::AccountType, coin::Coin};
 
-use crate::account::AccountTransactionVerification;
-use crate::SignatureProof;
-use crate::{Transaction, TransactionError, TransactionFlags};
+use crate::{
+    account::AccountTransactionVerification, SignatureProof, Transaction, TransactionError,
+    TransactionFlags,
+};
 
 /// The verifier trait for a basic account. This only uses data available in the transaction.
 pub struct VestingContractVerifier {}

--- a/primitives/transaction/src/extended_transaction.rs
+++ b/primitives/transaction/src/extended_transaction.rs
@@ -1,18 +1,12 @@
-use std::error;
-use std::fmt;
-use std::io;
+use std::{error, fmt, io};
 
 use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError, WriteBytesExt};
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_mmr::hash::Hash as MMRHash;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{coin::Coin, networks::NetworkId, policy::Policy};
 
-use crate::inherent::Inherent;
-use crate::ExecutedTransaction;
-use crate::Transaction as BlockchainTransaction;
+use crate::{inherent::Inherent, ExecutedTransaction, Transaction as BlockchainTransaction};
 
 /// A single struct that stores information that represents any possible transaction (basic
 /// transaction or inherent) on the blockchain.

--- a/primitives/transaction/src/inherent.rs
+++ b/primitives/transaction/src/inherent.rs
@@ -1,11 +1,10 @@
-use crate::reward::RewardTransaction;
 use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Hash, SerializeContent};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_keys::Address;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::SlashedSlot;
+use nimiq_primitives::{coin::Coin, policy::Policy, slots::SlashedSlot};
+
+use crate::reward::RewardTransaction;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, SerializeContent, Deserialize)]
 #[repr(u8)]

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -1,28 +1,28 @@
 #[macro_use]
 extern crate log;
 
-use std::cmp::{Ord, Ordering};
-use std::convert::TryFrom;
-use std::io;
-use std::sync::Arc;
-
-use bitflags::bitflags;
-use num_traits::SaturatingAdd;
-use thiserror::Error;
+use std::{
+    cmp::{Ord, Ordering},
+    convert::TryFrom,
+    io,
+    sync::Arc,
+};
 
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
     SerializingError, WriteBytesExt,
 };
+use bitflags::bitflags;
 use nimiq_hash::{Blake2bHash, Hash, SerializeContent};
-use nimiq_keys::Address;
-use nimiq_keys::{PublicKey, Signature};
+use nimiq_keys::{Address, PublicKey, Signature};
 use nimiq_network_interface::network::Topic;
 use nimiq_primitives::{
     account::AccountType, coin::Coin, networks::NetworkId, policy::Policy,
     transaction::TransactionError,
 };
 use nimiq_utils::merkle::{Blake2bMerklePath, Blake2bMerkleProof};
+use num_traits::SaturatingAdd;
+use thiserror::Error;
 
 use crate::account::AccountTransactionVerification;
 

--- a/primitives/transaction/src/reward.rs
+++ b/primitives/transaction/src/reward.rs
@@ -1,5 +1,4 @@
 use beserial::{Deserialize, Serialize};
-
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 

--- a/primitives/transaction/tests/serialization.rs
+++ b/primitives/transaction/tests/serialization.rs
@@ -2,9 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use beserial::{Deserialize, Serialize, SerializingError};
 use nimiq_keys::Address;
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
 use nimiq_test_log::test;
 use nimiq_transaction::*;
 

--- a/primitives/transaction/tests/staking_contract_verify.rs
+++ b/primitives/transaction/tests/staking_contract_verify.rs
@@ -12,10 +12,13 @@ use nimiq_primitives::{
 };
 use nimiq_test_log::test;
 use nimiq_test_utils::test_rng::test_rng;
-use nimiq_transaction::account::staking_contract::{
-    IncomingStakingTransactionData, OutgoingStakingTransactionProof,
+use nimiq_transaction::{
+    account::{
+        staking_contract::{IncomingStakingTransactionData, OutgoingStakingTransactionProof},
+        AccountTransactionVerification,
+    },
+    SignatureProof, Transaction,
 };
-use nimiq_transaction::{account::AccountTransactionVerification, SignatureProof, Transaction};
 use nimiq_utils::key_rng::SecureGenerate;
 
 const VALIDATOR_ADDRESS: &str = "83fa05dbe31f85e719f4c4fd67ebdba2e444d9f8";

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -7,9 +7,8 @@ use std::{
     mem, ops,
 };
 
-use log::error;
-
 use beserial::{Deserialize, Serialize};
+use log::error;
 use nimiq_database::{
     traits::{Database, ReadCursor, ReadTransaction, WriteTransaction},
     DatabaseProxy, IntoIterProxy, TableProxy, TransactionProxy, WriteTransactionProxy,
@@ -19,9 +18,7 @@ use nimiq_primitives::{
     key_nibbles::KeyNibbles,
     trie::{
         error::MerkleRadixTrieError,
-        trie_chunk::TrieChunk,
-        trie_chunk::TrieChunkPushResult,
-        trie_chunk::TrieItem,
+        trie_chunk::{TrieChunk, TrieChunkPushResult, TrieItem},
         trie_node::{RootData, TrieNode, TrieNodeKind},
         trie_proof::TrieProof,
         trie_proof_node::TrieProofNode,
@@ -1505,8 +1502,9 @@ impl<'txn, T: Deserialize> Iterator for TrieNodeIter<'txn, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nimiq_test_log::test;
+
+    use super::*;
 
     #[test]
     fn get_put_remove_works() {

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -1,7 +1,5 @@
 use anyhow::{bail, Error};
 use clap::Parser;
-use url::Url;
-
 use nimiq_jsonrpc_client::{websocket::WebsocketClient, ArcClient, Client as RPCclient};
 use nimiq_jsonrpc_core::Credentials;
 use nimiq_rpc_interface::{
@@ -9,6 +7,7 @@ use nimiq_rpc_interface::{
     network::NetworkProxy, policy::PolicyProxy, validator::ValidatorProxy, wallet::WalletProxy,
     zkp_component::ZKPComponentProxy,
 };
+use url::Url;
 pub mod subcommands;
 
 use crate::subcommands::*;

--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-
 use nimiq_keys::{Address, PublicKey, Signature};
 use nimiq_rpc_interface::{blockchain::BlockchainInterface, wallet::WalletInterface};
 

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -1,13 +1,10 @@
 use anyhow::Error;
 use async_trait::async_trait;
-use clap::ArgGroup;
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use futures::StreamExt;
-
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_rpc_interface::blockchain::BlockchainInterface;
-use nimiq_rpc_interface::types::LogType;
+use nimiq_rpc_interface::{blockchain::BlockchainInterface, types::LogType};
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;

--- a/rpc-client/src/subcommands/mempool_subcommands.rs
+++ b/rpc-client/src/subcommands/mempool_subcommands.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-
 use nimiq_rpc_interface::mempool::MempoolInterface;
 
 use super::accounts_subcommands::HandleSubcommand;

--- a/rpc-client/src/subcommands/mod.rs
+++ b/rpc-client/src/subcommands/mod.rs
@@ -1,5 +1,4 @@
-pub use accounts_subcommands::AccountCommand;
-pub use accounts_subcommands::HandleSubcommand;
+pub use accounts_subcommands::{AccountCommand, HandleSubcommand};
 pub use blockchain_subcommands::BlockchainCommand;
 pub use mempool_subcommands::MempoolCommand;
 pub use network_subcommands::NetworkCommand;

--- a/rpc-client/src/subcommands/network_subcommands.rs
+++ b/rpc-client/src/subcommands/network_subcommands.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-
 use nimiq_rpc_interface::network::NetworkInterface;
 
 use super::accounts_subcommands::HandleSubcommand;

--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-
 use nimiq_rpc_interface::policy::PolicyInterface;
 
 use super::accounts_subcommands::HandleSubcommand;

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::{Args, Parser};
-
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_rpc_interface::{
@@ -10,9 +9,8 @@ use nimiq_rpc_interface::{
 };
 use nimiq_transaction::account::htlc_contract::AnyHash;
 
-use crate::Client;
-
 use super::accounts_subcommands::HandleSubcommand;
+use crate::Client;
 
 #[derive(Debug, Args)]
 pub struct TxCommon {

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -1,13 +1,13 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-
 use nimiq_keys::Address;
-use nimiq_rpc_interface::consensus::ConsensusInterface;
-use nimiq_rpc_interface::validator::ValidatorInterface;
+use nimiq_rpc_interface::{consensus::ConsensusInterface, validator::ValidatorInterface};
 
-use super::accounts_subcommands::HandleSubcommand;
-use super::transactions_subcommands::{TxCommon, TxCommonWithValue};
+use super::{
+    accounts_subcommands::HandleSubcommand,
+    transactions_subcommands::{TxCommon, TxCommonWithValue},
+};
 use crate::Client;
 
 #[derive(Debug, Parser)]

--- a/rpc-client/src/subcommands/zkp_component_subcommands.rs
+++ b/rpc-client/src/subcommands/zkp_component_subcommands.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-
 use nimiq_rpc_interface::zkp_component::ZKPComponentInterface;
 
 use super::accounts_subcommands::HandleSubcommand;

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
-
-use crate::types::{RPCResult, Transaction, ValidityStartHeight};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
+
+use crate::types::{RPCResult, Transaction, ValidityStartHeight};
 
 #[nimiq_jsonrpc_derive::proxy(name = "ConsensusProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -1,7 +1,8 @@
-use crate::types::{HashOrTx, MempoolInfo, RPCResult};
 use async_trait::async_trait;
 use nimiq_hash::Blake2bHash;
 use nimiq_transaction::Transaction;
+
+use crate::types::{HashOrTx, MempoolInfo, RPCResult};
 
 #[nimiq_jsonrpc_derive::proxy(name = "MempoolProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -1,5 +1,6 @@
-use crate::types::RPCResult;
 use async_trait::async_trait;
+
+use crate::types::RPCResult;
 
 #[nimiq_jsonrpc_derive::proxy(name = "NetworkProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 
-use crate::types::PolicyConstants;
-use crate::types::RPCResult;
+use crate::types::{PolicyConstants, RPCResult};
 
 #[nimiq_jsonrpc_derive::proxy(name = "PolicyProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -6,27 +6,24 @@ use std::{
     str::FromStr,
 };
 
-use clap::ValueEnum;
-use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainError};
-use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DeserializeFromStr, DisplayFromStr, SerializeDisplay};
-
 use beserial::Serialize as BeSerialize;
+use clap::ValueEnum;
 use nimiq_account::{BlockLog as BBlockLog, Log, TransactionLog};
 use nimiq_block::{MicroJustification, MultiSignature};
-
+use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainError};
 use nimiq_blockchain_proxy::BlockchainReadProxy;
 use nimiq_bls::CompressedPublicKey;
 use nimiq_collections::BitSet;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::{Address, PublicKey};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
-use nimiq_transaction::account::htlc_contract::AnyHash;
-use nimiq_transaction::account::htlc_contract::HashAlgorithm as HTLCContractHashAlgorithm;
-use nimiq_transaction::inherent::Inherent as BaseInherent;
+use nimiq_primitives::{coin::Coin, policy::Policy, slots::Validators};
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, HashAlgorithm as HTLCContractHashAlgorithm},
+    inherent::Inherent as BaseInherent,
+};
 use nimiq_vrf::VrfSeed;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DeserializeFromStr, DisplayFromStr, SerializeDisplay};
 
 use crate::error::Error;
 

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -1,6 +1,7 @@
-use crate::types::RPCResult;
 use async_trait::async_trait;
 use nimiq_keys::Address;
+
+use crate::types::RPCResult;
 
 #[nimiq_jsonrpc_derive::proxy(name = "ValidatorProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -1,6 +1,7 @@
-use crate::types::RPCResult;
 use async_trait::async_trait;
 use nimiq_keys::{Address, PrivateKey, PublicKey, Signature};
+
+use crate::types::RPCResult;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc-interface/src/zkp_component.rs
+++ b/rpc-interface/src/zkp_component.rs
@@ -1,5 +1,6 @@
-use crate::types::{RPCResult, ZKPState};
 use async_trait::async_trait;
+
+use crate::types::{RPCResult, ZKPState};
 
 #[nimiq_jsonrpc_derive::proxy(name = "ZKPComponentProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -1,19 +1,18 @@
 use async_trait::async_trait;
 use futures::{future, stream::BoxStream, StreamExt};
-
 use nimiq_account::{BlockLog as BBlockLog, TransactionLog};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
 use nimiq_blockchain_proxy::{BlockchainProxy, BlockchainReadProxy};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::policy::Policy;
-use nimiq_rpc_interface::types::{
-    is_of_log_type_and_related_to_addresses, BlockLog, BlockchainState, ParkedSet, RPCData,
-    RPCResult, Validator,
-};
 use nimiq_rpc_interface::{
     blockchain::BlockchainInterface,
-    types::{Account, Block, ExecutedTransaction, Inherent, LogType, SlashedSlots, Slot, Staker},
+    types::{
+        is_of_log_type_and_related_to_addresses, Account, Block, BlockLog, BlockchainState,
+        ExecutedTransaction, Inherent, LogType, ParkedSet, RPCData, RPCResult, SlashedSlots, Slot,
+        Staker, Validator,
+    },
 };
 use tokio_stream::wrappers::BroadcastStream;
 

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use parking_lot::RwLock;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_bls::{KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
@@ -13,12 +11,14 @@ use nimiq_network_libp2p::Network;
 use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_rpc_interface::{
     consensus::ConsensusInterface,
-    types::RPCResult,
-    types::{Transaction as RPCTransaction, ValidityStartHeight},
+    types::{RPCResult, Transaction as RPCTransaction, ValidityStartHeight},
 };
-use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
-use nimiq_transaction::{SignatureProof, Transaction};
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, HashAlgorithm},
+    SignatureProof, Transaction,
+};
 use nimiq_transaction_builder::TransactionBuilder;
+use parking_lot::RwLock;
 
 use crate::{error::Error, wallets::UnlockedWallets};
 

--- a/rpc-server/src/dispatchers/mempool.rs
+++ b/rpc-server/src/dispatchers/mempool.rs
@@ -2,14 +2,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use beserial::Deserialize;
-
 use nimiq_hash::{Blake2bHash, Hash};
-use nimiq_mempool::mempool::Mempool;
-
-use nimiq_mempool::mempool_transactions::TxPriority;
-use nimiq_rpc_interface::mempool::MempoolInterface;
-use nimiq_rpc_interface::types::RPCResult;
-use nimiq_rpc_interface::types::{HashOrTx, MempoolInfo};
+use nimiq_mempool::{mempool::Mempool, mempool_transactions::TxPriority};
+use nimiq_rpc_interface::{
+    mempool::MempoolInterface,
+    types::{HashOrTx, MempoolInfo, RPCResult},
+};
 use nimiq_transaction::Transaction;
 
 use crate::error::Error;

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use nimiq_network_interface::network::Network as InterfaceNetwork;
 use nimiq_network_libp2p::Network;
-use nimiq_rpc_interface::network::NetworkInterface;
-use nimiq_rpc_interface::types::RPCResult;
+use nimiq_rpc_interface::{network::NetworkInterface, types::RPCResult};
 
 use crate::error::Error;
 

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
-
 use nimiq_primitives::policy::Policy;
-use nimiq_rpc_interface::policy::PolicyInterface;
-use nimiq_rpc_interface::types::{PolicyConstants, RPCResult};
+use nimiq_rpc_interface::{
+    policy::PolicyInterface,
+    types::{PolicyConstants, RPCResult},
+};
 
 use crate::error::Error;
 

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -2,10 +2,8 @@ use std::sync::atomic::Ordering;
 
 use async_trait::async_trait;
 use beserial::Serialize;
-
 use nimiq_keys::Address;
-use nimiq_rpc_interface::types::RPCResult;
-use nimiq_rpc_interface::validator::ValidatorInterface;
+use nimiq_rpc_interface::{types::RPCResult, validator::ValidatorInterface};
 use nimiq_validator::validator::ValidatorProxy;
 
 use crate::error::Error;

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use parking_lot::RwLock;
-
 use beserial::Deserialize;
 use nimiq_database::traits::WriteTransaction;
 use nimiq_keys::{Address, KeyPair, PrivateKey, PublicKey, Signature};
@@ -12,6 +10,7 @@ use nimiq_rpc_interface::{
 };
 use nimiq_utils::otp::Locked;
 use nimiq_wallet::{WalletAccount, WalletStore};
+use parking_lot::RwLock;
 
 use crate::{error::Error, wallets::UnlockedWallets};
 

--- a/rpc-server/src/dispatchers/zkp_component.rs
+++ b/rpc-server/src/dispatchers/zkp_component.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-
 use nimiq_network_libp2p::Network;
-use nimiq_rpc_interface::types::RPCResult;
-use nimiq_rpc_interface::types::ZKPState;
-use nimiq_rpc_interface::zkp_component::ZKPComponentInterface;
+use nimiq_rpc_interface::{
+    types::{RPCResult, ZKPState},
+    zkp_component::ZKPComponentInterface,
+};
 use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 
 use crate::error::Error;

--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -1,9 +1,8 @@
-use nimiq_jsonrpc_core::RpcError;
-use thiserror::Error;
-
 use nimiq_hash::Blake2bHash;
+use nimiq_jsonrpc_core::RpcError;
 use nimiq_keys::Address;
 use nimiq_mempool::verify::VerifyErr;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/rpc-server/src/lib.rs
+++ b/rpc-server/src/lib.rs
@@ -1,6 +1,5 @@
-pub use nimiq_jsonrpc_server::{Config, Server};
-
 pub use error::Error;
+pub use nimiq_jsonrpc_server::{Config, Server};
 
 pub mod dispatchers;
 pub mod error;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -1,25 +1,17 @@
-use std::collections::VecDeque;
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{
+    collections::VecDeque,
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
 
 use clap::Parser;
 use futures::StreamExt;
 use log::info;
-use rand::{
-    distributions::{Distribution, WeightedIndex},
-    thread_rng, Rng,
-};
-
-use serde::Deserialize;
-
-use std::sync::{Arc, RwLock};
-
 use nimiq::client::ConsensusProxy;
 pub use nimiq::{
     client::{Client, Consensus},
-    config::command_line::CommandLine,
-    config::config::ClientConfig,
-    config::config_file::ConfigFile,
+    config::{command_line::CommandLine, config::ClientConfig, config_file::ConfigFile},
     error::Error,
     extras::{
         deadlock::initialize_deadlock_detection,
@@ -32,10 +24,14 @@ use nimiq_block::BlockType;
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
 use nimiq_keys::{Address, KeyPair, PrivateKey, SecureGenerate};
 use nimiq_mempool::mempool::Mempool;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_transaction::Transaction;
 use nimiq_transaction_builder::TransactionBuilder;
+use rand::{
+    distributions::{Distribution, WeightedIndex},
+    thread_rng, Rng,
+};
+use serde::Deserialize;
 
 #[derive(Debug, Parser)]
 pub struct SpammerCommandLine {

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -1,8 +1,7 @@
-use crate::utils::Step;
-
 use futures::{future::BoxFuture, stream::BoxStream};
-
 use nimiq_collections::BitSet;
+
+use crate::utils::Step;
 
 /// Error for proposal verification. Currently not really used, but in place to allow for potential
 /// punishment of misbehaving contributors to the tendermint protocol.

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -11,14 +11,13 @@ use futures::{
     future::{BoxFuture, FutureExt},
     stream::{BoxStream, FuturesUnordered, SelectAll, Stream, StreamExt},
 };
+use nimiq_collections::BitSet;
+use nimiq_macros::store_waker;
 use tokio::{
     sync::mpsc,
     time::{error::Elapsed, Duration},
 };
 use tokio_stream::wrappers::ReceiverStream;
-
-use nimiq_collections::BitSet;
-use nimiq_macros::store_waker;
 
 use crate::{
     protocol::{Aggregation, Protocol, SignedProposalMessage, TaggedAggregationMessage},

--- a/tendermint/tests/common/mod.rs
+++ b/tendermint/tests/common/mod.rs
@@ -7,11 +7,10 @@ use futures::{
     future::{self, FutureExt},
     stream::{BoxStream, StreamExt},
 };
-use tokio::{sync::mpsc, time::timeout};
-use tokio_stream::wrappers::ReceiverStream;
-
 use nimiq_collections::BitSet;
 use nimiq_tendermint::*;
+use tokio::{sync::mpsc, time::timeout};
+use tokio_stream::wrappers::ReceiverStream;
 
 pub mod helper;
 

--- a/tendermint/tests/detailed.rs
+++ b/tendermint/tests/detailed.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeMap;
 
 use futures::stream::{self, StreamExt};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-
 use nimiq_collections::BitSet;
 use nimiq_tendermint::*;
 use nimiq_test_log::test;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
 pub mod common;
 

--- a/test-log/src/lib.rs
+++ b/test-log/src/lib.rs
@@ -1,12 +1,9 @@
 use log::level_filters::LevelFilter;
 use nimiq_log::TargetsExt;
 use nimiq_primitives::policy::{Policy, TEST_POLICY};
-use parking_lot::Once;
-use tracing_subscriber::filter::Targets;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-
 pub use nimiq_test_log_proc_macro::test;
+use parking_lot::Once;
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
 
 static INITIALIZE: Once = Once::new();
 

--- a/test-utils/src/accounts_revert.rs
+++ b/test-utils/src/accounts_revert.rs
@@ -1,4 +1,3 @@
-use paste::paste;
 use std::{fmt::Debug, ops::Deref};
 
 use nimiq_account::{
@@ -13,6 +12,7 @@ use nimiq_database::{
 use nimiq_keys::Address;
 use nimiq_primitives::{account::AccountError, coin::Coin, key_nibbles::KeyNibbles};
 use nimiq_transaction::{inherent::Inherent, Transaction};
+use paste::paste;
 
 macro_rules! impl_accounts_trait {
     ($fn_name: ident, $target: ident, $op_type: ty, $log_type: ty) => {

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-
 use beserial::Deserialize;
 use nimiq_block::{
     Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo,
@@ -24,6 +22,7 @@ use nimiq_primitives::{
 use nimiq_tendermint::ProposalMessage;
 use nimiq_transaction::Transaction;
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
 
 /// Secret keys of validator. Tests run with `genesis/src/genesis/unit-albatross.toml`
 const SIGNING_KEY: &str = "041580cc67e66e9e08b68fd9e4c9deb68737168fbe7488de2638c2e906c2f5ad";

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -1,12 +1,5 @@
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc, time::Instant};
 
-use parking_lot::RwLock;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
-use std::time::Instant;
-
-use crate::blockchain_with_rng::*;
-use crate::test_rng::test_rng;
 use beserial::Deserialize;
 use nimiq_block::{
     Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo,
@@ -18,12 +11,16 @@ use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_bls::{AggregateSignature, KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
 use nimiq_collections::BitSet;
 use nimiq_genesis::NetworkId;
-use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, PrivateKey as SchnorrPrivateKey};
-use nimiq_keys::{KeyPair, PrivateKey};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::policy::Policy;
+use nimiq_keys::{
+    Address, KeyPair as SchnorrKeyPair, KeyPair, PrivateKey as SchnorrPrivateKey, PrivateKey,
+};
+use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_transaction::Transaction;
 use nimiq_transaction_builder::TransactionBuilder;
+use parking_lot::RwLock;
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+
+use crate::{blockchain_with_rng::*, test_rng::test_rng};
 
 /// Secret keys of validator. Tests run with `genesis/src/genesis/unit-albatross.toml`
 pub const SIGNING_KEY: &str = "041580cc67e66e9e08b68fd9e4c9deb68737168fbe7488de2638c2e906c2f5ad";

--- a/test-utils/src/blockchain_with_rng.rs
+++ b/test-utils/src/blockchain_with_rng.rs
@@ -1,14 +1,12 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-use rand::CryptoRng;
-use rand::Rng;
-
 use nimiq_block::Block;
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_primitives::policy::Policy;
+use parking_lot::RwLock;
+use rand::{CryptoRng, Rng};
 
 use crate::blockchain::sign_macro_block;
 

--- a/test-utils/src/mock_node.rs
+++ b/test-utils/src/mock_node.rs
@@ -1,12 +1,10 @@
-use std::pin::Pin;
-use std::task::Context;
-use std::{sync::Arc, task::Poll};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
-use futures::future::BoxFuture;
-use futures::stream::BoxStream;
-use futures::{ready, FutureExt, Stream, StreamExt};
-use parking_lot::RwLock;
-
+use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, Stream, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -20,9 +18,9 @@ use nimiq_network_interface::{
     request::{Handle, Request},
 };
 use nimiq_network_mock::MockHub;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::trie::TrieItem;
+use nimiq_primitives::{networks::NetworkId, trie::TrieItem};
 use nimiq_utils::time::OffsetTime;
+use parking_lot::RwLock;
 
 use crate::test_network::TestNetwork;
 

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -1,26 +1,26 @@
-use std::path::PathBuf;
-use std::sync::Arc;
-
-use parking_lot::{Mutex, RwLock};
+use std::{path::PathBuf, sync::Arc};
 
 use nimiq_block::Block;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_consensus::{sync::syncer_proxy::SyncerProxy, Consensus};
-use nimiq_database::volatile::VolatileDatabase;
-use nimiq_database::DatabaseProxy;
+use nimiq_database::{volatile::VolatileDatabase, DatabaseProxy};
 use nimiq_genesis_builder::GenesisInfo;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_mock::MockHub;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::trie::TrieItem;
+use nimiq_primitives::{networks::NetworkId, trie::TrieItem};
 use nimiq_utils::time::OffsetTime;
-use nimiq_zkp_component::proof_store::ProofStore;
-use nimiq_zkp_component::{proof_store::DBProofStore, ZKPComponent};
+use nimiq_zkp_component::{
+    proof_store::{DBProofStore, ProofStore},
+    ZKPComponent,
+};
+use parking_lot::{Mutex, RwLock};
 
-use crate::test_network::TestNetwork;
-use crate::zkp_test_data::{zkp_test_exe, ZKP_TEST_KEYS_PATH};
+use crate::{
+    test_network::TestNetwork,
+    zkp_test_data::{zkp_test_exe, ZKP_TEST_KEYS_PATH},
+};
 
 pub const TESTING_BLS_CACHE_MAX_CAPACITY: usize = 100;
 

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -1,6 +1,6 @@
-use async_trait::async_trait;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network as NetworkInterface, peer_info::Services};
 use nimiq_network_libp2p::{

--- a/test-utils/src/test_transaction.rs
+++ b/test-utils/src/test_transaction.rs
@@ -1,8 +1,7 @@
 use beserial::Serialize;
 use nimiq_genesis_builder::GenesisBuilder;
 use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_transaction::{SignatureProof, Transaction};
 use rand::{CryptoRng, Rng};
 

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -1,7 +1,5 @@
-use log::debug;
-use rand::{CryptoRng, Rng};
-
 use beserial::Serialize;
+use log::debug;
 use nimiq_account::{
     Account, AccountInherentInteraction, Accounts, BasicAccount, BlockState,
     HashedTimeLockedContract, InherentLogger, StakingContractStoreWrite, TransactionLog,
@@ -17,8 +15,9 @@ use nimiq_primitives::{
 };
 use nimiq_transaction::{
     account::{
-        htlc_contract::CreationTransactionData as HTLCCreationTransactionData,
-        htlc_contract::{AnyHash, HashAlgorithm},
+        htlc_contract::{
+            AnyHash, CreationTransactionData as HTLCCreationTransactionData, HashAlgorithm,
+        },
         staking_contract::IncomingStakingTransactionData,
         vesting_contract::CreationTransactionData as VestingCreationTransactionData,
     },
@@ -26,6 +25,7 @@ use nimiq_transaction::{
     SignatureProof, Transaction,
 };
 use nimiq_transaction_builder::TransactionProofBuilder;
+use rand::{CryptoRng, Rng};
 
 pub enum ValidatorState {
     Active,

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -1,9 +1,7 @@
-use futures::{future, StreamExt};
-use rand::{rngs::StdRng, SeedableRng};
 use std::sync::Arc;
-use tokio_stream::wrappers::BroadcastStream;
 
 use beserial::{Deserialize, Serialize};
+use futures::{future, StreamExt};
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_consensus::{Consensus, ConsensusEvent};
@@ -15,9 +13,10 @@ use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_mock::MockHub;
 use nimiq_validator::validator::Validator;
 use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
+use rand::{rngs::StdRng, SeedableRng};
+use tokio_stream::wrappers::BroadcastStream;
 
-use crate::node::Node;
-use crate::test_network::TestNetwork;
+use crate::{node::Node, test_network::TestNetwork};
 
 pub fn seeded_rng(seed: u64) -> StdRng {
     StdRng::seed_from_u64(seed)

--- a/test-utils/src/zkp_test_data.rs
+++ b/test-utils/src/zkp_test_data.rs
@@ -4,16 +4,15 @@ use ark_ff::ToConstraintField;
 use ark_groth16::VerifyingKey;
 use ark_mnt6_753::MNT6_753;
 use ark_serialize::CanonicalDeserialize;
-use nimiq_zkp_component::types::ZKProof;
-use parking_lot::RwLock;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha20Rng;
-
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_genesis::NetworkInfo;
 use nimiq_zkp_circuits::test_setup::ToxicWaste;
+use nimiq_zkp_component::types::ZKProof;
 use nimiq_zkp_primitives::{state_commitment, vk_commitment};
+use parking_lot::RwLock;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 
 pub fn get_base_seed() -> ChaCha20Rng {
     let seed = [

--- a/tools/src/address/main.rs
+++ b/tools/src/address/main.rs
@@ -1,7 +1,8 @@
+use std::{error::Error, process};
+
 use beserial::Deserialize;
 use clap::{Arg, Command};
 use nimiq_keys::{Address, PrivateKey, PublicKey, SecureGenerate};
-use std::{error::Error, process};
 
 fn parse_private_key(s: &str) -> Result<PrivateKey, Box<dyn Error>> {
     Ok(PrivateKey::deserialize_from_vec(&hex::decode(s)?)?)

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -1,18 +1,14 @@
-use std::io::stdin;
-use std::process::exit;
-use std::str::FromStr;
+use std::{io::stdin, process::exit, str::FromStr};
 
 use anyhow::Error;
+use beserial::{Deserialize, Serialize};
 use clap::{
     crate_authors, crate_description, crate_version, value_parser, Arg, ArgAction, Command,
 };
-use thiserror::Error;
-
-use beserial::{Deserialize, Serialize};
 use nimiq_keys::{Address, KeyPair, PrivateKey};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_transaction::Transaction;
+use thiserror::Error;
 
 fn run_app() -> Result<(), Error> {
     let matches = Command::new("Sign transaction")

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -1,15 +1,14 @@
-use thiserror::Error;
-
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, KeyPair, PublicKey};
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
-use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
-use nimiq_transaction::{SignatureProof, Transaction};
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, HashAlgorithm},
+    SignatureProof, Transaction,
+};
+use thiserror::Error;
 
-pub use crate::proof::TransactionProofBuilder;
-pub use crate::recipient::Recipient;
+pub use crate::{proof::TransactionProofBuilder, recipient::Recipient};
 
 pub mod proof;
 pub mod recipient;

--- a/transaction-builder/src/proof/htlc_contract.rs
+++ b/transaction-builder/src/proof/htlc_contract.rs
@@ -1,10 +1,10 @@
 use beserial::Serialize;
 use nimiq_hash::{Blake2bHash, Sha256Hash};
 use nimiq_keys::KeyPair;
-use nimiq_transaction::account::htlc_contract::{
-    AnyHash, HashAlgorithm, OutgoingHTLCTransactionProof,
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, HashAlgorithm, OutgoingHTLCTransactionProof},
+    SignatureProof, Transaction,
 };
-use nimiq_transaction::{SignatureProof, Transaction};
 
 /// The `HtlcProofBuilder` can be used to build proofs for transactions
 /// that originate in a HTLC contract.

--- a/transaction-builder/src/proof/mod.rs
+++ b/transaction-builder/src/proof/mod.rs
@@ -6,8 +6,10 @@ use nimiq_keys::KeyPair;
 use nimiq_primitives::account::AccountType;
 use nimiq_transaction::{SignatureProof, Transaction};
 
-use crate::proof::htlc_contract::HtlcProofBuilder;
-use crate::proof::staking_contract::{StakingDataBuilder, StakingProofBuilder};
+use crate::proof::{
+    htlc_contract::HtlcProofBuilder,
+    staking_contract::{StakingDataBuilder, StakingProofBuilder},
+};
 
 pub mod htlc_contract;
 pub mod staking_contract;

--- a/transaction-builder/src/proof/staking_contract.rs
+++ b/transaction-builder/src/proof/staking_contract.rs
@@ -1,9 +1,9 @@
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::KeyPair;
-use nimiq_transaction::account::staking_contract::{
-    IncomingStakingTransactionData, OutgoingStakingTransactionProof,
+use nimiq_transaction::{
+    account::staking_contract::{IncomingStakingTransactionData, OutgoingStakingTransactionProof},
+    SignatureProof, Transaction,
 };
-use nimiq_transaction::{SignatureProof, Transaction};
 
 use crate::proof::TransactionProofBuilder;
 

--- a/transaction-builder/src/recipient/htlc_contract.rs
+++ b/transaction-builder/src/recipient/htlc_contract.rs
@@ -1,9 +1,9 @@
-use thiserror::Error;
-
 use nimiq_hash::{Blake2bHash, Sha256Hash};
 use nimiq_keys::Address;
-use nimiq_transaction::account::htlc_contract::CreationTransactionData as HtlcCreationData;
-use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
+use nimiq_transaction::account::htlc_contract::{
+    AnyHash, CreationTransactionData as HtlcCreationData, HashAlgorithm,
+};
+use thiserror::Error;
 
 use crate::recipient::Recipient;
 

--- a/transaction-builder/src/recipient/mod.rs
+++ b/transaction-builder/src/recipient/mod.rs
@@ -1,13 +1,16 @@
 use beserial::Serialize;
 use nimiq_keys::Address;
 use nimiq_primitives::{account::AccountType, policy::Policy};
-use nimiq_transaction::account::htlc_contract::CreationTransactionData as HtlcCreationData;
-use nimiq_transaction::account::staking_contract::IncomingStakingTransactionData;
-use nimiq_transaction::account::vesting_contract::CreationTransactionData as VestingCreationData;
+use nimiq_transaction::account::{
+    htlc_contract::CreationTransactionData as HtlcCreationData,
+    staking_contract::IncomingStakingTransactionData,
+    vesting_contract::CreationTransactionData as VestingCreationData,
+};
 
-use crate::recipient::htlc_contract::HtlcRecipientBuilder;
-use crate::recipient::staking_contract::StakingRecipientBuilder;
-use crate::recipient::vesting_contract::VestingRecipientBuilder;
+use crate::recipient::{
+    htlc_contract::HtlcRecipientBuilder, staking_contract::StakingRecipientBuilder,
+    vesting_contract::VestingRecipientBuilder,
+};
 
 pub mod htlc_contract;
 pub mod staking_contract;

--- a/transaction-builder/src/recipient/vesting_contract.rs
+++ b/transaction-builder/src/recipient/vesting_contract.rs
@@ -1,10 +1,9 @@
 use std::ops::Div;
 
-use thiserror::Error;
-
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
 use nimiq_transaction::account::vesting_contract::CreationTransactionData as VestingCreationData;
+use thiserror::Error;
 
 use crate::recipient::Recipient;
 

--- a/transaction-builder/tests/htlc_contract.rs
+++ b/transaction-builder/tests/htlc_contract.rs
@@ -3,13 +3,14 @@ use std::convert::TryInto;
 use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Blake2bHash, Blake2bHasher, HashOutput, Hasher};
 use nimiq_keys::{Address, KeyPair, PrivateKey};
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{account::AccountType, networks::NetworkId};
 use nimiq_test_log::test;
-use nimiq_transaction::account::htlc_contract::{
-    AnyHash, CreationTransactionData, HashAlgorithm, OutgoingHTLCTransactionProof,
+use nimiq_transaction::{
+    account::htlc_contract::{
+        AnyHash, CreationTransactionData, HashAlgorithm, OutgoingHTLCTransactionProof,
+    },
+    SignatureProof, Transaction,
 };
-use nimiq_transaction::{SignatureProof, Transaction};
 use nimiq_transaction_builder::{Recipient, TransactionBuilder};
 
 #[test]

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -4,15 +4,12 @@ use beserial::{Deserialize, Serialize};
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, KeyPair, PrivateKey};
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
-use nimiq_transaction::account::staking_contract::{
-    IncomingStakingTransactionData, OutgoingStakingTransactionProof,
+use nimiq_transaction::{
+    account::staking_contract::{IncomingStakingTransactionData, OutgoingStakingTransactionProof},
+    SignatureProof, Transaction,
 };
-use nimiq_transaction::{SignatureProof, Transaction};
 use nimiq_transaction_builder::{TransactionBuilder, TransactionBuilderError};
 
 const ADDRESS: &str = "9cd82948650d902d95d52ea2ec91eae6deb0c9fe";

--- a/transaction-builder/tests/vesting_contract.rs
+++ b/transaction-builder/tests/vesting_contract.rs
@@ -2,9 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::{Address, KeyPair, PrivateKey};
-use nimiq_primitives::account::AccountType;
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
 use nimiq_test_log::test;
 use nimiq_transaction::{SignatureProof, Transaction};
 use nimiq_transaction_builder::{Recipient, TransactionBuilder};

--- a/utils/src/file_store.rs
+++ b/utils/src/file_store.rs
@@ -4,9 +4,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use thiserror::Error;
-
 use beserial::{Deserialize, Serialize, SerializingError};
+use thiserror::Error;
 
 pub struct FileStore {
     path: PathBuf,

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -34,8 +34,9 @@ ceiling_div!(usize);
 
 #[cfg(test)]
 mod tests {
-    use super::log2;
     use nimiq_test_log::test;
+
+    use super::log2;
 
     #[test]
     fn test_log2() {

--- a/utils/src/merkle/mod.rs
+++ b/utils/src/merkle/mod.rs
@@ -1,10 +1,4 @@
-use std::borrow::Cow;
-use std::cmp::Ordering;
-use std::error;
-use std::fmt;
-use std::io;
-use std::io::Write;
-use std::ops::Deref;
+use std::{borrow::Cow, cmp::Ordering, error, fmt, io, io::Write, ops::Deref};
 
 use beserial::{
     Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
@@ -563,9 +557,9 @@ pub type Blake2bMerkleProof = MerkleProof<Blake2bHash>;
 #[cfg(test)]
 mod tests {
     use nimiq_hash::Blake2bHasher;
+    use nimiq_test_log::test;
 
     use super::*;
-    use nimiq_test_log::test;
 
     #[test]
     fn it_correctly_computes_a_simple_proof() {

--- a/utils/src/merkle/partial.rs
+++ b/utils/src/merkle/partial.rs
@@ -1,5 +1,4 @@
-use std::io::Write;
-use std::ops::Range;
+use std::{io::Write, ops::Range};
 
 use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Blake2bHash, HashOutput, Hasher, SerializeContent};

--- a/utils/src/otp.rs
+++ b/utils/src/otp.rs
@@ -1,17 +1,17 @@
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+use std::{
+    io,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
+use beserial::{
+    Deserialize, DeserializeWithLength, ReadBytesExt, Serialize, SerializeWithLength,
+    SerializingError, WriteBytesExt,
+};
 use clear_on_drop::clear::Clear;
-use rand::rngs::OsRng;
-use rand::RngCore;
-
-use beserial::ReadBytesExt;
-use beserial::SerializingError;
-use beserial::WriteBytesExt;
-use beserial::{Deserialize, DeserializeWithLength, Serialize, SerializeWithLength};
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::argon2kdf::{compute_argon2_kdf, Argon2Error};
-use std::io;
+use rand::{rngs::OsRng, RngCore};
 
 pub trait Verify {
     fn verify(&self) -> bool;

--- a/utils/src/tagged_signing.rs
+++ b/utils/src/tagged_signing.rs
@@ -137,11 +137,10 @@ pub trait TaggedPublicKey {
 
 #[cfg(test)]
 mod tests {
+    use beserial::{Deserialize, Serialize};
     use nimiq_keys::{KeyPair, PublicKey, SecureGenerate, Signature};
     use nimiq_test_log::test;
     use nimiq_test_utils::test_rng::test_rng;
-
-    use beserial::{Deserialize, Serialize};
 
     use super::{TaggedKeypair, TaggedPublicKey, TaggedSignable, TaggedSignature};
 

--- a/utils/src/time.rs
+++ b/utils/src/time.rs
@@ -1,6 +1,7 @@
-use std::sync::atomic::{AtomicI64, Ordering};
-use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    sync::atomic::{AtomicI64, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 /// Time with fixed offset from wall-clock, in milliseconds
 #[derive(Debug, Default)]

--- a/utils/tests/merkle/incremental.rs
+++ b/utils/tests/merkle/incremental.rs
@@ -2,8 +2,7 @@ use std::cmp;
 
 use nimiq_hash::{Blake2bHash, Blake2bHasher};
 use nimiq_test_log::test;
-use nimiq_utils::merkle::compute_root_from_content;
-use nimiq_utils::merkle::incremental::*;
+use nimiq_utils::merkle::{compute_root_from_content, incremental::*};
 
 fn incremental(values: &[&str], chunk_size: usize) -> Vec<IncrementalMerkleProof<Blake2bHash>> {
     let mut builder = IncrementalMerkleProofBuilder::<Blake2bHash>::new(chunk_size).unwrap();

--- a/utils/tests/merkle/partial.rs
+++ b/utils/tests/merkle/partial.rs
@@ -2,8 +2,7 @@ use std::cmp;
 
 use nimiq_hash::{Blake2bHash, Blake2bHasher};
 use nimiq_test_log::test;
-use nimiq_utils::merkle::compute_root_from_content;
-use nimiq_utils::merkle::partial::*;
+use nimiq_utils::merkle::{compute_root_from_content, partial::*};
 
 #[test]
 fn it_correctly_computes_a_simple_proof() {

--- a/validator-network/src/error.rs
+++ b/validator-network/src/error.rs
@@ -1,7 +1,6 @@
-use thiserror::Error;
-
 use beserial::SerializingError;
 use nimiq_network_interface::{network::SendError, request::RequestError};
+use thiserror::Error;
 
 /// No notion of connected or disconnected!
 /// If a peer is not connected the connection must be pursued.

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -7,7 +7,6 @@ use std::{pin::Pin, time::Duration};
 
 use async_trait::async_trait;
 use futures::{stream::BoxStream, Stream};
-
 use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
     network::{MsgAcceptance, Network, PubsubId, Topic},

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -1,15 +1,14 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use futures::{stream::BoxStream, StreamExt, TryFutureExt};
-use parking_lot::RwLock;
-
 use beserial::{Deserialize, Serialize};
+use futures::{stream::BoxStream, StreamExt, TryFutureExt};
 use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
     network::{MsgAcceptance, Network, NetworkEvent, Topic},
     request::{Message, Request, RequestCommon},
 };
+use parking_lot::RwLock;
 
 use super::{MessageStream, NetworkError, ValidatorNetwork};
 use crate::validator_record::{SignedValidatorRecord, ValidatorRecord};

--- a/validator-network/src/single_response_requester.rs
+++ b/validator-network/src/single_response_requester.rs
@@ -9,7 +9,6 @@ use futures::{
     stream::FuturesUnordered,
     StreamExt,
 };
-
 use nimiq_network_interface::request::{Request, RequestCommon};
 
 use crate::ValidatorNetwork;

--- a/validator/src/aggregation/registry.rs
+++ b/validator/src/aggregation/registry.rs
@@ -3,8 +3,7 @@ use std::collections::HashSet;
 use nimiq_bls::PublicKey;
 use nimiq_collections::BitSet;
 use nimiq_handel::identity::{Identity, IdentityRegistry, WeightRegistry};
-use nimiq_primitives::policy::Policy;
-use nimiq_primitives::slots::Validators;
+use nimiq_primitives::{policy::Policy, slots::Validators};
 
 /// Implementation for Handel registry using a `Validators` list.
 #[derive(Debug)]

--- a/validator/src/aggregation/tendermint/proposal.rs
+++ b/validator/src/aggregation/tendermint/proposal.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_block::{MacroBody, MacroHeader};
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
@@ -11,6 +9,7 @@ use nimiq_network_interface::{
     request::{Handle, RequestCommon, RequestMarker},
 };
 use nimiq_tendermint::{Inherent, Proposal, ProposalMessage, SignedProposalMessage};
+use parking_lot::RwLock;
 
 use crate::aggregation::tendermint::state::MacroState;
 

--- a/validator/src/aggregation/tendermint/protocol.rs
+++ b/validator/src/aggregation/tendermint/protocol.rs
@@ -1,16 +1,16 @@
-use parking_lot::RwLock;
 use std::sync::Arc;
 
 use nimiq_block::TendermintIdentifier;
-use nimiq_handel::evaluator::WeightedVote;
-use nimiq_handel::partitioner::BinomialPartitioner;
-use nimiq_handel::protocol::Protocol;
-use nimiq_handel::store::ReplaceStore;
+use nimiq_handel::{
+    evaluator::WeightedVote, partitioner::BinomialPartitioner, protocol::Protocol,
+    store::ReplaceStore,
+};
+use parking_lot::RwLock;
 
-use super::super::registry::ValidatorRegistry;
-
-use super::contribution::TendermintContribution;
-use super::verifier::TendermintVerifier;
+use super::{
+    super::registry::ValidatorRegistry, contribution::TendermintContribution,
+    verifier::TendermintVerifier,
+};
 
 #[derive(std::fmt::Debug)]
 pub(crate) struct TendermintAggregationProtocol {

--- a/validator/src/aggregation/tendermint/state.rs
+++ b/validator/src/aggregation/tendermint/state.rs
@@ -8,12 +8,11 @@ use nimiq_keys::Signature as SchnorrSignature;
 use nimiq_tendermint::{State as TendermintState, Step};
 use nimiq_validator_network::ValidatorNetwork;
 
-use crate::tendermint::TendermintProtocol;
-
 use super::{
     contribution::TendermintContribution,
     proposal::{Body, Header, SignedProposal},
 };
+use crate::tendermint::TendermintProtocol;
 
 #[derive(Clone)]
 pub struct MacroState {

--- a/validator/src/aggregation/tendermint/verifier.rs
+++ b/validator/src/aggregation/tendermint/verifier.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use tokio::task;
-
 use nimiq_block::{TendermintIdentifier, TendermintVote};
 use nimiq_bls::AggregatePublicKey;
-use nimiq_handel::identity::IdentityRegistry;
-use nimiq_handel::verifier::{VerificationResult, Verifier};
+use nimiq_handel::{
+    identity::IdentityRegistry,
+    verifier::{VerificationResult, Verifier},
+};
 use nimiq_hash::Hash;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use tokio::task;
 
 use super::contribution::TendermintContribution;
 

--- a/validator/src/aggregation/verifier.rs
+++ b/validator/src/aggregation/verifier.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use nimiq_bls::AggregatePublicKey;
-use nimiq_handel::identity::IdentityRegistry;
-use nimiq_handel::verifier::{VerificationResult, Verifier};
+use nimiq_handel::{
+    identity::IdentityRegistry,
+    verifier::{VerificationResult, Verifier},
+};
 use nimiq_hash::Blake2sHash;
 
 use super::skip_block::SignedSkipBlockMessage;

--- a/validator/src/macro.rs
+++ b/validator/src/macro.rs
@@ -9,8 +9,6 @@ use futures::{
     future,
     stream::{BoxStream, Stream, StreamExt},
 };
-use parking_lot::RwLock;
-
 use nimiq_block::MacroBlock;
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
@@ -19,6 +17,7 @@ use nimiq_network_interface::network::Topic;
 use nimiq_primitives::slots::Validators;
 use nimiq_tendermint::{Return as TendermintReturn, SignedProposalMessage, Tendermint};
 use nimiq_validator_network::ValidatorNetwork;
+use parking_lot::RwLock;
 
 use crate::{
     aggregation::tendermint::{

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -1,13 +1,12 @@
-use std::cmp;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::{Duration, SystemTime};
+use std::{
+    cmp,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::{Duration, SystemTime},
+};
 
 use futures::{future::BoxFuture, ready, FutureExt, Stream};
-use parking_lot::RwLock;
-use tokio::time;
-
 use nimiq_block::{Block, ForkProof, MicroBlock, SkipBlockInfo};
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
@@ -16,6 +15,8 @@ use nimiq_mempool::mempool::Mempool;
 use nimiq_utils::time::systemtime_to_timestamp;
 use nimiq_validator_network::ValidatorNetwork;
 use nimiq_vrf::VrfSeed;
+use parking_lot::RwLock;
+use tokio::time;
 
 use crate::aggregation::skip_block::SkipBlockAggregation;
 

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
+use beserial::{Serialize, WriteBytesExt};
 use futures::{
     future::{self, FutureExt},
     stream::{BoxStream, StreamExt},
 };
-use parking_lot::RwLock;
-
-use beserial::{Serialize, WriteBytesExt};
 use nimiq_account::BlockLogger;
 use nimiq_block::{
     Block, MacroBlock, TendermintIdentifier, TendermintProof, TendermintStep, TendermintVote,
@@ -27,6 +25,7 @@ use nimiq_tendermint::{
 use nimiq_validator_network::{
     single_response_requester::SingleResponseRequester, ValidatorNetwork,
 };
+use parking_lot::RwLock;
 
 use crate::{
     aggregation::{

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1,20 +1,17 @@
-use std::error::Error;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    error::Error,
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll, Waker},
+    time::Duration,
 };
-use std::task::{Context, Poll, Waker};
-use std::time::Duration;
 
 use futures::stream::{BoxStream, Stream, StreamExt};
 use linked_hash_map::LinkedHashMap;
-use parking_lot::RwLock;
-#[cfg(feature = "metrics")]
-use tokio_metrics::TaskMonitor;
-use tokio_stream::wrappers::BroadcastStream;
-
 use nimiq_block::{Block, BlockHeaderTopic, BlockTopic, BlockType};
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
@@ -37,6 +34,10 @@ use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_tendermint::SignedProposalMessage;
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_validator_network::ValidatorNetwork;
+use parking_lot::RwLock;
+#[cfg(feature = "metrics")]
+use tokio_metrics::TaskMonitor;
+use tokio_stream::wrappers::BroadcastStream;
 
 use crate::{
     aggregation::tendermint::{

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -1,9 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use futures::{future, StreamExt};
-use tokio::time;
-
 use beserial::{Deserialize, Serialize};
+use futures::{future, StreamExt};
 use nimiq_block::{MultiSignature, SignedSkipBlockInfo, SkipBlockInfo};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
 use nimiq_bls::{AggregateSignature, KeyPair as BlsKeyPair};
@@ -26,6 +24,7 @@ use nimiq_test_utils::{
     },
 };
 use nimiq_validator::aggregation::skip_block::SignedSkipBlockMessage;
+use tokio::time;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct SkipBlockMessage(LevelUpdate<SignedSkipBlockMessage>);

--- a/vrf/src/alias.rs
+++ b/vrf/src/alias.rs
@@ -1,11 +1,12 @@
 #![allow(non_snake_case)]
 
-use std::cmp::{Ord, Ordering, PartialOrd};
-use std::fmt::Debug;
-use std::ops::{Add, Mul, Sub};
+use std::{
+    cmp::{Ord, Ordering, PartialOrd},
+    fmt::Debug,
+    ops::{Add, Mul, Sub},
+};
 
-use num_traits::sign::Unsigned;
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::{sign::Unsigned, FromPrimitive, ToPrimitive};
 
 use crate::rng::Rng;
 

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -1,24 +1,23 @@
 #![allow(non_snake_case)]
 
-use std::fmt;
-use std::hash::Hash;
-use std::io::Write;
+use std::{fmt, hash::Hash, io::Write};
 
+use beserial::{Deserialize, Serialize, SerializingError};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use curve25519_dalek::constants;
-use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
-use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::IsIdentity;
+use curve25519_dalek::{
+    constants,
+    edwards::{CompressedEdwardsY, EdwardsPoint},
+    scalar::Scalar,
+    traits::IsIdentity,
+};
 use log::debug;
+use nimiq_hash::{Blake2bHash, Blake2bHasher, HashOutput, Hasher};
+use nimiq_keys::{KeyPair, PublicKey};
+use nimiq_macros::create_typed_array;
 use rand::{CryptoRng, RngCore};
 #[cfg(feature = "serde-derive")]
 use serde_big_array::BigArray;
 use sha2::{Digest, Sha256, Sha512};
-
-use beserial::{Deserialize, Serialize, SerializingError};
-use nimiq_hash::{Blake2bHash, Blake2bHasher, HashOutput, Hasher};
-use nimiq_keys::{KeyPair, PublicKey};
-use nimiq_macros::create_typed_array;
 
 use crate::rng::Rng;
 

--- a/wallet/src/wallet_account.rs
+++ b/wallet/src/wallet_account.rs
@@ -4,8 +4,7 @@ use beserial::{Deserialize, ReadBytesExt, Serialize, SerializingError};
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Hash, HashOutput, Sha256Hash};
 use nimiq_keys::{Address, KeyPair, PublicKey, SecureGenerate, Signature};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_transaction::{SignatureProof, Transaction};
 use nimiq_utils::otp::Verify;
 

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1,9 +1,7 @@
-use lazy_static::lazy_static;
-
 use beserial::{Deserialize, Serialize};
+use lazy_static::lazy_static;
 use nimiq_keys::{Address, KeyPair, PrivateKey};
-use nimiq_primitives::coin::Coin;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_test_log::test;
 use nimiq_wallet::WalletAccount;
 

--- a/web-client/src/block.rs
+++ b/web-client/src/block.rs
@@ -1,10 +1,9 @@
-use serde::ser::SerializeStruct;
-use tsify::Tsify;
-use wasm_bindgen::prelude::*;
-
 use beserial::Serialize;
 use nimiq_block::Block;
 use nimiq_primitives::policy::Policy;
+use serde::ser::SerializeStruct;
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
 
 /// JSON-compatible and human-readable format of blocks.
 #[derive(Tsify)]

--- a/web-client/src/client.rs
+++ b/web-client/src/client.rs
@@ -9,21 +9,18 @@ use std::{
     time::Duration,
 };
 
-use futures::{channel::oneshot, future::select, future::Either};
+use futures::{
+    channel::oneshot,
+    future::{select, Either},
+};
 use futures_util::StreamExt;
 use js_sys::{global, Array, Function, JsString};
 use log::level_filters::LevelFilter;
-use tsify::Tsify;
-use wasm_bindgen::{
-    prelude::{wasm_bindgen, Closure, JsError, JsValue},
-    JsCast,
-};
-use wasm_bindgen_futures::spawn_local;
-use web_sys::MessageEvent;
-
 pub use nimiq::{
-    config::config::ClientConfig,
-    config::config_file::{LogSettings, Seed},
+    config::{
+        config::ClientConfig,
+        config_file::{LogSettings, Seed},
+    },
     extras::{panic::initialize_panic_reporting, web_logging::initialize_web_logging},
 };
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
@@ -34,23 +31,32 @@ use nimiq_network_interface::{
     Multiaddr,
 };
 use nimiq_primitives::policy::Policy;
+use tsify::Tsify;
+use wasm_bindgen::{
+    prelude::{wasm_bindgen, Closure, JsError, JsValue},
+    JsCast,
+};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::MessageEvent;
 
-use crate::account::{
-    PlainAccount, PlainAccountArrayType, PlainAccountType, PlainStaker, PlainStakerArrayType,
-    PlainStakerType, PlainValidator, PlainValidatorArrayType, PlainValidatorType,
+use crate::{
+    account::{
+        PlainAccount, PlainAccountArrayType, PlainAccountType, PlainStaker, PlainStakerArrayType,
+        PlainStakerType, PlainValidator, PlainValidatorArrayType, PlainValidatorType,
+    },
+    address::{Address, AddressAnyArrayType, AddressAnyType},
+    block::{PlainBlock, PlainBlockType},
+    client_configuration::{
+        ClientConfiguration, PlainClientConfiguration, PlainClientConfigurationType,
+    },
+    peer_info::PlainPeerInfo,
+    transaction::{
+        PlainTransactionData, PlainTransactionDetails, PlainTransactionDetailsArrayType,
+        PlainTransactionDetailsType, PlainTransactionReceipt, PlainTransactionReceiptArrayType,
+        Transaction, TransactionAnyType, TransactionState,
+    },
+    utils::from_network_id,
 };
-use crate::address::{Address, AddressAnyArrayType, AddressAnyType};
-use crate::block::{PlainBlock, PlainBlockType};
-use crate::client_configuration::{
-    ClientConfiguration, PlainClientConfiguration, PlainClientConfigurationType,
-};
-use crate::peer_info::PlainPeerInfo;
-use crate::transaction::{
-    PlainTransactionData, PlainTransactionDetails, PlainTransactionDetailsArrayType,
-    PlainTransactionDetailsType, PlainTransactionReceipt, PlainTransactionReceiptArrayType,
-    Transaction, TransactionAnyType, TransactionState,
-};
-use crate::utils::from_network_id;
 
 /// Maximum number of transactions that can be requested by address
 pub const MAX_TRANSACTIONS_BY_ADDRESS: u16 = 500;

--- a/web-client/src/client_configuration.rs
+++ b/web-client/src/client_configuration.rs
@@ -1,14 +1,13 @@
 #[cfg(any(feature = "client", feature = "primitives"))]
 use std::str::FromStr;
 
+use nimiq_primitives::networks::NetworkId;
 use tsify::Tsify;
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(any(feature = "client", feature = "primitives"))]
 use wasm_bindgen::prelude::JsError;
 #[cfg(feature = "primitives")]
 use wasm_bindgen::prelude::JsValue;
-
-use nimiq_primitives::networks::NetworkId;
 
 /// Use this to provide initialization-time configuration to the Client.
 /// This is a simplified version of the configuration that is used for regular nodes,

--- a/web-client/src/key_pair.rs
+++ b/web-client/src/key_pair.rs
@@ -1,16 +1,13 @@
 use std::str::FromStr;
 
-use wasm_bindgen::prelude::*;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::SecureGenerate;
+use wasm_bindgen::prelude::*;
 
-use crate::address::Address;
-use crate::private_key::PrivateKey;
-use crate::public_key::PublicKey;
-use crate::signature::Signature;
-use crate::signature_proof::SignatureProof;
-use crate::transaction::Transaction;
+use crate::{
+    address::Address, private_key::PrivateKey, public_key::PublicKey, signature::Signature,
+    signature_proof::SignatureProof, transaction::Transaction,
+};
 
 /// A keypair represents a private key and its respective public key.
 /// It is used for signing data, usually transactions.

--- a/web-client/src/peer_info.rs
+++ b/web-client/src/peer_info.rs
@@ -1,6 +1,5 @@
-use tsify::Tsify;
-
 use nimiq_network_interface::peer_info::{NodeType, Services};
+use tsify::Tsify;
 
 /// Information about a networking peer.
 #[derive(serde::Serialize, Tsify)]

--- a/web-client/src/private_key.rs
+++ b/web-client/src/private_key.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr;
 
-use wasm_bindgen::prelude::*;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_keys::SecureGenerate;
+use wasm_bindgen::prelude::*;
 
 /// The secret (private) part of an asymmetric key pair that is typically used to digitally sign or decrypt data.
 #[wasm_bindgen]

--- a/web-client/src/public_key.rs
+++ b/web-client/src/public_key.rs
@@ -1,12 +1,9 @@
 use std::str::FromStr;
 
+use beserial::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use beserial::{Deserialize, Serialize};
-
-use crate::address::Address;
-use crate::private_key::PrivateKey;
-use crate::signature::Signature;
+use crate::{address::Address, private_key::PrivateKey, signature::Signature};
 
 /// The non-secret (public) part of an asymmetric key pair that is typically used to digitally verify or encrypt data.
 #[wasm_bindgen]

--- a/web-client/src/signature_proof.rs
+++ b/web-client/src/signature_proof.rs
@@ -1,10 +1,7 @@
+use beserial::Serialize;
 use wasm_bindgen::prelude::*;
 
-use beserial::Serialize;
-
-use crate::address::Address;
-use crate::public_key::PublicKey;
-use crate::signature::Signature;
+use crate::{address::Address, public_key::PublicKey, signature::Signature};
 
 /// A signature proof represents a signature together with its public key and the public key's merkle path.
 /// It is used as the proof for transactions.

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -1,18 +1,10 @@
 use std::str::FromStr;
 
-#[cfg(feature = "client")]
-use serde::ser::SerializeStruct;
-use tsify::Tsify;
-use wasm_bindgen::prelude::*;
-#[cfg(feature = "primitives")]
-use wasm_bindgen_derive::TryFromJsValue;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_hash::{Blake2bHash, Hash};
 #[cfg(feature = "client")]
 use nimiq_primitives::policy::Policy;
 use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
-
 #[cfg(feature = "client")]
 use nimiq_transaction::extended_transaction::ExtendedTransaction;
 use nimiq_transaction::{
@@ -25,11 +17,19 @@ use nimiq_transaction::{
 };
 #[cfg(feature = "primitives")]
 use nimiq_transaction_builder::TransactionProofBuilder;
+#[cfg(feature = "client")]
+use serde::ser::SerializeStruct;
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+#[cfg(feature = "primitives")]
+use wasm_bindgen_derive::TryFromJsValue;
 
-use crate::address::Address;
 #[cfg(feature = "primitives")]
 use crate::key_pair::KeyPair;
-use crate::utils::{from_network_id, to_network_id};
+use crate::{
+    address::Address,
+    utils::{from_network_id, to_network_id},
+};
 
 /// Transactions describe a transfer of value, usually from the sender to the recipient.
 /// However, transactions can also have no value, when they are used to _signal_ a change in the staking contract.

--- a/web-client/src/transaction_builder.rs
+++ b/web-client/src/transaction_builder.rs
@@ -1,11 +1,8 @@
-use wasm_bindgen::prelude::*;
-
 use nimiq_primitives::{account::AccountType, coin::Coin, policy::Policy};
 use nimiq_transaction_builder::Recipient;
+use wasm_bindgen::prelude::*;
 
-use crate::address::Address;
-use crate::transaction::Transaction;
-use crate::utils::to_network_id;
+use crate::{address::Address, transaction::Transaction, utils::to_network_id};
 
 /// The TransactionBuilder class provides helper methods to easily create standard types of transactions.
 /// It can only be instantiated from a Client with `client.transactionBuilder()`.

--- a/web-client/src/utils.rs
+++ b/web-client/src/utils.rs
@@ -1,6 +1,5 @@
-use wasm_bindgen::JsError;
-
 use nimiq_primitives::networks::NetworkId;
+use wasm_bindgen::JsError;
 
 /// Convert a NetworkId to u8
 pub fn from_network_id(network_id: NetworkId) -> u8 {

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -1,11 +1,7 @@
 use std::sync::Arc;
 
-use futures::{Stream, StreamExt};
-use parking_lot::{Mutex, RwLock};
-use wasm_bindgen_futures::spawn_local;
-use wasm_bindgen_test::wasm_bindgen_test;
-
 use beserial::{Deserialize, Serialize};
+use futures::{Stream, StreamExt};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_consensus::{sync::syncer_proxy::SyncerProxy, Consensus};
@@ -15,6 +11,9 @@ use nimiq_network_interface::network::{Network, Topic};
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_component::ZKPComponent;
+use parking_lot::{Mutex, RwLock};
+use wasm_bindgen_futures::spawn_local;
+use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
 pub async fn it_can_initialize_with_mock_network() {

--- a/zkp-circuits/src/circuits/mnt4/pk_tree_node.rs
+++ b/zkp-circuits/src/circuits/mnt4/pk_tree_node.rs
@@ -10,9 +10,8 @@ use ark_r1cs_std::{
     uint8::UInt8,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
-use rand::Rng;
-
 use nimiq_primitives::policy::Policy;
+use rand::Rng;
 
 use crate::gadgets::{bits::BitVec, recursive_input::RecursiveInputVar};
 

--- a/zkp-circuits/src/circuits/mnt6/macro_block.rs
+++ b/zkp-circuits/src/circuits/mnt6/macro_block.rs
@@ -10,19 +10,17 @@ use ark_mnt6_753::{
 };
 use ark_r1cs_std::prelude::{AllocVar, Boolean, EqGadget, UInt32, UInt8};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
-use rand::Rng;
-
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::{MacroBlock, PEDERSEN_PARAMETERS};
+use rand::Rng;
 
+use super::pk_tree_node::{hash_g2, PkInnerNodeWindow};
 use crate::gadgets::{
     mnt6::{DefaultPedersenParametersVar, MacroBlockGadget, StateCommitmentGadget},
     pedersen::PedersenHashGadget,
     recursive_input::RecursiveInputVar,
     serialize::SerializeGadget,
 };
-
-use super::pk_tree_node::{hash_g2, PkInnerNodeWindow};
 
 /// This is the macro block circuit. It takes as inputs the previous state commitment and final state commitment
 /// and it produces a proof that there exists a valid macro block that transforms the previous state

--- a/zkp-circuits/src/circuits/mnt6/pk_tree_leaf.rs
+++ b/zkp-circuits/src/circuits/mnt6/pk_tree_leaf.rs
@@ -5,10 +5,9 @@ use ark_r1cs_std::{
     uint8::UInt8,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
-use rand::{distributions::Standard, prelude::Distribution};
-
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::{PEDERSEN_PARAMETERS, PK_TREE_BREADTH};
+use rand::{distributions::Standard, prelude::Distribution};
 
 use crate::gadgets::{
     bits::BitVec,

--- a/zkp-circuits/src/circuits/mnt6/pk_tree_node.rs
+++ b/zkp-circuits/src/circuits/mnt6/pk_tree_node.rs
@@ -13,11 +13,10 @@ use ark_r1cs_std::{
     uint8::UInt8,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
-use rand::Rng;
-
 use nimiq_pedersen_generators::GenericWindow;
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::PEDERSEN_PARAMETERS;
+use rand::Rng;
 
 use crate::gadgets::{
     bits::BitVec, mnt6::DefaultPedersenParametersVar, pedersen::PedersenHashGadget,

--- a/zkp-circuits/src/gadgets/mnt4/y_to_bit.rs
+++ b/zkp-circuits/src/gadgets/mnt4/y_to_bit.rs
@@ -55,7 +55,6 @@ mod tests {
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
-
     use nimiq_test_log::test;
     use nimiq_zkp_primitives::{serialize_g1_mnt4, serialize_g2_mnt4};
 

--- a/zkp-circuits/src/gadgets/mnt6/check_sig.rs
+++ b/zkp-circuits/src/gadgets/mnt6/check_sig.rs
@@ -1,8 +1,7 @@
 use ark_ec::Group;
-use ark_mnt6_753::Fq as MNT6Fq;
 use ark_mnt6_753::{
     constraints::{G1Var, G2Var, PairingVar},
-    G2Projective,
+    Fq as MNT6Fq, G2Projective,
 };
 use ark_r1cs_std::prelude::{AllocVar, Boolean, EqGadget, PairingVar as PV};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};

--- a/zkp-circuits/src/gadgets/mnt6/hash_to_curve.rs
+++ b/zkp-circuits/src/gadgets/mnt6/hash_to_curve.rs
@@ -4,15 +4,13 @@ use ark_r1cs_std::{
     fields::{fp::FpVar, FieldVar},
     prelude::{AllocVar, EqGadget},
     uint8::UInt8,
-    ToBitsGadget, {R1CSVar, ToConstraintFieldGadget},
+    R1CSVar, ToBitsGadget, ToConstraintFieldGadget,
 };
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use ark_std::Zero;
-
 use nimiq_hash::blake2s::Blake2sWithParameterBlock;
 
-use crate::blake2s::evaluate_blake2s_with_parameters;
-use crate::gadgets::y_to_bit::YToBitGadget;
+use crate::{blake2s::evaluate_blake2s_with_parameters, gadgets::y_to_bit::YToBitGadget};
 
 /// This gadget implements the functionality to hash a message into an elliptic curve point.
 pub struct HashToCurve;

--- a/zkp-circuits/src/gadgets/mnt6/macro_block.rs
+++ b/zkp-circuits/src/gadgets/mnt6/macro_block.rs
@@ -12,15 +12,17 @@ use ark_r1cs_std::{
     prelude::{AllocVar, Boolean, CondSelectGadget, FieldVar, UInt32, UInt8},
 };
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
-
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::MacroBlock;
 
-use crate::gadgets::{
-    be_bytes::ToBeBytesGadget,
-    mnt6::{CheckSigGadget, HashToCurve},
+use crate::{
+    blake2s::evaluate_blake2s,
+    gadgets::{
+        be_bytes::ToBeBytesGadget,
+        bits::BitVec,
+        mnt6::{CheckSigGadget, HashToCurve},
+    },
 };
-use crate::{blake2s::evaluate_blake2s, gadgets::bits::BitVec};
 
 /// A gadget that contains utilities to verify the validity of a macro block. Mainly it checks that:
 ///  1. The macro block was signed by the aggregate public key.
@@ -243,10 +245,9 @@ mod tests {
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{ops::MulAssign, test_rng, UniformRand};
-    use rand::{Rng, RngCore};
-
     use nimiq_primitives::policy::Policy;
     use nimiq_test_log::test;
+    use rand::{Rng, RngCore};
 
     use super::*;
 

--- a/zkp-circuits/src/gadgets/mnt6/state_commitment.rs
+++ b/zkp-circuits/src/gadgets/mnt6/state_commitment.rs
@@ -3,11 +3,10 @@ use ark_r1cs_std::{prelude::UInt32, uint8::UInt8};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use nimiq_pedersen_generators::GenericWindow;
 
+use super::DefaultPedersenParametersVar;
 use crate::gadgets::{
     be_bytes::ToBeBytesGadget, pedersen::PedersenHashGadget, serialize::SerializeGadget,
 };
-
-use super::DefaultPedersenParametersVar;
 
 /// This gadget is meant to calculate the "state commitment" in-circuit, which is simply a commitment,
 /// for a given block, of the block number concatenated with the root of a Merkle tree over the public
@@ -64,15 +63,13 @@ mod tests {
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
     use nimiq_pedersen_generators::pedersen_generator_powers;
-    use rand::RngCore;
-
     use nimiq_primitives::policy::Policy;
     use nimiq_test_log::test;
     use nimiq_zkp_primitives::{pk_tree_construct, state_commitment};
-
-    use crate::gadgets::pedersen::PedersenParametersVar;
+    use rand::RngCore;
 
     use super::*;
+    use crate::gadgets::pedersen::PedersenParametersVar;
 
     #[test]
     fn state_commitment_works() {

--- a/zkp-circuits/src/gadgets/mnt6/vk_commitment.rs
+++ b/zkp-circuits/src/gadgets/mnt6/vk_commitment.rs
@@ -2,13 +2,11 @@ use ark_groth16::constraints::VerifyingKeyVar;
 use ark_mnt6_753::{constraints::PairingVar, Fq as MNT6Fq, MNT6_753};
 use ark_r1cs_std::{alloc::AllocVar, uint8::UInt8};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-
 use nimiq_pedersen_generators::DefaultWindow;
 use nimiq_zkp_primitives::PEDERSEN_PARAMETERS;
 
-use crate::gadgets::{pedersen::PedersenHashGadget, serialize::SerializeGadget};
-
 use super::DefaultPedersenParametersVar;
+use crate::gadgets::{pedersen::PedersenHashGadget, serialize::SerializeGadget};
 
 /// This gadget is meant to calculate a commitment in-circuit for a verifying key of a SNARK in the
 /// MNT6-753 curve. This means we can open this commitment inside of a circuit in the MNT4-753 curve
@@ -68,13 +66,11 @@ mod tests {
     use ark_ec::CurveGroup;
     use ark_groth16::{constraints::VerifyingKeyVar, VerifyingKey};
     use ark_mnt6_753::{
-        constraints::PairingVar,
-        Fq as MNT6Fq, MNT6_753, {G1Projective, G2Projective},
+        constraints::PairingVar, Fq as MNT6Fq, G1Projective, G2Projective, MNT6_753,
     };
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
-
     use nimiq_test_log::test;
     use nimiq_zkp_primitives::vk_commitment;
 

--- a/zkp-circuits/src/gadgets/mnt6/y_to_bit.rs
+++ b/zkp-circuits/src/gadgets/mnt6/y_to_bit.rs
@@ -61,7 +61,6 @@ mod tests {
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
-
     use nimiq_test_log::test;
     use nimiq_zkp_primitives::{serialize_g1_mnt6, serialize_g2_mnt6};
 

--- a/zkp-circuits/src/gadgets/pedersen.rs
+++ b/zkp-circuits/src/gadgets/pedersen.rs
@@ -93,11 +93,10 @@ mod tests {
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::test_rng;
-    use nimiq_zkp_primitives::pedersen::pedersen_hash;
-    use rand::RngCore;
-
     use nimiq_pedersen_generators::{pedersen_generator_powers, GenericWindow};
     use nimiq_test_log::test;
+    use nimiq_zkp_primitives::pedersen::pedersen_hash;
+    use rand::RngCore;
 
     use super::*;
 

--- a/zkp-circuits/src/gadgets/recursive_input.rs
+++ b/zkp-circuits/src/gadgets/recursive_input.rs
@@ -69,10 +69,11 @@ impl<F: PrimeField, CF: PrimeField> From<RecursiveInputVar<F, CF>> for BooleanIn
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ark_mnt4_753::Fq as MNT4Fq;
     use ark_mnt6_753::Fq as MNT6Fq;
     use ark_r1cs_std::{uint8::UInt8, R1CSVar};
+
+    use super::*;
 
     const BYTES: [u8; 95] = [
         227, 90, 6, 29, 55, 139, 106, 148, 42, 203, 6, 18, 181, 134, 13, 109, 178, 112, 145, 3,

--- a/zkp-circuits/src/gadgets/serialize.rs
+++ b/zkp-circuits/src/gadgets/serialize.rs
@@ -81,7 +81,6 @@ mod tests_mnt4 {
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
-
     use nimiq_test_log::test;
     use nimiq_zkp_primitives::{serialize_g1_mnt4, serialize_g2_mnt4};
 
@@ -149,13 +148,13 @@ mod tests_mnt4 {
 
 #[cfg(test)]
 mod tests_mnt6 {
-    use ark_mnt6_753::constraints::{G1Var, G2Var};
-    use ark_mnt6_753::Fq as MNT4Fq;
-    use ark_mnt6_753::{G1Projective, G2Projective};
+    use ark_mnt6_753::{
+        constraints::{G1Var, G2Var},
+        Fq as MNT4Fq, G1Projective, G2Projective,
+    };
     use ark_r1cs_std::{prelude::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
-
     use nimiq_test_log::test;
     use nimiq_zkp_primitives::{serialize_g1_mnt6, serialize_g2_mnt6};
 

--- a/zkp-circuits/src/gadgets/y_to_bit.rs
+++ b/zkp-circuits/src/gadgets/y_to_bit.rs
@@ -3,7 +3,7 @@ use ark_r1cs_std::{
     boolean::Boolean,
     fields::fp::FpVar,
     prelude::{AllocVar, EqGadget, FieldVar},
-    {R1CSVar, ToBitsGadget},
+    R1CSVar, ToBitsGadget,
 };
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 

--- a/zkp-circuits/src/setup.rs
+++ b/zkp-circuits/src/setup.rs
@@ -1,5 +1,7 @@
-use std::fs::{DirBuilder, File};
-use std::path::Path;
+use std::{
+    fs::{DirBuilder, File},
+    path::Path,
+};
 
 use ark_crypto_primitives::snark::CircuitSpecificSetupSNARK;
 use ark_ec::{mnt6::MNT6, pairing::Pairing};
@@ -7,23 +9,21 @@ use ark_groth16::{Groth16, ProvingKey, VerifyingKey};
 use ark_mnt4_753::MNT4_753;
 use ark_mnt6_753::{Config, MNT6_753};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use rand::{CryptoRng, Rng};
-
 use nimiq_genesis::NetworkInfo;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_zkp_primitives::NanoZKPError;
+use rand::{CryptoRng, Rng};
 
 use crate::{
-    circuits::mnt4::{
-        MacroBlockWrapperCircuit, MergerWrapperCircuit, PKTreeNodeCircuit as NodeMNT4,
+    circuits::{
+        mnt4::{MacroBlockWrapperCircuit, MergerWrapperCircuit, PKTreeNodeCircuit as NodeMNT4},
+        mnt6::{
+            MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT6,
+            PKTreeNodeCircuit as NodeMNT6,
+        },
     },
-    circuits::mnt6::{
-        MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT6,
-        PKTreeNodeCircuit as NodeMNT6,
-    },
+    metadata::VerifyingKeyMetadata,
 };
-
-use crate::metadata::VerifyingKeyMetadata;
 
 pub const DEVELOPMENT_SEED: [u8; 32] = [
     1, 0, 52, 0, 0, 0, 0, 0, 1, 0, 10, 0, 22, 32, 0, 0, 2, 0, 55, 49, 0, 11, 0, 0, 3, 0, 0, 0, 0,

--- a/zkp-circuits/src/test_setup.rs
+++ b/zkp-circuits/src/test_setup.rs
@@ -14,13 +14,12 @@ use ark_relations::r1cs::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{cfg_into_iter, cfg_iter, rand::Rng};
+use nimiq_zkp_primitives::NanoZKPError;
 use rand::CryptoRng;
 #[cfg(feature = "parallel")]
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
 };
-
-use nimiq_zkp_primitives::NanoZKPError;
 
 use crate::{circuits::mnt4::MergerWrapperCircuit, setup::keys_to_file};
 
@@ -273,8 +272,6 @@ pub fn setup_merger_wrapper_simulation<R: Rng + CryptoRng>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use ark_crypto_primitives::snark::SNARK;
     use ark_ff::ToConstraintField;
     use ark_groth16::Groth16;
@@ -282,8 +279,9 @@ mod tests {
     use ark_r1cs_std::{prelude::EqGadget, uint8::UInt8};
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
     use ark_std::test_rng;
-
     use nimiq_test_log::test;
+
+    use super::*;
 
     #[derive(Clone)]
     pub struct InnerCircuit {

--- a/zkp-circuits/src/utils.rs
+++ b/zkp-circuits/src/utils.rs
@@ -1,10 +1,9 @@
 use ark_ec::Group;
 use ark_mnt6_753::{Fr as MNT6Fr, G2Projective as G2MNT6};
 use ark_std::{ops::MulAssign, UniformRand};
-use rand::{rngs::SmallRng, seq::SliceRandom, RngCore, SeedableRng};
-
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::{pk_tree_construct, state_commitment, MacroBlock};
+use rand::{rngs::SmallRng, seq::SliceRandom, RngCore, SeedableRng};
 
 /// Transforms a u8 into a vector of little endian bits.
 pub fn byte_to_le_bits(mut byte: u8) -> Vec<bool> {

--- a/zkp-circuits/zkp-setup/main.rs
+++ b/zkp-circuits/zkp-setup/main.rs
@@ -1,10 +1,6 @@
 use std::{path::Path, time::Instant};
 
 use clap::Parser;
-use nimiq_zkp_primitives::NanoZKPError;
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
-
 use nimiq_primitives::{
     networks::NetworkId,
     policy::{Policy, TEST_POLICY},
@@ -14,6 +10,9 @@ use nimiq_zkp_circuits::{
     test_setup::{setup_merger_wrapper_simulation, UNIT_TOXIC_WASTE_SEED},
     DEFAULT_KEYS_PATH,
 };
+use nimiq_zkp_primitives::NanoZKPError;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 
 // This is a copied constant from nimiq-test-utils.
 const DEFAULT_TEST_KEYS_PATH: &str = ".zkp_tests";

--- a/zkp-component/src/bin/nimiq-test-prove.rs
+++ b/zkp-component/src/bin/nimiq-test-prove.rs
@@ -2,12 +2,11 @@ use std::io;
 
 use log::level_filters::LevelFilter;
 use nimiq_genesis::NetworkId;
-use tracing_subscriber::{filter::Targets, prelude::*};
-
 use nimiq_log::TargetsExt;
 use nimiq_primitives::policy::{Policy, TEST_POLICY};
 use nimiq_zkp::ZKP_VERIFYING_KEY;
 use nimiq_zkp_component::prover_binary::prover_main;
+use tracing_subscriber::{filter::Targets, prelude::*};
 
 /// This binary is only used in tests.
 #[tokio::main]

--- a/zkp-component/src/proof_gen_utils.rs
+++ b/zkp-component/src/proof_gen_utils.rs
@@ -1,19 +1,20 @@
-use std::env;
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 
 use ark_groth16::Proof;
 use ark_mnt6_753::{G2Projective as G2MNT6, MNT6_753};
+use beserial::{Deserialize, Serialize};
+use nimiq_block::MacroBlock;
+use nimiq_zkp::prove::prove;
+use nimiq_zkp_primitives::MacroBlock as ZKPMacroBlock;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     process::Command,
     sync::oneshot::Receiver,
 };
-
-use beserial::{Deserialize, Serialize};
-use nimiq_block::MacroBlock;
-use nimiq_zkp::prove::prove;
-use nimiq_zkp_primitives::MacroBlock as ZKPMacroBlock;
 
 use super::types::ZKPState;
 use crate::types::*;

--- a/zkp-component/src/proof_utils.rs
+++ b/zkp-component/src/proof_utils.rs
@@ -1,6 +1,5 @@
 use ark_groth16::Proof;
 use ark_mnt6_753::{G2Projective as G2MNT6, MNT6_753};
-
 use nimiq_block::MacroBlock;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;

--- a/zkp-component/src/prover_binary.rs
+++ b/zkp-component/src/prover_binary.rs
@@ -1,11 +1,12 @@
 use std::io::{self, BufReader, BufWriter};
 
-use crate::proof_gen_utils::generate_new_proof;
-use crate::types::{ProofInput, PROOF_GENERATION_OUTPUT_DELIMITER};
 use ark_serialize::Write;
 use beserial::{Deserialize, Serialize, SerializingError};
 
-use crate::types::ZKProofGenerationError;
+use crate::{
+    proof_gen_utils::generate_new_proof,
+    types::{ProofInput, ZKProofGenerationError, PROOF_GENERATION_OUTPUT_DELIMITER},
+};
 
 pub async fn prover_main() -> Result<(), SerializingError> {
     // Read proof input from stdin.

--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -1,12 +1,10 @@
-use std::io;
-use std::sync::Arc;
+use std::{borrow::Cow, io, path::PathBuf, sync::Arc};
 
 use ark_groth16::Proof;
 use ark_mnt6_753::{G2Projective as G2MNT6, MNT6_753};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, SerializationError as ArkSerializingError,
 };
-
 use beserial::{
     Deserialize, DeserializeWithLength, Serialize, SerializeWithLength, SerializingError,
     SerializingError as BeserialSerializingError,
@@ -16,18 +14,12 @@ use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};
 use nimiq_hash::Blake2bHash;
-use nimiq_network_interface::network::Network;
-use nimiq_network_interface::request::{Handle, RequestError};
 use nimiq_network_interface::{
-    network::Topic,
-    request::{RequestCommon, RequestMarker},
+    network::{Network, Topic},
+    request::{Handle, RequestCommon, RequestError, RequestMarker},
 };
-use nimiq_zkp_primitives::MacroBlock as ZKPMacroBlock;
+use nimiq_zkp_primitives::{MacroBlock as ZKPMacroBlock, NanoZKPError};
 use parking_lot::RwLock;
-use std::borrow::Cow;
-use std::path::PathBuf;
-
-use nimiq_zkp_primitives::NanoZKPError;
 use thiserror::Error;
 
 use crate::ZKPComponent;

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -1,32 +1,31 @@
-use futures::{Future, StreamExt};
 #[cfg(feature = "zkp-prover")]
 use std::path::PathBuf;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{stream::BoxStream, Future, StreamExt};
+use nimiq_block::MacroBlock;
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_genesis::NetworkInfo;
+use nimiq_network_interface::{
+    network::{MsgAcceptance, Network, PubsubId},
+    request::request_handler,
+};
+use nimiq_primitives::task_executor::TaskExecutor;
+use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use tokio::sync::{
     broadcast::{channel as broadcast, Sender as BroadcastSender},
     oneshot::error::RecvError,
 };
 use tokio_stream::wrappers::BroadcastStream;
 
-use nimiq_genesis::NetworkInfo;
-use nimiq_network_interface::network::{MsgAcceptance, PubsubId};
-use nimiq_primitives::task_executor::TaskExecutor;
-use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-
-use nimiq_block::MacroBlock;
-use nimiq_blockchain_interface::AbstractBlockchain;
-use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_network_interface::{network::Network, request::request_handler};
-
-use crate::proof_store::ProofStore;
-use crate::proof_utils::*;
-use crate::types::*;
 #[cfg(feature = "zkp-prover")]
 use crate::zkp_prover::ZKProver;
-use crate::zkp_requests::ZKPRequests;
-use futures::stream::BoxStream;
+use crate::{proof_store::ProofStore, proof_utils::*, types::*, zkp_requests::ZKPRequests};
 
 pub type ZKProofsStream<N> = BoxStream<'static, (ZKProof, <N as Network>::PubsubId)>;
 

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -1,16 +1,14 @@
-use std::collections::VecDeque;
-use std::error::Error;
-use std::future;
-use std::path::PathBuf;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    collections::VecDeque,
+    error::Error,
+    future,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt};
-use parking_lot::lock_api::RwLockUpgradableReadGuard;
-use parking_lot::{RwLock, RwLockWriteGuard};
-use tokio::sync::oneshot::{channel, Sender};
-
 use nimiq_block::{Block, MacroBlock};
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction};
@@ -18,9 +16,10 @@ use nimiq_genesis::NetworkInfo;
 use nimiq_network_interface::network::Network;
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_primitives::state_commitment;
+use parking_lot::{lock_api::RwLockUpgradableReadGuard, RwLock, RwLockWriteGuard};
+use tokio::sync::oneshot::{channel, Sender};
 
-use crate::proof_gen_utils::*;
-use crate::types::*;
+use crate::{proof_gen_utils::*, types::*};
 
 /// ZK Prover generates the zk proof for an election block. It has:
 ///

--- a/zkp-component/src/zkp_requests.rs
+++ b/zkp-component/src/zkp_requests.rs
@@ -1,19 +1,16 @@
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll, Waker},
+};
 
-use futures::future::BoxFuture;
-use futures::{FutureExt, Stream, StreamExt};
-
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, Stream, StreamExt};
+use nimiq_block::MacroBlock;
 use nimiq_macros::store_waker;
-use nimiq_network_interface::request::RequestError;
+use nimiq_network_interface::{network::Network, request::RequestError};
 use tokio::sync::oneshot::{channel, Receiver, Sender};
 
-use nimiq_block::MacroBlock;
-use nimiq_network_interface::network::Network;
-
 use crate::types::*;
-use futures::stream::FuturesUnordered;
 
 pub struct ZKPRequestsItem<N: Network> {
     pub peer_id: N::PeerId,

--- a/zkp-component/tests/proof_utils.rs
+++ b/zkp-component/tests/proof_utils.rs
@@ -1,27 +1,25 @@
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use ark_groth16::Proof;
-use nimiq_zkp::ZKP_VERIFYING_KEY;
-use parking_lot::RwLock;
-
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_database::volatile::VolatileDatabase;
 use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
-use nimiq_test_utils::zkp_test_data::ZKP_TEST_KEYS_PATH;
 use nimiq_test_utils::{
     blockchain::{signing_key, voting_key},
     blockchain_with_rng::produce_macro_blocks_with_rng,
-    zkp_test_data::{get_base_seed, simulate_merger_wrapper},
+    zkp_test_data::{get_base_seed, simulate_merger_wrapper, ZKP_TEST_KEYS_PATH},
 };
 use nimiq_utils::time::OffsetTime;
-
-use nimiq_zkp_component::proof_store::{DBProofStore, ProofStore};
-use nimiq_zkp_component::proof_utils::validate_proof;
-use nimiq_zkp_component::types::ZKProof;
+use nimiq_zkp::ZKP_VERIFYING_KEY;
+use nimiq_zkp_component::{
+    proof_store::{DBProofStore, ProofStore},
+    proof_utils::validate_proof,
+    types::ZKProof,
+};
+use parking_lot::RwLock;
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());

--- a/zkp-component/tests/types.rs
+++ b/zkp-component/tests/types.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use ark_groth16::Proof;
-
 use beserial::{Deserialize, Serialize};
 use nimiq_block::MacroBlock;
 use nimiq_database_value::{AsDatabaseBytes, FromDatabaseValue};

--- a/zkp-component/tests/zkp_component.rs
+++ b/zkp-component/tests/zkp_component.rs
@@ -1,10 +1,4 @@
-use std::path::Path;
-use std::sync::Arc;
-
-use nimiq_test_utils::zkp_test_data::simulate_merger_wrapper;
-use nimiq_test_utils::zkp_test_data::ZKP_TEST_KEYS_PATH;
-use nimiq_zkp::ZKP_VERIFYING_KEY;
-use parking_lot::RwLock;
+use std::{path::Path, sync::Arc};
 
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
@@ -16,14 +10,17 @@ use nimiq_test_log::test;
 use nimiq_test_utils::{
     blockchain::{signing_key, voting_key},
     blockchain_with_rng::produce_macro_blocks_with_rng,
-    zkp_test_data::get_base_seed,
+    zkp_test_data::{get_base_seed, simulate_merger_wrapper, ZKP_TEST_KEYS_PATH},
 };
 use nimiq_utils::time::OffsetTime;
-
-use nimiq_zkp_component::proof_store::{DBProofStore, ProofStore};
-use nimiq_zkp_component::proof_utils::validate_proof;
-use nimiq_zkp_component::types::ZKProof;
-use nimiq_zkp_component::zkp_component::ZKPComponent;
+use nimiq_zkp::ZKP_VERIFYING_KEY;
+use nimiq_zkp_component::{
+    proof_store::{DBProofStore, ProofStore},
+    proof_utils::validate_proof,
+    types::ZKProof,
+    zkp_component::ZKPComponent,
+};
+use parking_lot::RwLock;
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());

--- a/zkp-component/tests/zkp_requests.rs
+++ b/zkp-component/tests/zkp_requests.rs
@@ -1,7 +1,6 @@
 use std::{path::Path, sync::Arc};
 
 use futures::StreamExt;
-
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -15,15 +14,15 @@ use nimiq_test_utils::{
     blockchain_with_rng::produce_macro_blocks_with_rng,
     zkp_test_data::{get_base_seed, simulate_merger_wrapper, ZKP_TEST_KEYS_PATH},
 };
-
-use nimiq_zkp::ZKP_VERIFYING_KEY;
-use nimiq_zkp_component::proof_store::{DBProofStore, ProofStore};
-use nimiq_zkp_component::proof_utils::validate_proof;
-use nimiq_zkp_component::zkp_requests::ZKPRequests;
-use nimiq_zkp_component::ZKPComponent;
-use parking_lot::RwLock;
-
 use nimiq_utils::time::OffsetTime;
+use nimiq_zkp::ZKP_VERIFYING_KEY;
+use nimiq_zkp_component::{
+    proof_store::{DBProofStore, ProofStore},
+    proof_utils::validate_proof,
+    zkp_requests::ZKPRequests,
+    ZKPComponent,
+};
+use parking_lot::RwLock;
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {
     let time = Arc::new(OffsetTime::new());

--- a/zkp-component/zkp-test-gen/src/main.rs
+++ b/zkp-component/zkp-test-gen/src/main.rs
@@ -1,10 +1,7 @@
+use std::{io, path::Path, sync::Arc, time::Instant};
+
 use beserial::Serialize;
 use log::metadata::LevelFilter;
-use nimiq_zkp::ZKP_VERIFYING_KEY;
-use parking_lot::RwLock;
-use std::{io, path::Path, sync::Arc, time::Instant};
-use tracing_subscriber::{filter::Targets, prelude::*};
-
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::AbstractBlockchain;
@@ -22,11 +19,14 @@ use nimiq_test_utils::{
     zkp_test_data::{get_base_seed, DEFAULT_TEST_KEYS_PATH},
 };
 use nimiq_utils::time::OffsetTime;
+use nimiq_zkp::ZKP_VERIFYING_KEY;
 use nimiq_zkp_circuits::setup::{load_verifying_key_from_file, setup};
 use nimiq_zkp_component::{
     proof_gen_utils::generate_new_proof, proof_utils::validate_proof, types::ZKPState,
 };
 use nimiq_zkp_primitives::{pk_tree_construct, state_commitment, NanoZKPError};
+use parking_lot::RwLock;
+use tracing_subscriber::{filter::Targets, prelude::*};
 
 fn initialize() {
     tracing_subscriber::registry()

--- a/zkp-primitives/pedersen-generators/src/generators.rs
+++ b/zkp-primitives/pedersen-generators/src/generators.rs
@@ -2,7 +2,6 @@ use ark_crypto_primitives::crh::pedersen::{Parameters, Window};
 use ark_ec::{AffineRepr, CurveGroup, Group};
 use ark_ff::{One, PrimeField, ToConstraintField};
 use ark_mnt6_753::{Fq, G1Affine, G1Projective};
-
 use nimiq_hash::blake2s::Blake2sWithParameterBlock;
 
 use crate::rand_gen::generate_random_seed;

--- a/zkp-primitives/pedersen-generators/src/lib.rs
+++ b/zkp-primitives/pedersen-generators/src/lib.rs
@@ -3,9 +3,8 @@ use std::marker::PhantomData;
 use ark_crypto_primitives::crh::pedersen::Window;
 use ark_ff::PrimeField;
 use ark_mnt6_753::G1Projective;
-pub use generators::pedersen_generator_powers;
-pub use generators::PedersenParameters;
 use generators::POINT_CAPACITY;
+pub use generators::{pedersen_generator_powers, PedersenParameters};
 use nimiq_primitives::policy::Policy;
 
 mod generators;

--- a/zkp-primitives/src/macro_block.rs
+++ b/zkp-primitives/src/macro_block.rs
@@ -1,11 +1,11 @@
-use ark_ec::Group;
-use ark_mnt6_753::{Fr, G1Projective};
-use num_traits::identities::Zero;
 use std::ops::Mul;
 
+use ark_ec::Group;
+use ark_mnt6_753::{Fr, G1Projective};
 use nimiq_bls::Signature;
 use nimiq_hash::{Blake2sHash, Hash, HashOutput};
 use nimiq_primitives::policy::Policy;
+use num_traits::identities::Zero;
 
 /// A struct representing an election macro block in Albatross.
 #[derive(Clone)]
@@ -99,18 +99,20 @@ impl Default for MacroBlock {
 
 #[cfg(test)]
 mod tests {
-    use crate::pk_tree_construct;
     use nimiq_block::{MacroBlock as Block, MacroBody as Body, MultiSignature, TendermintProof};
     use nimiq_bls::{AggregateSignature, KeyPair};
     use nimiq_collections::BitSet;
     use nimiq_keys::{Address, PublicKey as SchnorrPK};
-    use nimiq_primitives::policy::Policy;
-    use nimiq_primitives::slots::{Validator, Validators};
+    use nimiq_primitives::{
+        policy::Policy,
+        slots::{Validator, Validators},
+    };
     use nimiq_test_log::test;
     use nimiq_test_utils::test_rng::test_rng;
     use nimiq_utils::key_rng::SecureGenerate;
 
     use super::*;
+    use crate::pk_tree_construct;
 
     #[test]
     fn hash_and_sign_works() {

--- a/zkp-primitives/src/pk_tree.rs
+++ b/zkp-primitives/src/pk_tree.rs
@@ -1,11 +1,9 @@
 use ark_mnt6_753::G2Projective;
+use nimiq_primitives::policy::Policy;
 #[cfg(feature = "parallel")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-use nimiq_primitives::policy::Policy;
-
-use crate::merkle_tree::merkle_tree_construct;
-use crate::serialize::serialize_g2_mnt6;
+use crate::{merkle_tree::merkle_tree_construct, serialize::serialize_g2_mnt6};
 
 /// This is the depth of the PKTree circuit.
 pub const PK_TREE_DEPTH: usize = 5;

--- a/zkp/examples/prover/prove.rs
+++ b/zkp/examples/prover/prove.rs
@@ -1,18 +1,17 @@
-use std::fs::{DirBuilder, File};
-use std::io;
-use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::{
+    fs::{DirBuilder, File},
+    io,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 use ark_groth16::Proof;
 use ark_serialize::CanonicalSerialize;
 use log::level_filters::LevelFilter;
-use tracing_subscriber::filter::Targets;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-
 use nimiq_log::TargetsExt;
 use nimiq_zkp::prove::prove;
 use nimiq_zkp_circuits::utils::create_test_blocks;
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Generates a proof for a chain of election blocks. The random parameters generation uses always
 /// the same seed, so it will always generate the same data (validators, signatures, etc).

--- a/zkp/examples/verify.rs
+++ b/zkp/examples/verify.rs
@@ -1,10 +1,7 @@
-use std::fs::File;
-use std::io;
-use std::time::Instant;
+use std::{fs::File, io, time::Instant};
 
 use ark_groth16::Proof;
 use ark_serialize::CanonicalDeserialize;
-
 use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_zkp::{verify::verify, ZKP_VERIFYING_KEY};
 use nimiq_zkp_circuits::utils::create_test_blocks;

--- a/zkp/src/poseidon/mnt4.rs
+++ b/zkp/src/poseidon/mnt4.rs
@@ -1,6 +1,7 @@
-use super::{create_parameters, DefaultPoseidonParameters};
 use ark_crypto_primitives::sponge::poseidon::{PoseidonConfig, PoseidonDefaultConfigEntry};
 use ark_mnt4_753::Fq;
+
+use super::{create_parameters, DefaultPoseidonParameters};
 
 // Parameters have been generated using the reference implementation here: https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/generate_parameters_grain.sage
 // Partial rounds have been rounded up to the nearest multiple of `t`.

--- a/zkp/src/poseidon/mnt6.rs
+++ b/zkp/src/poseidon/mnt6.rs
@@ -1,6 +1,7 @@
-use super::{create_parameters, DefaultPoseidonParameters};
 use ark_crypto_primitives::sponge::poseidon::{PoseidonConfig, PoseidonDefaultConfigEntry};
 use ark_mnt6_753::Fq;
+
+use super::{create_parameters, DefaultPoseidonParameters};
 
 // Parameters have been generated using the reference implementation here: https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/generate_parameters_grain.sage
 // Partial rounds have been rounded up to the nearest multiple of `t`.

--- a/zkp/src/proof_system/prove.rs
+++ b/zkp/src/proof_system/prove.rs
@@ -1,6 +1,8 @@
-use std::fs;
-use std::fs::{DirBuilder, File};
-use std::path::Path;
+use std::{
+    fs,
+    fs::{DirBuilder, File},
+    path::Path,
+};
 
 use ark_crypto_primitives::snark::SNARK;
 use ark_ec::{pairing::Pairing, CurveGroup};
@@ -10,25 +12,23 @@ use ark_mnt4_753::{Fq as MNT4Fq, MNT4_753};
 use ark_mnt6_753::{Fq as MNT6Fq, G1Projective as G1MNT6, G2Projective as G2MNT6, MNT6_753};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
-use rand::{thread_rng, CryptoRng, Rng};
-
 use beserial::{Deserialize, Serialize};
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_circuits::{
     bits::BitVec,
-    circuits::mnt4::{
-        MacroBlockWrapperCircuit, MergerWrapperCircuit, PKTreeNodeCircuit as NodeMNT4,
-    },
-    circuits::mnt6::{
-        MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT6,
-        PKTreeNodeCircuit as NodeMNT6,
+    circuits::{
+        mnt4::{MacroBlockWrapperCircuit, MergerWrapperCircuit, PKTreeNodeCircuit as NodeMNT4},
+        mnt6::{
+            MacroBlockCircuit, MergerCircuit, PKTreeLeafCircuit as LeafMNT6,
+            PKTreeNodeCircuit as NodeMNT6,
+        },
     },
 };
-use nimiq_zkp_primitives::pedersen::default_pedersen_hash;
 use nimiq_zkp_primitives::{
-    pk_tree_construct, serialize_g1_mnt6, serialize_g2_mnt6, state_commitment, vk_commitment,
-    MacroBlock, NanoZKPError, PK_TREE_DEPTH,
+    pedersen::default_pedersen_hash, pk_tree_construct, serialize_g1_mnt6, serialize_g2_mnt6,
+    state_commitment, vk_commitment, MacroBlock, NanoZKPError, PK_TREE_DEPTH,
 };
+use rand::{thread_rng, CryptoRng, Rng};
 
 /// Checks whether cached proofs are compatible with the current proof.
 /// If not, it clears the folder and creates a new metadata file.

--- a/zkp/src/proof_system/verify.rs
+++ b/zkp/src/proof_system/verify.rs
@@ -3,7 +3,6 @@ use ark_ec::mnt6::MNT6;
 use ark_ff::ToConstraintField;
 use ark_groth16::{Groth16, Proof, VerifyingKey};
 use ark_mnt6_753::{Config, MNT6_753};
-
 use nimiq_zkp_primitives::{state_commitment, vk_commitment, NanoZKPError};
 
 /// This function verifies a proof for the Merger Wrapper circuit, which implicitly is a proof for

--- a/zkp/src/verifying_key.rs
+++ b/zkp/src/verifying_key.rs
@@ -4,11 +4,10 @@ use ark_ec::mnt6::MNT6;
 use ark_groth16::VerifyingKey;
 use ark_mnt6_753::Config;
 use ark_serialize::CanonicalDeserialize;
-use once_cell::sync::OnceCell;
-
 use beserial::Deserialize;
 use nimiq_primitives::networks::NetworkId;
 use nimiq_zkp_circuits::metadata::VerifyingKeyMetadata;
+use once_cell::sync::OnceCell;
 
 pub struct ZKPVerifyingKey {
     cell: OnceCell<VerifyingKey<MNT6<Config>>>,

--- a/zkp/tests/prover/recursive_input.rs
+++ b/zkp/tests/prover/recursive_input.rs
@@ -1,9 +1,10 @@
 use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARKGadget, SNARK};
-use ark_groth16::constraints::{Groth16VerifierGadget, ProofVar, VerifyingKeyVar};
-use ark_groth16::{Groth16, Proof, VerifyingKey};
+use ark_groth16::{
+    constraints::{Groth16VerifierGadget, ProofVar, VerifyingKeyVar},
+    Groth16, Proof, VerifyingKey,
+};
 use ark_mnt4_753::{Fq as FqMNT4, MNT4_753};
-use ark_mnt6_753::constraints::PairingVar;
-use ark_mnt6_753::{Fq as FqMNT6, MNT6_753};
+use ark_mnt6_753::{constraints::PairingVar, Fq as FqMNT6, MNT6_753};
 use ark_r1cs_std::{
     prelude::{AllocVar, Boolean, EqGadget},
     uint8::UInt8,
@@ -12,10 +13,9 @@ use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystemRef, SynthesisError, ToConstraintField,
 };
 use ark_std::rand::RngCore;
-use nimiq_zkp_circuits::recursive::RecursiveInputVar;
-
 use nimiq_test_log::test;
 use nimiq_test_utils::test_rng::test_rng;
+use nimiq_zkp_circuits::recursive::RecursiveInputVar;
 
 const NUMBER_OF_BYTES: usize = 128;
 


### PR DESCRIPTION
This will allow us to forget entirely about it and not require manual changes anymore. Unfortunately, these configs require nightly, so they need to be formatted using `cargo +nightly fmt` if you are on stable by default.