### PR TITLE
 Add HS method to query the block number of the last leaf 

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -872,6 +872,22 @@ impl HistoryStore {
         Ok(root)
     }
 
+    /// Returns the block number of the last leaf in the history store
+    pub fn get_last_leaf_block_number(&self, txn_option: Option<&TransactionProxy>) -> Option<u32> {
+        let read_txn: TransactionProxy;
+        let txn = match txn_option {
+            Some(txn) => txn,
+            None => {
+                read_txn = self.db.read_transaction();
+                &read_txn
+            }
+        };
+
+        // Seek to the last leaf index of the block, if it exists.
+        let mut cursor = txn.cursor(&self.last_leaf_table);
+        cursor.last::<u32, u32>().map(|(key, _)| key)
+    }
+
     /// Gets an extended transaction by its hash. Note that this hash is the leaf hash (see MMRHash)
     /// of the transaction, not a simple Blake2b hash of the transaction.
     fn get_extended_tx(


### PR DESCRIPTION
Add method to the history store to query the block number of the last leaf.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
