### PR TITLE
Reward calculation fix with disabled slots

### DIFF
--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -162,7 +162,7 @@ impl Blockchain {
             state
                 .current_slots
                 .as_ref()
-                .expect("Slots for last batch are missing")
+                .expect("Slots for current batch are missing")
         };
 
         // Calculate the slots that will receive rewards.
@@ -170,14 +170,13 @@ impl Blockchain {
         // lost_rewards_set (clears on batch end) makes rewards being lost for at least one batch
         // disabled_set (clears on epoch end) makes rewards being lost further if validator doesn't unpark
         let lost_rewards_set = staking_contract.previous_batch_lost_rewards();
-        let disabled_set =
-            if Policy::is_election_block_at(Policy::last_macro_block(macro_header.block_number)) {
-                // Use the previous epoch disabled slots for the first batch of the epoch
-                staking_contract.previous_epoch_disabled_slots()
-            } else {
-                // Use the current epoch disabled slots for the rest of the batches
-                staking_contract.current_disabled_slots()
-            };
+        let disabled_set = if Policy::first_batch_of_epoch(macro_header.block_number) {
+            // Use the previous epoch's disabled slots for the first batch of the epoch
+            staking_contract.previous_epoch_disabled_slots()
+        } else {
+            // Use the current epoch's disabled slots for the rest of the batches
+            staking_contract.current_disabled_slots()
+        };
         let slashed_set = lost_rewards_set | disabled_set;
 
         // Total reward for the previous batch
@@ -271,7 +270,7 @@ impl Blockchain {
                 debug!(
                     target_address = %tx.recipient,
                     reward = %tx.value,
-                    "Can't accept epoch reward"
+                    "Can't accept batch reward"
                 );
                 burned_reward += reward;
             }

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -169,8 +169,8 @@ impl Blockchain {
         // Rewards are for the previous batch (to give validators time to report misbehavior)
         // lost_rewards_set (clears on batch end) makes rewards being lost for at least one batch
         // disabled_set (clears on epoch end) makes rewards being lost further if validator doesn't unpark
-        let lost_rewards_set = staking_contract.previous_lost_rewards();
-        let disabled_set = staking_contract.previous_disabled_slots();
+        let lost_rewards_set = staking_contract.previous_batch_lost_rewards();
+        let disabled_set = staking_contract.previous_epoch_disabled_slots();
         let slashed_set = lost_rewards_set | disabled_set;
 
         // Total reward for the previous batch

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -170,7 +170,14 @@ impl Blockchain {
         // lost_rewards_set (clears on batch end) makes rewards being lost for at least one batch
         // disabled_set (clears on epoch end) makes rewards being lost further if validator doesn't unpark
         let lost_rewards_set = staking_contract.previous_batch_lost_rewards();
-        let disabled_set = staking_contract.previous_epoch_disabled_slots();
+        let disabled_set =
+            if Policy::is_election_block_at(Policy::last_macro_block(macro_header.block_number)) {
+                // Use the previous epoch disabled slots for the first batch of the epoch
+                staking_contract.previous_epoch_disabled_slots()
+            } else {
+                // Use the current epoch disabled slots for the rest of the batches
+                staking_contract.current_disabled_slots()
+            };
         let slashed_set = lost_rewards_set | disabled_set;
 
         // Total reward for the previous batch

--- a/primitives/account/src/account/staking_contract/receipts.rs
+++ b/primitives/account/src/account/staking_contract/receipts.rs
@@ -31,8 +31,6 @@ convert_receipt!(UpdateValidatorReceipt);
 pub struct UnparkValidatorReceipt {
     #[beserial(len_type(u16))]
     pub current_disabled_slots: Option<BTreeSet<u16>>,
-    #[beserial(len_type(u16))]
-    pub previous_disabled_slots: Option<BTreeSet<u16>>,
 }
 convert_receipt!(UnparkValidatorReceipt);
 

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -302,9 +302,8 @@ impl StakingContract {
         // Remove the validator from the parked_set.
         self.parked_set.remove(validator_address);
 
-        // Clear the validators current and previous disabled slots.
+        // Clear the validators current disabled slots.
         let current_disabled_slots = self.current_disabled_slots.remove(validator_address);
-        let previous_disabled_slots = self.previous_epoch_disabled_slots.remove(validator_address);
 
         tx_logger.push_log(Log::UnparkValidator {
             validator_address: validator_address.clone(),
@@ -312,7 +311,6 @@ impl StakingContract {
 
         Ok(UnparkValidatorReceipt {
             current_disabled_slots,
-            previous_disabled_slots,
         })
     }
 
@@ -330,10 +328,6 @@ impl StakingContract {
         // Re-add current and previous disabled slots.
         if let Some(slots) = receipt.current_disabled_slots {
             self.current_disabled_slots
-                .insert(validator_address.clone(), slots);
-        }
-        if let Some(slots) = receipt.previous_disabled_slots {
-            self.previous_epoch_disabled_slots
                 .insert(validator_address.clone(), slots);
         }
 

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -304,7 +304,7 @@ impl StakingContract {
 
         // Clear the validators current and previous disabled slots.
         let current_disabled_slots = self.current_disabled_slots.remove(validator_address);
-        let previous_disabled_slots = self.previous_disabled_slots.remove(validator_address);
+        let previous_disabled_slots = self.previous_epoch_disabled_slots.remove(validator_address);
 
         tx_logger.push_log(Log::UnparkValidator {
             validator_address: validator_address.clone(),
@@ -333,7 +333,7 @@ impl StakingContract {
                 .insert(validator_address.clone(), slots);
         }
         if let Some(slots) = receipt.previous_disabled_slots {
-            self.previous_disabled_slots
+            self.previous_epoch_disabled_slots
                 .insert(validator_address.clone(), slots);
         }
 

--- a/primitives/account/tests/staking_contract.rs
+++ b/primitives/account/tests/staking_contract.rs
@@ -487,9 +487,6 @@ fn unpark_validator_works() {
     staking_contract
         .current_disabled_slots
         .insert(validator_address.clone(), slots.clone());
-    staking_contract
-        .previous_epoch_disabled_slots
-        .insert(validator_address.clone(), slots.clone());
 
     // Works in the valid case.
     let tx = make_signed_incoming_transaction(
@@ -511,17 +508,13 @@ fn unpark_validator_works() {
         .expect("Failed to commit transaction");
 
     let expected_receipt = UnparkValidatorReceipt {
-        current_disabled_slots: Some(slots.clone()),
-        previous_disabled_slots: Some(slots),
+        current_disabled_slots: Some(slots),
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
     assert!(!staking_contract.parked_set.contains(&validator_address));
     assert!(!staking_contract
         .current_disabled_slots
-        .contains_key(&validator_address));
-    assert!(!staking_contract
-        .previous_epoch_disabled_slots
         .contains_key(&validator_address));
 
     // Try with an already unparked validator.
@@ -557,9 +550,6 @@ fn unpark_validator_works() {
     assert!(staking_contract.parked_set.contains(&validator_address));
     assert!(staking_contract
         .current_disabled_slots
-        .contains_key(&validator_address));
-    assert!(staking_contract
-        .previous_epoch_disabled_slots
         .contains_key(&validator_address));
 
     // Try with a non-existent validator.

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -560,8 +560,8 @@ impl BlockchainInterface for BlockchainDispatcher {
             Ok(RPCData::with_blockchain(
                 SlashedSlots {
                     block_number,
-                    lost_rewards: staking_contract.previous_lost_rewards(),
-                    disabled: staking_contract.previous_disabled_slots(),
+                    lost_rewards: staking_contract.previous_batch_lost_rewards(),
+                    disabled: staking_contract.previous_epoch_disabled_slots(),
                 },
                 &blockchain_proxy,
             ))

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -703,7 +703,7 @@ where
                 .current_disabled_slots
                 .contains_key(&validator_address)
             || staking_contract
-                .previous_disabled_slots
+                .previous_epoch_disabled_slots
                 .contains_key(&validator_address)
         {
             return ValidatorStakingState::Parked;

--- a/web-client/src/account.rs
+++ b/web-client/src/account.rs
@@ -101,7 +101,7 @@ impl PlainAccount {
                     .map(|address| address.to_user_friendly_address())
                     .collect(),
                 current_lost_rewards: acc.current_lost_rewards.to_string(),
-                previous_lost_rewards: acc.previous_lost_rewards.to_string(),
+                previous_lost_rewards: acc.previous_batch_lost_rewards.to_string(),
                 current_disabled_slots: acc
                     .current_disabled_slots
                     .iter()
@@ -113,7 +113,7 @@ impl PlainAccount {
                     })
                     .collect(),
                 previous_disabled_slots: acc
-                    .previous_disabled_slots
+                    .previous_epoch_disabled_slots
                     .iter()
                     .map(|(address, slots)| {
                         (


### PR DESCRIPTION
## What's in this pull request?

> **Note**
> This PR should be reviewed by individual commit. Explainer of every commit below:

While investigating why my validator consistently receives exactly 0 luna reward transactions in the current epoch, I stumbled upon a combination of two issues. The first is already fixed by #1637, which was that the wrong lost-rewards and disabled-slots were included in and shown for blocks, namely the lists of the previous batch **and epoch**. That brings us to the next issue I found which this PR addresses:
> The `previous_disabled_slots` are **not** the ones of the previous batch as their explainer comment and association with `previous_lost_rewards` suggests. Instead `current_disabled_slots` and therefore `previous_disabled_slots` are only reset/overwritten on **epoch finalization**. 

### 1st commit

To make this differentiation clear, in the first commit of this PR, I have renamed these two properties and their getters in the staking contract to `previous_batch_lost_rewards` and `previous_epoch_disabled_slots` instead.

### 2nd commit

The second commit then fixes the reward calculation (which is the second issue I found) to only use the `previous_epoch_disabled_slots` for the first batch of an epoch (which still pays out rewards for the last batch of the previous epoch). The following batches will then correctly use the `current_disabled_slots` to omit rewards.

The reason why my validator is not receiving rewards in this epoch, although it was not slashed, is that it was assigned a slot that was slashed and therefore disabled in the previous epoch, but since the reward-calculation always uses the previous epoch's disabled slots, no reward is paid the whole current epoch.

### 3rd commit

The third commit then removes the removal of a validator from this `previous_epoch_disabled_slots` set during unparking, as I think it's not necessary (and unparking should also not change the history of the previous epoch at all). I am open to remove this last commit though, if you think the behavior was correct. 

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
