### PR TITLE
Introduce the notions of `DoubleProposalProof` and `DoubleVoteProof`

### DIFF
--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -40,7 +40,8 @@ impl BlockProducer {
         // The timestamp for the block.
         timestamp: u64,
         // Proofs of any misbehavior by malicious validators. An equivocation proof may be submitted
-        // during the batch when it happened or in the next one, but not after that.
+        // during the batch when it happened or until the end of the reporting window, but not after
+        // that.
         equivocation_proofs: Vec<EquivocationProof>,
         // The transactions to be included in the block body.
         transactions: Vec<Transaction>,
@@ -68,7 +69,8 @@ impl BlockProducer {
         // The timestamp for the block.
         timestamp: u64,
         // Proofs of any misbehavior by malicious validators. An equivocation proof may be submitted
-        // during the batch when it happened or in the next one, but not after that.
+        // during the batch when it happened or until the end of the reporting window, but not after
+        // that.
         equivocation_proofs: Vec<EquivocationProof>,
         // The transactions to be included in the block body.
         transactions: Vec<Transaction>,

--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -39,7 +39,7 @@ impl BlockProducer {
         blockchain: &Blockchain,
         // The timestamp for the block.
         timestamp: u64,
-        // Proofs of any misbehavior by malicious validators. A equivocation proof may be submitted
+        // Proofs of any misbehavior by malicious validators. An equivocation proof may be submitted
         // during the batch when it happened or in the next one, but not after that.
         equivocation_proofs: Vec<EquivocationProof>,
         // The transactions to be included in the block body.
@@ -67,7 +67,7 @@ impl BlockProducer {
         blockchain: &Blockchain,
         // The timestamp for the block.
         timestamp: u64,
-        // Proofs of any misbehavior by malicious validators. A equivocation proof may be submitted
+        // Proofs of any misbehavior by malicious validators. An equivocation proof may be submitted
         // during the batch when it happened or in the next one, but not after that.
         equivocation_proofs: Vec<EquivocationProof>,
         // The transactions to be included in the block body.

--- a/block-production/src/lib.rs
+++ b/block-production/src/lib.rs
@@ -1,6 +1,6 @@
 use nimiq_account::BlockState;
 use nimiq_block::{
-    ForkProof, MacroBlock, MacroBody, MacroHeader, MicroBlock, MicroBody, MicroHeader,
+    EquivocationProof, MacroBlock, MacroBody, MacroHeader, MicroBlock, MicroBody, MicroHeader,
     MicroJustification, SkipBlockInfo, SkipBlockProof,
 };
 use nimiq_blockchain::Blockchain;
@@ -39,9 +39,9 @@ impl BlockProducer {
         blockchain: &Blockchain,
         // The timestamp for the block.
         timestamp: u64,
-        // Proofs of any forks created by malicious validators. A fork proof may be submitted during
-        // the batch when it happened or in the next one, but not after that.
-        fork_proofs: Vec<ForkProof>,
+        // Proofs of any misbehavior by malicious validators. A equivocation proof may be submitted
+        // during the batch when it happened or in the next one, but not after that.
+        equivocation_proofs: Vec<EquivocationProof>,
         // The transactions to be included in the block body.
         transactions: Vec<Transaction>,
         // Extra data for this block.
@@ -52,7 +52,7 @@ impl BlockProducer {
         self.next_micro_block_with_rng(
             blockchain,
             timestamp,
-            fork_proofs,
+            equivocation_proofs,
             transactions,
             extra_data,
             skip_block_proof,
@@ -67,9 +67,9 @@ impl BlockProducer {
         blockchain: &Blockchain,
         // The timestamp for the block.
         timestamp: u64,
-        // Proofs of any forks created by malicious validators. A fork proof may be submitted during
-        // the batch when it happened or in the next one, but not after that.
-        fork_proofs: Vec<ForkProof>,
+        // Proofs of any misbehavior by malicious validators. A equivocation proof may be submitted
+        // during the batch when it happened or in the next one, but not after that.
+        equivocation_proofs: Vec<EquivocationProof>,
         // The transactions to be included in the block body.
         transactions: Vec<Transaction>,
         // Extra data for this block.
@@ -113,10 +113,10 @@ impl BlockProducer {
             prev_seed.sign_next_with_rng(&self.signing_key, rng)
         };
 
-        // Create the inherents from the fork proofs or skip block info.
+        // Create the inherents from the equivocation proofs or skip block info.
         let inherents = blockchain.create_punishment_inherents(
             block_number,
-            &fork_proofs,
+            &equivocation_proofs,
             skip_block_info,
             None,
         );
@@ -153,7 +153,7 @@ impl BlockProducer {
 
         // Create the micro block body.
         let body = MicroBody {
-            fork_proofs,
+            equivocation_proofs,
             transactions: executed_txns,
         };
 

--- a/block-production/src/test_custom_block.rs
+++ b/block-production/src/test_custom_block.rs
@@ -1,8 +1,8 @@
 use nimiq_account::BlockState;
 use nimiq_block::{
-    Block, ForkProof, MacroBlock, MacroBody, MacroHeader, MicroBlock, MicroBody, MicroHeader,
-    MicroJustification, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo, SkipBlockProof,
-    TendermintIdentifier, TendermintProof, TendermintStep, TendermintVote,
+    Block, EquivocationProof, MacroBlock, MacroBody, MacroHeader, MicroBlock, MicroBody,
+    MicroHeader, MicroJustification, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo,
+    SkipBlockProof, TendermintIdentifier, TendermintProof, TendermintStep, TendermintVote,
 };
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
@@ -37,7 +37,7 @@ pub struct BlockConfig {
 
     // Micro only
     pub test_micro: bool,
-    pub fork_proofs: Vec<ForkProof>,
+    pub equivocation_proofs: Vec<EquivocationProof>,
     pub transactions: Vec<Transaction>,
     pub extra_data: Vec<u8>,
 
@@ -66,7 +66,7 @@ impl Default for BlockConfig {
             history_root: None,
             skip_block_proof: None,
             test_micro: true,
-            fork_proofs: vec![],
+            equivocation_proofs: vec![],
             transactions: vec![],
             extra_data: vec![],
             test_macro: true,
@@ -102,8 +102,12 @@ pub fn next_micro_block(
     let mut transactions = config.transactions.clone();
     transactions.sort_unstable();
 
-    let inherents =
-        blockchain.create_punishment_inherents(block_number, &config.fork_proofs, None, None);
+    let inherents = blockchain.create_punishment_inherents(
+        block_number,
+        &config.equivocation_proofs,
+        None,
+        None,
+    );
 
     let block_state = BlockState::new(block_number, timestamp);
 
@@ -134,7 +138,7 @@ pub fn next_micro_block(
     txn.abort();
 
     let body = MicroBody {
-        fork_proofs: config.fork_proofs.clone(),
+        equivocation_proofs: config.equivocation_proofs.clone(),
         transactions: executed_txns,
     };
 
@@ -227,7 +231,7 @@ pub fn next_skip_block(
     txn.abort();
 
     let body = MicroBody {
-        fork_proofs: vec![],
+        equivocation_proofs: vec![],
         transactions: vec![],
     };
 

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -105,7 +105,7 @@ fn it_can_produce_micro_blocks() {
     let block = producer.next_micro_block(
         &bc,
         bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
-        vec![fork_proof],
+        vec![fork_proof.into()],
         vec![],
         vec![0x41],
         None,

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -91,13 +91,13 @@ fn it_can_produce_micro_blocks() {
         header2.timestamp += 1;
         let hash2 = header2.hash::<Blake2bHash>();
         let justification2 = signing_key().sign(hash2.as_slice());
-        ForkProof {
+        ForkProof::new(
             header1,
-            header2,
             justification1,
+            header2,
             justification2,
             prev_vrf_seed,
-        }
+        )
     };
 
     let bc = blockchain.upgradable_read();

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -1,4 +1,4 @@
-use nimiq_block::{Block, BlockError, EquivocationProof};
+use nimiq_block::{Block, BlockError, ForkProof};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{account::AccountError, networks::NetworkId};
 use thiserror::Error;
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// An enum used when a fork is detected.
 #[derive(Clone, Debug)]
 pub enum ForkEvent {
-    Detected(EquivocationProof),
+    Detected(ForkProof),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -1,4 +1,4 @@
-use nimiq_block::{Block, BlockError, ForkProof};
+use nimiq_block::{Block, BlockError, EquivocationProofError, ForkProof};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{account::AccountError, networks::NetworkId};
 use thiserror::Error;
@@ -84,6 +84,8 @@ pub enum PushError {
     InvalidPredecessor,
     #[error("Duplicate transaction")]
     DuplicateTransaction,
+    #[error("Equivocation proof: {0}")]
+    InvalidEquivocationProof(#[from] EquivocationProofError),
     #[error("Account error: {0}")]
     AccountsError(#[from] AccountError),
     #[error("Invalid fork")]

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -1,4 +1,4 @@
-use nimiq_block::{Block, BlockError, ForkProof};
+use nimiq_block::{Block, BlockError, EquivocationProof};
 use nimiq_hash::Blake2bHash;
 use nimiq_primitives::{account::AccountError, networks::NetworkId};
 use thiserror::Error;
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// An enum used when a fork is detected.
 #[derive(Clone, Debug)]
 pub enum ForkEvent {
-    Detected(ForkProof),
+    Detected(EquivocationProof),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -87,10 +87,10 @@ impl Blockchain {
 
                 let skip_block_info = SkipBlockInfo::from_micro_block(micro_block);
 
-                // Create the inherents from any forks or skip block info.
+                // Create the inherents from any equivocation proofs or skip block info.
                 let inherents = self.create_punishment_inherents(
                     block_state.number,
-                    &body.fork_proofs,
+                    &body.equivocation_proofs,
                     skip_block_info,
                     Some(txn),
                 );
@@ -181,7 +181,7 @@ impl Blockchain {
             block = %block,
             is_skip = block.is_skip_block(),
             num_transactions = body.transactions.len(),
-            num_fork_proofs = body.fork_proofs.len(),
+            num_equivocation_proofs = body.equivocation_proofs.len(),
             "Reverting block"
         );
 
@@ -194,11 +194,11 @@ impl Blockchain {
             );
         }
 
-        // Create the inherents from any forks or skip block info.
+        // Create the inherents from any equivocation proofs or skip block info.
         let skip_block_info = SkipBlockInfo::from_micro_block(block);
         let inherents = self.create_punishment_inherents(
             block.block_number(),
-            &body.fork_proofs,
+            &body.equivocation_proofs,
             skip_block_info,
             Some(txn),
         );

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -87,7 +87,7 @@ impl Blockchain {
 
                 let skip_block_info = SkipBlockInfo::from_micro_block(micro_block);
 
-                // Create the inherents from any equivocation proofs or skip block info.
+                // Create the inherents from any equivocation proof or skip block info.
                 let inherents = self.create_punishment_inherents(
                     block_state.number,
                     &body.equivocation_proofs,
@@ -194,7 +194,7 @@ impl Blockchain {
             );
         }
 
-        // Create the inherents from any equivocation proofs or skip block info.
+        // Create the inherents from any equivocation proof or skip block info.
         let skip_block_info = SkipBlockInfo::from_micro_block(block);
         let inherents = self.create_punishment_inherents(
             block.block_number(),

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -47,8 +47,8 @@ impl Blockchain {
 
         for equivocation_proof in equivocation_proofs {
             trace!(
-                "Creating inherent from equivocation proof: {:?}",
-                equivocation_proof,
+                ?equivocation_proof,
+                "Creating inherent from equivocation proof",
             );
             inherents.push(self.inherent_from_equivocation_proof(
                 block_number,
@@ -108,7 +108,6 @@ impl Blockchain {
                 None
             };
 
-        // Create the JailedValidator struct.
         let jailed_validator = JailedValidator {
             slots: proposer_slot.validator.slots,
             validator_address: proposer_slot.validator.address,
@@ -147,7 +146,6 @@ impl Blockchain {
             None
         };
 
-        // Create the JailedValidator struct.
         let jailed_validator = JailedValidator {
             slots: proposer_slot.validator.slots,
             validator_address: proposer_slot.validator.address,
@@ -190,7 +188,6 @@ impl Blockchain {
             None
         };
 
-        // Create the JailedValidator struct.
         let jailed_validator = JailedValidator {
             slots: validator.slots.clone(),
             validator_address: validator.address.clone(),

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -93,12 +93,7 @@ impl Blockchain {
     ) -> Inherent {
         // Get the slot owner and slot number for this block number.
         let proposer_slot = self
-            .get_proposer_at(
-                fork_proof.block_number(),
-                fork_proof.block_number(),
-                fork_proof.prev_vrf_seed().entropy(),
-                txn_option,
-            )
+            .get_proposer_for_fork_proof(fork_proof, txn_option)
             .expect("Couldn't calculate slot owner!");
 
         // If the reporting block is in a new epoch, we check if the proposer is still a validator in this epoch
@@ -136,12 +131,7 @@ impl Blockchain {
     ) -> Inherent {
         // Get the slot owner and slot number for this block number.
         let proposer_slot = self
-            .get_proposer_at(
-                double_proposal_proof.block_number(),
-                double_proposal_proof.round(),
-                double_proposal_proof.prev_vrf_seed1().entropy(),
-                txn_option,
-            )
+            .get_proposer_for_double_proposal_proof(double_proposal_proof, txn_option)
             .expect("Couldn't calculate slot owner!");
 
         // If the reporting block is in a new epoch, we check if the proposer is still a validator in this epoch
@@ -178,12 +168,9 @@ impl Blockchain {
         double_vote_proof: &DoubleVoteProof,
         txn_option: Option<&db::TransactionProxy>,
     ) -> Inherent {
-        // Get the validator for this slot number.
+        // Get the validators for this epoch.
         let validators = self
-            .get_validators_for_epoch(
-                Policy::epoch_at(double_vote_proof.block_number()),
-                txn_option,
-            )
+            .get_validators_for_double_vote_proof(double_vote_proof, txn_option)
             .expect("Couldn't calculate validators");
         // `double_vote_proof.slot_number` is checked in `DoubleVoteProof::verify`.
         let validator = validators

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -94,31 +94,30 @@ impl Blockchain {
         // Get the slot owner and slot number for this block number.
         let proposer_slot = self
             .get_proposer_at(
-                fork_proof.header1.block_number,
-                fork_proof.header1.block_number,
-                fork_proof.prev_vrf_seed.entropy(),
+                fork_proof.block_number(),
+                fork_proof.block_number(),
+                fork_proof.prev_vrf_seed().entropy(),
                 txn_option,
             )
             .expect("Couldn't calculate slot owner!");
 
         // If the reporting block is in a new epoch, we check if the proposer is still a validator in this epoch
         // and retrieve its new slots.
-        let new_epoch_slot_range = if Policy::epoch_at(reporting_block)
-            > Policy::epoch_at(fork_proof.header1.block_number)
-        {
-            self.current_validators()
-                .expect("We need to have validators")
-                .get_validator_by_address(&proposer_slot.validator.address)
-                .map(|validator| validator.slots.clone())
-        } else {
-            None
-        };
+        let new_epoch_slot_range =
+            if Policy::epoch_at(reporting_block) > Policy::epoch_at(fork_proof.block_number()) {
+                self.current_validators()
+                    .expect("We need to have validators")
+                    .get_validator_by_address(&proposer_slot.validator.address)
+                    .map(|validator| validator.slots.clone())
+            } else {
+                None
+            };
 
         // Create the JailedValidator struct.
         let jailed_validator = JailedValidator {
             slots: proposer_slot.validator.slots,
             validator_address: proposer_slot.validator.address,
-            offense_event_block: fork_proof.header1.block_number,
+            offense_event_block: fork_proof.block_number(),
         };
 
         // Create the corresponding jail inherent.
@@ -138,9 +137,9 @@ impl Blockchain {
         // Get the slot owner and slot number for this block number.
         let proposer_slot = self
             .get_proposer_at(
-                double_proposal_proof.header1.block_number,
-                double_proposal_proof.header1.round,
-                double_proposal_proof.prev_vrf_seed1.entropy(),
+                double_proposal_proof.block_number(),
+                double_proposal_proof.round(),
+                double_proposal_proof.prev_vrf_seed1().entropy(),
                 txn_option,
             )
             .expect("Couldn't calculate slot owner!");
@@ -148,7 +147,7 @@ impl Blockchain {
         // If the reporting block is in a new epoch, we check if the proposer is still a validator in this epoch
         // and retrieve its new slots.
         let new_epoch_slot_range = if Policy::epoch_at(reporting_block)
-            > Policy::epoch_at(double_proposal_proof.header1.block_number)
+            > Policy::epoch_at(double_proposal_proof.block_number())
         {
             self.current_validators()
                 .expect("We need to have validators")
@@ -162,7 +161,7 @@ impl Blockchain {
         let jailed_validator = JailedValidator {
             slots: proposer_slot.validator.slots,
             validator_address: proposer_slot.validator.address,
-            offense_event_block: double_proposal_proof.header1.block_number,
+            offense_event_block: double_proposal_proof.block_number(),
         };
 
         // Create the corresponding jail inherent.
@@ -187,7 +186,7 @@ impl Blockchain {
             )
             .expect("Couldn't calculate validators");
         // `double_vote_proof.slot_number` is checked in `DoubleVoteProof::verify`.
-        let validator = validators.get_validator_by_slot_number(double_vote_proof.slot_number);
+        let validator = validators.get_validator_by_slot_number(double_vote_proof.slot_number());
 
         // If the reporting block is in a new epoch, we check if the proposer is still a validator in this epoch
         // and retrieve its new slots.

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -186,7 +186,9 @@ impl Blockchain {
             )
             .expect("Couldn't calculate validators");
         // `double_vote_proof.slot_number` is checked in `DoubleVoteProof::verify`.
-        let validator = validators.get_validator_by_slot_number(double_vote_proof.slot_number());
+        let validator = validators
+            .get_validator_by_address(double_vote_proof.validator_address())
+            .expect("Validator must have been present");
 
         // If the reporting block is in a new epoch, we check if the proposer is still a validator in this epoch
         // and retrieve its new slots.

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -778,7 +778,7 @@ impl Blockchain {
                 );
 
                 // We shouldn't log errors if there are no listeners.
-                _ = self.fork_notifier.send(ForkEvent::Detected(proof.into()));
+                _ = self.fork_notifier.send(ForkEvent::Detected(proof));
             }
         }
     }

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -769,13 +769,13 @@ impl Blockchain {
                     .expect("Missing justification")
                     .unwrap_micro();
 
-                let proof = ForkProof {
-                    header1: block.header.clone(),
-                    header2: micro_block.header,
+                let proof = ForkProof::new(
+                    block.header.clone(),
                     justification1,
+                    micro_block.header,
                     justification2,
-                    prev_vrf_seed: prev_vrf_seed.clone(),
-                };
+                    prev_vrf_seed.clone(),
+                );
 
                 // We shouldn't log errors if there are no listeners.
                 _ = self.fork_notifier.send(ForkEvent::Detected(proof));

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -778,7 +778,7 @@ impl Blockchain {
                 );
 
                 // We shouldn't log errors if there are no listeners.
-                _ = self.fork_notifier.send(ForkEvent::Detected(proof));
+                _ = self.fork_notifier.send(ForkEvent::Detected(proof.into()));
             }
         }
     }

--- a/blockchain/src/blockchain/slots.rs
+++ b/blockchain/src/blockchain/slots.rs
@@ -1,3 +1,4 @@
+use nimiq_block::{DoubleProposalProof, DoubleVoteProof, ForkProof};
 use nimiq_blockchain_interface::BlockchainError;
 use nimiq_collections::BitSet;
 use nimiq_database::TransactionProxy;
@@ -95,6 +96,45 @@ impl Blockchain {
             band: slot_band,
             validator: validator.clone(),
         })
+    }
+
+    pub fn get_proposer_for_fork_proof(
+        &self,
+        fork_proof: &ForkProof,
+        txn_option: Option<&TransactionProxy>,
+    ) -> Result<Slot, BlockchainError> {
+        self.get_proposer_at(
+            fork_proof.block_number(),
+            fork_proof.block_number(),
+            fork_proof.prev_vrf_seed().entropy(),
+            txn_option,
+        )
+    }
+
+    pub fn get_proposer_for_double_proposal_proof(
+        &self,
+        double_proposal_proof: &DoubleProposalProof,
+        txn_option: Option<&TransactionProxy>,
+    ) -> Result<Slot, BlockchainError> {
+        self.get_proposer_at(
+            double_proposal_proof.block_number(),
+            double_proposal_proof.round(),
+            // It doesn't matter which VRF seed we choose, in the validation
+            // it will be checked that the validator has actually signed both.
+            double_proposal_proof.prev_vrf_seed1().entropy(),
+            txn_option,
+        )
+    }
+
+    pub fn get_validators_for_double_vote_proof(
+        &self,
+        double_vote_proof: &DoubleVoteProof,
+        txn_option: Option<&TransactionProxy>,
+    ) -> Result<Validators, BlockchainError> {
+        self.get_validators_for_epoch(
+            Policy::epoch_at(double_vote_proof.block_number()),
+            txn_option,
+        )
     }
 
     fn compute_slot_number(offset: u32, vrf_entropy: VrfEntropy, disabled_slots: BitSet) -> u16 {

--- a/blockchain/src/blockchain/slots.rs
+++ b/blockchain/src/blockchain/slots.rs
@@ -98,6 +98,7 @@ impl Blockchain {
         })
     }
 
+    /// Get the proposer slot for a given fork proof.
     pub fn get_proposer_for_fork_proof(
         &self,
         fork_proof: &ForkProof,
@@ -111,6 +112,7 @@ impl Blockchain {
         )
     }
 
+    /// Get the proposer slot for a given double proposal proof.
     pub fn get_proposer_for_double_proposal_proof(
         &self,
         double_proposal_proof: &DoubleProposalProof,
@@ -126,6 +128,7 @@ impl Blockchain {
         )
     }
 
+    /// Get the validators currently active for a given double vote proof.
     pub fn get_validators_for_double_vote_proof(
         &self,
         double_vote_proof: &DoubleVoteProof,

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -199,6 +199,7 @@ impl Blockchain {
         Ok(())
     }
 
+    /// Verify that all the given equivocation proofs of a block are actually valid offenses.
     pub fn verify_equivocation_proofs(
         &self,
         block: &Block,

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -287,7 +287,7 @@ fn it_correctly_creates_inherents_from_skip_block() {
     // Create the inherents from any forks or skip block info.
     let inherents = blockchain_rg.create_punishment_inherents(
         skip_block.block_number(),
-        &skip_block.body.as_ref().unwrap().fork_proofs,
+        &skip_block.body.as_ref().unwrap().equivocation_proofs,
         skip_block_info,
         None,
     );
@@ -341,8 +341,8 @@ fn it_correctly_creates_inherents_from_fork_proof() {
         .body
         .as_mut()
         .unwrap()
-        .fork_proofs
-        .push(fork_proof);
+        .equivocation_proofs
+        .push(fork_proof.into());
 
     let blockchain_rg = temp_producer1.blockchain.read();
     let (validator, _slot) = blockchain_rg
@@ -358,7 +358,7 @@ fn it_correctly_creates_inherents_from_fork_proof() {
     // Create the inherents from any forks or skip block info.
     let inherents = blockchain_rg.create_punishment_inherents(
         reporting_micro_block.block_number(),
-        &reporting_micro_block.body.unwrap().fork_proofs,
+        &reporting_micro_block.body.unwrap().equivocation_proofs,
         skip_block_info,
         None,
     );
@@ -426,8 +426,8 @@ fn it_correctly_creates_inherents_in_next_epoch_from_fork_proof() {
         .body
         .as_mut()
         .unwrap()
-        .fork_proofs
-        .push(fork_proof);
+        .equivocation_proofs
+        .push(fork_proof.into());
 
     let blockchain_rg = temp_producer1.blockchain.read();
     let (validator, _slot) = blockchain_rg
@@ -449,7 +449,7 @@ fn it_correctly_creates_inherents_in_next_epoch_from_fork_proof() {
     // Create the inherents from any forks or skip block info.
     let inherents = blockchain_rg.create_punishment_inherents(
         reporting_micro_block.block_number(),
-        &reporting_micro_block.body.unwrap().fork_proofs,
+        &reporting_micro_block.body.unwrap().equivocation_proofs,
         skip_block_info,
         None,
     );

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -322,21 +322,21 @@ fn it_correctly_creates_inherents_from_fork_proof() {
     let mut reporting_micro_block = reporting_micro_block.unwrap_micro();
 
     // Produce and add the fork proof.
-    let fork_proof = ForkProof {
-        header1: micro_block_fork1.header.clone(),
-        header2: micro_block_fork2.header.clone(),
-        justification1: micro_block_fork1
+    let fork_proof = ForkProof::new(
+        micro_block_fork1.header.clone(),
+        micro_block_fork1
             .justification
             .clone()
             .unwrap()
             .unwrap_micro(),
-        justification2: micro_block_fork2
+        micro_block_fork2.header.clone(),
+        micro_block_fork2
             .justification
             .clone()
             .unwrap()
             .unwrap_micro(),
-        prev_vrf_seed: micro_block_fork2.header.seed.clone(),
-    };
+        micro_block_fork2.header.seed.clone(),
+    );
     reporting_micro_block
         .body
         .as_mut()
@@ -407,21 +407,21 @@ fn it_correctly_creates_inherents_in_next_epoch_from_fork_proof() {
     );
 
     // Produce and add the fork proof.
-    let fork_proof = ForkProof {
-        header1: micro_block_fork1.header.clone(),
-        header2: micro_block_fork2.header.clone(),
-        justification1: micro_block_fork1
+    let fork_proof = ForkProof::new(
+        micro_block_fork1.header.clone(),
+        micro_block_fork1
             .justification
             .clone()
             .unwrap()
             .unwrap_micro(),
-        justification2: micro_block_fork2
+        micro_block_fork2.header.clone(),
+        micro_block_fork2
             .justification
             .clone()
             .unwrap()
             .unwrap_micro(),
-        prev_vrf_seed: micro_block_fork2.header.seed.clone(),
-    };
+        micro_block_fork2.header.seed.clone(),
+    );
     reporting_micro_block
         .body
         .as_mut()

--- a/bls/src/types/aggregate_signature.rs
+++ b/bls/src/types/aggregate_signature.rs
@@ -15,6 +15,8 @@ use crate::{CompressedSignature, Signature};
 pub struct AggregateSignature(pub Signature);
 
 impl AggregateSignature {
+    pub const SIZE: usize = Signature::SIZE;
+
     /// Creates a new "empty" aggregate signature. It is simply the identity element of the elliptic curve, also known as the point at infinity.
     pub fn new() -> Self {
         let signature = G1Projective::zero();

--- a/bls/src/types/aggregate_signature.rs
+++ b/bls/src/types/aggregate_signature.rs
@@ -15,6 +15,7 @@ use crate::{CompressedSignature, Signature};
 pub struct AggregateSignature(pub Signature);
 
 impl AggregateSignature {
+    /// Maximum size in bytes for a single `AggregateSignature` in binary serialization.
     pub const SIZE: usize = Signature::SIZE;
 
     /// Creates a new "empty" aggregate signature. It is simply the identity element of the elliptic curve, also known as the point at infinity.

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -144,6 +144,7 @@ mod serde_derive {
     use super::{CompressedSignature, Signature};
 
     impl Signature {
+        /// Maximum size in bytes for a single `Signature` in binary serialization.
         pub const SIZE: usize = CompressedSignature::SIZE;
     }
 

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -143,6 +143,10 @@ mod serde_derive {
 
     use super::{CompressedSignature, Signature};
 
+    impl Signature {
+        pub const SIZE: usize = CompressedSignature::SIZE;
+    }
+
     impl Serialize for Signature {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -19,6 +19,8 @@ maintenance = { status = "experimental" }
 [dependencies]
 serde = "1.0"
 
+nimiq-serde = { workspace = true }
+
 [dev-dependencies]
 hex = "0.4"
 rand = "0.8"

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -371,9 +371,10 @@ impl FromIterator<usize> for BitSet {
 }
 
 impl BitSet {
-    pub const fn size(largest_bit_index: usize) -> usize {
+    /// Maximum size in bytes for a single `BitSet` in binary serialization.
+    pub const fn max_size(largest_bit_index: usize) -> usize {
         let num_u64 = (largest_bit_index + 63) / 64;
-        nimiq_serde::vec_size(nimiq_serde::U64_SIZE, num_u64)
+        nimiq_serde::vec_max_size(nimiq_serde::U64_MAX_SIZE, num_u64)
     }
 }
 

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -370,6 +370,13 @@ impl FromIterator<usize> for BitSet {
     }
 }
 
+impl BitSet {
+    pub const fn size(largest_bit_index: usize) -> usize {
+        let num_u64 = (largest_bit_index + 63) / 64;
+        nimiq_serde::vec_size(nimiq_serde::U64_SIZE, num_u64)
+    }
+}
+
 impl Serialize for BitSet {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -9,7 +9,7 @@ use futures::{stream::BoxStream, Stream, StreamExt};
 use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction, ForkEvent};
 use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
 use nimiq_primitives::policy::Policy;
 use parking_lot::RwLock;
@@ -455,8 +455,8 @@ impl<N: Network> BlockQueue<N> {
 
         match event {
             ForkEvent::Detected(proof) => {
-                block_infos.push((proof.header1.block_number, proof.header1.hash()));
-                block_infos.push((proof.header2.block_number, proof.header2.hash()));
+                block_infos.push((proof.block_number(), proof.header1_hash()));
+                block_infos.push((proof.block_number(), proof.header2_hash()));
             }
         }
         block_infos

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use futures::{stream::BoxStream, Stream, StreamExt};
-use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
+use nimiq_block::{Block, BlockHeaderTopic, BlockTopic, EquivocationProof};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction, ForkEvent};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::{Blake2bHash, Hash};
@@ -454,7 +454,7 @@ impl<N: Network> BlockQueue<N> {
         let mut block_infos = vec![];
 
         match event {
-            ForkEvent::Detected(proof) => {
+            ForkEvent::Detected(EquivocationProof::Fork(proof)) => {
                 block_infos.push((proof.header1.block_number, proof.header1.hash()));
                 block_infos.push((proof.header2.block_number, proof.header2.hash()));
             }

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use futures::{stream::BoxStream, Stream, StreamExt};
-use nimiq_block::{Block, BlockHeaderTopic, BlockTopic, EquivocationProof};
+use nimiq_block::{Block, BlockHeaderTopic, BlockTopic};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, Direction, ForkEvent};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::{Blake2bHash, Hash};
@@ -454,7 +454,7 @@ impl<N: Network> BlockQueue<N> {
         let mut block_infos = vec![];
 
         match event {
-            ForkEvent::Detected(EquivocationProof::Fork(proof)) => {
+            ForkEvent::Detected(proof) => {
                 block_infos.push((proof.header1.block_number, proof.header1.hash()));
                 block_infos.push((proof.header2.block_number, proof.header2.hash()));
             }

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -424,13 +424,13 @@ impl LightBlockchain {
                     .expect("Missing justification")
                     .unwrap_micro();
 
-                let proof = ForkProof {
-                    header1: block.header.clone(),
-                    header2: micro_block.header,
+                let proof = ForkProof::new(
+                    block.header.clone(),
                     justification1,
+                    micro_block.header,
                     justification2,
-                    prev_vrf_seed: prev_vrf_seed.clone(),
-                };
+                    prev_vrf_seed.clone(),
+                );
 
                 // We shouldn't log errors if there are no listeners.
                 _ = self.fork_notifier.send(ForkEvent::Detected(proof));

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -433,7 +433,7 @@ impl LightBlockchain {
                 );
 
                 // We shouldn't log errors if there are no listeners.
-                _ = self.fork_notifier.send(ForkEvent::Detected(proof));
+                _ = self.fork_notifier.send(ForkEvent::Detected(proof.into()));
             }
         }
     }

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -433,7 +433,7 @@ impl LightBlockchain {
                 );
 
                 // We shouldn't log errors if there are no listeners.
-                _ = self.fork_notifier.send(ForkEvent::Detected(proof.into()));
+                _ = self.fork_notifier.send(ForkEvent::Detected(proof));
             }
         }
     }

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -266,7 +266,7 @@ fn create_dummy_micro_block(transactions: Option<Vec<Transaction>>) -> Block {
     }
 
     let micro_body = MicroBody {
-        fork_proofs: vec![],
+        equivocation_proofs: vec![],
         transactions: executed_txns,
     };
 

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -19,9 +19,23 @@ pub enum EquivocationProof {
     DoubleVote(DoubleVoteProof),
 }
 
+const fn max3(a: usize, b: usize, c: usize) -> usize {
+    if a > b && a > c {
+        a
+    } else if b > c {
+        b
+    } else {
+        c
+    }
+}
+
 impl EquivocationProof {
     /// The size of a single equivocation proof. This is the maximum possible size.
-    pub const SIZE: usize = ForkProof::SIZE + 1;
+    pub const SIZE: usize = 1 + max3(
+        ForkProof::SIZE,
+        DoubleProposalProof::SIZE,
+        DoubleVoteProof::SIZE,
+    );
 
     /// Returns the block number of an equivocation proof. This assumes that the equivocation proof
     /// is valid.
@@ -194,6 +208,10 @@ pub struct DoubleProposalProof {
 }
 
 impl DoubleProposalProof {
+    /// The maximum size of a double proposal proof.
+    pub const SIZE: usize =
+        2 * MacroHeader::MAX_SIZE + 2 * SchnorrSignature::SIZE + 2 * VrfSeed::SIZE;
+
     pub fn new(
         mut header1: MacroHeader,
         mut justification1: SchnorrSignature,
@@ -298,6 +316,12 @@ pub struct DoubleVoteProof {
 }
 
 impl DoubleVoteProof {
+    /// The maximum size of a double proposal proof.
+    pub const SIZE: usize = 2 * MacroHeader::MAX_SIZE
+        + 2 * nimiq_serde::option_size(Blake2sHash::SIZE)
+        + 2 * AggregateSignature::SIZE
+        + 2 * BitSet::size(Policy::SLOTS as usize);
+
     pub fn new(
         tendermint_id: TendermintIdentifier,
         validator_address: Address,

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -8,6 +8,7 @@ use nimiq_keys::{Address, PublicKey as SchnorrPublicKey, Signature as SchnorrSig
 use nimiq_primitives::{policy::Policy, slots_allocation::Validators};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_vrf::VrfSeed;
+use thiserror::Error;
 
 use crate::{MacroHeader, MicroHeader, TendermintIdentifier, TendermintVote};
 
@@ -49,6 +50,18 @@ impl EquivocationProof {
 impl From<ForkProof> for EquivocationProof {
     fn from(proof: ForkProof) -> EquivocationProof {
         EquivocationProof::Fork(proof)
+    }
+}
+
+impl From<DoubleProposalProof> for EquivocationProof {
+    fn from(proof: DoubleProposalProof) -> EquivocationProof {
+        EquivocationProof::DoubleProposal(proof)
+    }
+}
+
+impl From<DoubleVoteProof> for EquivocationProof {
+    fn from(proof: DoubleVoteProof) -> EquivocationProof {
+        EquivocationProof::DoubleVote(proof)
     }
 }
 
@@ -152,13 +165,19 @@ impl std::hash::Hash for ForkProof {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum EquivocationProofError {
+    #[error("Slot mismatch")]
     SlotMismatch,
+    #[error("No overlap between signer sets")]
     NoOverlap,
+    #[error("Invalid justification")]
     InvalidJustification,
+    #[error("Invalid validator address")]
     InvalidValidatorAddress,
+    #[error("Same header")]
     SameHeader,
+    #[error("Wrong order")]
     WrongOrder,
 }
 

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -1,28 +1,43 @@
 use std::{cmp::Ordering, hash::Hasher, mem};
 
-use nimiq_hash::{Blake2bHash, Hash, HashOutput};
+use nimiq_bls::{AggregatePublicKey, AggregateSignature};
+use nimiq_collections::BitSet;
+use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput};
 use nimiq_hash_derive::SerializeContent;
 use nimiq_keys::{PublicKey as SchnorrPublicKey, Signature as SchnorrSignature};
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{policy::Policy, slots_allocation::Validators};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_vrf::VrfSeed;
 
-use crate::MicroHeader;
+use crate::{MacroHeader, MicroHeader, TendermintIdentifier, TendermintVote};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, SerializeContent)]
 pub enum EquivocationProof {
     Fork(ForkProof),
+    DoubleProposal(DoubleProposalProof),
+    DoubleVote(DoubleVoteProof),
 }
 
 impl EquivocationProof {
     /// The size of a single equivocation proof. This is the maximum possible size.
     pub const SIZE: usize = ForkProof::SIZE + 1;
 
-    pub fn is_valid_at(&self, block_number: u32) -> bool {
+    /// Returns the block number of an equivocation proof. This assumes that the equivocation proof
+    /// is valid.
+    pub fn block_number(&self) -> u32 {
         use self::EquivocationProof::*;
         match self {
-            Fork(proof) => proof.is_valid_at(block_number),
+            Fork(proof) => proof.block_number(),
+            DoubleProposal(proof) => proof.block_number(),
+            DoubleVote(proof) => proof.block_number(),
         }
+    }
+
+    /// Check if an equivocation proof is valid at a given block height. Equivocation proofs are
+    /// valid only until the end of the reporting window.
+    pub fn is_valid_at(&self, block_number: u32) -> bool {
+        block_number <= Policy::last_block_of_reporting_window(self.block_number())
+            && Policy::batch_at(block_number) >= Policy::batch_at(self.block_number())
     }
 
     /// Returns the key by which equivocation proofs are supposed to be sorted.
@@ -85,54 +100,42 @@ impl ForkProof {
         }
     }
 
+    pub fn block_number(&self) -> u32 {
+        self.header1.block_number
+    }
+
     /// Verify the validity of a fork proof.
-    pub fn verify(&self, signing_key: &SchnorrPublicKey) -> Result<(), ForkProofError> {
+    pub fn verify(&self, signing_key: &SchnorrPublicKey) -> Result<(), EquivocationProofError> {
         let hash1: Blake2bHash = self.header1.hash();
         let hash2: Blake2bHash = self.header2.hash();
 
         // Check that the headers are not equal and in the right order:
         match hash1.cmp(&hash2) {
             Ordering::Less => {}
-            Ordering::Equal => return Err(ForkProofError::SameHeader),
-            Ordering::Greater => return Err(ForkProofError::WrongOrder),
+            Ordering::Equal => return Err(EquivocationProofError::SameHeader),
+            Ordering::Greater => return Err(EquivocationProofError::WrongOrder),
         }
 
         // Check that the headers have equal block numbers and seeds.
         if self.header1.block_number != self.header2.block_number
             || self.header1.seed.entropy() != self.header2.seed.entropy()
         {
-            return Err(ForkProofError::SlotMismatch);
+            return Err(EquivocationProofError::SlotMismatch);
         }
 
         if let Err(e) = self.header1.seed.verify(&self.prev_vrf_seed, signing_key) {
             error!("ForkProof: VrfSeed failed to verify: {:?}", e);
-            return Err(ForkProofError::InvalidJustification);
+            return Err(EquivocationProofError::InvalidJustification);
         }
 
         // Check that the justifications are valid.
-        let hash1 = self.header1.hash::<Blake2bHash>();
-        let hash2 = self.header2.hash::<Blake2bHash>();
         if !signing_key.verify(&self.justification1, hash1.as_slice())
             || !signing_key.verify(&self.justification2, hash2.as_slice())
         {
-            return Err(ForkProofError::InvalidJustification);
+            return Err(EquivocationProofError::InvalidJustification);
         }
 
         Ok(())
-    }
-
-    /// Check if a fork proof is valid at a given block height.
-    /// Fork proofs are valid only until the end of the reporting window.
-    pub fn is_valid_at(&self, block_number: u32) -> bool {
-        let fork_block = self.header1.block_number;
-
-        block_number <= Policy::last_block_of_reporting_window(fork_block)
-            && Policy::batch_at(block_number) >= Policy::batch_at(fork_block)
-    }
-
-    /// Returns the block number of a fork proof. This assumes that the fork proof is valid.
-    pub fn block_number(&self) -> u32 {
-        self.header1.block_number
     }
 }
 
@@ -144,9 +147,217 @@ impl std::hash::Hash for ForkProof {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ForkProofError {
+pub enum EquivocationProofError {
     SlotMismatch,
     InvalidJustification,
+    InvalidSlotNumber,
     SameHeader,
     WrongOrder,
+}
+
+/// Struct representing a double proposal proof. A double proposal proof proves that a given
+/// validator created two macro block proposals at the same height, in the same round.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
+pub struct DoubleProposalProof {
+    pub header1: MacroHeader,
+    pub header2: MacroHeader,
+    pub justification1: SchnorrSignature,
+    pub justification2: SchnorrSignature,
+    pub prev_vrf_seed1: VrfSeed,
+    pub prev_vrf_seed2: VrfSeed,
+    dont_construct_me: (),
+}
+
+impl DoubleProposalProof {
+    pub fn new(
+        mut header1: MacroHeader,
+        mut justification1: SchnorrSignature,
+        mut prev_vrf_seed1: VrfSeed,
+        mut header2: MacroHeader,
+        mut justification2: SchnorrSignature,
+        mut prev_vrf_seed2: VrfSeed,
+    ) -> DoubleProposalProof {
+        let hash1: Blake2bHash = header1.hash();
+        let hash2: Blake2bHash = header2.hash();
+        if hash1 > hash2 {
+            mem::swap(&mut header1, &mut header2);
+            mem::swap(&mut justification1, &mut justification2);
+            mem::swap(&mut prev_vrf_seed1, &mut prev_vrf_seed2);
+        }
+        DoubleProposalProof {
+            header1,
+            header2,
+            justification1,
+            justification2,
+            prev_vrf_seed1,
+            prev_vrf_seed2,
+            dont_construct_me: (),
+        }
+    }
+
+    pub fn block_number(&self) -> u32 {
+        self.header1.block_number
+    }
+
+    /// Verify the validity of a double proposal proof.
+    pub fn verify(&self, signing_key: &SchnorrPublicKey) -> Result<(), EquivocationProofError> {
+        let hash1: Blake2bHash = self.header1.hash();
+        let hash2: Blake2bHash = self.header2.hash();
+
+        // Check that the headers are not equal and in the right order:
+        match hash1.cmp(&hash2) {
+            Ordering::Less => {}
+            Ordering::Equal => return Err(EquivocationProofError::SameHeader),
+            Ordering::Greater => return Err(EquivocationProofError::WrongOrder),
+        }
+
+        if self.header1.block_number != self.header2.block_number
+            || self.header1.round != self.header2.round
+        {
+            return Err(EquivocationProofError::SlotMismatch);
+        }
+
+        if let Err(e) = self.header1.seed.verify(&self.prev_vrf_seed1, signing_key) {
+            error!("DoubleProposalProof: VrfSeed 1 failed to verify: {:?}", e);
+            return Err(EquivocationProofError::InvalidJustification);
+        }
+
+        if let Err(e) = self.header2.seed.verify(&self.prev_vrf_seed2, signing_key) {
+            error!("DoubleProposalProof: VrfSeed 2 failed to verify: {:?}", e);
+            return Err(EquivocationProofError::InvalidJustification);
+        }
+
+        // Check that the justifications are valid.
+        if !signing_key.verify(&self.justification1, hash1.as_slice())
+            || !signing_key.verify(&self.justification2, hash2.as_slice())
+        {
+            return Err(EquivocationProofError::InvalidJustification);
+        }
+
+        Ok(())
+    }
+}
+
+impl std::hash::Hash for DoubleProposalProof {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(Hash::hash::<Blake2bHash>(self).as_bytes());
+    }
+}
+
+/// Struct representing a double vote proof. A double vote proof proves that a given
+/// validator voted twice at same height, in the same round.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
+pub struct DoubleVoteProof {
+    pub tendermint_id: TendermintIdentifier,
+    pub slot_number: u16,
+    pub proposal_hash1: Option<Blake2sHash>,
+    pub proposal_hash2: Option<Blake2sHash>,
+    pub signature1: AggregateSignature,
+    pub signature2: AggregateSignature,
+    pub signers1: BitSet,
+    pub signers2: BitSet,
+    dont_construct_me: (),
+}
+
+impl DoubleVoteProof {
+    pub fn new(
+        tendermint_id: TendermintIdentifier,
+        slot_number: u16,
+        mut proposal_hash1: Option<Blake2sHash>,
+        mut proposal_hash2: Option<Blake2sHash>,
+        mut signature1: AggregateSignature,
+        mut signature2: AggregateSignature,
+        mut signers1: BitSet,
+        mut signers2: BitSet,
+    ) -> DoubleVoteProof {
+        if proposal_hash1 > proposal_hash2 {
+            mem::swap(&mut proposal_hash1, &mut proposal_hash2);
+            mem::swap(&mut signature1, &mut signature2);
+            mem::swap(&mut signers1, &mut signers2);
+        }
+        DoubleVoteProof {
+            tendermint_id,
+            slot_number,
+            proposal_hash1,
+            proposal_hash2,
+            signature1,
+            signature2,
+            signers1,
+            signers2,
+            dont_construct_me: (),
+        }
+    }
+
+    pub fn block_number(&self) -> u32 {
+        self.tendermint_id.block_number
+    }
+
+    /// Verify the validity of a double vote proof.
+    ///
+    /// The parameter `validators` must be the historic validators of that
+    /// macro block production.
+    pub fn verify(&self, validators: &Validators) -> Result<(), EquivocationProofError> {
+        // Check that the proposals are not equal and in the right order:
+        match self.proposal_hash1.cmp(&self.proposal_hash2) {
+            Ordering::Less => {}
+            Ordering::Equal => return Err(EquivocationProofError::SameHeader),
+            Ordering::Greater => return Err(EquivocationProofError::WrongOrder),
+        }
+
+        if self.slot_number >= Policy::SLOTS {
+            return Err(EquivocationProofError::InvalidSlotNumber);
+        }
+
+        // Check that the signatures actually contain the reported validator.
+        if !self.signers1.contains(self.slot_number as usize) {
+            // The validator did not participate in the signature.
+            return Err(EquivocationProofError::SlotMismatch);
+        }
+        if !self.signers2.contains(self.slot_number as usize) {
+            // The validator did not participate in the signature.
+            return Err(EquivocationProofError::SlotMismatch);
+        }
+
+        // Calculate the messages that were actually signed by the validators.
+        let message1 = TendermintVote {
+            proposal_hash: self.proposal_hash1.clone(),
+            id: self.tendermint_id.clone(),
+        };
+        let message2 = TendermintVote {
+            proposal_hash: self.proposal_hash2.clone(),
+            id: self.tendermint_id.clone(),
+        };
+
+        // Verify the signatures.
+        {
+            let mut agg_pk1 = AggregatePublicKey::new();
+            for (i, pk) in validators.voting_keys().iter().enumerate() {
+                if self.signers1.contains(i) {
+                    agg_pk1.aggregate(pk);
+                }
+            }
+            if !agg_pk1.verify(&message1, &self.signature1) {
+                return Err(EquivocationProofError::InvalidJustification);
+            }
+        }
+        {
+            let mut agg_pk2 = AggregatePublicKey::new();
+            for (i, pk) in validators.voting_keys().iter().enumerate() {
+                if self.signers2.contains(i) {
+                    agg_pk2.aggregate(pk);
+                }
+            }
+            if !agg_pk2.verify(&message2, &self.signature2) {
+                return Err(EquivocationProofError::InvalidJustification);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::hash::Hash for DoubleVoteProof {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(Hash::hash::<Blake2bHash>(self).as_bytes());
+    }
 }

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -58,17 +58,15 @@ impl From<ForkProof> for EquivocationProof {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
 pub struct ForkProof {
     /// Header number 1.
-    pub header1: MicroHeader,
+    header1: MicroHeader,
     /// Header number 2.
-    pub header2: MicroHeader,
+    header2: MicroHeader,
     /// Justification for header number 1.
-    pub justification1: SchnorrSignature,
+    justification1: SchnorrSignature,
     /// Justification for header number 2.
-    pub justification2: SchnorrSignature,
+    justification2: SchnorrSignature,
     /// Vrf seed of the previous block. Used to determine the slot.
-    pub prev_vrf_seed: VrfSeed,
-    /// Make sure everyone has to go through the constructor.
-    dont_construct_me: (),
+    prev_vrf_seed: VrfSeed,
 }
 
 impl ForkProof {
@@ -96,12 +94,20 @@ impl ForkProof {
             justification1,
             justification2,
             prev_vrf_seed,
-            dont_construct_me: (),
         }
     }
 
+    pub fn header1_hash(&self) -> Blake2bHash {
+        self.header1.hash()
+    }
+    pub fn header2_hash(&self) -> Blake2bHash {
+        self.header2.hash()
+    }
     pub fn block_number(&self) -> u32 {
         self.header1.block_number
+    }
+    pub fn prev_vrf_seed(&self) -> &VrfSeed {
+        &self.prev_vrf_seed
     }
 
     /// Verify the validity of a fork proof.
@@ -159,13 +165,12 @@ pub enum EquivocationProofError {
 /// validator created two macro block proposals at the same height, in the same round.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
 pub struct DoubleProposalProof {
-    pub header1: MacroHeader,
-    pub header2: MacroHeader,
-    pub justification1: SchnorrSignature,
-    pub justification2: SchnorrSignature,
-    pub prev_vrf_seed1: VrfSeed,
-    pub prev_vrf_seed2: VrfSeed,
-    dont_construct_me: (),
+    header1: MacroHeader,
+    header2: MacroHeader,
+    justification1: SchnorrSignature,
+    justification2: SchnorrSignature,
+    prev_vrf_seed1: VrfSeed,
+    prev_vrf_seed2: VrfSeed,
 }
 
 impl DoubleProposalProof {
@@ -191,12 +196,26 @@ impl DoubleProposalProof {
             justification2,
             prev_vrf_seed1,
             prev_vrf_seed2,
-            dont_construct_me: (),
         }
     }
 
     pub fn block_number(&self) -> u32 {
         self.header1.block_number
+    }
+    pub fn round(&self) -> u32 {
+        self.header1.round
+    }
+    pub fn header1_hash(&self) -> Blake2bHash {
+        self.header1.hash()
+    }
+    pub fn header2_hash(&self) -> Blake2bHash {
+        self.header2.hash()
+    }
+    pub fn prev_vrf_seed1(&self) -> &VrfSeed {
+        &self.prev_vrf_seed1
+    }
+    pub fn prev_vrf_seed2(&self) -> &VrfSeed {
+        &self.prev_vrf_seed2
     }
 
     /// Verify the validity of a double proposal proof.
@@ -248,15 +267,14 @@ impl std::hash::Hash for DoubleProposalProof {
 /// validator voted twice at same height, in the same round.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
 pub struct DoubleVoteProof {
-    pub tendermint_id: TendermintIdentifier,
-    pub slot_number: u16,
-    pub proposal_hash1: Option<Blake2sHash>,
-    pub proposal_hash2: Option<Blake2sHash>,
-    pub signature1: AggregateSignature,
-    pub signature2: AggregateSignature,
-    pub signers1: BitSet,
-    pub signers2: BitSet,
-    dont_construct_me: (),
+    tendermint_id: TendermintIdentifier,
+    slot_number: u16,
+    proposal_hash1: Option<Blake2sHash>,
+    proposal_hash2: Option<Blake2sHash>,
+    signature1: AggregateSignature,
+    signature2: AggregateSignature,
+    signers1: BitSet,
+    signers2: BitSet,
 }
 
 impl DoubleVoteProof {
@@ -284,12 +302,14 @@ impl DoubleVoteProof {
             signature2,
             signers1,
             signers2,
-            dont_construct_me: (),
         }
     }
 
     pub fn block_number(&self) -> u32 {
         self.tendermint_id.block_number
+    }
+    pub fn slot_number(&self) -> u16 {
+        self.slot_number
     }
 
     /// Verify the validity of a double vote proof.

--- a/primitives/block/src/fork_proof.rs
+++ b/primitives/block/src/fork_proof.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, hash::Hasher, mem};
 
 use nimiq_hash::{Blake2bHash, Hash, HashOutput};
 use nimiq_hash_derive::SerializeContent;
@@ -12,7 +12,7 @@ use crate::MicroHeader;
 /// Struct representing a fork proof. A fork proof proves that a given validator created or
 /// continued a fork. For this it is enough to provide two different headers, with the same block
 /// number, signed by the same validator.
-#[derive(Clone, Debug, Serialize, Deserialize, SerializeContent)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
 pub struct ForkProof {
     /// Header number 1.
     pub header1: MicroHeader,
@@ -24,6 +24,8 @@ pub struct ForkProof {
     pub justification2: SchnorrSignature,
     /// Vrf seed of the previous block. Used to determine the slot.
     pub prev_vrf_seed: VrfSeed,
+    /// Make sure everyone has to go through the constructor.
+    dont_construct_me: (),
 }
 
 impl ForkProof {
@@ -32,11 +34,39 @@ impl ForkProof {
     /// has the maximum size.
     pub const SIZE: usize = 2 * MicroHeader::MAX_SIZE + 2 * SchnorrSignature::SIZE + VrfSeed::SIZE;
 
+    pub fn new(
+        mut header1: MicroHeader,
+        mut justification1: SchnorrSignature,
+        mut header2: MicroHeader,
+        mut justification2: SchnorrSignature,
+        prev_vrf_seed: VrfSeed,
+    ) -> ForkProof {
+        let hash1: Blake2bHash = header1.hash();
+        let hash2: Blake2bHash = header2.hash();
+        if hash1 > hash2 {
+            mem::swap(&mut header1, &mut header2);
+            mem::swap(&mut justification1, &mut justification2);
+        }
+        ForkProof {
+            header1,
+            header2,
+            justification1,
+            justification2,
+            prev_vrf_seed,
+            dont_construct_me: (),
+        }
+    }
+
     /// Verify the validity of a fork proof.
     pub fn verify(&self, signing_key: &SchnorrPublicKey) -> Result<(), ForkProofError> {
-        // Check that the headers are not equal.
-        if self.header1.hash::<Blake2bHash>() == self.header2.hash::<Blake2bHash>() {
-            return Err(ForkProofError::SameHeader);
+        let hash1: Blake2bHash = self.header1.hash();
+        let hash2: Blake2bHash = self.header2.hash();
+
+        // Check that the headers are not equal and in the right order:
+        match hash1.cmp(&hash2) {
+            Ordering::Less => {}
+            Ordering::Equal => return Err(ForkProofError::SameHeader),
+            Ordering::Greater => return Err(ForkProofError::WrongOrder),
         }
 
         // Check that the headers have equal block numbers and seeds.
@@ -72,53 +102,21 @@ impl ForkProof {
             && Policy::batch_at(block_number) >= Policy::batch_at(fork_block)
     }
 
+    /// Returns the key by which fork proofs are supposed to be sorted.
+    pub fn sort_key(&self) -> Blake2bHash {
+        self.hash()
+    }
+
     /// Returns the block number of a fork proof. This assumes that the fork proof is valid.
     pub fn block_number(&self) -> u32 {
         self.header1.block_number
     }
 }
 
-impl PartialEq for ForkProof {
-    fn eq(&self, other: &ForkProof) -> bool {
-        // Equality is invariant to ordering.
-        if self.header1 == other.header1 {
-            return self.header2 == other.header2
-                && self.justification1 == other.justification1
-                && self.justification2 == other.justification2;
-        }
-
-        if self.header1 == other.header2 {
-            return self.header2 == other.header1
-                && self.justification1 == other.justification2
-                && self.justification2 == other.justification1;
-        }
-
-        false
-    }
-}
-
-impl Eq for ForkProof {}
-
-impl PartialOrd for ForkProof {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ForkProof {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.hash::<Blake2bHash>().cmp(&other.hash::<Blake2bHash>())
-    }
-}
-
 impl std::hash::Hash for ForkProof {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // We need to sort the hashes, so that it is invariant to the internal ordering.
-        let mut hashes: Vec<Blake2bHash> = vec![self.header1.hash(), self.header2.hash()];
-        hashes.sort();
-
-        std::hash::Hash::hash(hashes[0].as_bytes(), state);
-        std::hash::Hash::hash(hashes[1].as_bytes(), state);
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.header1.hash::<Blake2bHash>().as_bytes());
+        state.write(self.header2.hash::<Blake2bHash>().as_bytes());
     }
 }
 
@@ -127,4 +125,5 @@ pub enum ForkProofError {
     SlotMismatch,
     InvalidJustification,
     SameHeader,
+    WrongOrder,
 }

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -3,7 +3,7 @@ extern crate log;
 
 pub use block::*;
 pub use block_proof::*;
-pub use fork_proof::*;
+pub use equivocation_proof::*;
 pub use macro_block::*;
 pub use micro_block::*;
 pub use multisig::*;
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 mod block;
 mod block_proof;
-mod fork_proof;
+mod equivocation_proof;
 mod macro_block;
 mod micro_block;
 mod multisig;

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -197,16 +197,17 @@ pub struct MacroHeader {
 impl MacroHeader {
     /// Returns the size, in bytes, of a Macro block header. This represents the maximum possible
     /// size since we assume that the extra_data field is completely filled.
+    #[allow(clippy::identity_op)]
     pub const MAX_SIZE: usize = 0
-        + /*version*/ nimiq_serde::U16_SIZE
-        + /*block_number*/ nimiq_serde::U32_SIZE
-        + /*round*/ nimiq_serde::U32_SIZE
-        + /*timestamp*/ nimiq_serde::U64_SIZE
+        + /*version*/ nimiq_serde::U16_MAX_SIZE
+        + /*block_number*/ nimiq_serde::U32_MAX_SIZE
+        + /*round*/ nimiq_serde::U32_MAX_SIZE
+        + /*timestamp*/ nimiq_serde::U64_MAX_SIZE
         + /*parent_hash*/ Blake2bHash::SIZE
         + /*parent_election_hash*/ Blake2bHash::SIZE
-        + /*interlink*/ nimiq_serde::option_size(nimiq_serde::vec_size(Blake2bHash::SIZE, 32))
+        + /*interlink*/ nimiq_serde::option_max_size(nimiq_serde::vec_max_size(Blake2bHash::SIZE, 32))
         + /*seed*/ VrfSeed::SIZE
-        + /*extra_data*/ nimiq_serde::vec_size(nimiq_serde::U8_SIZE, 32)
+        + /*extra_data*/ nimiq_serde::vec_max_size(nimiq_serde::U8_SIZE, 32)
         + /*state_root*/ Blake2bHash::SIZE
         + /*body_root*/ Blake2sHash::SIZE
         + /*diff_root*/ Blake2bHash::SIZE

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -194,6 +194,25 @@ pub struct MacroHeader {
     pub history_root: Blake2bHash,
 }
 
+impl MacroHeader {
+    /// Returns the size, in bytes, of a Macro block header. This represents the maximum possible
+    /// size since we assume that the extra_data field is completely filled.
+    pub const MAX_SIZE: usize = 0
+        + /*version*/ nimiq_serde::U16_SIZE
+        + /*block_number*/ nimiq_serde::U32_SIZE
+        + /*round*/ nimiq_serde::U32_SIZE
+        + /*timestamp*/ nimiq_serde::U64_SIZE
+        + /*parent_hash*/ Blake2bHash::SIZE
+        + /*parent_election_hash*/ Blake2bHash::SIZE
+        + /*interlink*/ nimiq_serde::option_size(nimiq_serde::vec_size(Blake2bHash::SIZE, 32))
+        + /*seed*/ VrfSeed::SIZE
+        + /*extra_data*/ nimiq_serde::vec_size(nimiq_serde::U8_SIZE, 32)
+        + /*state_root*/ Blake2bHash::SIZE
+        + /*body_root*/ Blake2sHash::SIZE
+        + /*diff_root*/ Blake2bHash::SIZE
+        + /*history_root*/ Blake2bHash::SIZE;
+}
+
 impl Message for MacroHeader {
     const PREFIX: u8 = PREFIX_TENDERMINT_PROPOSAL;
 }

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -255,7 +255,7 @@ impl MicroBody {
 
             // Check proof ordering and uniqueness.
             if let Some(previous) = previous_proof {
-                match previous.cmp(proof) {
+                match previous.sort_key().cmp(&proof.sort_key()) {
                     Ordering::Equal => {
                         return Err(BlockError::DuplicateForkProof);
                     }

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -187,11 +187,17 @@ pub struct MicroHeader {
 impl MicroHeader {
     /// Returns the size, in bytes, of a Micro block header. This represents the maximum possible
     /// size since we assume that the extra_data field is completely filled.
-    pub const MAX_SIZE: usize =
-        /*version*/
-        2 + /*block_number*/ 4 + /*timestamp*/ 8 + /*parent_hash*/ 32
-            + /*seed*/ VrfSeed::SIZE + /*extra_data*/ 32 + /*state_root*/ 32
-            + /*body_root*/ 32 + /*history_root*/ 32;
+    pub const MAX_SIZE: usize = 0
+        + /*version*/ nimiq_serde::U16_SIZE
+        + /*block_number*/ nimiq_serde::U32_SIZE
+        + /*timestamp*/ nimiq_serde::U64_SIZE
+        + /*parent_hash*/ Blake2bHash::SIZE
+        + /*seed*/ VrfSeed::SIZE
+        + /*extra_data*/ nimiq_serde::vec_size(nimiq_serde::U8_SIZE, 32)
+        + /*state_root*/ Blake2bHash::SIZE
+        + /*body_root*/ Blake2sHash::SIZE
+        + /*diff_root*/ Blake2bHash::SIZE
+        + /*history_root*/ Blake2bHash::SIZE;
 }
 
 impl fmt::Display for MicroHeader {

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -52,7 +52,7 @@ impl MicroBlock {
     /// Returns the available size, in bytes, in a micro block body for transactions.
     pub fn get_available_bytes(num_equivocation_proofs: usize) -> usize {
         Policy::MAX_SIZE_MICRO_BODY
-            - (/*equivocation_proofs vector length*/2 + num_equivocation_proofs * EquivocationProof::SIZE
+            - (/*equivocation_proofs vector length*/2 + num_equivocation_proofs * EquivocationProof::MAX_SIZE
             + /*transactions vector length*/ 2)
     }
 
@@ -187,13 +187,14 @@ pub struct MicroHeader {
 impl MicroHeader {
     /// Returns the size, in bytes, of a Micro block header. This represents the maximum possible
     /// size since we assume that the extra_data field is completely filled.
+    #[allow(clippy::identity_op)]
     pub const MAX_SIZE: usize = 0
-        + /*version*/ nimiq_serde::U16_SIZE
-        + /*block_number*/ nimiq_serde::U32_SIZE
-        + /*timestamp*/ nimiq_serde::U64_SIZE
+        + /*version*/ nimiq_serde::U16_MAX_SIZE
+        + /*block_number*/ nimiq_serde::U32_MAX_SIZE
+        + /*timestamp*/ nimiq_serde::U64_MAX_SIZE
         + /*parent_hash*/ Blake2bHash::SIZE
         + /*seed*/ VrfSeed::SIZE
-        + /*extra_data*/ nimiq_serde::vec_size(nimiq_serde::U8_SIZE, 32)
+        + /*extra_data*/ nimiq_serde::vec_max_size(nimiq_serde::U8_SIZE, 32)
         + /*state_root*/ Blake2bHash::SIZE
         + /*body_root*/ Blake2sHash::SIZE
         + /*diff_root*/ Blake2bHash::SIZE

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -86,6 +86,10 @@ pub enum TendermintStep {
     Propose = PREFIX_TENDERMINT_PROPOSAL,
 }
 
+impl TendermintStep {
+    pub const SIZE: usize = 1;
+}
+
 /// Unique identifier for a single instance of TendermintAggregation
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct TendermintIdentifier {
@@ -95,6 +99,10 @@ pub struct TendermintIdentifier {
     pub round_number: u32,
     /// the Step for which contributions are accepted
     pub step: TendermintStep,
+}
+
+impl TendermintIdentifier {
+    pub const SIZE: usize = 2 * nimiq_serde::U32_SIZE + TendermintStep::SIZE;
 }
 
 // Multiple things this needs to take care of when it comes to what needs signing here:

--- a/primitives/block/src/tendermint.rs
+++ b/primitives/block/src/tendermint.rs
@@ -87,6 +87,7 @@ pub enum TendermintStep {
 }
 
 impl TendermintStep {
+    /// Size in bytes for a `TendermintStep` in binary serialization.
     pub const SIZE: usize = 1;
 }
 
@@ -102,7 +103,8 @@ pub struct TendermintIdentifier {
 }
 
 impl TendermintIdentifier {
-    pub const SIZE: usize = 2 * nimiq_serde::U32_SIZE + TendermintStep::SIZE;
+    /// Maximum size in bytes for a `TendermintIdentifier` in binary serialization.
+    pub const MAX_SIZE: usize = 2 * nimiq_serde::U32_MAX_SIZE + TendermintStep::SIZE;
 }
 
 // Multiple things this needs to take care of when it comes to what needs signing here:

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -304,11 +304,21 @@ fn test_verify_micro_block_body_fork_proofs() {
         VrfSeed::default(),
     );
 
-    let mut fork_proof_2 = fork_proof_1.clone();
-    fork_proof_2.header1 = micro_header_2;
+    let fork_proof_2 = ForkProof::new(
+        micro_header_1.clone(),
+        Signature::default(),
+        micro_header_2.clone(),
+        Signature::default(),
+        VrfSeed::default(),
+    );
 
-    let mut fork_proof_3 = fork_proof_2.clone();
-    fork_proof_3.header2 = micro_header_1;
+    let fork_proof_3 = ForkProof::new(
+        micro_header.clone(),
+        Signature::default(),
+        micro_header_2.clone(),
+        Signature::default(),
+        VrfSeed::default(),
+    );
 
     let micro_justification = MicroJustification::Micro(Signature::default());
 
@@ -364,10 +374,19 @@ fn test_verify_micro_block_body_fork_proofs() {
     assert_eq!(block.verify(), Err(BlockError::DuplicateForkProof));
 
     // Now modify the block height of the first header of the first fork proof
-    let mut fork_proof = fork_proofs.pop().unwrap();
-    fork_proof.header1.block_number = Policy::blocks_per_epoch() + genesis_block_number;
-    fork_proof.header2.block_number = Policy::blocks_per_epoch() + genesis_block_number + 1;
-    fork_proofs.push(fork_proof);
+    let mut micro_header_large_block_number_1 = micro_header.clone();
+    micro_header_large_block_number_1.block_number =
+        Policy::blocks_per_epoch() + genesis_block_number;
+    let mut micro_header_large_block_number_2 = micro_header_large_block_number_1.clone();
+    micro_header_large_block_number_2.block_number += 1;
+    fork_proofs.pop().unwrap();
+    fork_proofs.push(ForkProof::new(
+        micro_header_large_block_number_1,
+        Signature::default(),
+        micro_header_large_block_number_2,
+        Signature::default(),
+        VrfSeed::default(),
+    ));
     fork_proofs.sort_by_key(|p| EquivocationProof::from(p.clone()).sort_key());
 
     let micro_body = MicroBody {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -379,15 +379,23 @@ pub struct PenalizedSlots {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "type")]
 pub enum EquivocationProof {
     Fork(ForkProof),
+    DoubleProposal(DoubleProposalProof),
+    DoubleVote(DoubleVoteProof),
 }
 
 impl From<nimiq_block::EquivocationProof> for EquivocationProof {
     fn from(proof: nimiq_block::EquivocationProof) -> Self {
         match proof {
             nimiq_block::EquivocationProof::Fork(proof) => EquivocationProof::Fork(proof.into()),
+            nimiq_block::EquivocationProof::DoubleProposal(proof) => {
+                EquivocationProof::DoubleProposal(proof.into())
+            }
+            nimiq_block::EquivocationProof::DoubleVote(proof) => {
+                EquivocationProof::DoubleVote(proof.into())
+            }
         }
     }
 }
@@ -404,6 +412,39 @@ impl From<nimiq_block::ForkProof> for ForkProof {
         Self {
             block_number: fork_proof.header1.block_number,
             hashes: [fork_proof.header1.hash(), fork_proof.header2.hash()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoubleProposalProof {
+    pub block_number: u32,
+    pub hashes: [Blake2bHash; 2],
+}
+
+impl From<nimiq_block::DoubleProposalProof> for DoubleProposalProof {
+    fn from(double_proposal_proof: nimiq_block::DoubleProposalProof) -> Self {
+        Self {
+            block_number: double_proposal_proof.header1.block_number,
+            hashes: [
+                double_proposal_proof.header1.hash(),
+                double_proposal_proof.header2.hash(),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoubleVoteProof {
+    pub block_number: u32,
+}
+
+impl From<nimiq_block::DoubleVoteProof> for DoubleVoteProof {
+    fn from(double_vote_proof: nimiq_block::DoubleVoteProof) -> Self {
+        Self {
+            block_number: double_vote_proof.block_number(),
         }
     }
 }

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -378,6 +378,10 @@ pub struct PenalizedSlots {
     pub disabled: BitSet,
 }
 
+/// An equivocation proof proves that a validator misbehaved.
+///
+/// This can come in several forms, but e.g. producing two blocks in a single slot or voting twice
+/// in the same round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum EquivocationProof {
@@ -400,6 +404,9 @@ impl From<nimiq_block::EquivocationProof> for EquivocationProof {
     }
 }
 
+/// Struct representing a fork proof. A fork proof proves that a given validator created or
+/// continued a fork. For this it is enough to provide two different headers, with the same block
+/// number, signed by the same validator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ForkProof {
@@ -416,6 +423,8 @@ impl From<nimiq_block::ForkProof> for ForkProof {
     }
 }
 
+/// Struct representing a double proposal proof. A double proposal proof proves that a given
+/// validator created two macro block proposals at the same height, in the same round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DoubleProposalProof {
@@ -435,6 +444,8 @@ impl From<nimiq_block::DoubleProposalProof> for DoubleProposalProof {
     }
 }
 
+/// Struct representing a double vote proof. A double vote proof proves that a given
+/// validator voted twice at same height, in the same round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DoubleVoteProof {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -410,8 +410,8 @@ pub struct ForkProof {
 impl From<nimiq_block::ForkProof> for ForkProof {
     fn from(fork_proof: nimiq_block::ForkProof) -> Self {
         Self {
-            block_number: fork_proof.header1.block_number,
-            hashes: [fork_proof.header1.hash(), fork_proof.header2.hash()],
+            block_number: fork_proof.block_number(),
+            hashes: [fork_proof.header1_hash(), fork_proof.header2_hash()],
         }
     }
 }
@@ -426,10 +426,10 @@ pub struct DoubleProposalProof {
 impl From<nimiq_block::DoubleProposalProof> for DoubleProposalProof {
     fn from(double_proposal_proof: nimiq_block::DoubleProposalProof) -> Self {
         Self {
-            block_number: double_proposal_proof.header1.block_number,
+            block_number: double_proposal_proof.block_number(),
             hashes: [
-                double_proposal_proof.header1.hash(),
-                double_proposal_proof.header2.hash(),
+                double_proposal_proof.header1_hash(),
+                double_proposal_proof.header2_hash(),
             ],
         }
     }

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -45,28 +45,44 @@ impl fmt::Display for DeserializeError {
 
 impl Error for DeserializeError {}
 
+/// Size in bytes for a single `i8` in binary serialization.
 pub const I8_SIZE: usize = 1;
+/// Size in bytes for a single `u8` in binary serialization.
 pub const U8_SIZE: usize = 1;
 
-pub const I16_SIZE: usize = (16 + 6) / 7;
-pub const U16_SIZE: usize = (16 + 6) / 7;
-pub const I32_SIZE: usize = (32 + 6) / 7;
-pub const U32_SIZE: usize = (32 + 6) / 7;
-pub const I64_SIZE: usize = (64 + 6) / 7;
-pub const U64_SIZE: usize = (64 + 6) / 7;
+/// Maximum size in bytes for a single `i16` in binary serialization.
+pub const I16_MAX_SIZE: usize = (16 + 6) / 7;
+/// Maximum size in bytes for a single `u16` in binary serialization.
+pub const U16_MAX_SIZE: usize = (16 + 6) / 7;
+/// Maximum size in bytes for a single `i32` in binary serialization.
+pub const I32_MAX_SIZE: usize = (32 + 6) / 7;
+/// Maximum size in bytes for a single `u32` in binary serialization.
+pub const U32_MAX_SIZE: usize = (32 + 6) / 7;
+/// Maximum size in bytes for a single `i64` in binary serialization.
+pub const I64_MAX_SIZE: usize = (64 + 6) / 7;
+/// Maximum size in bytes for a single `u64` in binary serialization.
+pub const U64_MAX_SIZE: usize = (64 + 6) / 7;
 
-pub const fn uint_size(max_value: u64) -> usize {
+/// Maximum size in bytes for a integer value in binary serialization, given its maximum value.
+pub const fn uint_max_size(max_value: u64) -> usize {
     let bits = match max_value.checked_ilog2() {
         Some(n) => n + 1,
         None => 1,
     };
     ((bits + 6) / 7) as usize
 }
-pub const fn option_size(inner_size: usize) -> usize {
+/// Maximum size in bytes for an `Option<T>` value in binary serialization.
+///
+/// `inner_size` is the maximum size of its inner value `T`.
+pub const fn option_max_size(inner_size: usize) -> usize {
     1 + inner_size
 }
-pub const fn vec_size(inner_size: usize, max_elems: usize) -> usize {
-    uint_size(max_elems as u64) + inner_size * max_elems
+/// Maximum size in bytes for a `Vec<T>` value in binary serialization.
+///
+/// `inner_size` is the maximum size of its inner value `T`. `max_elems` is the maximum number of
+/// elements in that `Vec<T>`.
+pub const fn vec_max_size(inner_size: usize, max_elems: usize) -> usize {
+    uint_max_size(max_elems as u64) + inner_size * max_elems
 }
 
 /// The Nimiq human readable array serialization helper trait

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -45,6 +45,30 @@ impl fmt::Display for DeserializeError {
 
 impl Error for DeserializeError {}
 
+pub const I8_SIZE: usize = 1;
+pub const U8_SIZE: usize = 1;
+
+pub const I16_SIZE: usize = (16 + 6) / 7;
+pub const U16_SIZE: usize = (16 + 6) / 7;
+pub const I32_SIZE: usize = (32 + 6) / 7;
+pub const U32_SIZE: usize = (32 + 6) / 7;
+pub const I64_SIZE: usize = (64 + 6) / 7;
+pub const U64_SIZE: usize = (64 + 6) / 7;
+
+pub const fn uint_size(max_value: u64) -> usize {
+    let bits = match max_value.checked_ilog2() {
+        Some(n) => n + 1,
+        None => 1,
+    };
+    ((bits + 6) / 7) as usize
+}
+pub const fn option_size(inner_size: usize) -> usize {
+    1 + inner_size
+}
+pub const fn vec_size(inner_size: usize, max_elems: usize) -> usize {
+    uint_size(max_elems as u64) + inner_size * max_elems
+}
+
 /// The Nimiq human readable array serialization helper trait
 ///
 /// ```

--- a/validator/src/aggregation/tendermint/contribution.rs
+++ b/validator/src/aggregation/tendermint/contribution.rs
@@ -36,7 +36,7 @@ impl TendermintContribution {
             .sign(&vote)
             .multiply(validator_slots.len() as u16)]);
 
-        // get the slots of the validator ad insert them into the bitset
+        // get the slots of the validator and insert them into the bitset
         let mut signers = BitSet::new();
         for slot in validator_slots {
             signers.insert(slot as usize);

--- a/validator/src/jail.rs
+++ b/validator/src/jail.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use nimiq_block::{Block, EquivocationProof, MacroBlock, MacroHeader, MicroBlock};
 use nimiq_serde::Serialize;
 
+/// Pool for holding distinct equivocation proofs that haven't been seen in blocks yet.
 #[derive(Default)]
 pub struct EquivocationProofPool {
     equivocation_proofs: HashSet<EquivocationProof>,
@@ -13,7 +14,7 @@ impl EquivocationProofPool {
         Self::default()
     }
 
-    /// Adds a equivocation proof if it is not yet part of the pool.
+    /// Adds an equivocation proof if it is not yet part of the pool.
     /// Returns whether it has been added.
     pub fn insert(&mut self, equivocation_proof: EquivocationProof) -> bool {
         self.equivocation_proofs.insert(equivocation_proof)

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use futures::{future::BoxFuture, ready, FutureExt, Stream};
-use nimiq_block::{Block, ForkProof, MicroBlock, SkipBlockInfo};
+use nimiq_block::{Block, EquivocationProof, MicroBlock, SkipBlockInfo};
 use nimiq_block_production::BlockProducer;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
@@ -34,7 +34,7 @@ struct NextProduceMicroBlockEvent<TValidatorNetwork> {
     network: Arc<TValidatorNetwork>,
     block_producer: BlockProducer,
     validator_slot_band: u16,
-    fork_proofs: Vec<ForkProof>,
+    equivocation_proofs: Vec<EquivocationProof>,
     prev_seed: VrfSeed,
     block_number: u32,
     producer_timeout: Duration,
@@ -51,7 +51,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         network: Arc<TValidatorNetwork>,
         block_producer: BlockProducer,
         validator_slot_band: u16,
-        fork_proofs: Vec<ForkProof>,
+        equivocation_proofs: Vec<EquivocationProof>,
         prev_seed: VrfSeed,
         block_number: u32,
         producer_timeout: Duration,
@@ -63,7 +63,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             network,
             block_producer,
             validator_slot_band,
-            fork_proofs,
+            equivocation_proofs,
             prev_seed,
             block_number,
             producer_timeout,
@@ -282,7 +282,8 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         );
 
         // First we try to fill the block with control transactions
-        let mut block_available_bytes = MicroBlock::get_available_bytes(self.fork_proofs.len());
+        let mut block_available_bytes =
+            MicroBlock::get_available_bytes(self.equivocation_proofs.len());
 
         let (mut transactions, txn_size) = self
             .mempool
@@ -299,7 +300,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         self.block_producer.next_micro_block(
             blockchain,
             timestamp,
-            self.fork_proofs.clone(),
+            self.equivocation_proofs.clone(),
             transactions,
             vec![], // TODO: Allow validators to set extra data field.
             None,
@@ -337,7 +338,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> ProduceMicroBlock<TValidator
         network: Arc<TValidatorNetwork>,
         block_producer: BlockProducer,
         validator_slot_band: u16,
-        fork_proofs: Vec<ForkProof>,
+        equivocation_proofs: Vec<EquivocationProof>,
         prev_seed: VrfSeed,
         block_number: u32,
         producer_timeout: Duration,
@@ -349,7 +350,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> ProduceMicroBlock<TValidator
             network,
             block_producer,
             validator_slot_band,
-            fork_proofs,
+            equivocation_proofs,
             prev_seed,
             block_number,
             producer_timeout,

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -529,9 +529,10 @@ where
 
     fn on_fork_event(&mut self, event: ForkEvent) {
         match event {
-            ForkEvent::Detected(fork_proof) => {
-                self.blockchain_state.equivocation_proofs.insert(fork_proof)
-            }
+            ForkEvent::Detected(fork_proof) => self
+                .blockchain_state
+                .equivocation_proofs
+                .insert(fork_proof.into()),
         };
     }
 


### PR DESCRIPTION
A `DoubleProposalProof` contains the two proposed macro headers plus some signatures to verify that they originate from the same validator.

A `DoubleVoteProof` contains two proposals (either `None`, or `Some(block_hash)`) for the same block height, same round. A `slot_number` is used to verify that the same validator is contained in both of the multisignatures.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
