### PR TITLE
Bump warp from 0.3.3 to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,16 +872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,6 +3306,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,24 +3386,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand 0.8.5",
- "safemem",
- "tempfile",
- "twoway",
-]
 
 [[package]]
 name = "multistream-select"
@@ -4027,7 +4017,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rustls-pemfile 1.0.3",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "signal-hook",
@@ -6005,15 +5995,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
@@ -6042,12 +6023,6 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
@@ -6309,17 +6284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6459,7 +6423,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
 ]
 
 [[package]]
@@ -6812,14 +6776,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.17.3",
+ "tungstenite 0.18.0",
 ]
 
 [[package]]
@@ -7151,9 +7115,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -7162,7 +7126,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.10.1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -7204,15 +7168,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "webrtc-util",
-]
-
-[[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -7397,9 +7352,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7b8be92646fc3d18b06147664ebc5f48d222686cb11a8755e561a735aacc6d"
+checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -7410,17 +7365,17 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multipart",
+ "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile 0.2.1",
+ "rustls-pemfile",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.17.2",
+ "tokio-tungstenite 0.18.0",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -7787,7 +7742,7 @@ dependencies = [
  "log",
  "rtcp",
  "rtp",
- "sha-1 0.9.8",
+ "sha-1",
  "subtle",
  "thiserror",
  "tokio",

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -57,7 +57,7 @@ fn test_skip_block_single_signature() {
         Address::default(),
         LazyPublicKey::from(key_pair.public_key),
         PublicKey::from([0u8; 32]),
-        (0, Policy::SLOTS),
+        0..Policy::SLOTS,
     )]);
 
     assert!(skip_block_proof.verify(&skip_block_info, &validators));

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -362,7 +362,7 @@ impl Slots {
 
         for validator in validators.iter() {
             slots.push(Slots {
-                first_slot_number: validator.slot_range.0,
+                first_slot_number: validator.slots.start,
                 num_slots: validator.num_slots(),
                 validator: validator.address.clone(),
                 public_key: validator.voting_key.compressed().clone(),

--- a/validator/src/aggregation/registry.rs
+++ b/validator/src/aggregation/registry.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, ops};
 
 use nimiq_bls::PublicKey;
 use nimiq_collections::BitSet;
@@ -20,10 +20,8 @@ impl ValidatorRegistry {
         self.validators.num_validators()
     }
 
-    pub fn get_slots(&self, idx: u16) -> Vec<u16> {
-        let validator = &self.validators.validators[idx as usize];
-
-        (validator.slot_range.0..validator.slot_range.1).collect()
+    pub fn get_slots(&self, idx: u16) -> ops::Range<u16> {
+        self.validators.validators[idx as usize].slots.clone()
     }
 }
 
@@ -64,8 +62,8 @@ impl IdentityRegistry for ValidatorRegistry {
         // This holds for Single and Multiple signatories.
         let mut validators_slots = BitSet::new();
         for validator_id in ids.iter() {
-            for slot in self.get_slots(*validator_id).iter() {
-                validators_slots.insert(*slot as usize);
+            for slot in self.get_slots(*validator_id) {
+                validators_slots.insert(slot as usize);
             }
         }
 

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -253,9 +253,9 @@ impl SkipBlockAggregation {
         // TODO expose this somewehere else so we don't need to clone here.
         let weights = Arc::new(ValidatorRegistry::new(active_validators.clone()));
 
-        let slot_range = active_validators.validators[validator_id as usize].slot_range;
-
-        let slots: Vec<u16> = (slot_range.0..slot_range.1).collect();
+        let slots = active_validators.validators[validator_id as usize]
+            .slots
+            .clone();
 
         loop {
             let message_hash = skip_block_info.hash_with_prefix();
@@ -275,8 +275,8 @@ impl SkipBlockAggregation {
                 .multiply(slots.len() as u16)]);
 
             let mut signers = BitSet::new();
-            for slot in &slots {
-                signers.insert(*slot as usize);
+            for slot in slots.clone() {
+                signers.insert(slot as usize);
             }
 
             let own_contribution = SignedSkipBlockMessage {

--- a/validator/src/aggregation/tendermint/contribution.rs
+++ b/validator/src/aggregation/tendermint/contribution.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops};
 
 use nimiq_block::{MultiSignature, TendermintVote};
 use nimiq_bls::{AggregateSignature, SecretKey};
@@ -28,7 +28,7 @@ impl TendermintContribution {
     pub(crate) fn from_vote(
         vote: TendermintVote,
         secret_key: &SecretKey,
-        validator_slots: Vec<u16>,
+        validator_slots: ops::Range<u16>,
     ) -> Self {
         assert!(!validator_slots.is_empty());
         // sign the hash

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -251,11 +251,11 @@ async fn validator_can_catch_up() {
     // Listen for blockchain events from the block producer (after two skip blocks).
     let mut events = blockchain.read().notifier_as_stream();
 
-    let (start, end) = blockchain.read().current_validators().unwrap().validators
+    let slots = blockchain.read().current_validators().unwrap().validators
         [validator.validator_slot_band() as usize]
-        .slot_range;
-
-    let slots = (start..end).collect();
+        .slots
+        .clone()
+        .collect();
 
     let skip_block_info = SkipBlockInfo {
         block_number: 1,


### PR DESCRIPTION
This gets rid of the future incompatibility warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: buf_redux v0.8.4, multipart v0.18.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```
