### PR TITLE
Add caching of Rust dependencies

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -16,15 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: nightly
@@ -52,19 +43,11 @@ jobs:
     - uses: actions/checkout@v3
     - name: "Check for duplicate message IDs"
       run: "! grep -rEoh --exclude-dir tests --exclude-dir target 'TYPE_ID: u16 = [^;]+;' | sort | uniq -d | grep '^'"
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
         components: llvm-tools-preview
+    - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler
     - name: Install cargo-nextest
@@ -98,19 +81,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
         components: clippy
+    - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler
     - uses: actions-rs/clippy-check@v1
@@ -138,18 +113,10 @@ jobs:
         large-packages: false
         swap-storage: true
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
+    - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler
     - name: Install wasm-pack
@@ -171,19 +138,11 @@ jobs:
         python-version: '3.8'
     - name: Install python dependencies
       run: pip install scripts/devnet
-    - uses: actions/cache@v3
-      with:
-        path:
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
+    - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler
     - name: Build the code


### PR DESCRIPTION
This caches all non-local dependencies, making the CI able to skip downloading and compiling these dependencies.

This saves around 3 minutes of build time if the dependencies don't change.
