### PR TITLE
Add support for SHA512 in HTLCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,7 +4576,6 @@ dependencies = [
  "nimiq-utils",
  "num-traits",
  "serde",
- "serde_repr",
  "strum_macros",
  "thiserror",
  "tracing",
@@ -6221,9 +6220,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+checksum = "6f0a21fba416426ac927b1691996e82079f8b6156e920c85345f135b2e9ba2de"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -3,7 +3,7 @@ use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
 use nimiq_primitives::coin::Coin;
 use nimiq_serde::Deserialize;
-use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
+use nimiq_transaction::account::htlc_contract::AnyHash;
 use nimiq_vrf::VrfSeed;
 use time::OffsetDateTime;
 
@@ -100,8 +100,6 @@ pub struct GenesisHTLC {
     pub recipient: Address,
     /// HTLC coin balance
     pub balance: Coin,
-    /// HTLC hashing algorithm
-    pub hash_algorithm: HashAlgorithm,
     /// HTLC hash root
     pub hash_root: AnyHash,
     /// HTLC hash count

--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -265,7 +265,6 @@ impl GenesisBuilder {
                 balance: htlc_contract.balance,
                 sender: htlc_contract.sender.clone(),
                 recipient: htlc_contract.recipient.clone(),
-                hash_algorithm: htlc_contract.hash_algorithm,
                 hash_count: htlc_contract.hash_count,
                 hash_root: htlc_contract.hash_root.clone(),
                 timeout: htlc_contract.timeout,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -14,7 +14,7 @@ pub extern crate nimiq_serde;
 macro_rules! create_typed_array {
     ($name: ident, $t: ty, $len: expr) => {
         #[repr(C)]
-        #[derive(Clone, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
         pub struct $name(pub [$t; $len]);
 
         impl<'a> From<&'a [$t]> for $name {
@@ -27,6 +27,12 @@ macro_rules! create_typed_array {
                 let mut a = [0 as $t; $len];
                 a.clone_from_slice(&slice[0..$len]);
                 $name(a)
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                $name([<$t>::default(); $len])
             }
         }
 

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -5,7 +5,10 @@ use nimiq_primitives::{
     coin::Coin,
 };
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_transaction::{account::htlc_contract::AnyHash, Transaction};
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, PreImage},
+    Transaction,
+};
 
 use crate::TransactionOperationReceipt;
 
@@ -45,7 +48,7 @@ pub enum Log {
     #[serde(rename_all = "camelCase")]
     HTLCRegularTransfer {
         contract_address: Address,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_depth: u8,
     },
 

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -5,10 +5,7 @@ use nimiq_primitives::{
     coin::Coin,
 };
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_transaction::{
-    account::htlc_contract::{AnyHash, HashAlgorithm},
-    Transaction,
-};
+use nimiq_transaction::{account::htlc_contract::AnyHash, Transaction};
 
 use crate::TransactionOperationReceipt;
 
@@ -36,7 +33,6 @@ pub enum Log {
         contract_address: Address,
         sender: Address,
         recipient: Address,
-        hash_algorithm: HashAlgorithm,
         hash_root: AnyHash,
         hash_count: u8,
         timeout: u64,

--- a/primitives/account/tests/htlc_contract.rs
+++ b/primitives/account/tests/htlc_contract.rs
@@ -18,7 +18,7 @@ use nimiq_test_utils::{
 };
 use nimiq_transaction::{
     account::htlc_contract::{
-        AnyHash, AnyHash32, CreationTransactionData, OutgoingHTLCTransactionProof,
+        AnyHash, AnyHash32, CreationTransactionData, OutgoingHTLCTransactionProof, PreImage,
     },
     SignatureProof, Transaction,
 };
@@ -376,7 +376,7 @@ fn it_refuses_invalid_transactions() {
     let proof = OutgoingHTLCTransactionProof::RegularTransfer {
         hash_depth: 1,
         hash_root: start_contract.hash_root.clone(),
-        pre_image: AnyHash::from(Blake2bHasher::default().digest(pre_image.as_bytes())),
+        pre_image: PreImage::from(Blake2bHasher::default().digest(pre_image.as_bytes())),
         signature_proof: recipient_signature_proof.clone(),
     };
     tx.proof = proof.serialize_to_vec();
@@ -456,7 +456,7 @@ fn it_refuses_invalid_transactions() {
 fn prepare_outgoing_transaction() -> (
     HashedTimeLockedContract,
     Transaction,
-    AnyHash,
+    PreImage,
     SignatureProof,
     SignatureProof,
 ) {
@@ -473,7 +473,7 @@ fn prepare_outgoing_transaction() -> (
     let recipient_key_pair = KeyPair::from(recipient_priv_key);
     let sender = Address::from(&sender_key_pair.public);
     let recipient = Address::from(&recipient_key_pair.public);
-    let pre_image = AnyHash::Blake2b(AnyHash32::from([1u8; 32]));
+    let pre_image = PreImage::PreImage32(AnyHash32::from([1u8; 32]));
     let hash_root = AnyHash::from(
         Blake2bHasher::default().digest(
             Blake2bHasher::default()

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -16,7 +16,6 @@ bitflags = "1.0"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 num-traits = "0.2"
 serde = "1.0"
-serde_repr = "0.1"
 strum_macros = "0.24"
 thiserror = "1.0"
 tsify = { version = "0.4", optional = true }

--- a/primitives/transaction/tests/htlc_contract_verify.rs
+++ b/primitives/transaction/tests/htlc_contract_verify.rs
@@ -6,6 +6,7 @@ use nimiq_transaction::{
     account::{
         htlc_contract::{
             AnyHash, AnyHash32, AnyHash64, CreationTransactionData, OutgoingHTLCTransactionProof,
+            PreImage,
         },
         AccountTransactionVerification,
     },
@@ -129,7 +130,7 @@ fn it_can_verify_regular_transfer() {
     let proof = OutgoingHTLCTransactionProof::RegularTransfer {
         hash_depth: 1,
         hash_root: AnyHash::from(Blake2bHasher::default().digest(&[0u8; 32])),
-        pre_image: AnyHash::Blake2b(AnyHash32::from([0u8; 32])),
+        pre_image: PreImage::PreImage32(AnyHash32::from([0u8; 32])),
         signature_proof: recipient_signature_proof.clone(),
     };
     tx.proof = proof.serialize_to_vec();
@@ -139,7 +140,7 @@ fn it_can_verify_regular_transfer() {
     let proof = OutgoingHTLCTransactionProof::RegularTransfer {
         hash_depth: 1,
         hash_root: AnyHash::from(Sha512Hasher::default().digest(&[0u8; 64])),
-        pre_image: AnyHash::Sha512(AnyHash64::from([0u8; 64])),
+        pre_image: PreImage::PreImage64(AnyHash64::from([0u8; 64])),
         signature_proof: recipient_signature_proof.clone(),
     };
     tx.proof = proof.serialize_to_vec();
@@ -149,7 +150,7 @@ fn it_can_verify_regular_transfer() {
     let proof = OutgoingHTLCTransactionProof::RegularTransfer {
         hash_depth: 1,
         hash_root: AnyHash::from(Sha256Hasher::default().digest(&[0u8; 32])),
-        pre_image: AnyHash::Sha256(AnyHash32::from([0u8; 32])),
+        pre_image: PreImage::PreImage32(AnyHash32::from([0u8; 32])),
         signature_proof: recipient_signature_proof.clone(),
     };
     tx.proof = proof.serialize_to_vec();
@@ -193,7 +194,7 @@ fn it_can_verify_regular_transfer() {
     let proof = OutgoingHTLCTransactionProof::RegularTransfer {
         hash_depth: 1,
         hash_root: AnyHash::from(Blake2bHasher::default().digest(&[0u8; 32])),
-        pre_image: AnyHash::Blake2b(AnyHash32::from([0u8; 32])),
+        pre_image: PreImage::PreImage32(AnyHash32::from([0u8; 32])),
         signature_proof: recipient_signature_proof,
     };
     tx.proof = proof.serialize_to_vec();

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -9,7 +9,7 @@ use nimiq_rpc_interface::{
     consensus::ConsensusInterface,
     types::{HashAlgorithm, ValidityStartHeight},
 };
-use nimiq_transaction::account::htlc_contract::{AnyHash, AnyHash32, AnyHash64};
+use nimiq_transaction::account::htlc_contract::{AnyHash, AnyHash32, AnyHash64, PreImage};
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;
@@ -199,7 +199,7 @@ pub enum TransactionCommand {
         /// The address of the basic account that will receive the funds.
         htlc_recipient: Address,
 
-        pre_image: String,
+        pre_image: PreImage,
 
         /// The result of hashing the pre-image hash `hash_count` times.
         hash_root: String,
@@ -590,7 +590,7 @@ impl HandleSubcommand for TransactionCommand {
                             sender_wallet,
                             contract_address,
                             htlc_recipient,
-                            Self::parse_hash(&hash_algorithm, pre_image)?,
+                            pre_image,
                             Self::parse_hash(&hash_algorithm, hash_root)?,
                             hash_count,
                             tx_commons.value,
@@ -606,7 +606,7 @@ impl HandleSubcommand for TransactionCommand {
                             sender_wallet,
                             contract_address,
                             htlc_recipient,
-                            Self::parse_hash(&hash_algorithm, pre_image)?,
+                            pre_image,
                             Self::parse_hash(&hash_algorithm, hash_root)?,
                             hash_count,
                             tx_commons.value,

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
-use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
+use nimiq_transaction::account::htlc_contract::AnyHash;
 
 use crate::types::{RPCResult, Transaction, ValidityStartHeight};
 
@@ -114,7 +114,6 @@ pub trait ConsensusInterface {
         htlc_recipient: Address,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         timeout: u64,
         value: Coin,
         fee: Coin,
@@ -128,7 +127,6 @@ pub trait ConsensusInterface {
         htlc_recipient: Address,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         timeout: u64,
         value: Coin,
         fee: Coin,
@@ -143,7 +141,6 @@ pub trait ConsensusInterface {
         pre_image: AnyHash,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
@@ -157,7 +154,6 @@ pub trait ConsensusInterface {
         pre_image: AnyHash,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
-use nimiq_transaction::account::htlc_contract::AnyHash;
+use nimiq_transaction::account::htlc_contract::{AnyHash, PreImage};
 
 use crate::types::{RPCResult, Transaction, ValidityStartHeight};
 
@@ -138,7 +138,7 @@ pub trait ConsensusInterface {
         wallet: Address,
         contract_address: Address,
         recipient: Address,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_root: AnyHash,
         hash_count: u8,
         value: Coin,
@@ -151,7 +151,7 @@ pub trait ConsensusInterface {
         wallet: Address,
         contract_address: Address,
         recipient: Address,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_root: AnyHash,
         hash_count: u8,
         value: Coin,

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -18,13 +18,11 @@ use nimiq_keys::{Address, PublicKey};
 use nimiq_primitives::{coin::Coin, policy::Policy, slots::Validators};
 use nimiq_serde::Serialize as NimiqSerialize;
 use nimiq_transaction::{
-    account::htlc_contract::{AnyHash, HashAlgorithm as HTLCContractHashAlgorithm},
-    inherent::Inherent as BaseInherent,
-    reward::RewardTransaction,
+    account::htlc_contract::AnyHash, inherent::Inherent as BaseInherent, reward::RewardTransaction,
 };
 use nimiq_vrf::VrfSeed;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DeserializeFromStr, DisplayFromStr, SerializeDisplay};
+use serde_with::{serde_as, DeserializeFromStr, SerializeDisplay};
 
 use crate::error::Error;
 
@@ -95,16 +93,7 @@ impl FromStr for ValidityStartHeight {
 pub enum HashAlgorithm {
     Blake2b = 1,
     Sha256 = 3,
-}
-
-#[allow(clippy::from_over_into)]
-impl Into<HTLCContractHashAlgorithm> for HashAlgorithm {
-    fn into(self) -> HTLCContractHashAlgorithm {
-        match self {
-            HashAlgorithm::Blake2b => HTLCContractHashAlgorithm::Blake2b,
-            HashAlgorithm::Sha256 => HTLCContractHashAlgorithm::Sha256,
-        }
-    }
+    Sha512 = 4,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -619,8 +608,7 @@ pub enum AccountAdditionalFields {
         sender: Address,
         /// User friendly address (NQ-address) of the recipient of the HTLC.
         recipient: Address,
-        /// Hex-encoded 32 byte hash root.
-        #[serde_as(as = "DisplayFromStr")]
+        /// Hash algorithm and Hex-encoded hash root.
         hash_root: AnyHash,
         /// Number of hashes this HTLC is split into
         hash_count: u8,

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -14,10 +14,7 @@ use nimiq_rpc_interface::{
     types::{RPCResult, Transaction as RPCTransaction, ValidityStartHeight},
 };
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_transaction::{
-    account::htlc_contract::{AnyHash, HashAlgorithm},
-    SignatureProof, Transaction,
-};
+use nimiq_transaction::{account::htlc_contract::AnyHash, SignatureProof, Transaction};
 use nimiq_transaction_builder::TransactionBuilder;
 use parking_lot::RwLock;
 
@@ -295,7 +292,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         htlc_recipient: Address,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         timeout: u64,
         value: Coin,
         fee: Coin,
@@ -307,7 +303,6 @@ impl ConsensusInterface for ConsensusDispatcher {
             htlc_recipient,
             hash_root,
             hash_count,
-            hash_algorithm,
             timeout,
             value,
             fee,
@@ -326,7 +321,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         htlc_recipient: Address,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         timeout: u64,
         value: Coin,
         fee: Coin,
@@ -339,7 +333,6 @@ impl ConsensusInterface for ConsensusDispatcher {
                 htlc_recipient,
                 hash_root,
                 hash_count,
-                hash_algorithm,
                 timeout,
                 value,
                 fee,
@@ -360,7 +353,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         pre_image: AnyHash,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
@@ -372,7 +364,6 @@ impl ConsensusInterface for ConsensusDispatcher {
             pre_image,
             hash_root,
             hash_count,
-            hash_algorithm,
             value,
             fee,
             self.validity_start_height(validity_start_height),
@@ -392,7 +383,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         pre_image: AnyHash,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         value: Coin,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
@@ -405,7 +395,6 @@ impl ConsensusInterface for ConsensusDispatcher {
                 pre_image,
                 hash_root,
                 hash_count,
-                hash_algorithm,
                 value,
                 fee,
                 validity_start_height,

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -14,7 +14,10 @@ use nimiq_rpc_interface::{
     types::{RPCResult, Transaction as RPCTransaction, ValidityStartHeight},
 };
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_transaction::{account::htlc_contract::AnyHash, SignatureProof, Transaction};
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, PreImage},
+    SignatureProof, Transaction,
+};
 use nimiq_transaction_builder::TransactionBuilder;
 use parking_lot::RwLock;
 
@@ -350,7 +353,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         wallet: Address,
         contract_address: Address,
         recipient: Address,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_root: AnyHash,
         hash_count: u8,
         value: Coin,
@@ -380,7 +383,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         wallet: Address,
         contract_address: Address,
         recipient: Address,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_root: AnyHash,
         hash_count: u8,
         value: Coin,

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -13,9 +13,7 @@ use nimiq_primitives::{
 use nimiq_serde::Serialize;
 use nimiq_transaction::{
     account::{
-        htlc_contract::{
-            AnyHash, CreationTransactionData as HTLCCreationTransactionData, HashAlgorithm,
-        },
+        htlc_contract::{AnyHash, CreationTransactionData as HTLCCreationTransactionData},
         staking_contract::IncomingStakingTransactionData,
         vesting_contract::CreationTransactionData as VestingCreationTransactionData,
     },
@@ -336,7 +334,6 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
 
                 match sender {
                     OutgoingType::HTLCRegularTransfer => htlc_proof_builder.regular_transfer(
-                        HashAlgorithm::Blake2b,
                         pre_image,
                         1,
                         hash_root,
@@ -452,13 +449,11 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
 
                 // HTLC account.
                 let pre_image = Blake2bHash(self.rng.gen());
-                let hash_root =
-                    AnyHash::from(Blake2bHasher::default().chain(&pre_image).finish().0);
+                let hash_root = AnyHash::from(Blake2bHasher::default().chain(&pre_image).finish());
                 let account = Account::HTLC(HashedTimeLockedContract {
                     balance,
                     sender: Address::from(&sender_key_pair),
                     recipient: Address::from(&recipient_key_pair),
-                    hash_algorithm: HashAlgorithm::Blake2b,
                     hash_root: hash_root.clone(),
                     hash_count: 1,
                     timeout,
@@ -472,7 +467,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                     contract_address,
                     sender_key_pair,
                     recipient_key_pair,
-                    pre_image: AnyHash::from(pre_image.0),
+                    pre_image: AnyHash::from(pre_image),
                     hash_root,
                 }
             }
@@ -519,7 +514,6 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 parameters: HTLCCreationTransactionData {
                     sender: Address(self.rng.gen()),
                     recipient: Address(self.rng.gen()),
-                    hash_algorithm: HashAlgorithm::Blake2b,
                     hash_root: AnyHash::default(),
                     hash_count: 1,
                     timeout: 100,

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -2,10 +2,7 @@ use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, KeyPair, PublicKey};
 use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
-use nimiq_transaction::{
-    account::htlc_contract::{AnyHash, HashAlgorithm},
-    SignatureProof, Transaction,
-};
+use nimiq_transaction::{account::htlc_contract::AnyHash, SignatureProof, Transaction};
 use thiserror::Error;
 
 pub use crate::{proof::TransactionProofBuilder, recipient::Recipient};
@@ -678,8 +675,6 @@ impl TransactionBuilder {
     ///  - `htlc_recipient`:        The address of the recipient in the HTLC contract.
     ///  - `hash_root`,
     ///    `hash_count`,
-    ///    `hash_algorithm`:        The `hash_root` is the result of hashing the pre-image
-    ///                             `hash_count` times using `hash_algorithm`.
     ///  - `timeout`:               Sets the blockchain height at which the `htlc_sender`
     ///                             automatically gains control over the funds.
     ///  - `value`:                 The value for the vesting contract. This is sent from the
@@ -698,7 +693,6 @@ impl TransactionBuilder {
         htlc_recipient: Address,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         timeout: u64,
         value: Coin,
         fee: Coin,
@@ -709,7 +703,7 @@ impl TransactionBuilder {
         recipient
             .with_sender(htlc_sender)
             .with_recipient(htlc_recipient)
-            .with_hash(hash_root, hash_count, hash_algorithm)
+            .with_hash(hash_root, hash_count)
             .with_timeout(timeout);
 
         let mut builder = Self::new();
@@ -748,8 +742,6 @@ impl TransactionBuilder {
     ///  - `pre_image`,
     ///    `hash_root`,
     ///    `hash_count`,
-    ///    `hash_algorithm`:        The `hash_root` is the result of hashing the `pre_image`
-    ///                             `hash_count` times using `hash_algorithm`.
     ///  - `value`:                 The value that will be sent to the recipient account.
     ///  - `fee`:                   Transaction fee.
     ///  - `validity_start_height`: Block height from which this transaction is valid.
@@ -766,7 +758,6 @@ impl TransactionBuilder {
         pre_image: AnyHash,
         hash_root: AnyHash,
         hash_count: u8,
-        hash_algorithm: HashAlgorithm,
         value: Coin,
         fee: Coin,
         validity_start_height: u32,
@@ -786,7 +777,7 @@ impl TransactionBuilder {
         match proof_builder {
             TransactionProofBuilder::Htlc(mut builder) => {
                 let sig = builder.signature_with_key_pair(key_pair);
-                builder.regular_transfer(hash_algorithm, pre_image, hash_count, hash_root, sig);
+                builder.regular_transfer(pre_image, hash_count, hash_root, sig);
                 Ok(builder.generate().unwrap())
             }
             _ => unreachable!(),

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -2,7 +2,10 @@ use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, KeyPair, PublicKey};
 use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
-use nimiq_transaction::{account::htlc_contract::AnyHash, SignatureProof, Transaction};
+use nimiq_transaction::{
+    account::htlc_contract::{AnyHash, PreImage},
+    SignatureProof, Transaction,
+};
 use thiserror::Error;
 
 pub use crate::{proof::TransactionProofBuilder, recipient::Recipient};
@@ -755,7 +758,7 @@ impl TransactionBuilder {
         key_pair: &KeyPair,
         contract_address: Address,
         recipient: Address,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_root: AnyHash,
         hash_count: u8,
         value: Coin,

--- a/transaction-builder/src/proof/htlc_contract.rs
+++ b/transaction-builder/src/proof/htlc_contract.rs
@@ -2,7 +2,7 @@ use nimiq_hash::{Blake2bHash, Sha256Hash};
 use nimiq_keys::KeyPair;
 use nimiq_serde::Serialize;
 use nimiq_transaction::{
-    account::htlc_contract::{AnyHash, HashAlgorithm, OutgoingHTLCTransactionProof},
+    account::htlc_contract::{AnyHash, OutgoingHTLCTransactionProof},
     SignatureProof, Transaction,
 };
 
@@ -194,14 +194,12 @@ impl HtlcProofBuilder {
     /// [`signature_with_key_pair`]: struct.HtlcProofBuilder.html#method.signature_with_key_pair
     pub fn regular_transfer(
         &mut self,
-        hash_algorithm: HashAlgorithm,
         pre_image: AnyHash,
         hash_count: u8,
         hash_root: AnyHash,
         recipient_signature: SignatureProof,
     ) -> &mut Self {
         self.proof = Some(OutgoingHTLCTransactionProof::RegularTransfer {
-            hash_algorithm,
             hash_depth: hash_count,
             hash_root,
             pre_image,
@@ -277,10 +275,7 @@ impl HtlcProofBuilder {
         hash_root: Sha256Hash,
         recipient_signature: SignatureProof,
     ) -> &mut Self {
-        let pre_image: [u8; 32] = pre_image.into();
-        let hash_root: [u8; 32] = hash_root.into();
         self.regular_transfer(
-            HashAlgorithm::Sha256,
             pre_image.into(),
             hash_count,
             hash_root.into(),
@@ -355,10 +350,7 @@ impl HtlcProofBuilder {
         hash_root: Blake2bHash,
         recipient_signature: SignatureProof,
     ) -> &mut Self {
-        let pre_image: [u8; 32] = pre_image.into();
-        let hash_root: [u8; 32] = hash_root.into();
         self.regular_transfer(
-            HashAlgorithm::Blake2b,
             pre_image.into(),
             hash_count,
             hash_root.into(),

--- a/transaction-builder/src/proof/htlc_contract.rs
+++ b/transaction-builder/src/proof/htlc_contract.rs
@@ -2,7 +2,7 @@ use nimiq_hash::{Blake2bHash, Sha256Hash};
 use nimiq_keys::KeyPair;
 use nimiq_serde::Serialize;
 use nimiq_transaction::{
-    account::htlc_contract::{AnyHash, OutgoingHTLCTransactionProof},
+    account::htlc_contract::{AnyHash, OutgoingHTLCTransactionProof, PreImage},
     SignatureProof, Transaction,
 };
 
@@ -194,7 +194,7 @@ impl HtlcProofBuilder {
     /// [`signature_with_key_pair`]: struct.HtlcProofBuilder.html#method.signature_with_key_pair
     pub fn regular_transfer(
         &mut self,
-        pre_image: AnyHash,
+        pre_image: PreImage,
         hash_count: u8,
         hash_root: AnyHash,
         recipient_signature: SignatureProof,

--- a/transaction-builder/src/recipient/htlc_contract.rs
+++ b/transaction-builder/src/recipient/htlc_contract.rs
@@ -1,7 +1,7 @@
 use nimiq_hash::{Blake2bHash, Sha256Hash};
 use nimiq_keys::Address;
 use nimiq_transaction::account::htlc_contract::{
-    AnyHash, CreationTransactionData as HtlcCreationData, HashAlgorithm,
+    AnyHash, CreationTransactionData as HtlcCreationData,
 };
 use thiserror::Error;
 
@@ -63,7 +63,6 @@ pub enum HtlcRecipientBuilderError {
 pub struct HtlcRecipientBuilder {
     sender: Option<Address>,
     recipient: Option<Address>,
-    hash_algorithm: Option<HashAlgorithm>,
     hash_root: Option<AnyHash>,
     hash_count: u8,
     timeout: Option<u64>,
@@ -107,15 +106,9 @@ impl HtlcRecipientBuilder {
 
     /// Sets the hash data for the HTLC.
     /// The `hash_root` is the result of hashing the pre-image hash `hash_count` times.
-    pub fn with_hash(
-        &mut self,
-        hash_root: AnyHash,
-        hash_count: u8,
-        hash_algorithm: HashAlgorithm,
-    ) -> &mut Self {
+    pub fn with_hash(&mut self, hash_root: AnyHash, hash_count: u8) -> &mut Self {
         self.hash_root = Some(hash_root);
         self.hash_count = hash_count;
-        self.hash_algorithm = Some(hash_algorithm);
         self
     }
 
@@ -143,10 +136,8 @@ impl HtlcRecipientBuilder {
     /// recipient_builder.with_sha256_hash(hash_root, hash_count);
     /// ```
     pub fn with_sha256_hash(&mut self, hash_root: Sha256Hash, hash_count: u8) -> &mut Self {
-        let hash: [u8; 32] = hash_root.into();
-        self.hash_root = Some(AnyHash::from(hash));
+        self.hash_root = Some(AnyHash::from(hash_root));
         self.hash_count = hash_count;
-        self.hash_algorithm = Some(HashAlgorithm::Sha256);
         self
     }
 
@@ -174,10 +165,8 @@ impl HtlcRecipientBuilder {
     /// recipient_builder.with_blake2b_hash(hash_root, hash_count);
     /// ```
     pub fn with_blake2b_hash(&mut self, hash_root: Blake2bHash, hash_count: u8) -> &mut Self {
-        let hash: [u8; 32] = hash_root.into();
-        self.hash_root = Some(AnyHash::from(hash));
+        self.hash_root = Some(AnyHash::from(hash_root));
         self.hash_count = hash_count;
-        self.hash_algorithm = Some(HashAlgorithm::Blake2b);
         self
     }
 
@@ -231,9 +220,6 @@ impl HtlcRecipientBuilder {
                 recipient: self
                     .recipient
                     .ok_or(HtlcRecipientBuilderError::NoRecipient)?,
-                hash_algorithm: self
-                    .hash_algorithm
-                    .ok_or(HtlcRecipientBuilderError::NoHash)?,
                 hash_root: self.hash_root.ok_or(HtlcRecipientBuilderError::NoHash)?,
                 hash_count: self.hash_count,
                 timeout: self.timeout.ok_or(HtlcRecipientBuilderError::NoTimeout)?,

--- a/transaction-builder/tests/htlc_contract.rs
+++ b/transaction-builder/tests/htlc_contract.rs
@@ -7,7 +7,7 @@ use nimiq_serde::{Deserialize, Serialize};
 use nimiq_test_log::test;
 use nimiq_transaction::{
     account::htlc_contract::{
-        AnyHash, AnyHash32, CreationTransactionData, OutgoingHTLCTransactionProof,
+        AnyHash, AnyHash32, CreationTransactionData, OutgoingHTLCTransactionProof, PreImage,
     },
     SignatureProof, Transaction,
 };
@@ -61,7 +61,7 @@ fn it_can_create_creation_transaction() {
 
 fn prepare_outgoing_transaction() -> (
     Transaction,
-    AnyHash,
+    PreImage,
     AnyHash,
     KeyPair,
     SignatureProof,
@@ -79,7 +79,7 @@ fn prepare_outgoing_transaction() -> (
 
     let sender_key_pair = KeyPair::from(sender_priv_key);
     let recipient_key_pair = KeyPair::from(recipient_priv_key);
-    let pre_image = AnyHash::Blake2b(AnyHash32([1u8; 32]));
+    let pre_image = PreImage::PreImage32(AnyHash32([1u8; 32]));
     let hash_root = AnyHash::from(
         Blake2bHasher::default().digest(
             Blake2bHasher::default()

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -69,15 +69,28 @@ impl PlainAccount {
                 balance: acc.balance.into(),
                 sender: acc.sender.to_user_friendly_address(),
                 recipient: acc.recipient.to_user_friendly_address(),
-                hash_algorithm: match acc.hash_algorithm {
-                    nimiq_transaction::account::htlc_contract::HashAlgorithm::Blake2b => {
+                hash_algorithm: match acc.hash_root {
+                    nimiq_transaction::account::htlc_contract::AnyHash::Blake2b(_) => {
                         "blake2b".to_string()
                     }
-                    nimiq_transaction::account::htlc_contract::HashAlgorithm::Sha256 => {
+                    nimiq_transaction::account::htlc_contract::AnyHash::Sha256(_) => {
                         "sha256".to_string()
                     }
+                    nimiq_transaction::account::htlc_contract::AnyHash::Sha512(_) => {
+                        "sha512".to_string()
+                    }
                 },
-                hash_root: acc.hash_root.to_hex(),
+                hash_root: match &acc.hash_root {
+                    nimiq_transaction::account::htlc_contract::AnyHash::Blake2b(hash) => {
+                        hash.to_hex()
+                    }
+                    nimiq_transaction::account::htlc_contract::AnyHash::Sha256(hash) => {
+                        hash.to_hex()
+                    }
+                    nimiq_transaction::account::htlc_contract::AnyHash::Sha512(hash) => {
+                        hash.to_hex()
+                    }
+                },
                 hash_count: acc.hash_count,
                 timeout: acc.timeout,
                 total_amount: acc.total_amount.into(),

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -515,15 +515,28 @@ impl Transaction {
                         raw: hex::encode(self.data()),
                         sender: data.sender.to_user_friendly_address(),
                         recipient: data.recipient.to_user_friendly_address(),
-                        hash_algorithm: match data.hash_algorithm {
-                            nimiq_transaction::account::htlc_contract::HashAlgorithm::Blake2b => {
+                        hash_algorithm: match data.hash_root {
+                            nimiq_transaction::account::htlc_contract::AnyHash::Blake2b(_) => {
                                 "blake2b".to_string()
                             }
-                            nimiq_transaction::account::htlc_contract::HashAlgorithm::Sha256 => {
+                            nimiq_transaction::account::htlc_contract::AnyHash::Sha256(_) => {
                                 "sha256".to_string()
                             }
+                            nimiq_transaction::account::htlc_contract::AnyHash::Sha512(_) => {
+                                "sha512".to_string()
+                            }
                         },
-                        hash_root: hex::encode(data.hash_root),
+                        hash_root: match data.hash_root {
+                            nimiq_transaction::account::htlc_contract::AnyHash::Blake2b(hash) => {
+                                hash.to_hex()
+                            }
+                            nimiq_transaction::account::htlc_contract::AnyHash::Sha256(hash) => {
+                                hash.to_hex()
+                            }
+                            nimiq_transaction::account::htlc_contract::AnyHash::Sha512(hash) => {
+                                hash.to_hex()
+                            }
+                        },
                         hash_count: data.hash_count,
                         timeout: data.timeout,
                     })


### PR DESCRIPTION
Add support for the SHA512 algorithm in HTLCs.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
