### PR TITLE
Get rid of `SerRangeFrom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6148,9 +6148,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
@@ -6186,9 +6186,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/blockchain-interface/src/chain_info.rs
+++ b/blockchain-interface/src/chain_info.rs
@@ -4,7 +4,7 @@ use nimiq_block::Block;
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{coin::Coin, key_nibbles::KeyNibbles, policy::Policy};
-use nimiq_serde::{Deserialize, SerRangeFrom, Serialize};
+use nimiq_serde::{Deserialize, Serialize};
 
 /// Struct that, for each block, keeps information relative to the chain the block is on.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -25,7 +25,7 @@ pub struct ChainInfo {
     /// A boolean stating if this block can be pruned.
     pub prunable: bool,
     /// Missing range of the accounts before this block.
-    pub prev_missing_range: Option<SerRangeFrom<KeyNibbles>>,
+    pub prev_missing_range: Option<RangeFrom<KeyNibbles>>,
 }
 
 impl ChainInfo {
@@ -72,7 +72,7 @@ impl ChainInfo {
             cum_ext_tx_size: 0,
             history_tree_len: 0,
             prunable,
-            prev_missing_range: prev_missing_range.map(SerRangeFrom),
+            prev_missing_range,
         }
     }
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -441,7 +441,7 @@ impl Blockchain {
                 let result = this
                     .state
                     .accounts
-                    .revert_chunk(&mut write_txn, prev_missing_range.0.start.clone());
+                    .revert_chunk(&mut write_txn, prev_missing_range.start.clone());
 
                 if let Err(e) = result {
                     // Check if the revert chunk failed.

--- a/primitives/src/trie/trie_node.rs
+++ b/primitives/src/trie/trie_node.rs
@@ -4,7 +4,7 @@ use byteorder::WriteBytesExt;
 use log::error;
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
 use nimiq_hash::{Blake2bHash, Hash, HashOutput, Hasher};
-use nimiq_serde::{Deserialize, SerRangeFrom, Serialize};
+use nimiq_serde::{Deserialize, Serialize};
 
 use crate::{key_nibbles::KeyNibbles, trie::error::MerkleRadixTrieError};
 
@@ -25,7 +25,7 @@ pub struct TrieNode {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct RootData {
-    pub incomplete: Option<SerRangeFrom<KeyNibbles>>,
+    pub incomplete: Option<RangeFrom<KeyNibbles>>,
     pub num_branches: u64,
     pub num_hybrids: u64,
     pub num_leaves: u64,
@@ -109,7 +109,7 @@ impl TrieNode {
             key: KeyNibbles::ROOT,
             root_data: Some(RootData {
                 incomplete: if incomplete {
-                    Some(SerRangeFrom(KeyNibbles::ROOT..))
+                    Some(KeyNibbles::ROOT..)
                 } else {
                     None
                 },

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -23,7 +23,7 @@ use nimiq_primitives::{
         trie_proof_node::TrieProofNode,
     },
 };
-use nimiq_serde::{Deserialize, SerRangeFrom, Serialize};
+use nimiq_serde::{Deserialize, Serialize};
 
 /// A Merkle Radix Trie is a hybrid between a Merkle tree and a Radix trie. Like a Merkle tree each
 /// node contains the hashes of all its children. That creates a tree that is resistant to
@@ -218,8 +218,7 @@ impl MerkleRadixTrie {
             .root_data
             .clone()
             .expect("root node needs root data")
-            .incomplete
-            .map(|range| range.0);
+            .incomplete;
         let mut stack = vec![root];
 
         while let Some(item) = stack.pop() {
@@ -567,8 +566,7 @@ impl MerkleRadixTrie {
             .root_data
             .clone()
             .expect("root node needs root data")
-            .incomplete
-            .map(|range| range.0);
+            .incomplete;
 
         // And initialize the root path.
         let mut root_path: Vec<TrieNode> = vec![];
@@ -749,14 +747,7 @@ impl MerkleRadixTrie {
         chunk: TrieChunk,
         expected_hash: Blake2bHash,
     ) -> Result<TrieChunkPushResult, MerkleRadixTrieError> {
-        match self
-            .get_root(txn)
-            .unwrap()
-            .root_data
-            .unwrap()
-            .incomplete
-            .map(|range| range.0)
-        {
+        match self.get_root(txn).unwrap().root_data.unwrap().incomplete {
             Some(i) if i.start == start_key => {}
             Some(_) => return Ok(TrieChunkPushResult::Ignored),
             None => return Err(MerkleRadixTrieError::TrieAlreadyComplete),
@@ -863,8 +854,7 @@ impl MerkleRadixTrie {
         }
 
         let mut root_node = self.get_root(txn).unwrap();
-        root_node.root_data.as_mut().unwrap().incomplete =
-            chunk.end_key.clone().map(|end| SerRangeFrom(end..));
+        root_node.root_data.as_mut().unwrap().incomplete = chunk.end_key.clone().map(|end| end..);
         self.put_node(txn, &root_node);
 
         Ok(TrieChunkPushResult::Applied)
@@ -917,7 +907,7 @@ impl MerkleRadixTrie {
 
         let mut root_node = self.get_root(txn).unwrap();
         root_node.root_data.as_mut().unwrap().incomplete =
-            Some(SerRangeFrom(ops::RangeFrom { start: start_key }));
+            Some(ops::RangeFrom { start: start_key });
         self.put_node(txn, &root_node);
 
         Ok(())
@@ -1244,7 +1234,6 @@ impl MerkleRadixTrie {
             .root_data
             .expect("root node needs root data")
             .incomplete
-            .map(|range| range.0)
     }
 
     /// Returns the root node, if there is one.
@@ -1338,8 +1327,7 @@ impl MerkleRadixTrie {
             .root_data
             .clone()
             .expect("root node needs root data")
-            .incomplete
-            .map(|range| range.0);
+            .incomplete;
 
         // First, find the node.
         loop {
@@ -1428,8 +1416,7 @@ impl MerkleRadixTrie {
             .root_data
             .clone()
             .expect("root node needs root data")
-            .incomplete
-            .map(|range| range.0);
+            .incomplete;
 
         let mut stack = vec![root];
 

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, io, io::Write, ops};
+use std::{error::Error, fmt, io, io::Write};
 
 pub use postcard::fixint;
 use serde::{
@@ -90,29 +90,6 @@ impl<'de, const N: usize> HexArray<'de> for [u8; N] {
         } else {
             BigArray::deserialize(deserializer)
         }
-    }
-}
-
-/// The Nimiq wrapper for serializing std::ops::RangeFrom
-#[derive(Clone, Debug)]
-pub struct SerRangeFrom<T>(pub ops::RangeFrom<T>);
-
-impl<T: Serialize> serde::Serialize for SerRangeFrom<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serde::Serialize::serialize(&self.0.start, serializer)
-    }
-}
-
-impl<'de, T: Deserialize> serde::Deserialize<'de> for SerRangeFrom<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let start: T = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self(std::ops::RangeFrom { start }))
     }
 }
 


### PR DESCRIPTION
`Serialize`/`Deserialize` for `RangeFrom`/`RangeTo` is now implemented in `serde`.