### PR TITLE
Bump sha2 from 0.9.9 to 0.10.6, curve25519-dalek from 3.2.0 to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -1350,16 +1350,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da00a7a9a4eb92a0a0f8e75660926d48f0d0f3c537e455c457bcdaa1e16b1ac"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.6",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2643,12 +2657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
 name = "libmdbx"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,7 +3865,7 @@ dependencies = [
  "nimiq-test-log",
  "rust-argon2",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3953,7 +3961,7 @@ dependencies = [
 name = "nimiq-keys"
 version = "0.1.0"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek 4.0.0",
  "data-encoding",
  "ed25519-zebra",
  "hex",
@@ -3969,7 +3977,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde-big-array 0.5.1",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -4698,7 +4706,7 @@ name = "nimiq-vrf"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek 4.0.0",
  "hex",
  "nimiq-hash",
  "nimiq-keys",
@@ -4709,7 +4717,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "tracing",
 ]
 
@@ -5153,16 +5161,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.6",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm",
 ]
 
 [[package]]
@@ -6379,14 +6377,14 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ba5f4d4ff12bdb6a169ed51b7c48c0e0ac4b0b4b31012b2571e97d78d3201d"
+checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
 dependencies = [
  "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0-rc.0",
+ "curve25519-dalek 4.0.0",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.2"
 hex = "0.4"
 rust-argon2 = "1.0"
 serde = "1.0"
-sha2 = "0.9"
+sha2 = "0.10"
 
 nimiq-database-value = { workspace = true }
 nimiq-macros = { workspace = true }

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -17,7 +17,7 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-curve25519-dalek = "3"
+curve25519-dalek = { version = "4", features = ["digest", "legacy_compatibility"] }
 data-encoding = "2.4"
 ed25519-zebra = "3.1"
 hex = "0.4"
@@ -25,7 +25,7 @@ rand = "0.8"
 rand_core = "0.6"
 serde = { version = "1.0", optional = true }
 serde-big-array = { version = "0.5", optional = true }
-sha2 = "0.9"
+sha2 = "0.10"
 thiserror = "1.0"
 
 nimiq-database-value = { workspace = true }

--- a/keys/src/multisig.rs
+++ b/keys/src/multisig.rs
@@ -108,12 +108,12 @@ impl CommitmentPair {
 
         h.update(randomness);
         let scalar = Scalar::from_hash::<sha2::Sha512>(h);
-        if scalar == Scalar::zero() || scalar == Scalar::one() {
+        if scalar == Scalar::ZERO || scalar == Scalar::ONE {
             return Err(InvalidScalarError);
         }
 
         // Compute the point [scalar]B.
-        let commitment: EdwardsPoint = &scalar * &constants::ED25519_BASEPOINT_TABLE;
+        let commitment: EdwardsPoint = &scalar * constants::ED25519_BASEPOINT_TABLE;
 
         let rs = RandomSecret(scalar);
         let ct = Commitment(commitment);
@@ -141,7 +141,7 @@ impl SecureGenerate for CommitmentPair {
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct PartialSignature(Scalar);
-implement_simple_add_sum_traits!(PartialSignature, Scalar::zero());
+implement_simple_add_sum_traits!(PartialSignature, Scalar::ZERO);
 
 impl PartialSignature {
     pub const SIZE: usize = 32;
@@ -290,6 +290,9 @@ impl ToScalar for ::ed25519_zebra::SigningKey {
         scalar_bytes[0] &= 248;
         scalar_bytes[31] &= 127;
         scalar_bytes[31] |= 64;
+        // The above bit operations ensure that the integer represented by
+        // `scalar_bytes` is less than 2***255-19 as required by this function.
+        #[allow(deprecated)]
         Scalar::from_bits(scalar_bytes)
     }
 }

--- a/keys/src/private_key.rs
+++ b/keys/src/private_key.rs
@@ -34,6 +34,9 @@ impl PrivateKey {
         scalar_bytes[0] &= 248;
         scalar_bytes[31] &= 127;
         scalar_bytes[31] |= 64;
+        // The above bit operations ensure that the integer represented by
+        // `scalar_bytes` is less than 2***255-19 as required by this function.
+        #[allow(deprecated)]
         Scalar::from_bits(scalar_bytes)
     }
 

--- a/keys/tests/multisig.rs
+++ b/keys/tests/multisig.rs
@@ -319,8 +319,7 @@ fn it_correctly_calculates_commitments() {
     let scalar = Scalar::from_hash::<::sha2::Sha512>(h);
 
     // Compute the point [scalar]B.
-    let commitment: EdwardsPoint =
-        &scalar * &::curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
+    let commitment: EdwardsPoint = &scalar * ::curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 
     assert_eq!(
         scalar.as_bytes(),
@@ -504,7 +503,7 @@ fn it_can_construct_commitments() {
 
         for i in 0..test.priv_keys.len() {
             let commitment: EdwardsPoint =
-                &test.secrets[i].0 * &::curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
+                &test.secrets[i].0 * ::curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
             assert_eq!(
                 (j, i, commitment.compress().to_bytes()),
                 (j, i, test.commitments[i].to_bytes())

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -12,13 +12,13 @@ keywords.workspace = true
 
 [dependencies]
 byteorder = "1.3"
-curve25519-dalek = "3"
+curve25519-dalek = { version = "4", features = ["digest"] }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 num-traits = "0.2"
 rand = "0.8"
 serde = { version = "1.0", optional = true }
-sha2 = "0.9"
+sha2 = "0.10"
 
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }


### PR DESCRIPTION
The old curvee25519-dalek is still depended on by `libp2p-core`.

Fixes #1422.