### PR TITLE
genesis-builder: Serialize also the timestamp using RFC3339

### DIFF
--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -8,7 +8,7 @@ hex = "0.4"
 log = { package = "tracing", version = "0.1" }
 serde = "1.0"
 thiserror = "1.0"
-time = { version = "0.3", features = ["parsing", "serde"] }
+time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 toml = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -25,7 +25,7 @@ pub struct GenesisConfig {
     pub parent_hash: Option<Blake2bHash>,
 
     /// Timestamp for the genesis block.
-    #[serde(deserialize_with = "time::serde::rfc3339::option::deserialize")]
+    #[serde(with = "time::serde::rfc3339::option")]
     pub timestamp: Option<OffsetDateTime>,
 
     /// The set of validators for the genesis state.


### PR DESCRIPTION
Make `GenesisConfig` to also use RFC3339 to serialize the timestamp.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
