### PR TITLE
Use the workspace inheritance feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,3 +143,13 @@ ark-ec = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-ff = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-r1cs-std = { git = "https://github.com/paberr/r1cs-std", branch = "pb/fix-pedersen" }
 wasm-timer = { git = "https://github.com/sisou/wasm-timer.git" }
+
+[workspace.package]
+version = "0.1.0"
+authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+edition = "2021"
+homepage = "https://nimiq.com"
+repository = "https://github.com/nimiq/core-rs-albatross"
+license = "Apache-2.0"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["nimiq", "cryptocurrency", "blockchain"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,61 @@ repository = "https://github.com/nimiq/core-rs-albatross"
 license = "Apache-2.0"
 categories = ["cryptography::cryptocurrencies"]
 keywords = ["nimiq", "cryptocurrency", "blockchain"]
+
+[workspace.dependencies]
+nimiq-account = { path = "primitives/account", default-features = false }
+nimiq-block = { path = "primitives/block", default-features = false }
+nimiq-block-production = { path = "block-production", default-features = false }
+nimiq-blockchain = { path = "blockchain", default-features = false }
+nimiq-blockchain-interface = { path = "blockchain-interface", default-features = false }
+nimiq-blockchain-proxy = { path = "blockchain-proxy", default-features = false }
+nimiq-bls = { path = "bls", default-features = false }
+nimiq-collections = { path = "collections", default-features = false }
+nimiq-consensus = { path = "consensus", default-features = false }
+nimiq-database = { path = "database", default-features = false }
+nimiq-database-value = { path = "database/database-value", default-features = false }
+nimiq-genesis = { path = "genesis", default-features = false }
+nimiq-genesis-builder = { path = "genesis-builder", default-features = false }
+nimiq-handel = { path = "handel", default-features = false }
+nimiq-hash = { path = "hash", default-features = false }
+nimiq-hash_derive = { path = "hash/hash_derive", default-features = false }
+nimiq-jsonrpc-client = { git = "https://github.com/nimiq/jsonrpc.git", default-features = false }
+nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git", default-features = false }
+nimiq-jsonrpc-derive = { git = "https://github.com/nimiq/jsonrpc.git", default-features = false }
+nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git", default-features = false }
+nimiq-key-derivation = { path = "key-derivation", default-features = false }
+nimiq-keys = { path = "keys", default-features = false }
+nimiq-lib = { path = "lib", default-features = false }
+nimiq-light-blockchain = { path = "light-blockchain", default-features = false }
+nimiq-log = { path = "log", default-features = false }
+nimiq-macros = { path = "macros", default-features = false }
+nimiq-mempool = { path = "mempool", default-features = false }
+nimiq-metrics-server = { path = "metrics-server", default-features = false }
+nimiq-mmr = { path = "primitives/mmr", default-features = false }
+nimiq-mnemonic = { path = "mnemonic", default-features = false }
+nimiq-network-interface = { path = "network-interface", default-features = false }
+nimiq-network-libp2p = { path = "network-libp2p", default-features = false }
+nimiq-network-mock = { path = "network-mock", default-features = false }
+nimiq-pedersen-generators = { path = "zkp-primitives/pedersen-generators", default-features = false }
+nimiq-primitives = { path = "primitives", default-features = false }
+nimiq-rpc-interface = { path = "rpc-interface", default-features = false }
+nimiq-rpc-server = { path = "rpc-server", default-features = false }
+nimiq-serde = { path = "serde", default-features = false }
+nimiq-subscription = { path = "primitives/subscription", default-features = false }
+nimiq-tendermint = { path = "tendermint", default-features = false }
+nimiq-test-log = { path = "test-log", default-features = false }
+nimiq-test-log-proc-macro = { path = "test-log/proc-macro", default-features = false }
+nimiq-test-utils = { path = "test-utils", default-features = false }
+nimiq-transaction = { path = "primitives/transaction", default-features = false }
+nimiq-transaction-builder = { path = "transaction-builder", default-features = false }
+nimiq-trie = { path = "primitives/trie", default-features = false }
+nimiq-utils = { path = "utils", default-features = false }
+nimiq-validator = { path = "validator", default-features = false }
+nimiq-validator-network = { path = "validator-network", default-features = false }
+nimiq-vrf = { path = "vrf", default-features = false }
+nimiq-wallet = { path = "wallet", default-features = false }
+nimiq-web-client = { path = "web-client", default-features = false }
+nimiq-zkp = { path = "zkp", default-features = false }
+nimiq-zkp-circuits = { path = "zkp-circuits", default-features = false }
+nimiq-zkp-component = { path = "zkp-component", default-features = false }
+nimiq-zkp-primitives = { path = "zkp-primitives", default-features = false }

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -23,34 +23,34 @@ parking_lot = "0.12"
 rand = "0.8"
 serde = "1.0"
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-blockchain-interface = { path ="../blockchain-interface" }
-nimiq-bls = { path = "../bls" }
-nimiq-collections = { path = "../collections" }
-nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-tendermint = { path = "../tendermint" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-vrf = { path = "../vrf" }
-nimiq-utils = { path = "../utils"}
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-tendermint = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-vrf = { workspace = true }
+nimiq-utils = { workspace = true }
 
 [dev-dependencies]
 rand = "0.8"
 tempfile = "3.3"
 
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }
 # This adds a circular dev-dependency which is fine but breaks VS code rust-analyzer.
 # See https://github.com/rust-analyzer/rust-analyzer/issues/14167
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-serde = { path = "../serde" }
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-trie = { path = "../primitives/trie" }
-nimiq-transaction-builder = { path = "../transaction-builder" }
+nimiq-genesis-builder = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-transaction-builder = { workspace = true }
+nimiq-trie = { workspace = true }
 
 [features]
 default = []

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-block-production"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-license = "Apache-2.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Block Production logic for Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -24,9 +24,9 @@ serde = "1.0"
 thiserror = "1.0"
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-hash = { path = "../hash" }
-nimiq-primitives = { path = "../primitives", features = ["coin", "key-nibbles", "policy"] }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-block = { workspace = true }
+nimiq-database-value = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "key-nibbles", "policy"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-blockchain-interface"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Generic blockchain structures"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/blockchain-proxy/Cargo.toml
+++ b/blockchain-proxy/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-blockchain-proxy"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Persistent block storage for Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/blockchain-proxy/Cargo.toml
+++ b/blockchain-proxy/Cargo.toml
@@ -17,17 +17,17 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
+futures = { package = "futures-util", version = "0.3" }
 parking_lot = "0.12"
 tokio-stream = { version = "0.1", features = ["sync"] }
-futures = { package = "futures-util", version = "0.3" }
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain", optional = true }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-light-blockchain = { path = "../light-blockchain" }
-nimiq-hash = { path = "../hash" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true, optional = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-light-blockchain = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-transaction = { workspace = true }
 
 [features]
 full = ["nimiq-blockchain"]

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -28,36 +28,36 @@ thiserror = "1.0"
 tokio = { version = "1.29", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-bls = { path = "../bls", features = ["serde-derive"] }
-nimiq-collections = { path = "../collections" }
-nimiq-database = { path = "../database" }
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-genesis = { path = "../genesis" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-mmr = { path = "../primitives/mmr" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-trie = { path = "../primitives/trie" }
-nimiq-utils = { path = "../utils", features = ["math", "time"] }
-nimiq-vrf = { path = "../vrf" }
-nimiq-zkp = { path = "../zkp" }
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-bls = { workspace = true, features = ["serde-derive"] }
+nimiq-collections = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-database-value = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-mmr = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-trie = { workspace = true }
+nimiq-utils = { workspace = true, features = ["math", "time"] }
+nimiq-vrf = { workspace = true }
+nimiq-zkp = { workspace = true }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"
 
-nimiq-block-production = { path = "../block-production", features = ["test-utils"] }
-nimiq-test-log = { path = "../test-log" }
-nimiq-tendermint = { path = "../tendermint" }
-nimiq-transaction-builder = { path = "../transaction-builder" }
+nimiq-block-production = { workspace = true, features = ["test-utils"] }
+nimiq-tendermint = { workspace = true }
+nimiq-test-log = { workspace = true }
+nimiq-transaction-builder = { workspace = true }
 # This adds a circular dev-dependency which is fine but breaks VS code rust-analyzer.
 # See https://github.com/rust-analyzer/rust-analyzer/issues/14167
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-zkp-primitives = { path = "../zkp-primitives" }
+nimiq-test-utils = { workspace = true }
+nimiq-zkp-primitives = { workspace = true }
 
 [features]
 metrics = ["prometheus-client"]

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-blockchain"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Persistent block storage for Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -30,14 +30,14 @@ ark-mnt6-753 = "0.4"
 ark-crypto-primitives = { version = "0.4", features = ["prf"] }
 ark-serialize = "0.4"
 
-nimiq-hash = { path = "../hash" }
-nimiq-hash_derive = { path = "../hash/hash_derive" }
-nimiq-serde = { path = "../serde", optional = true }
-nimiq-utils = { path = "../utils", features = ["key-rng"] }
+nimiq-hash = { workspace = true }
+nimiq-hash_derive = { workspace = true }
+nimiq-serde = { workspace = true, optional = true }
+nimiq-utils = { workspace = true, features = ["key-rng"] }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 
 [features]
 cache = ["lazy"]

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-bls"
-version = "0.1.0"
+version.workspace = true
 authors = ["Jack Grigg <str4d@i2pmail.org>", "The Nimiq Core Development Team <info@nimiq.com>"]
 description = "BLS signatures"
-license = "Apache-2.0"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-edition = "2021"
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 blake2 = "0.10"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-client"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq's Rust client"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 exclude = ["db", "peer_key.dat"]
 
 [badges]

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -25,5 +25,5 @@ hex = "0.4"
 rand = "0.8"
 serde_json = "1.0"
 
-nimiq-serde = { path = "../serde" }
-nimiq-test-log = { path = "../test-log" }
+nimiq-serde = { workspace = true }
+nimiq-test-log = { workspace = true }

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-collections"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "A set of advanced collections for use in the Nimiq Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -31,45 +31,45 @@ thiserror = "1.0"
 tokio = { version = "1.29", features = ["rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-account = { path = "../primitives/account", default-features = false }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
-nimiq-bls = { path = "../bls" }
-nimiq-blockchain = { path = "../blockchain", optional = true }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-light-blockchain = { path = "../light-blockchain" }
-nimiq-macros = { path = "../macros" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-utils = { path = "../utils", features = [
+nimiq-account = { workspace = true, default-features = false }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true, optional = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, default-features = false }
+nimiq-bls = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-light-blockchain = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = [
     "math",
     "merkle",
     "time",
 ] }
-nimiq-validator-network = { path = "../validator-network" }
-nimiq-zkp-component = { path = "../zkp-component" }
+nimiq-validator-network = { workspace = true }
+nimiq-zkp-component = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"
 
-nimiq-block-production = { path = "../block-production", features = ["test-utils"] }
-nimiq-bls = { path = "../bls" }
-nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-keys = { path = "../keys" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-network-libp2p = { path = "../network-libp2p" }
-nimiq-test-log = { path = "../test-log" }
+nimiq-block-production = { workspace = true, features = ["test-utils"] }
+nimiq-bls = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-genesis-builder = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-network-libp2p = { workspace = true }
+nimiq-test-log = { workspace = true }
 # This adds a circular dev-dependency which is fine but breaks VS code rust-analyzer.
 # See https://github.com/rust-analyzer/rust-analyzer/issues/14167
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-trie = { path = "../primitives/trie" }
-nimiq-zkp-component = { path = "../zkp-component", features = ["zkp-prover", "parallel"] }
+nimiq-test-utils = { workspace = true }
+nimiq-trie = { workspace = true }
+nimiq-zkp-component = { workspace = true, features = ["zkp-prover", "parallel"] }
 
 [features]
 full = ["nimiq-blockchain", "nimiq-blockchain-proxy/full"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-consensus"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Consensus logic of Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-database"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "A LMDB database wrapper with support for volatile storage"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -18,12 +18,12 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 bitflags = "1.0"
+libmdbx = "0.3.5"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 tempfile = "3"
 thiserror = "1.0"
-libmdbx = "0.3.5"
 
-nimiq-database-value = { path = "database-value"}
+nimiq-database-value = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }

--- a/database/database-value/Cargo.toml
+++ b/database/database-value/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-database-value"
-version = "0.1.0"
-authors = ["JD Hernandez <jd@nimiq.com>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "A simple trait for writing and reading from a Nimiq DB"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "nimiq-genesis-builder"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Tools for building a Nimiq genesis"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 hex = "0.4"

--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -19,14 +19,14 @@ time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 toml = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-bls = { path = "../bls", features = ["serde-derive"] }
-nimiq-database = { path = "../database" }
-nimiq-hash = { path = "../hash" }
-nimiq-serde = { path = "../serde" }
-nimiq-keys = { path = "../keys", features = ["serde-derive"] }
-nimiq-primitives = { path = "../primitives", features = ["serde-derive", "tree-proof"] }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-trie = { path = "../primitives/trie" }
-nimiq-vrf = { path = "../vrf", features = ["serde-derive"] }
+nimiq-account = { workspace = true, features = ["accounts", "interaction-traits"] }
+nimiq-block = { workspace = true }
+nimiq-bls = { workspace = true, features = ["serde-derive"] }
+nimiq-database = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
+nimiq-primitives = { workspace = true, features = ["serde-derive", "tree-proof"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-trie = { workspace = true }
+nimiq-vrf = { workspace = true, features = ["serde-derive"] }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-genesis"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq Genesis configuration"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 build = "build.rs"
 
 [badges]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -23,27 +23,27 @@ hex = "0.4"
 serde = "1.0"
 url = "2.3"
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-bls = { path = "../bls" }
-nimiq-database = { path = "../database", optional = true }
-nimiq-genesis-builder = { path = "../genesis-builder", optional = true }
-nimiq-hash = { path = "../hash" }
-nimiq-hash_derive = { path = "../hash/hash_derive" }
-nimiq-keys = { path = "../keys" }
-nimiq-macros = { path = "../macros" }
-nimiq-primitives = { path = "../primitives", features = ["coin", "networks"] }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-utils = { path = "../utils", features = ["time"] }
+nimiq-block = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-database = { workspace = true, optional = true }
+nimiq-genesis-builder = { workspace = true, optional = true }
+nimiq-hash = { workspace = true }
+nimiq-hash_derive = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "networks"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = ["time"] }
 
 [build-dependencies]
 log = { package = "tracing", version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-nimiq-database = { path = "../database" }
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
+nimiq-database = { workspace = true }
+nimiq-genesis-builder = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
 
 [features]
 default = ["genesis-override"]

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "nimiq-handel"
-version = "0.1.0"
+version.workspace = true
 authors = ["Janosch Gräf <janosch@nimiq.com>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
+description = "Nimiq implementation of the handel protocol"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -21,20 +21,20 @@ thiserror = "1.0"
 tokio = { version = "1.29", features = ["rt", "time"] }
 tokio-stream = "0.1"
 
-nimiq-bls = { path = "../bls" }
-nimiq-collections = { path = "../collections" }
-nimiq-hash = { path = "../hash" }
-nimiq-macros = { path = "../macros" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-serde = { path = "../serde" }
-nimiq-utils = { path = "../utils", features = [
+nimiq-bls = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-serde = { workspace = true }
+nimiq-utils = { workspace = true, features = [
     "math",
 ] }
 
 [dev-dependencies]
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-test-log = { path = "../test-log" }
+nimiq-network-interface = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-test-log = { workspace = true }
 
 tokio = { version = "1.29", features = ["rt", "time", "macros"] }

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -24,10 +24,10 @@ rust-argon2 = "1.0"
 serde = "1.0"
 sha2 = "0.9"
 
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-macros = { path = "../macros" }
-nimiq-mmr = { path = "../primitives/mmr" }
-nimiq-serde = { path = "../serde" }
+nimiq-database-value = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-mmr = { workspace = true }
+nimiq-serde = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-hash"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "Common wrapper around hash implementations used in Nimiq"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/hash/hash_derive/Cargo.toml
+++ b/hash/hash_derive/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-hash_derive"
-version = "0.1.0"
+version.workspace = true
 authors = ["Janosch Gräf <janosch@nimiq.com>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "Derive macros for nimiq-hash"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/key-derivation/Cargo.toml
+++ b/key-derivation/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-key-derivation"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "Helper library for key derivation in Nimiq"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/key-derivation/Cargo.toml
+++ b/key-derivation/Cargo.toml
@@ -21,11 +21,11 @@ byteorder = "1.2"
 regex = "1"
 serde = "1.0"
 
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys", features = ["serde-derive"] }
-nimiq-serde = { path = "../serde" }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
+nimiq-serde = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"
 
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-keys"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "Ed25519 cryptographic key handling and signatures for Nimiq"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -28,16 +28,16 @@ serde-big-array = { version = "0.5", optional = true }
 sha2 = "0.9"
 thiserror = "1.0"
 
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-hash = { path = "../hash" }
-nimiq-hash_derive = { path = "../hash/hash_derive" }
-nimiq-macros = { path = "../macros" }
-nimiq-serde = { path = "../serde", optional = true }
-nimiq-utils = { path = "../utils", features = ["key-rng"] }
+nimiq-database-value = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-hash_derive = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-serde = { workspace = true, optional = true }
+nimiq-utils = { workspace = true, features = ["key-rng"] }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 
 [features]
 serde-derive = ["nimiq-serde", "serde", "serde-big-array"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-lib"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq's Rust library"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,46 +33,46 @@ serde = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 signal-hook = { version = "0.3", optional = true }
 strum_macros = "0.24"
-toml = "0.7"
-url = { version = "2.3", features = ["serde"] }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.29", features = ["rt"], optional = true }
+toml = "0.7"
 tracing-loki = { version = "0.2.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 tracing-web = { version = "0.1", optional = true}
+url = { version = "2.3", features = ["serde"] }
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain", optional = true }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
-nimiq-bls = { path = "../bls" }
-nimiq-consensus = { path = "../consensus", default-features = false }
-nimiq-database = { path = "../database", optional = true }
-nimiq-genesis = { path = "../genesis", default-features = false }
-nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git", optional = true }
-nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git", optional = true }
-nimiq-keys = { path = "../keys" }
-nimiq-light-blockchain = { path = "../light-blockchain" }
-nimiq-log = { path = "../log", optional = true }
-nimiq-mempool = { path = "../mempool", optional = true }
-nimiq-metrics-server = { path = "../metrics-server", optional = true }
-nimiq-network-libp2p = { path = "../network-libp2p" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = { path = "../primitives", features = ["networks"] }
-nimiq-rpc-server = { path = "../rpc-server", optional = true }
-nimiq-serde = { path = "../serde" }
-nimiq-utils = { path = "../utils", features = ["time", "key-store"] }
-nimiq-validator = { path = "../validator", optional = true, features = ["trusted_push"] }
-nimiq-validator-network = { path = "../validator-network", optional = true }
-nimiq-wallet = { path = "../wallet", optional = true }
-nimiq-zkp = { path = "../zkp" }
-nimiq-zkp-circuits = { path = "../zkp-circuits" }
-nimiq-zkp-component = { path = "../zkp-component" }
-nimiq-zkp-primitives = { path = "../zkp-primitives" }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true, optional = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, default-features = false }
+nimiq-bls = { workspace = true }
+nimiq-consensus = { workspace = true, default-features = false }
+nimiq-database = { workspace = true, optional = true }
+nimiq-genesis = { workspace = true, default-features = false }
+nimiq-jsonrpc-core = { workspace = true, optional = true }
+nimiq-jsonrpc-server = { workspace = true, optional = true }
+nimiq-keys = { workspace = true }
+nimiq-light-blockchain = { workspace = true }
+nimiq-log = { workspace = true, optional = true }
+nimiq-mempool = { workspace = true, optional = true }
+nimiq-metrics-server = { workspace = true, optional = true }
+nimiq-network-libp2p = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["networks"] }
+nimiq-rpc-server = { workspace = true, optional = true }
+nimiq-serde = { workspace = true }
+nimiq-utils = { workspace = true, features = ["time", "key-store"] }
+nimiq-validator = { workspace = true, optional = true, features = ["trusted_push"] }
+nimiq-validator-network = { workspace = true, optional = true }
+nimiq-wallet = { workspace = true, optional = true }
+nimiq-zkp = { workspace = true }
+nimiq-zkp-circuits = { workspace = true }
+nimiq-zkp-component = { workspace = true }
+nimiq-zkp-primitives = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }
 
 [features]
 database-storage = ["nimiq-database", "nimiq-zkp-component/database-storage"]

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -18,19 +18,20 @@ thiserror = "1.0"
 tokio = { version = "1.29", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-collections = { path = "../collections" }
-nimiq-genesis = { path = "../genesis", default-features = false }
-nimiq-hash = { path = "../hash" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-utils = { path = "../utils", features = ["time"] }
-nimiq-vrf = { path = "../vrf" }
-nimiq-zkp = { path = "../zkp" }
+nimiq-block = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-genesis = { workspace = true, default-features = false }
+nimiq-hash = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-utils = { workspace = true, features = ["time"] }
+nimiq-vrf = { workspace = true }
+nimiq-zkp = { workspace = true }
 
 [dev-dependencies]
-nimiq-block-production = { path = "../block-production", features = ["test-utils"] }
-nimiq-blockchain = { path="../blockchain" }
-nimiq-test-utils = { path= "../test-utils" }
-nimiq-test-log = { path = "../test-log" }
 rand = "^0.8"
+
+nimiq-block-production = { workspace = true, features = ["test-utils"] }
+nimiq-blockchain = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-test-log = { workspace = true }

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-light-blockchain"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Block storage for Nimiq's Light Nodes"
-license = "Apache-2.0"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "nimiq-log"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Nimiq utilities for logging"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 ansi_term = "0.12"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4"
 serde = "1.0"
 serde-big-array = "0.5"
 
-nimiq-serde = { path = "../serde" }
+nimiq-serde = { workspace = true }
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -29,35 +29,35 @@ tokio = { version = "1.29", features = ["rt", "rt-multi-thread", "sync", "tracin
 tokio-metrics = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-database = { path = "../database" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives", features = ["coin", "networks"] }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-utils = { path = "../utils", features = ["time"] }
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "networks"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 hex = "0.4"
 rand = "0.8"
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-block-production = { path = "../block-production" }
-nimiq-bls = { path = "../bls" }
-nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-transaction-builder = { path = "../transaction-builder" }
-nimiq-vrf = { path = "../vrf" }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-block-production = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-genesis-builder = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-transaction-builder = { workspace = true }
+nimiq-vrf = { workspace = true }
 
 [features]
 metrics = ["prometheus-client"]

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-mempool"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Mempool implementation for Nimiq"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -29,10 +29,10 @@ tokio = { version = "1.29", features = [
 ] }
 tokio-metrics = "0.1"
 
-nimiq-blockchain = { path = "../blockchain", features = ["metrics"] }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy" }
-nimiq-consensus = { path = "../consensus" }
-nimiq-mempool = { path = "../mempool", features = ["metrics"] }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-network-libp2p = { path = "../network-libp2p", features = ["metrics"] }
+nimiq-blockchain = { workspace = true, features = ["metrics"] }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true }
+nimiq-consensus = { workspace = true }
+nimiq-mempool = { workspace = true, features = ["metrics"] }
+nimiq-network-interface = { workspace = true }
+nimiq-network-libp2p = { workspace = true, features = ["metrics"] }

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-metrics-server"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-license = "Apache-2.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Prometheus metrics server for the Nimiq Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/mnemonic/Cargo.toml
+++ b/mnemonic/Cargo.toml
@@ -22,13 +22,13 @@ hex = "0.4"
 serde = "1.0"
 unicode-normalization = "0.1"
 
-nimiq-hash = { path = "../hash" }
-nimiq-key-derivation = { path = "../key-derivation", optional = true }
-nimiq-macros = { path = "../macros" }
-nimiq-utils = { path = "../utils", features = ["crc"] }
+nimiq-hash = { workspace = true }
+nimiq-key-derivation = { workspace = true, optional = true }
+nimiq-macros = { workspace = true }
+nimiq-utils = { workspace = true, features = ["crc"] }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }
 
 [features]
 default = ["key-derivation"]

--- a/mnemonic/Cargo.toml
+++ b/mnemonic/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-mnemonic"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "Mnemonic helper library for Nimiq"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-network-interface"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq's network implementation in Rust"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "1.0"
 tokio = { version = "1.29", features = ["rt"] }
 tokio-stream = { version = "0.1", features = ["default", "sync"] }
 
-nimiq-serde = { path = "../serde" }
+nimiq-serde = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -40,19 +40,19 @@ tokio = { version = "1.29", features = ["macros", "rt", "tracing"] }
 tokio-stream = "0.1"
 wasm-timer = "0.2"
 
-nimiq-bls = { path = "../bls" }
-nimiq-macros = { path = "../macros" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-hash = { path = "../hash" }
-nimiq-serde = { path = "../serde" }
-nimiq-utils = { path = "../utils", features = [
+nimiq-bls = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-hash = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-utils = { workspace = true, features = [
     "tagged-signing",
     "serde-derive",
     "libp2p",
     "time",
 ] }
-nimiq-validator-network = { path = "../validator-network" }
+nimiq-validator-network = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false, features = [
@@ -84,7 +84,8 @@ libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-feature
 [dev-dependencies]
 # In dev/testing we require more tokio features
 tokio = { version = "1.29", features = ["macros", "rt", "rt-multi-thread", "test-util", "tracing"] }
-nimiq-test-log = { path = "../test-log" }
+
+nimiq-test-log = { workspace = true }
 
 [features]
 metrics = ["prometheus-client"]

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-network-libp2p"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq network implementation based on libp2p"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -30,8 +30,8 @@ tokio = { version = "1.29", features = [
 ] }
 tokio-stream = "0.1"
 
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-serde = { path = "../serde" }
+nimiq-network-interface = { workspace = true }
+nimiq-serde = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-network-mock"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Mock network implementation for testing purposes"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -35,15 +35,15 @@ thiserror = { version = "1.0", optional = true }
 tsify = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
-nimiq-bls = { path = "../bls", features = ["serde-derive"], optional = true }
-nimiq-database-value = { path = "../database/database-value", optional = true }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys", optional = true, features = ["serde-derive"] }
-nimiq-serde = { path = "../serde", optional = true }
-nimiq-utils = { path = "../utils", features = ["math"], optional = true }
+nimiq-bls = { workspace = true, features = ["serde-derive"], optional = true }
+nimiq-database-value = { workspace = true, optional = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true, optional = true, features = ["serde-derive"] }
+nimiq-serde = { workspace = true, optional = true }
+nimiq-utils = { workspace = true, features = ["math"], optional = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }
 
 [features]
 account = ["coin", "hex", "serde-derive", "thiserror", "transaction", "trie"]

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -19,27 +19,27 @@ serde = "1.0"
 strum_macros = "0.24"
 thiserror = "1.0"
 
-nimiq-bls = { path = "../../bls" }
-nimiq-collections = { path = "../../collections" }
-nimiq-database = { path = "../../database", optional = true }
-nimiq-database-value = { path = "../../database/database-value" }
-nimiq-hash = { path = "../../hash" }
-nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
-nimiq-macros = { path = "../../macros" }
-nimiq-primitives = { path = "..", features = ["coin", "policy", "serde-derive", "slots", "tree-proof", "trie"] }
-nimiq-serde = { path = "../../serde" }
-nimiq-transaction = { path = "../transaction" }
-nimiq-trie = { path = "../trie", optional = true }
-nimiq-utils = { path = "../../utils", features = ["key-rng"] }
-nimiq-vrf = { path = "../../vrf" }
+nimiq-bls = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-database = { workspace = true, optional = true }
+nimiq-database-value = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
+nimiq-macros = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "policy", "serde-derive", "slots", "tree-proof", "trie"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-trie = { workspace = true, optional = true }
+nimiq-utils = { workspace = true, features = ["key-rng"] }
+nimiq-vrf = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"
 tempfile = "3.3"
 
-nimiq-genesis-builder = { path = "../../genesis-builder" }
-nimiq-test-log = { path = "../../test-log" }
-nimiq-test-utils = { path = "../../test-utils" }
+nimiq-genesis-builder = { workspace = true }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 
 [features]
 accounts = ["interaction-traits", "nimiq-database", "nimiq-trie"]

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-categories = ["cryptography::cryptocurrencies"]
-description = "Account primitives to be used in Nimiq's Albatross implementation"
-edition = "2021"
-homepage = "https://nimiq.com"
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
-license = "Apache-2.0"
 name = "nimiq-account"
-repository = "https://github.com/nimiq/core-rs-albatross"
-version = "0.1.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Account primitives to be used in Nimiq's Albatross implementation"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 hex = "0.4"

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -24,24 +24,24 @@ serde = "1.0"
 serde_repr = "0.1"
 thiserror = "1.0"
 
-nimiq-bls = { path = "../../bls", features = ["cache", "serde-derive"]}
-nimiq-collections = { path = "../../collections" }
-nimiq-database-value = { path = "../../database/database-value" }
-nimiq-handel = { path = "../../handel" }
-nimiq-hash = { path = "../../hash" }
-nimiq-hash_derive = { path = "../../hash/hash_derive" }
-nimiq-keys = { path = "../../keys" }
-nimiq-macros = { path = "../../macros" }
-nimiq-network-interface = { path = "../../network-interface" }
-nimiq-primitives = { path = "..", features = ["coin", "networks", "policy", "slots"] }
-nimiq-serde = { path = "../../serde" }
-nimiq-transaction = { path = "../transaction" }
-nimiq-utils = { path = "../../utils", features = ["merkle"] }
-nimiq-vrf = { path = "../../vrf", features = ["serde-derive"] }
-nimiq-zkp-primitives = { path = "../../zkp-primitives" }
+nimiq-bls = { workspace = true, features = ["cache", "serde-derive"]}
+nimiq-collections = { workspace = true }
+nimiq-database-value = { workspace = true }
+nimiq-handel = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-hash_derive = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "networks", "policy", "slots"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = ["merkle"] }
+nimiq-vrf = { workspace = true, features = ["serde-derive"] }
+nimiq-zkp-primitives = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../../test-log" }
-nimiq-test-utils = { path = "../../test-utils" }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 num-traits = "0.2"
 

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-block"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Block primitives to be used in Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/primitives/mmr/Cargo.toml
+++ b/primitives/mmr/Cargo.toml
@@ -13,10 +13,10 @@ keywords.workspace = true
 [dependencies]
 serde = { version = "1.0", optional = true }
 
-nimiq-serde = { path = "../../serde", optional = true }
+nimiq-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../../test-log" }
+nimiq-test-log = { workspace = true }
 
 [features]
 serde-derive = ["nimiq-serde", "serde"]

--- a/primitives/mmr/Cargo.toml
+++ b/primitives/mmr/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-mmr"
-version = "0.1.0"
+version.workspace = true
 authors = ["Pascal Berrang <contact@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 description = "Merkle Mountain Range primitive for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 serde = { version = "1.0", optional = true }

--- a/primitives/subscription/Cargo.toml
+++ b/primitives/subscription/Cargo.toml
@@ -19,14 +19,14 @@ hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
 
-nimiq-bls = { path = "../../bls", features = ["serde-derive"] }
-nimiq-hash = { path = "../../hash" }
-nimiq-keys = { path = "../../keys" }
-nimiq-macros = { path = "../../macros" }
-nimiq-primitives = { path = "..", features = ["policy", "networks", "account", "coin"] }
-nimiq-serde = { path = "../../serde" }
-nimiq-transaction = { path = "../transaction" }
-nimiq-utils = { path = "../../utils", features = ["merkle"] }
+nimiq-bls = { workspace = true, features = ["serde-derive"] }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy", "networks", "account", "coin"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = ["merkle"] }
 
 [dev-dependencies]
 hex = "0.4"

--- a/primitives/subscription/Cargo.toml
+++ b/primitives/subscription/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-subscription"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Subscription primitives to be used in Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -23,24 +23,24 @@ thiserror = "1.0"
 tsify = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
-nimiq-bls = { path = "../../bls", features = ["serde-derive"] }
-nimiq-database-value = { path = "../../database/database-value"}
-nimiq-hash = { path = "../../hash" }
-nimiq-hash_derive = { path = "../../hash/hash_derive" }
-nimiq-keys = { path = "../../keys", features = ["serde-derive"] }
-nimiq-macros = { path = "../../macros" }
-nimiq-mmr = { path = "../mmr", features = ["serde-derive"] }
-nimiq-network-interface = { path = "../../network-interface" }
-nimiq-primitives = { path = "..", features = ["account", "coin", "networks", "policy", "serde-derive", "slots"] }
-nimiq-serde = { path = "../../serde" }
-nimiq-utils = { path = "../../utils", features = ["merkle"] }
+nimiq-bls = { workspace = true, features = ["serde-derive"] }
+nimiq-database-value = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-hash_derive = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
+nimiq-macros = { workspace = true }
+nimiq-mmr = { workspace = true, features = ["serde-derive"] }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["account", "coin", "networks", "policy", "serde-derive", "slots"] }
+nimiq-serde = { workspace = true }
+nimiq-utils = { workspace = true, features = ["merkle"] }
 
 [dev-dependencies]
 hex = "0.4"
 serde_json = "1.0"
 
-nimiq-test-log = { path = "../../test-log" }
-nimiq-test-utils = { path = "../../test-utils" }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 
 
 [features]

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-transaction"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Transaction primitives to be used in Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-trie"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Merkle radix trie primitive for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 hex = "0.4"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -16,10 +16,10 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
 thiserror = "1.0"
 
-nimiq-database = { path = "../../database" }
-nimiq-hash = { path = "../../hash" }
-nimiq-primitives = { path = "..", features = ["key-nibbles", "serde-derive", "trie"] }
-nimiq-serde = { path = "../../serde" }
+nimiq-database = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["key-nibbles", "serde-derive", "trie"] }
+nimiq-serde = { workspace = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../../test-log" }
+nimiq-test-log = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -34,12 +34,12 @@ tokio = { version = "1.29", features = [
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.3"
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-bls = { path = "../bls" }
-nimiq-hash = { path = "../hash" }
-nimiq-jsonrpc-client = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-rpc-interface = { path = "../rpc-interface" }
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-account = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-jsonrpc-client = { workspace = true, features = ["http-client", "websocket-client"] }
+nimiq-jsonrpc-core = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-rpc-interface = { workspace = true }
+nimiq-transaction = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-rpc-client"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-license = "Apache-2.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "JSON RPC client for the Nimiq Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [[bin]]
 name = "nimiq-rpc"

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-rpc-interface"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-license = "Apache-2.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "JSON RPC server for the Nimiq Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -28,23 +28,23 @@ serde = "1.0"
 serde_with = "3.0"
 thiserror = "1.0"
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy" }
-nimiq-bls = { path = "../bls", features = ["serde-derive"] }
-nimiq-collections = { path = "../collections" }
-nimiq-hash = { path = "../hash" }
-nimiq-jsonrpc-client = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-jsonrpc-derive = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-keys = { path = "../keys", features = ["serde-derive"] }
-nimiq-primitives = { path = "../primitives", features = ["coin", "account", "serde-derive"] }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-vrf = { path = "../vrf", features = ["serde-derive"] }
-nimiq-zkp-component = { path = "../zkp-component" }
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true }
+nimiq-bls = { workspace = true, features = ["serde-derive"] }
+nimiq-collections = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-jsonrpc-client = { workspace = true }
+nimiq-jsonrpc-core = { workspace = true }
+nimiq-jsonrpc-derive = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
+nimiq-primitives = { workspace = true, features = ["coin", "account", "serde-derive"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-vrf = { workspace = true, features = ["serde-derive"] }
+nimiq-zkp-component = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -28,37 +28,37 @@ thiserror = "1.0"
 tokio = "1.29"
 tokio-stream = "0.1"
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-bls = { path = "../bls", features = ["serde-derive"] }
-nimiq-collections = { path = "../collections" }
-nimiq-consensus = { path = "../consensus" }
-nimiq-database = { path = "../database" }
-nimiq-hash = { path = "../hash" }
-nimiq-jsonrpc-core = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-jsonrpc-derive = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git" }
-nimiq-keys = { path = "../keys", features = ["serde-derive"] }
-nimiq-mempool = { path = "../mempool" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-network-libp2p = { path = "../network-libp2p" }
-nimiq-primitives = { path = "../primitives", features = [
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-bls = { workspace = true, features = ["serde-derive"] }
+nimiq-collections = { workspace = true }
+nimiq-consensus = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-jsonrpc-core = { workspace = true }
+nimiq-jsonrpc-derive = { workspace = true }
+nimiq-jsonrpc-server = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
+nimiq-mempool = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-network-libp2p = { workspace = true }
+nimiq-primitives = { workspace = true, features = [
     "coin",
     "account",
     "serde-derive",
 ] }
-nimiq-rpc-interface = { path = "../rpc-interface" }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-transaction-builder = { path = "../transaction-builder", features = [
+nimiq-rpc-interface = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-transaction-builder = { workspace = true, features = [
     "serde-derive",
 ] }
-nimiq-utils = { path = "../utils", features = ["otp"] }
-nimiq-validator = { path = "../validator" }
-nimiq-validator-network = { path = "../validator-network" }
-nimiq-vrf = { path = "../vrf", features = ["serde-derive"] }
-nimiq-wallet = { path = "../wallet" }
-nimiq-zkp-component = { path = "../zkp-component" }
+nimiq-utils = { workspace = true, features = ["otp"] }
+nimiq-validator = { workspace = true }
+nimiq-validator-network = { workspace = true }
+nimiq-vrf = { workspace = true, features = ["serde-derive"] }
+nimiq-wallet = { workspace = true }
+nimiq-zkp-component = { workspace = true }

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-rpc-server"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-license = "Apache-2.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "JSON RPC server for the Nimiq Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "nimiq-serde"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Nimiq helpers for SerDe usage"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 hex = "0.4"

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-spammer"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq's Rust client"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 exclude = ["db", "peer_key.dat"]
 
 [badges]

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -27,14 +27,14 @@ tokio = { version = "1.29", features = ["rt-multi-thread", "time", "tracing"] }
 tokio-metrics = { version = "0.1" }
 toml = "0.7"
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-keys = { path = "../keys" }
-nimiq-mempool = { path = "../mempool" }
-nimiq-primitives = { path = "../primitives", features = ["coin", "networks"] }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-transaction-builder = { path = "../transaction-builder" }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-mempool = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "networks"] }
+nimiq-transaction = { workspace = true }
+nimiq-transaction-builder = { workspace = true }
 
 [dependencies.nimiq]
 package = "nimiq-lib"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -22,14 +22,14 @@ tokio = { version = "1.29", features = [
 ] }
 tokio-stream = "0.1"
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-collections = { path = "../collections" }
-nimiq-hash = { path = "../hash" }
-nimiq-macros = { path = "../macros" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
+nimiq-block = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }
 tokio = { version = "1.29", features = [
     "macros",
     "rt-multi-thread",

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-tendermint"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Tendermint implementation for Nimiq's Albatross"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 futures = { package = "futures-util", version = "0.3" }

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "nimiq-test-log"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Nimiq logging utilities for testing"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -15,7 +15,7 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-nimiq-genesis = { path = "../genesis" }
-nimiq-log = { path = "../log" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-test-log-proc-macro = { path = "proc-macro" }
+nimiq-genesis = { workspace = true }
+nimiq-log = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-test-log-proc-macro = { workspace = true }

--- a/test-log/proc-macro/Cargo.toml
+++ b/test-log/proc-macro/Cargo.toml
@@ -16,5 +16,6 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
-nimiq-test-log = { path = ".." }
 tokio = { version = "1.29", features = ["macros", "rt"] }
+
+nimiq-test-log = { workspace = true }

--- a/test-log/proc-macro/Cargo.toml
+++ b/test-log/proc-macro/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nimiq-test-log-proc-macro"
-version = "0.1.0"
+version.workspace = true
 authors = ["Daniel Mueller <deso@posteo.net>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 include = ["src/lib.rs", "LICENSE-*", "README.md", "CHANGELOG.md"]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-test-utils"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Test utilities for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 ark-ff = "0.4"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -28,34 +28,34 @@ serde = "1.0"
 tokio = { version = "1.29", features = ["rt", "time", "tracing"] }
 tokio-stream = "0.1"
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy" }
-nimiq-block-production = { path = "../block-production" }
-nimiq-bls = { path = "../bls" }
-nimiq-collections = { path = "../collections" }
-nimiq-consensus = { path = "../consensus" }
-nimiq-database = { path = "../database" }
-nimiq-genesis = { path = "../genesis" }
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-mempool = { path = "../mempool" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-network-libp2p = { path = "../network-libp2p" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-serde = { path = "../serde" }
-nimiq-tendermint = { path = "../tendermint" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-transaction-builder = { path = "../transaction-builder" }
-nimiq-trie = { path = "../primitives/trie" }
-nimiq-validator = { path = "../validator" }
-nimiq-validator-network = { path = "../validator-network" }
-nimiq-utils = { path = "../utils" }
-nimiq-vrf = { path = "../vrf" }
-nimiq-zkp-circuits = { path = "../zkp-circuits", features = ["test-setup", "zkp-prover", "parallel"] }
-nimiq-zkp-component = { path = "../zkp-component", features = ["database-storage", "zkp-prover", "parallel"] }
-nimiq-zkp-primitives = { path = "../zkp-primitives", features = ["parallel", "zkp-prover", "parallel"] }
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true }
+nimiq-block-production = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-consensus = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-genesis-builder = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-mempool = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-network-libp2p = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-tendermint = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-transaction-builder = { workspace = true }
+nimiq-trie = { workspace = true }
+nimiq-utils = { workspace = true }
+nimiq-validator = { workspace = true }
+nimiq-validator-network = { workspace = true }
+nimiq-vrf = { workspace = true }
+nimiq-zkp-circuits = { workspace = true, features = ["test-setup", "zkp-prover", "parallel"] }
+nimiq-zkp-component = { workspace = true, features = ["database-storage", "zkp-prover", "parallel"] }
+nimiq-zkp-primitives = { workspace = true, features = ["parallel", "zkp-prover", "parallel"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-tools"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Tools for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [[bin]]
 name = "nimiq-bls"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -30,10 +30,10 @@ log = { package = "tracing", version = "0.1", features = ["log"] }
 rand = "0.8"
 thiserror = "1.0"
 
-nimiq-bls = { path = "../bls" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-serde = { path = "../serde" }
-nimiq-utils = { path = "../utils" }
+nimiq-bls = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true }

--- a/transaction-builder/Cargo.toml
+++ b/transaction-builder/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-transaction-builder"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Wallet logic for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/transaction-builder/Cargo.toml
+++ b/transaction-builder/Cargo.toml
@@ -18,19 +18,19 @@ maintenance = { status = "experimental" }
 serde = { version = "1.0", optional = true }
 thiserror = "1.0"
 
-nimiq-bls = { path = "../bls" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-bls = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"
 rand = "0.8"
 
-nimiq-test-log = { path = "../test-log" }
-nimiq-utils = { path = "../utils", features = ["otp", "key-rng"]}
+nimiq-test-log = { workspace = true }
+nimiq-utils = { workspace = true, features = ["otp", "key-rng"]}
 
 
 [features]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-utils"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Various utilities (e.g., CRC, Merkle proofs, timers) for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -28,16 +28,16 @@ rand_core = { version = "0.6", optional = true }
 serde = { version = "1.0", optional = true }
 thiserror = { version = "1.0", optional = true }
 
-nimiq-collections = { path = "../collections", optional = true }
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-hash = { path = "../hash", optional = true }
-nimiq-serde = { path = "../serde", optional = true }
+nimiq-collections = { workspace = true, optional = true }
+nimiq-database-value = { workspace = true }
+nimiq-hash = { workspace = true, optional = true }
+nimiq-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-nimiq-keys = { path = "../keys" }
-nimiq-serde = { path = "../serde" }
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
+nimiq-keys = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 
 [features]
 crc = []

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-validator-network"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq's validator network abstraction in Rust"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.29", features = ["rt"] }
 
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-bls = { path = "../bls" }
-nimiq-serde = { path = "../serde" }
-nimiq-utils = { path = "../utils", features = ["tagged-signing"] }
+nimiq-bls = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-utils = { workspace = true, features = ["tagged-signing"] }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -28,32 +28,32 @@ tokio = { version = "1.29", features = ["rt", "time", "tracing"] }
 tokio-metrics = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-account = { path = "../primitives/account" }
-nimiq-block = { path = "../primitives/block" }
-nimiq-block-production = { path = "../block-production" }
-nimiq-blockchain = { path = "../blockchain" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-bls = { path = "../bls" }
-nimiq-collections = { path = "../collections" }
-nimiq-consensus = { path = "../consensus" }
-nimiq-database = { path = "../database" }
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-genesis = { path = "../genesis" }
-nimiq-handel = { path = "../handel" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-macros = { path = "../macros" }
-nimiq-mempool = { path = "../mempool" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-serde = { path = "../serde" }
-nimiq-tendermint = { path = "../tendermint" }
-nimiq-transaction-builder = { path = "../transaction-builder" }
-nimiq-utils = { path = "../utils", features = [
+nimiq-account = { workspace = true }
+nimiq-block = { workspace = true }
+nimiq-block-production = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-consensus = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-database-value = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-handel = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-mempool = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-tendermint = { workspace = true }
+nimiq-transaction-builder = { workspace = true }
+nimiq-utils = { workspace = true, features = [
     "time",
 ] }
-nimiq-validator-network = { path = "../validator-network" }
-nimiq-vrf = { path = "../vrf" }
+nimiq-validator-network = { workspace = true }
+nimiq-vrf = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"
@@ -61,13 +61,13 @@ tokio = { version = "1.29", features = ["rt", "test-util", "time", "tracing"] }
 tracing-core = "0.1"
 tracing-subscriber = "0.3"
 
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-network-libp2p = { path = "../network-libp2p" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-test-log = { path = "../test-log" }
+nimiq-genesis-builder = { workspace = true }
+nimiq-network-libp2p = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-test-log = { workspace = true }
 # This adds a circular dev-dependency which is fine but breaks VS code rust-analyzer.
 # See https://github.com/rust-analyzer/rust-analyzer/issues/14167
-nimiq-test-utils = { path = "../test-utils" }
+nimiq-test-utils = { workspace = true }
 
 [features]
 metrics = ["nimiq-mempool/metrics"]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-validator"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Validator logic of Albatross"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-description = "Verifiable Random Function based on VXEdDSA"
-documentation = "https://github.com/nimiq/core-rs-albatross"
-homepage = "https://github.com/nimiq/core-rs-albatross"
-license = "MIT/Apache-2.0"
 name = "nimiq-vrf"
-repository = "https://github.com/nimiq/core-rs-albatross"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Verifiable Random Function based on VXEdDSA"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 byteorder = "1.3"

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -20,14 +20,14 @@ rand = "0.8"
 serde = { version = "1.0", optional = true }
 sha2 = "0.9"
 
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-macros = { path = "../macros" }
-nimiq-serde = { path = "../serde", optional = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-macros = { workspace = true }
+nimiq-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
 
 [features]
 serde-derive = ["nimiq-serde", "serde"]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -17,15 +17,15 @@ maintenance = { status = "experimental" }
 [dependencies]
 serde = "1.0"
 
-nimiq-database = { path = "../database" }
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives" }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-utils = { path = "../utils", features = ["otp"]}
+nimiq-database = { workspace = true }
+nimiq-database-value = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = ["otp"]}
 
 [dev-dependencies]
 hex = "0.4"
-nimiq-test-log = { path = "../test-log" }
+nimiq-test-log = { workspace = true }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-wallet"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Wallet logic for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-web-client"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Nimiq's Rust-to-WASM web client"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain", "proof-of-stake"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "nimiq/core-rs-albatross" }

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -33,19 +33,19 @@ wasm-bindgen-derive = { version = "0.2", optional = true }
 wasm-timer = "0.2"
 web-sys = { version = "0.3.64", features = ["MessageEvent"]}
 
-nimiq-account = { path = "../primitives/account", default-features = false }
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
-nimiq-bls = { path = "../bls" }
-nimiq-consensus = { path = "../consensus", default-features = false }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = {path = "../primitives", features = ["coin", "networks", "ts-types"]}
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction", features = ["ts-types"] }
-nimiq-transaction-builder = { path = "../transaction-builder" }
+nimiq-account = { workspace = true, default-features = false }
+nimiq-block = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, default-features = false }
+nimiq-bls = { workspace = true }
+nimiq-consensus = { workspace = true, default-features = false }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["coin", "networks", "ts-types"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true, features = ["ts-types"] }
+nimiq-transaction-builder = { workspace = true }
 
 [dependencies.nimiq]
 package = "nimiq-lib"
@@ -63,14 +63,14 @@ parking_lot = "0.12"
 serde = "1.0"
 wasm-bindgen-test = "0.3"
 
-nimiq-bls = { path = "../bls"}
-nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
-nimiq-consensus = { path = "../consensus", default-features = false }
-nimiq-genesis = { path = "../genesis", default-features = false }
-nimiq-light-blockchain = { path = "../light-blockchain" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-zkp-component = { path = "../zkp-component", default-features = false }
+nimiq-bls = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, default-features = false }
+nimiq-consensus = { workspace = true, default-features = false }
+nimiq-genesis = { workspace = true, default-features = false }
+nimiq-light-blockchain = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-zkp-component = { workspace = true, default-features = false }
 
 [features]
 client = []

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -36,28 +36,28 @@ ark-r1cs-std = "0.4"
 ark-serialize = { version = "0.4", features = ["derive"] }
 ark-std = "0.4"
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-bls = { path = "../bls" }
-nimiq-genesis = { path = "../genesis", default-features = false }
-nimiq-hash = { path = "../hash" }
-nimiq-pedersen-generators = { path = "../zkp-primitives/pedersen-generators" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-serde = { path = "../serde" }
-nimiq-zkp-primitives = { path = "../zkp-primitives" }
-nimiq-keys = { path = "../keys" }
+nimiq-block = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-genesis = { workspace = true, default-features = false }
+nimiq-hash = { workspace = true }
+nimiq-pedersen-generators = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-serde = { workspace = true }
+nimiq-zkp-primitives = { workspace = true }
+nimiq-keys = { workspace = true }
 
 [dev-dependencies]
 ark-test-curves = { version = "0.4", features = ["bls12_381_curve"] }
 
-nimiq-collections = { path = "../collections" }
-nimiq-primitives = { path = "../primitives", features = ["policy", "slots"] }
-nimiq-tendermint = { path = "../tendermint" }
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-transaction = { path = "../primitives/transaction" }
+nimiq-collections = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy", "slots"] }
+nimiq-tendermint = { workspace = true }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-transaction = { workspace = true }
 
 
 [features]
 zkp-prover = ["ark-crypto-primitives/r1cs", "ark-mnt4-753/r1cs", "ark-mnt6-753/r1cs", "ark-groth16/r1cs", "nimiq-zkp-primitives/zkp-prover"]
-parallel = ["rayon", "ark-crypto-primitives/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel", "nimiq-zkp-primitives/parallel"]
+parallel = ["ark-crypto-primitives/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel", "nimiq-zkp-primitives/parallel", "rayon"]
 test-setup = ["ark-poly", "zkp-prover"]

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-zkp-circuits"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Shared Circuits of Recursive SNARKs for Nimiq's Light Nodes"
-license = "MIT/Apache-2.0"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [[bin]]
 name = "nimiq-zkp-setup"

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-zkp-component"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "All functionality related to the zk proof storage, dessimination and request handeling."
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [[bin]]
 name = "nimiq-test-prove"

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -37,44 +37,44 @@ tokio = { version = "1.29", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing-subscriber = { version = "0.3", optional = true }
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-blockchain = { path = "../blockchain", optional = true }
-nimiq-blockchain-interface = { path = "../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../blockchain-proxy", default-features = false }
-nimiq-database = { path = "../database", optional = true }
-nimiq-database-value = { path = "../database/database-value" }
-nimiq-genesis = { path = "../genesis", default-features = false }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-log = { path = "../log", optional = true }
-nimiq-macros = { path = "../macros" }
-nimiq-network-interface = { path = "../network-interface" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-serde = { path = "../serde" }
-nimiq-transaction = { path = "../primitives/transaction" }
-nimiq-utils = { path = "../utils", features = [
+nimiq-block = { workspace = true }
+nimiq-blockchain = { workspace = true, optional = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, default-features = false }
+nimiq-database = { workspace = true, optional = true }
+nimiq-database-value = { workspace = true }
+nimiq-genesis = { workspace = true, default-features = false }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-log = { workspace = true, optional = true }
+nimiq-macros = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-serde = { workspace = true }
+nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true, features = [
     "math",
     "merkle",
     "time",
 ] }
-nimiq-validator-network = { path = "../validator-network" }
-nimiq-zkp = { path = "../zkp"}
-nimiq-zkp-circuits = { path = "../zkp-circuits" }
-nimiq-zkp-primitives = { path = "../zkp-primitives" }
+nimiq-validator-network = { workspace = true }
+nimiq-zkp = { workspace = true }
+nimiq-zkp-circuits = { workspace = true }
+nimiq-zkp-primitives = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.3"
 
-nimiq-block-production = { path = "../block-production" }
-nimiq-bls = { path = "../bls" }
-nimiq-genesis-builder = { path = "../genesis-builder" }
-nimiq-keys = { path = "../keys" }
-nimiq-network-mock = { path = "../network-mock" }
-nimiq-network-libp2p = { path = "../network-libp2p" }
-nimiq-test-log = { path = "../test-log" }
+nimiq-block-production = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-genesis-builder = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-network-mock = { workspace = true }
+nimiq-network-libp2p = { workspace = true }
+nimiq-test-log = { workspace = true }
 # This adds a circular dev-dependency which is fine but breaks VS code rust-analyzer.
 # See https://github.com/rust-analyzer/rust-analyzer/issues/14167
-nimiq-test-utils = { path = "../test-utils" }
+nimiq-test-utils = { workspace = true }
 
 [features]
 database-storage = ["nimiq-database"]

--- a/zkp-component/zkp-test-gen/Cargo.toml
+++ b/zkp-component/zkp-test-gen/Cargo.toml
@@ -15,24 +15,24 @@ hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 serde = "1.0"
-tracing-subscriber = { version = "0.3" }
 tokio = { version = "1.29", features = ["macros", "rt", "sync"] }
+tracing-subscriber = { version = "0.3" }
 
-nimiq-block = { path = "../../primitives/block" }
-nimiq-block-production = { path = "../../block-production" }
-nimiq-blockchain = { path = "../../blockchain" }
-nimiq-blockchain-interface = { path = "../../blockchain-interface" }
-nimiq-blockchain-proxy = { path = "../../blockchain-proxy" }
-nimiq-database = { path = "../../database" }
-nimiq-genesis = { path = "../../genesis" }
-nimiq-log = { path = "../../log" }
-nimiq-primitives = { path = "../../primitives", features = ["policy"] }
-nimiq-serde = { path = "../../serde" }
-nimiq-test-utils = { path = "../../test-utils" }
-nimiq-utils = { path = "../../utils", features = [
+nimiq-block = { workspace = true }
+nimiq-block-production = { workspace = true }
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-genesis = { workspace = true }
+nimiq-log = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-serde = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-utils = { workspace = true, features = [
     "time",
 ] }
-nimiq-zkp = { path = "../../zkp", features = ["zkp-prover"] }
-nimiq-zkp-circuits = { path = "../../zkp-circuits", features = ["zkp-prover"] }
-nimiq-zkp-component = { path = "..", features = ["zkp-prover"] }
-nimiq-zkp-primitives = { path = "../../zkp-primitives", features = ["zkp-prover"] }
+nimiq-zkp = { workspace = true, features = ["zkp-prover"] }
+nimiq-zkp-circuits = { workspace = true, features = ["zkp-prover"] }
+nimiq-zkp-component = { workspace = true, features = ["zkp-prover"] }
+nimiq-zkp-primitives = { workspace = true, features = ["zkp-prover"] }

--- a/zkp-component/zkp-test-gen/Cargo.toml
+++ b/zkp-component/zkp-test-gen/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-zkp-test-gen"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "All functionality related to the zk proof storage, dissemination and request handeling."
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 hex = "0.4"

--- a/zkp-primitives/Cargo.toml
+++ b/zkp-primitives/Cargo.toml
@@ -29,20 +29,20 @@ rayon = { version = "^1.7", optional = true }
 serde = { version = "1.0" }
 thiserror = "1.0"
 
-nimiq-bls = { path = "../bls" }
-nimiq-hash = { path = "../hash" }
-nimiq-pedersen-generators = { path = "pedersen-generators" }
-nimiq-primitives = { path = "../primitives", features = ["policy"] }
-nimiq-serde = { path = "../serde" }
+nimiq-bls = { workspace = true }
+nimiq-hash = { workspace = true }
+nimiq-pedersen-generators = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
+nimiq-serde = { workspace = true }
 
 [dev-dependencies]
-nimiq-block = { path = "../primitives/block" }
-nimiq-collections = { path = "../collections" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives", features = ["slots"] }
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-utils = { path = "../utils" }
+nimiq-block = { workspace = true }
+nimiq-collections = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["slots"] }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-utils = { workspace = true }
 
 [features]
 parallel = ["rayon", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel"]

--- a/zkp-primitives/Cargo.toml
+++ b/zkp-primitives/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-zkp-primitives"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Shared Primitives of Recursive SNARKs for Nimiq's Nano Nodes"
-license = "MIT/Apache-2.0"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 ark-crypto-primitives = { version = "0.4", features = ["crh"] }

--- a/zkp-primitives/pedersen-generators/Cargo.toml
+++ b/zkp-primitives/pedersen-generators/Cargo.toml
@@ -21,8 +21,8 @@ ark-ff = "0.4"
 ark-mnt6-753 = "0.4"
 hex = "0.4"
 
-nimiq-hash = { path = "../../hash" }
-nimiq-primitives = { path = "../../primitives", features = ["policy"] }
+nimiq-hash = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy"] }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/zkp-primitives/pedersen-generators/Cargo.toml
+++ b/zkp-primitives/pedersen-generators/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "nimiq-pedersen-generators"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Shared Primitives of Recursive SNARKs for Nimiq's Nano Nodes"
-license = "MIT/Apache-2.0"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [[bench]]
 name = "generate"

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -28,24 +28,24 @@ rand = { version = "0.8", features = ["small_rng"] }
 serde = "1.0"
 thiserror = "1.0"
 
-nimiq-block = { path = "../primitives/block" }
-nimiq-bls = { path = "../bls" }
-nimiq-genesis = { path = "../genesis", default-features = false }
-nimiq-hash = { path = "../hash" }
-nimiq-keys = { path = "../keys" }
-nimiq-primitives = { path = "../primitives", features = ["policy", "networks"] }
-nimiq-serde = { path = "../serde" }
-nimiq-zkp-circuits = { path = "../zkp-circuits" }
-nimiq-zkp-primitives = { path = "../zkp-primitives" }
+nimiq-block = { workspace = true }
+nimiq-bls = { workspace = true }
+nimiq-genesis = { workspace = true, default-features = false }
+nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["policy", "networks"] }
+nimiq-serde = { workspace = true }
+nimiq-zkp-circuits = { workspace = true }
+nimiq-zkp-primitives = { workspace = true }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"
 tracing-subscriber = { version = "0.3" }
 
-nimiq-log = { path = "../log" }
-nimiq-test-log = { path = "../test-log" }
-nimiq-test-utils = { path = "../test-utils" }
-nimiq-zkp-circuits = { path = "../zkp-circuits", features = ["zkp-prover"] }
+nimiq-log = { workspace = true }
+nimiq-test-log = { workspace = true }
+nimiq-test-utils = { workspace = true }
+nimiq-zkp-circuits = { workspace = true, features = ["zkp-prover"] }
 
 [features]
 parallel = ["nimiq-zkp-circuits/parallel", "nimiq-zkp-primitives/parallel", "ark-crypto-primitives/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "ark-groth16/parallel"]

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-zkp"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Recursive SNARKs for Nimiq's Nano Nodes"
-license = "Apache-2.0"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-edition = "2021"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies]
 ark-crypto-primitives = { version = "0.4", features = ["prf", "sponge"] }


### PR DESCRIPTION
Use the workspace inheritance feature introduced in Rust 1.64. This allows to avoid constantly defining the package properties in each of the subcrate's Cargo manifest.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
