### PR TITLE
Check if validator can reactivate or retire

### DIFF
--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -54,6 +54,12 @@ pub enum Error {
     #[error("No validator with address: {0}")]
     ValidatorNotFound(Address),
 
+    #[error("Validator with address {0} is already {1}")]
+    ValidatorAlreadyInState(Address, String),
+
+    #[error("Validator with address {0} is retired thus cannot be reactivated")]
+    ValidatorRetired(Address),
+
     #[error("No staker with address: {0}")]
     StakerNotFound(Address),
 


### PR DESCRIPTION
## What's in this pull request?
`send_retire_validator_transaction` and `send_reactivate_validator_transaction` now check if it makes sense to send the transactions to the blockchain.


#### This fixes #___.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
