### PR TITLE
Fix mempool check for unstake

### DIFF
--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -600,9 +600,11 @@ impl AccountTransactionInteraction for StakingContract {
 
                 let staker = store.expect_staker(&staker_address)?;
 
+                self.can_remove_stake(&store, &staker, block_state.number)?;
+
                 reserved_balance.reserve_for(
                     &staker_address,
-                    staker.balance,
+                    staker.inactive_balance,
                     transaction.total_value(),
                 )
             }


### PR DESCRIPTION
## What's in this pull request?
The mempool used the wrong balance to check unstake transactions.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
