### PR TITLE
Fix SizeProof in MMR and add tests

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1106,6 +1106,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn prove_num_leaves_works() {
+        // Initialize History Store.
+        let env = VolatileDatabase::new(20).unwrap();
+        let history_store = HistoryStore::new(env.clone());
+
+        // Create extended transactions.
+        let ext_0 = create_transaction(1, 0);
+        let ext_1 = create_transaction(3, 1);
+        let ext_2 = create_transaction(7, 2);
+        let ext_3 = create_transaction(8, 3);
+
+        let ext_txs = vec![ext_0, ext_1, ext_2, ext_3];
+
+        // Add extended transactions to History Store.
+        let mut txn = env.write_transaction();
+        history_store.add_to_history(&mut txn, 1, &ext_txs);
+
+        // Prove number of leaves.
+        let size_proof = history_store
+            .prove_num_leaves(1, Some(&txn))
+            .expect("Should be able to prove number of leaves");
+
+        // Verify method works.
+        assert!(size_proof.verify(&history_store.get_history_tree_root(1, Some(&txn)).unwrap()));
+        assert_eq!(size_proof.size(), 4);
+    }
+
+    #[test]
     fn length_at_works() {
         // Initialize History Store.
         let env = VolatileDatabase::new(20).unwrap();

--- a/primitives/mmr/src/mmr/proof.rs
+++ b/primitives/mmr/src/mmr/proof.rs
@@ -13,16 +13,16 @@ use crate::{
 #[derive(Clone, Debug)]
 pub enum SizeProof<H: Merge, T: Hash<H>> {
     EmptyTree,
-    SinglePeak(u64, T),
-    MultiplePeaks(u64, H, H),
+    SingleElement(u64, T),
+    MultipleElements(u64, H, H),
 }
 
 impl<H: Merge + Eq, T: Hash<H>> SizeProof<H, T> {
     pub fn verify(&self, hash: &H) -> bool {
         let self_hash = match self {
             SizeProof::EmptyTree => H::empty(0),
-            SizeProof::SinglePeak(size, item) => item.hash(*size),
-            SizeProof::MultiplePeaks(size, left, right) => left.merge(right, *size),
+            SizeProof::SingleElement(size, item) => item.hash(*size),
+            SizeProof::MultipleElements(size, left, right) => left.merge(right, *size),
         };
         hash == &self_hash
     }
@@ -30,7 +30,7 @@ impl<H: Merge + Eq, T: Hash<H>> SizeProof<H, T> {
     pub fn size(&self) -> u64 {
         match self {
             SizeProof::EmptyTree => 0,
-            SizeProof::SinglePeak(size, _) | SizeProof::MultiplePeaks(size, _, _) => *size,
+            SizeProof::SingleElement(size, _) | SizeProof::MultipleElements(size, _, _) => *size,
         }
     }
 }


### PR DESCRIPTION
## What's in this pull request?
Fixes the proving of number of leaves on the history store.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
