### PR TITLE
Take upgradable_read() instead of read() in blockchain_push

### DIFF
--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -445,9 +445,10 @@ fn blockchain_push<N: Network>(
         match blockchain {
             #[cfg(feature = "full")]
             BlockchainProxy::Full(ref blockchain) => {
-                let block_hash = blockchain.read().head_hash();
+                let bc = blockchain.upgradable_read();
+                let block_hash = bc.head_hash();
                 // We push the chunks.
-                let chunks_push_result = blockchain.read().commit_chunks(chunks, &block_hash);
+                let chunks_push_result = bc.commit_chunks(chunks, &block_hash);
                 blockchain_push_result = BlockchainPushResult::with_chunks_result(
                     chunks_push_result,
                     block_hash,


### PR DESCRIPTION
As commit_chunks creates and commits a write_transaction it should not be called with a read lock only.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
