### PR TITLE
Discard some BlockchainEvents to prevent double emits for macro blocks

### DIFF
--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -664,8 +664,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                 let result = match event {
                     BlockchainEvent::Extended(hash) => Some(hash.into()),
                     BlockchainEvent::HistoryAdopted(hash) => Some(hash.into()),
-                    BlockchainEvent::Finalized(hash) => Some(hash.into()),
-                    BlockchainEvent::EpochFinalized(hash) => Some(hash.into()),
+                    BlockchainEvent::Finalized(_) | BlockchainEvent::EpochFinalized(_) => None,
                     BlockchainEvent::Rebranched(_, new_branch) => {
                         Some(new_branch.into_iter().last().unwrap().0.into())
                     }


### PR DESCRIPTION
## What's in this pull request?

With commit 7f89d0a6f1d20766273a5e6842611306de418629 a `BlockchainEvent`-event is now broadcasted twice when a macro block is pushed: `Extended` and `Finalized`/`EpochFinalized` (depending if the macro block is an election block or not).

This has introduced an unwanted behaviour when you are subscribed to the `head_block` or `head_block_hash` event through RPC. Because now you receive the message when a macro block is pushed twice.

This PR solves this issue by ignoring some of the `BlockchainEvent`s.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
