### PR TITLE
blockchain: Fix verifying history setting for the genesis

### DIFF
--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -199,9 +199,15 @@ impl Blockchain {
         // Correctly set flag for verifying the history root.
         let history_root = history_store
             .get_history_tree_root(Policy::epoch_at(main_chain.head.block_number()), None);
-        let can_verify_history = history_root
-            .map(|history_root| &history_root == main_chain.head.history_root())
-            .unwrap_or(false);
+        let can_verify_history = if main_chain.head.block_number() == Policy::genesis_block_number()
+        {
+            // We always can verify history for the genesis block
+            true
+        } else {
+            history_root
+                .map(|history_root| &history_root == main_chain.head.history_root())
+                .unwrap_or(false)
+        };
 
         // Load macro chain from store.
         let macro_chain_info = chain_store


### PR DESCRIPTION
Fix the verifying history setting for a corner case where a DB is loaded and the block number is still the genesis one (no history yet). This was provoking that `can_verify_history` to be set as false as the genesis history root doesn't match the hash of the history store.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
