### PR TITLE
Add RPC methods to dump the blockchain state

### DIFF
--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -204,9 +204,11 @@ impl Blockchain {
         Ok(total_size)
     }
 
+    /// Produces a Merkle proof of the inclusion of the given keys in the
+    /// Merkle Radix Trie.
     pub fn get_accounts_proof(&self, keys: Vec<&KeyNibbles>) -> Option<TrieProof> {
         let txn = self.env.read_transaction();
 
-        self.state().accounts.tree.get_proof(&txn, keys).ok()
+        self.state().accounts.get_proof(Some(&txn), keys).ok()
     }
 }

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -120,6 +120,17 @@ impl StakingContract {
         vec![]
     }
 
+    /// Get a list containing all validators
+    /// IMPORTANT: This is a very expensive operation, iterating over all existing validators in the contract.
+    pub fn get_validators<T: DataStoreReadOps + DataStoreIterOps>(
+        &self,
+        data_store: &T,
+    ) -> Vec<Validator> {
+        StakingContractStoreRead::new(data_store)
+            .iter_validators()
+            .collect()
+    }
+
     /// Given a seed, it randomly distributes the validator slots across all validators. It is
     /// used to select the validators for the next epoch.
     pub fn select_validators<T: DataStoreReadOps>(

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -75,6 +75,13 @@ impl<'read, T: DataStoreReadOps + DataStoreIterOps> StakingContractStoreRead<'re
             &StakingContractStore::staker_key(&Address::END_ADDRESS),
         )
     }
+
+    pub(crate) fn iter_validators(&self) -> impl Iterator<Item = Validator> {
+        self.0.iter(
+            &StakingContractStore::validator_key(&Address::START_ADDRESS),
+            &StakingContractStore::validator_key(&Address::END_ADDRESS),
+        )
+    }
 }
 
 #[cfg(feature = "interaction-traits")]

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -9,6 +9,7 @@ use nimiq_primitives::{
     key_nibbles::KeyNibbles,
     trie::{
         trie_chunk::{TrieChunk, TrieChunkPushResult},
+        trie_proof::TrieProof,
         TrieItem,
     },
 };
@@ -911,6 +912,19 @@ impl Accounts {
                 self.tree
                     .get_chunk_with_proof(&self.env.read_transaction(), start_key.., limit)
             }
+        }
+    }
+
+    /// Produces a Merkle proof of the inclusion of the given keys in the
+    /// Merkle Radix Trie.
+    pub fn get_proof(
+        &self,
+        txn_option: Option<&DBTransaction>,
+        keys: Vec<&KeyNibbles>,
+    ) -> Result<TrieProof, IncompleteTrie> {
+        match txn_option {
+            Some(txn) => self.tree.get_proof(txn, keys),
+            None => self.tree.get_proof(&self.env.read_transaction(), keys),
         }
     }
 }

--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -92,6 +92,9 @@ pub enum AccountCommand {
         is_hex: bool,
     },
 
+    /// Queries all accounts in the accounts tree
+    GetAll {},
+
     /// Queries the account state (e.g. account balance for basic accounts).
     Get {
         /// The account's address.
@@ -174,6 +177,10 @@ impl HandleSubcommand for AccountCommand {
                     "{:#?}",
                     client.blockchain.get_account_by_address(address).await?
                 );
+            }
+
+            AccountCommand::GetAll {} => {
+                println!("{:#?}", client.blockchain.get_accounts().await?);
             }
         }
 

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -123,6 +123,10 @@ pub enum BlockchainCommand {
         address: Address,
     },
 
+    /// Tries to fetch all validators in the staking contract.
+    /// IMPORTANT: This is a very expensive operation, iterating over all existing validators in the contract.
+    Validators {},
+
     /// Tries to fetch all stakers of a given validator.
     /// IMPORTANT: This is a very expensive operation, iterating over all existing stakers in the contract.
     StakersByValidator {
@@ -298,6 +302,10 @@ impl HandleSubcommand for BlockchainCommand {
                 "{:#?}",
                 client.blockchain.get_validator_by_address(address).await?
             ),
+
+            BlockchainCommand::Validators {} => {
+                println!("{:#?}", client.blockchain.get_validators().await?)
+            }
 
             BlockchainCommand::StakersByValidator { address } => println!(
                 "{:#?}",

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -85,6 +85,11 @@ pub trait BlockchainInterface {
         address: Address,
     ) -> RPCResult<Account, BlockchainState, Self::Error>;
 
+    /// Fetches all accounts in the accounts tree.
+    /// IMPORTANT: This operation iterates over all accounts in the accounts tree
+    /// and thus is extremely computationally expensive.
+    async fn get_accounts(&mut self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error>;
+
     async fn get_active_validators(
         &mut self,
     ) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -102,6 +102,11 @@ pub trait BlockchainInterface {
         address: Address,
     ) -> RPCResult<Validator, BlockchainState, Self::Error>;
 
+    /// Fetches all validators in the staking contract.
+    /// IMPORTANT: This operation iterates over all validators in the staking contract
+    /// and thus is extremely computationally expensive.
+    async fn get_validators(&mut self) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;
+
     /// Fetches all stakers for a given validator.
     /// IMPORTANT: This operation iterates over all stakers of the staking contract
     /// and thus is extremely computationally expensive.


### PR DESCRIPTION
- Add method to get an `Account`s chunk
  - Add method in the full blockchain to get a chunk of `Account`s.
  - Add `AccountsChunk` to return a chunk of accounts including the `end_key` for iteration purposes and the decoded `Account`s and their addresses.
  - Add a RPC method to query all of the accounts in the accounts tree along with annotations that it is currently very expensive computationally.
- Use `Accounts` to get a proof for accounts
  - Change the blockchain `get_accounts_proof` method to use an `Accounts` method instead of accesing directly the inner `AccounsTrie` for better encapsulation.
  - Add a method on `Accounts` to get a proof from a set of keys.
  - Add `rustdoc` documentation to the blockchain `get_accounts_proof` function and the chain of calls up to `AccountsTrie`.
- Add interface for getting all validators
  - Add an interface to the staking contract to be able to query all validators. This was added with the warning that the query requires the blockchain read lock and its computationally expensive.
  - Add RPC method to get all validators in the staking contract along with the warning on the expensive operation it is.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
