### PR TITLE
Remove the print of private keys for config

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 #[cfg(feature = "metrics-server")]
 use std::net::SocketAddr;
 use std::{
+    fmt::Debug,
     path::{Path, PathBuf},
     string::ToString,
 };
@@ -142,7 +143,7 @@ impl From<TlsSettings> for TlsConfig {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct FileStorageConfig {
     /// The parent directory where the database will be stored. The database directory name
     /// is determined by the network ID and consensus type using the `database_name` static
@@ -219,6 +220,28 @@ impl FileStorageConfig {
 impl Default for FileStorageConfig {
     fn default() -> Self {
         Self::home()
+    }
+}
+
+impl Debug for FileStorageConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_struct("FileStorageConfig");
+        debug_struct
+            .field("database_parent", &self.database_parent)
+            .field("peer_key_path", &self.peer_key_path)
+            .field("peer_key", &self.peer_key.as_ref().map(|_| "***"));
+
+        #[cfg(feature = "validator")]
+        {
+            debug_struct
+                .field("voting_key_path", &self.voting_key_path)
+                .field("voting_key", &self.voting_key.as_ref().map(|_| "***"))
+                .field("signing_key_path", &self.signing_key_path)
+                .field("signing_key", &self.signing_key.as_ref().map(|_| "***"))
+                .field("fee_key_path", &self.fee_key_path)
+                .field("fee_key", &self.fee_key.as_ref().map(|_| "***"));
+        }
+        debug_struct.finish()
     }
 }
 

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs::read_to_string, path::Path, str::FromStr};
+use std::{collections::HashMap, fmt::Debug, fs::read_to_string, path::Path, str::FromStr};
 
 use log::level_filters::LevelFilter;
 #[cfg(feature = "nimiq-mempool")]
@@ -430,7 +430,7 @@ impl From<MempoolFilterSettings> for MempoolRules {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ValidatorSettings {
     pub validator_address: String,
@@ -442,6 +442,21 @@ pub struct ValidatorSettings {
     pub fee_key: Option<String>,
     #[serde(default)]
     pub automatic_reactivate: bool,
+}
+
+impl Debug for ValidatorSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValidatorSettings")
+            .field("validator_address", &self.validator_address)
+            .field("signing_key_file", &self.signing_key_file)
+            .field("signing_key", &self.signing_key.as_ref().map(|_| "***"))
+            .field("voting_key_file", &self.voting_key_file)
+            .field("voting_key", &self.voting_key.as_ref().map(|_| "***"))
+            .field("fee_key_file", &self.fee_key_file)
+            .field("fee_key", &self.fee_key.as_ref().map(|_| "***"))
+            .field("automatic_reactivate", &self.automatic_reactivate)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]


### PR DESCRIPTION
## What's in this pull request?
Removes the printing of private keys from the client config.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
