### PR TITLE
Fix increasing and decreasing numStakers for a validator

### DIFF
--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -380,6 +380,9 @@ impl StakingContract {
             if new_active_balance.is_zero() {
                 self.remove_staker_from_validator(store, &staker)
                     .expect("inconsistent contract state");
+            } else if old_active_balance.is_zero() {
+                self.add_staker_to_validator(store, &staker)
+                    .expect("inconsistent contract state");
             } else {
                 self.update_stake_for_validator(
                     store,
@@ -447,6 +450,9 @@ impl StakingContract {
             // If the staker has previously been removed, we add it back.
             if old_balance.is_zero() {
                 self.add_staker_to_validator(store, &staker)
+                    .expect("inconsistent contract state");
+            } else if staker.balance.is_zero() {
+                self.remove_staker_from_validator(store, &staker)
                     .expect("inconsistent contract state");
             } else {
                 // Update the active stake of the validator.


### PR DESCRIPTION
This field was not correctly increased/decreased when the setting of inactive balance means that a previous zero active balance now becomes non-zero (and in reverse when reverting). Because when the active balance is zero, the staker is not counted towards the validator's stakers. But when it changes to non-zero, the staker needs to be added to the counter (with `add_staker_to_validator`), not just it's balance added (with `update_stake_for_validator`).

This has the `testnet-restart` label, because the `numStakers` counter affects the accounts tree hash, which will lead to a network split if only some nodes update.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
