### PR TITLE
Sync fixes

### DIFF
--- a/blockchain/src/chain_store.rs
+++ b/blockchain/src/chain_store.rs
@@ -380,6 +380,7 @@ impl ChainStore {
         Ok(blocks)
     }
 
+    /// Does not include the block with `start_block_hash`.
     fn get_blocks_forward(
         &self,
         start_block_hash: &Blake2bHash,

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -112,12 +112,12 @@ impl HistoryStore {
         match cursor.seek_range_key::<u32, u32>(&block_number.to_be()) {
             // If it exists, we simply get the last leaf index for the block. We increment by 1
             // because the leaf index is 0-based and we want the number of leaves.
-            Some((n, i)) if n == block_number => i + 1,
+            Some((n, i)) if u32::from_be(n) == block_number => i + 1,
             // Otherwise, seek to the previous block, if it exists.
             _ => match cursor.prev::<u32, u32>() {
                 // If it exists, we also need to check if the previous block is in the same epoch.
                 Some((n, i)) => {
-                    if Policy::epoch_at(n.to_be()) == Policy::epoch_at(block_number) {
+                    if Policy::epoch_at(u32::from_be(n)) == Policy::epoch_at(block_number) {
                         i + 1
                     } else {
                         0
@@ -1029,7 +1029,7 @@ impl HistoryStore {
                 None => 0,
                 Some((n, i)) => {
                     // If the previous block is from a different epoch, then we also have to start at zero.
-                    if Policy::epoch_at(n.to_be()) != Policy::epoch_at(block_number) {
+                    if Policy::epoch_at(u32::from_be(n)) != Policy::epoch_at(block_number) {
                         0
                     } else {
                         i + 1

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -109,12 +109,12 @@ impl HistoryStore {
         let mut cursor = txn.cursor(&self.last_leaf_table);
 
         // Seek to the last leaf index of the block, if it exists.
-        match cursor.seek_key::<u32, u32>(&block_number.to_be()) {
+        match cursor.seek_range_key::<u32, u32>(&block_number.to_be()) {
             // If it exists, we simply get the last leaf index for the block. We increment by 1
             // because the leaf index is 0-based and we want the number of leaves.
-            Some(i) => i + 1,
+            Some((n, i)) if n == block_number => i + 1,
             // Otherwise, seek to the previous block, if it exists.
-            None => match cursor.prev::<u32, u32>() {
+            _ => match cursor.prev::<u32, u32>() {
                 // If it exists, we also need to check if the previous block is in the same epoch.
                 Some((n, i)) => {
                     if Policy::epoch_at(n.to_be()) == Policy::epoch_at(block_number) {

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -237,7 +237,7 @@ impl<N: Network> BlockQueue<N> {
             self.get_parent_from_buffer(parent_block_number, &parent_hash)
         {
             parent_hash = parent_block_hash;
-            parent_block_number = block_number.saturating_sub(1);
+            parent_block_number = parent_block_number.saturating_sub(1);
         }
 
         // If the parent of this block is already being pushed or we already requested missing blocks for it, we're done.
@@ -265,14 +265,11 @@ impl<N: Network> BlockQueue<N> {
     }
 
     fn get_parent_from_buffer(&self, block_number: u32, hash: &Blake2bHash) -> Option<Blake2bHash> {
-        self.buffer
-            .get(&block_number)
-            .map(|blocks| {
-                blocks
-                    .get(hash)
-                    .map(|(block, _)| block.parent_hash().clone())
-            })
-            .flatten()
+        self.buffer.get(&block_number).and_then(|blocks| {
+            blocks
+                .get(hash)
+                .map(|(block, _)| block.parent_hash().clone())
+        })
     }
 
     /// Requests missing blocks.

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -23,6 +23,7 @@ pub struct Policy {
     /// Maximum size of accounts trie chunks.
     pub state_chunks_max_size: u32,
     /// Number of blocks a transaction is valid with Albatross consensus.
+    /// This should be a multiple of `blocks_per_batch`.
     pub transaction_validity_window: u32,
 }
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -447,10 +447,12 @@ where
     /// Check and update if we can enforce the tx validity window.
     /// This is important if we use the state sync and do not have the relevant parts of the history yet.
     fn update_can_enforce_validity_window(&mut self) {
-        if !self.blockchain_state.can_enforce_validity_window
-            && self.blockchain.read().can_enforce_validity_window()
-        {
-            self.blockchain_state.can_enforce_validity_window = true;
+        let old_can_enforce_validity_window = self.blockchain_state.can_enforce_validity_window;
+        self.blockchain_state.can_enforce_validity_window =
+            self.blockchain.read().can_enforce_validity_window();
+
+        // Re-initialize validator when flag returns to true.
+        if !old_can_enforce_validity_window && self.blockchain_state.can_enforce_validity_window {
             self.init();
             self.init_mempool();
         }


### PR DESCRIPTION
## What's in this pull request?

- Fixing an off-by-one error in the verification of subsequent missing blocks requests.
- Re-requesting missing blocks after failures.
- The validator cached a flag for whether it can verify the transaction validity window and never updated it after being true. It now updates the flag when necessary.
- The calculation of the transaction validity window flag in the blockchain used a history store function, whose comment promised functionality that was not correctly implemented. @nibhar fixed this.
- The history store is using `u32`s in BE format specifically. There was a bug in the conversion that @sisou fixed.

This fixes #1692

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
