### PR TITLE
genesis: Add options to receive parent (election) hashes

### DIFF
--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -1,6 +1,7 @@
 use std::convert::TryFrom;
 
 use nimiq_bls::PublicKey as BlsPublicKey;
+use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey};
 use nimiq_primitives::coin::Coin;
 use nimiq_transaction::account::htlc_contract::{AnyHash, HashAlgorithm};
@@ -8,28 +9,44 @@ use nimiq_vrf::VrfSeed;
 use serde::{de::Error, Deserialize, Deserializer};
 use time::OffsetDateTime;
 
+/// Struct that defines the genesis configuration that is going to be parsed
+/// from the genesis TOML files.
 #[derive(Clone, Debug, Deserialize)]
 pub struct GenesisConfig {
+    /// Seed message.
     #[serde(default)]
     pub seed_message: Option<String>,
 
+    /// VRF seed for the genesis block.
     pub vrf_seed: Option<VrfSeed>,
 
+    /// Hash of the parent election block for the genesis block.
+    pub parent_election_hash: Option<Blake2bHash>,
+
+    /// Hash of the parent block for the genesis block.
+    pub parent_hash: Option<Blake2bHash>,
+
+    /// Timestamp for the genesis block.
     #[serde(deserialize_with = "deserialize_timestamp")]
     pub timestamp: Option<OffsetDateTime>,
 
+    /// The set of validators for the genesis state.
     #[serde(default)]
     pub validators: Vec<GenesisValidator>,
 
+    /// The set of stakers for the genesis state.
     #[serde(default)]
     pub stakers: Vec<GenesisStaker>,
 
+    /// Set of basic accounts for the genesis state.
     #[serde(default)]
     pub basic_accounts: Vec<GenesisAccount>,
 
+    /// Set of vesting accounts for the genesis state.
     #[serde(default)]
     pub vesting_accounts: Vec<GenesisVestingContract>,
 
+    /// Set of HTLC accounts for the genesis state.
     #[serde(default)]
     pub htlc_accounts: Vec<GenesisHTLC>,
 }

--- a/genesis/src/genesis/dev-albatross-4-validators.toml
+++ b/genesis/src/genesis/dev-albatross-4-validators.toml
@@ -2,6 +2,8 @@ name = "dev-albatross"
 seed_message = "Albatross DevNet"
 timestamp = "2021-07-15T00:00:00.000+00:00"
 vrf_seed = "e8c7f2f3935da9ca39419aa7d2cc90817245f75e58cc543f2b9478766308e8a50fffccb09e2df3546f5a0c0059d73a506c48fa2b546f15b511d0f7a63f0ee20cd510a87f520e26478bb687ca31a08db8b02921f9a22e32a790c07f16dbdf4501"
+parent_hash = "d7b808129639b27cfc6c3245111db37ba85099496c66ffcb14a6754eb5a1007f"
+parent_election_hash = "264aaf8a4f9828a76c550635da078eb466306a189fcc03710bee9f649c869d12"
 
 [[validators]]
 validator_address = "NQ20 TSB0 DFSM UH9C 15GQ GAGJ TTE4 D3MA 859E"

--- a/genesis/src/genesis/dev-albatross.toml
+++ b/genesis/src/genesis/dev-albatross.toml
@@ -2,6 +2,8 @@ name = "dev-albatross"
 seed_message = "Albatross DevNet"
 timestamp = "2023-03-22T00:00:00.000+00:00"
 vrf_seed = "e8c7f2f3935da9ca39419aa7d2cc90817245f75e58cc543f2b9478766308e8a50fffccb09e2df3546f5a0c0059d73a506c48fa2b546f15b511d0f7a63f0ee20cd510a87f520e26478bb687ca31a08db8b02921f9a22e32a790c07f16dbdf4501"
+parent_hash = "d7b808129639b27cfc6c3245111db37ba85099496c66ffcb14a6754eb5a1007f"
+parent_election_hash = "264aaf8a4f9828a76c550635da078eb466306a189fcc03710bee9f649c869d12"
 
 [[validators]]
 validator_address = "NQ70 JM4N PU3R Y2U2 9RGX ABJE VKA4 4TBB HKF1"

--- a/genesis/src/genesis/test-albatross.toml
+++ b/genesis/src/genesis/test-albatross.toml
@@ -2,6 +2,8 @@ name = "test-albatross"
 seed_message = "Albatross TestNet"
 timestamp = "2023-03-23T00:00:00.000+00:00"
 vrf_seed = "e8c7f2f3935da9ca39419aa7d2cc90817245f75e58cc543f2b9478766308e8a50fffccb09e2df3546f5a0c0059d73a506c48fa2b546f15b511d0f7a63f0ee20cd510a87f520e26478bb687ca31a08db8b02921f9a22e32a790c07f16dbdf4501"
+parent_hash = "d7b808129639b27cfc6c3245111db37ba85099496c66ffcb14a6754eb5a1007f"
+parent_election_hash = "264aaf8a4f9828a76c550635da078eb466306a189fcc03710bee9f649c869d12"
 
 [[validators]]
 validator_address = "NQ70 JM4N PU3R Y2U2 9RGX ABJE VKA4 4TBB HKF1"

--- a/genesis/src/genesis/unit-albatross.toml
+++ b/genesis/src/genesis/unit-albatross.toml
@@ -2,6 +2,8 @@ name = "unit-albatross"
 seed_message = "Albatross Genesis for Unit Tests"
 timestamp = "2021-10-30T02:04:20.999999999-06:00"
 vrf_seed = "e8c7f2f3935da9ca39419aa7d2cc90817245f75e58cc543f2b9478766308e8a508633d7b5d08eea96770d55fe74c66660bff9f05f84c07f6b4760077ec0cab0a7b9b619db44f847f725d953d5856217b9b1caff25f4434b41c87cfe61f512904"
+parent_hash = "d7b808129639b27cfc6c3245111db37ba85099496c66ffcb14a6754eb5a1007f"
+parent_election_hash = "264aaf8a4f9828a76c550635da078eb466306a189fcc03710bee9f649c869d12"
 
 [[validators]]
 validator_address = "NQ20 TSB0 DFSM UH9C 15GQ GAGJ TTE4 D3MA 859E"

--- a/scripts/devnet/templates/dev-albatross-genesis.toml.j2
+++ b/scripts/devnet/templates/dev-albatross-genesis.toml.j2
@@ -2,6 +2,8 @@ name = "dev-albatross"
 seed_message = "Albatross DevNet"
 timestamp = "2021-07-15T00:00:00.000+00:00"
 vrf_seed = "e8c7f2f3935da9ca39419aa7d2cc90817245f75e58cc543f2b9478766308e8a50fffccb09e2df3546f5a0c0059d73a506c48fa2b546f15b511d0f7a63f0ee20cd510a87f520e26478bb687ca31a08db8b02921f9a22e32a790c07f16dbdf4501"
+parent_hash = "d7b808129639b27cfc6c3245111db37ba85099496c66ffcb14a6754eb5a1007f"
+parent_election_hash = "264aaf8a4f9828a76c550635da078eb466306a189fcc03710bee9f649c869d12"
 
 
 {% for validator in validators %}


### PR DESCRIPTION
Add options in the genesis block TOML description to receive:
- The parent hash of the genesis block.
- The parent election hash of the genesis block.

Also changed all of the existing genesis TOML files to have values for these new genesis properties.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
