### PR TITLE
Fix feature compilation and remove some unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,6 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-utils",
  "nimiq-vrf",
- "nimiq-zkp-primitives",
  "num-traits",
  "serde",
  "serde_repr",
@@ -3665,7 +3664,6 @@ dependencies = [
  "ark-mnt6-753",
  "ark-serialize",
  "ark-std",
- "blake2",
  "blake2-rfc",
  "byteorder",
  "hex",
@@ -3701,7 +3699,6 @@ dependencies = [
  "hex",
  "nimiq-serde",
  "nimiq-test-log",
- "num-traits",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -3714,7 +3711,6 @@ dependencies = [
  "async-trait",
  "futures-executor",
  "futures-util",
- "gloo-timers",
  "hex",
  "instant",
  "nimiq-account",
@@ -3741,7 +3737,6 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-trie",
  "nimiq-utils",
- "nimiq-validator-network",
  "nimiq-zkp-component",
  "parking_lot 0.12.1",
  "pin-project",
@@ -3769,9 +3764,6 @@ dependencies = [
 [[package]]
 name = "nimiq-database-value"
 version = "0.1.0"
-dependencies = [
- "tracing",
-]
 
 [[package]]
 name = "nimiq-genesis"
@@ -3833,7 +3825,6 @@ dependencies = [
  "nimiq-macros",
  "nimiq-network-interface",
  "nimiq-network-mock",
- "nimiq-primitives",
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-utils",
@@ -4171,7 +4162,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
- "derive_more",
  "futures-util",
  "libp2p",
  "nimiq-serde",
@@ -4191,7 +4181,6 @@ dependencies = [
  "base64 0.21.0",
  "bitflags 1.3.2",
  "bytes",
- "derive_more",
  "futures-util",
  "hex",
  "instant",
@@ -4260,7 +4249,6 @@ dependencies = [
  "ark-ec",
  "ark-mnt6-753",
  "ark-serialize",
- "bitvec",
  "byteorder",
  "hex",
  "nimiq-bls",
@@ -4441,14 +4429,10 @@ name = "nimiq-tendermint"
 version = "0.1.0"
 dependencies = [
  "futures-util",
- "nimiq-block",
  "nimiq-collections",
- "nimiq-hash",
  "nimiq-macros",
- "nimiq-primitives",
  "nimiq-test-log",
  "serde",
- "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4888,7 +4872,6 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-transaction",
  "nimiq-utils",
- "nimiq-validator-network",
  "nimiq-zkp",
  "nimiq-zkp-circuits",
  "nimiq-zkp-primitives",

--- a/block-production/Cargo.toml
+++ b/block-production/Cargo.toml
@@ -34,7 +34,7 @@ nimiq-genesis = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }
 nimiq-primitives = { workspace = true }
-nimiq-tendermint = { workspace = true }
+nimiq-tendermint = { workspace = true, optional = true }
 nimiq-transaction = { workspace = true }
 nimiq-vrf = { workspace = true }
 nimiq-utils = { workspace = true }
@@ -48,10 +48,11 @@ nimiq-test-log = { workspace = true }
 # See https://github.com/rust-analyzer/rust-analyzer/issues/14167
 nimiq-genesis-builder = { workspace = true }
 nimiq-serde = { workspace = true }
+nimiq-tendermint = { workspace = true }
 nimiq-test-utils = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
 nimiq-trie = { workspace = true }
 
 [features]
 default = []
-test-utils = []
+test-utils = ["nimiq-tendermint"]

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "1.0"
 tokio = { version = "1.29", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
-nimiq-account = { workspace = true }
+nimiq-account = { workspace = true, features = ["accounts"] }
 nimiq-block = { workspace = true }
 nimiq-blockchain-interface = { workspace = true }
 nimiq-bls = { workspace = true, features = ["serde-derive"] }

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -11,7 +11,6 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-blake2 = "0.10"
 blake2-rfc = "0.2"
 byteorder = "1.3.4"
 hex = "0.4"

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -17,7 +17,6 @@ is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-num-traits = "0.2"
 serde = "1.0"
 
 [dev-dependencies]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -20,7 +20,6 @@ maintenance = { status = "experimental" }
 async-trait = "0.1"
 futures = { package = "futures-util", version = "0.3" }
 futures-executor = { version = "0.3" }
-gloo-timers = { version = "0.2.6", features = [ "futures" ]}
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
@@ -50,7 +49,6 @@ nimiq-utils = { workspace = true, features = [
     "merkle",
     "time",
 ] }
-nimiq-validator-network = { workspace = true }
 nimiq-zkp-component = { workspace = true }
 
 [dev-dependencies]

--- a/database/database-value/Cargo.toml
+++ b/database/database-value/Cargo.toml
@@ -16,5 +16,3 @@ is-it-maintained-issue-resolution = { repository = "nimiq/core-rs" }
 is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
 maintenance = { status = "experimental" }
 
-[dependencies]
-log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -25,8 +25,6 @@ nimiq-bls = { workspace = true }
 nimiq-collections = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-macros = { workspace = true }
-nimiq-network-interface = { workspace = true }
-nimiq-primitives = { workspace = true, features = ["policy"] }
 nimiq-serde = { workspace = true }
 nimiq-utils = { workspace = true, features = [
     "math",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,7 +38,7 @@ time = { version = "0.3", optional = true }
 tokio = { version = "1.29", features = ["rt"], optional = true }
 toml = "0.7"
 tracing-loki = { version = "0.2.1", optional = true }
-tracing-subscriber = { version = "0.3", optional = true }
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "std"] }
 tracing-web = { version = "0.1", optional = true}
 url = { version = "2.3", features = ["serde"] }
 

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -31,8 +31,8 @@ tokio-metrics = "0.1"
 
 nimiq-blockchain = { workspace = true, features = ["metrics"] }
 nimiq-blockchain-interface = { workspace = true }
-nimiq-blockchain-proxy = { workspace = true }
-nimiq-consensus = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, features = ["full"] }
+nimiq-consensus = { workspace = true, features = ["full"] }
 nimiq-mempool = { workspace = true, features = ["metrics"] }
 nimiq-network-interface = { workspace = true }
 nimiq-network-libp2p = { workspace = true, features = ["metrics"] }

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -19,7 +19,6 @@ maintenance = { status = "experimental" }
 [dependencies]
 async-trait = "0.1"
 bitflags = "1.2"
-derive_more = "0.99"
 futures = { package = "futures-util", version = "0.3" }
 libp2p = { git = "https://github.com/jsdanielh/rust-libp2p.git", default-features = false }
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -21,7 +21,6 @@ async-trait = "0.1"
 base64 = "0.21"
 bitflags = "1.2"
 bytes = "1.4"
-derive_more = "0.99"
 futures = { package = "futures-util", version = "0.3" }
 hex = "0.4"
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = { version = "1.0", optional = true }
 tsify = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
-nimiq-bls = { workspace = true, features = ["serde-derive"], optional = true }
+nimiq-bls = { workspace = true, features = ["lazy", "serde-derive"], optional = true }
 nimiq-database-value = { workspace = true, optional = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true, optional = true, features = ["serde-derive"] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,7 +20,6 @@ maintenance = { status = "experimental" }
 ark-ec = "0.4"
 ark-mnt6-753 = "0.4"
 ark-serialize = "0.4"
-bitvec = "1.0"
 byteorder = "1.2"
 hex = { version = "0.4", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -38,7 +38,6 @@ nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true }
 nimiq-utils = { workspace = true, features = ["merkle"] }
 nimiq-vrf = { workspace = true, features = ["serde-derive"] }
-nimiq-zkp-primitives = { workspace = true }
 
 [dev-dependencies]
 nimiq-test-log = { workspace = true }

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -30,12 +30,12 @@ tokio-stream = "0.1"
 
 nimiq-account = { workspace = true }
 nimiq-block = { workspace = true }
-nimiq-blockchain-interface = { workspace = true }
-nimiq-blockchain-proxy = { workspace = true }
 nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, features = ["full"] }
 nimiq-bls = { workspace = true, features = ["serde-derive"] }
 nimiq-collections = { workspace = true }
-nimiq-consensus = { workspace = true }
+nimiq-consensus = { workspace = true, features = ["full"] }
 nimiq-database = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-jsonrpc-core = { workspace = true }

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -14,7 +14,6 @@ keywords.workspace = true
 futures = { package = "futures-util", version = "0.3" }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
-thiserror = "1.0"
 tokio = { version = "1.29", features = [
     "macros",
     "rt-multi-thread",
@@ -22,11 +21,8 @@ tokio = { version = "1.29", features = [
 ] }
 tokio-stream = "0.1"
 
-nimiq-block = { workspace = true }
 nimiq-collections = { workspace = true }
-nimiq-hash = { workspace = true }
 nimiq-macros = { workspace = true }
-nimiq-primitives = { workspace = true, features = ["policy"] }
 
 [dev-dependencies]
 nimiq-test-log = { workspace = true }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -36,7 +36,7 @@ nimiq-blockchain-proxy = { workspace = true }
 nimiq-block-production = { workspace = true }
 nimiq-bls = { workspace = true }
 nimiq-collections = { workspace = true }
-nimiq-consensus = { workspace = true }
+nimiq-consensus = { workspace = true, features = ["full"] }
 nimiq-database = { workspace = true }
 nimiq-genesis = { workspace = true }
 nimiq-genesis-builder = { workspace = true }

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.29", features = ["rt"] }
 
-nimiq-bls = { workspace = true }
+nimiq-bls = { workspace = true, features = ["lazy", "serde-derive"] }
 nimiq-network-interface = { workspace = true }
 nimiq-serde = { workspace = true }
 nimiq-utils = { workspace = true, features = ["tagged-signing"] }

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -57,7 +57,6 @@ nimiq-utils = { workspace = true, features = [
     "merkle",
     "time",
 ] }
-nimiq-validator-network = { workspace = true }
 nimiq-zkp = { workspace = true }
 nimiq-zkp-circuits = { workspace = true }
 nimiq-zkp-primitives = { workspace = true }


### PR DESCRIPTION
- Fix feature compilation for crates:
  - `blockchain`
  - `lib`
  - `metrics-server`
  - `primitives`
  - `rpc-server`
  - `test-utils`
 - Remove some unused dependencies in these crates:
   - `block-primitives`
   - `block-production`
   - `bls`
   - `collections`
   - `consensus`
   - `database-value`
   - `handel`
   - `network-interface`
   - `network-libp2p`
   - `primitives`
   - `tendermint`
   - `zkp-component`

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
