### PR TITLE
Modify transaction struct itself when calling sign() on it

### DIFF
--- a/web-client/example/module.js
+++ b/web-client/example/module.js
@@ -68,7 +68,8 @@ init().then(async () => {
                 BigInt(fee),
                 await client.getHeadHeight(),
                 await client.getNetworkId(),
-            ).sign(keyPair);
+            );
+            transaction.sign(keyPair);
         } else {
             transaction = Nimiq.TransactionBuilder.newBasic(
                 keyPair.toAddress(),
@@ -77,7 +78,8 @@ init().then(async () => {
                 BigInt(fee),
                 await client.getHeadHeight(),
                 await client.getNetworkId(),
-            ).sign(keyPair);
+            );
+            transaction.sign(keyPair);
         }
 
         return client.sendTransaction(transaction.toHex());
@@ -104,7 +106,8 @@ init().then(async () => {
             BigInt(fee),
             await client.getHeadHeight(),
             await client.getNetworkId(),
-        ).sign(keyPair);
+        );
+        transaction.sign(keyPair);
 
         return client.sendTransaction(transaction.toHex());
     }
@@ -128,7 +131,8 @@ init().then(async () => {
             BigInt(fee),
             await client.getHeadHeight(),
             await client.getNetworkId(),
-        ).sign(keyPair);
+        );
+        transaction.sign(keyPair);
 
         return client.sendTransaction(transaction.toHex());
     }
@@ -152,7 +156,8 @@ init().then(async () => {
             BigInt(fee),
             await client.getHeadHeight(),
             await client.getNetworkId(),
-        ).sign(keyPair);
+        );
+        transaction.sign(keyPair);
 
         return client.sendTransaction(transaction.toHex());
     }

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -140,12 +140,11 @@ impl Transaction {
     ///
     /// ### Limitations
     /// - HTLC redemption is not supported and will throw.
-    /// - Validator deletion transactions are not and cannot be supported.
     /// - For transaction to the staking contract, both signatures are made with the same keypair,
     ///   so it is not possible to interact with a staker that is different from the sender address
     ///   or using a different cold or signing key for validator transactions.
     #[cfg(feature = "primitives")]
-    pub fn sign(&self, key_pair: &KeyPair) -> Result<Transaction, JsError> {
+    pub fn sign(&mut self, key_pair: &KeyPair) -> Result<(), JsError> {
         let proof_builder = TransactionProofBuilder::new(self.native_ref().clone());
         let signed_transaction = match proof_builder {
             TransactionProofBuilder::Basic(mut builder) => {
@@ -196,7 +195,9 @@ impl Transaction {
             }
         };
 
-        Ok(Transaction::from_native(signed_transaction))
+        self.set_proof(signed_transaction.proof);
+
+        Ok(())
     }
 
     /// Computes the transaction's hash, which is used as its unique identifier on the blockchain.


### PR DESCRIPTION
Instead of returning a signed copy. I think this API is more intuitive.

I also don't want to do both, modify self _and_ return a signed copy (because it's not possible to just return self, that is first-of-all a compiler error, and secondly would create a second instance in JS-land anyway), as that would transparently create a copy of the variable, which is unexpected behavior for users of the library and will lead only to errors.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
