### PR TITLE
transaction: Fix `AnyHash` deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,6 +4580,7 @@ dependencies = [
  "nimiq-utils",
  "num-traits",
  "serde",
+ "serde_json",
  "strum_macros",
  "thiserror",
  "tracing",

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -35,8 +35,11 @@ nimiq-utils = { path = "../../utils", features = ["merkle"] }
 
 [dev-dependencies]
 hex = "0.4"
+serde_json = "1.0"
+
 nimiq-test-log = { path = "../../test-log" }
 nimiq-test-utils = { path = "../../test-utils" }
+
 
 [features]
 ts-types = ["tsify", "wasm-bindgen"]


### PR DESCRIPTION
Fix `AnyHash` deserialization for human readable deserializers. Human readable deserializers regularly use `visit_map` for deserializing `struct`s so it is actually unnecessary to detect them in the visitor and only implementing `visit_seq` would result in an error deserializing. This is why this change implements `visit_map` to the visitor.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
