### PR TITLE
Fix usage of lost_rewards set in macro blocks

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -274,18 +274,10 @@ impl BlockProducer {
         let staking_contract = blockchain.get_staking_contract();
 
         // Calculate the disabled set for the current validator set.
-        // TODO: Update comment, see issue #1274.
-        // Note: We are fetching the previous disabled set here because we have already updated the
-        // state. So the staking contract has already moved the disabled set for this batch into the
-        // previous disabled set.
-        let disabled_set = staking_contract.previous_disabled_slots();
+        let disabled_set = staking_contract.current_disabled_slots();
 
         // Calculate the lost reward set for the current validator set.
-        // TODO: Update comment, see issue #1274.
-        // Note: We are fetching the previous lost rewards set here because we have already updated the
-        // state. So the staking contract has already moved the lost rewards set for this batch into the
-        // previous lost rewards set.
-        let lost_reward_set = staking_contract.previous_lost_rewards();
+        let lost_reward_set = staking_contract.current_lost_rewards();
 
         // Get the state.
         let state = blockchain.state();

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -302,8 +302,8 @@ fn next_macro_block_proposal(
     // Get the staking contract PRIOR to any state changes.
     let staking_contract = blockchain.get_staking_contract();
 
-    let disabled_set = staking_contract.previous_disabled_slots();
-    let lost_reward_set = staking_contract.previous_lost_rewards();
+    let disabled_set = staking_contract.current_disabled_slots();
+    let lost_reward_set = staking_contract.current_lost_rewards();
     let reward_transactions =
         blockchain.create_reward_transactions(state, &header, &staking_contract);
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -663,6 +663,13 @@ impl Blockchain {
             }
         }
 
+        // Macro blocks: Verify the state against the block before modifying the staking contract.
+        // (FinalizeBatch and FinalizeEpoch Inherents clear some fields in preparation for the next epoch.)
+        if let Err(e) = self.verify_macro_block_state(state, block, txn) {
+            warn!(%block, reason = "bad state", error = &e as &dyn Error, "Rejecting block");
+            return Err(e);
+        }
+
         // Commit block to AccountsTree.
         let total_tx_size = self.commit_accounts(state, block, txn, block_logger).map_err(|e| {
             warn!(%block, reason = "commit failed", error = &e as &dyn Error, "Rejecting block");

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -100,16 +100,19 @@ impl Blockchain {
 
     /// Returns the current staking contract.
     pub fn get_staking_contract(&self) -> StakingContract {
-        self.get_staking_contract_if_complete()
+        self.get_staking_contract_if_complete(None)
             .expect("We should always have the staking contract.")
     }
 
     /// Returns the current staking contract.
-    pub fn get_staking_contract_if_complete(&self) -> Option<StakingContract> {
+    pub fn get_staking_contract_if_complete(
+        &self,
+        txn_option: Option<&DBTransaction>,
+    ) -> Option<StakingContract> {
         let staking_contract = self
             .state
             .accounts
-            .get(&Policy::STAKING_CONTRACT_ADDRESS, None)
+            .get(&Policy::STAKING_CONTRACT_ADDRESS, txn_option)
             .ok()?;
         match staking_contract {
             Account::Staking(x) => Some(x),

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -50,8 +50,8 @@ fn it_can_create_batch_finalization_inherents() {
 
     let body = MacroBody {
         validators: None,
-        lost_reward_set: staking_contract.previous_lost_rewards(),
-        disabled_set: staking_contract.previous_disabled_slots(),
+        lost_reward_set: staking_contract.current_lost_rewards(),
+        disabled_set: staking_contract.current_disabled_slots(),
         transactions: reward_transactions,
     };
 
@@ -111,8 +111,8 @@ fn it_can_create_batch_finalization_inherents() {
         blockchain.create_reward_transactions(blockchain.state(), &macro_header, &staking_contract);
     let body = MacroBody {
         validators: None,
-        lost_reward_set: staking_contract.previous_lost_rewards(),
-        disabled_set: staking_contract.previous_disabled_slots(),
+        lost_reward_set: staking_contract.current_lost_rewards(),
+        disabled_set: staking_contract.current_disabled_slots(),
         transactions: reward_transactions,
     };
     let macro_block = MacroBlock {
@@ -221,8 +221,8 @@ fn it_can_penalize_delayed_batch() {
 
     let body = MacroBody {
         validators: None,
-        lost_reward_set: staking_contract.previous_lost_rewards(),
-        disabled_set: staking_contract.previous_disabled_slots(),
+        lost_reward_set: staking_contract.current_lost_rewards(),
+        disabled_set: staking_contract.current_disabled_slots(),
         transactions: reward_transactions,
     };
 

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -499,7 +499,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         let blockchain_proxy = self.blockchain.read();
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
             let staking_contract =
-                if let Some(contract) = blockchain.get_staking_contract_if_complete() {
+                if let Some(contract) = blockchain.get_staking_contract_if_complete(None) {
                     contract
                 } else {
                     return Err(Error::NoConsensus);

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -428,7 +428,12 @@ where
             // Check the validity of the block against our state. If it is invalid, we return a proposal
             // timeout. This also returns the block body that matches the block header
             // (assuming that the block is valid).
-            let verification_result = blockchain.verify_block_state(state, &block, Some(&txn));
+            if let Err(error) = blockchain.verify_block_state(state, &block, Some(&txn)) {
+                log::debug!(?error, "Invalid block state");
+                return Err(ProposalError::InvalidProposal);
+            }
+
+            let verification_result = blockchain.verify_macro_block_state(state, &block, &txn);
             txn.abort();
             match verification_result {
                 Ok(Some(inherent)) => Ok(Body(inherent)),


### PR DESCRIPTION
- Include current lost_rewards instead of previous one when producing a block
- When verifying macro blocks, verify the staking-contract-related fields in blocks before clearing the stalking contract (and use the current sets)