### PR TITLE
Allow to set inactive balance with the update-staker functionality

### DIFF
--- a/primitives/account/src/account/staking_contract/receipts.rs
+++ b/primitives/account/src/account/staking_contract/receipts.rs
@@ -117,6 +117,10 @@ convert_receipt!(DeleteValidatorReceipt);
 pub struct StakerReceipt {
     // the delegation before this transaction is applied
     pub delegation: Option<Address>,
+    // the active balance before this transaction is applied
+    pub active_balance: Coin,
+    // the inactive release before this transaction is applied
+    pub inactive_release: Option<u32>,
 }
 convert_receipt!(StakerReceipt);
 

--- a/primitives/account/src/account/staking_contract/receipts.rs
+++ b/primitives/account/src/account/staking_contract/receipts.rs
@@ -34,7 +34,7 @@ pub struct JailReceipt {
     pub old_previous_batch_punished_slots: BitSet,
     /// the current batch punished slots of the affected validator before this jail is applied
     pub old_current_batch_punished_slots: Option<BTreeSet<u16>>,
-    // the jail release before this jail is applied
+    /// the jail release before this jail is applied
     pub old_jail_release: Option<u32>,
 }
 convert_receipt!(JailReceipt);
@@ -43,11 +43,11 @@ convert_receipt!(JailReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct UpdateValidatorReceipt {
-    // the signing key before this transaction is applied
+    /// the signing key before this transaction is applied
     pub old_signing_key: SchnorrPublicKey,
-    // the voting key before this transaction is applied
+    /// the voting key before this transaction is applied
     pub old_voting_key: BlsPublicKey,
-    // the reward address before this transaction is applied
+    /// the reward address before this transaction is applied
     pub old_reward_address: Address,
     // the signal data before this transaction is applied
     pub old_signal_data: Option<Blake2bHash>,
@@ -60,7 +60,7 @@ convert_receipt!(UpdateValidatorReceipt);
 pub struct JailValidatorReceipt {
     /// true if corresponding validator was deactivated by this jail
     pub newly_deactivated: bool,
-    // the jail release before this jail is applied
+    /// the jail release before this jail is applied
     pub old_jail_release: Option<u32>,
 }
 convert_receipt!(JailValidatorReceipt);
@@ -78,7 +78,7 @@ impl From<&JailReceipt> for JailValidatorReceipt {
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ReactivateValidatorReceipt {
-    // the value of `inactive_since` before this transaction is applied
+    /// the value of `inactive_since` before this transaction is applied
     pub was_inactive_since: u32,
 }
 convert_receipt!(ReactivateValidatorReceipt);
@@ -87,7 +87,7 @@ convert_receipt!(ReactivateValidatorReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct RetireValidatorReceipt {
-    // true if the validator was retired from an active state
+    /// true if the validator was retired from an active state
     pub was_active: bool,
 }
 convert_receipt!(RetireValidatorReceipt);
@@ -96,17 +96,17 @@ convert_receipt!(RetireValidatorReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DeleteValidatorReceipt {
-    // the signing key before this transaction is applied
+    /// the signing key before this transaction is applied
     pub signing_key: SchnorrPublicKey,
-    // the voting key before this transaction is applied
+    /// the voting key before this transaction is applied
     pub voting_key: BlsPublicKey,
-    // the reward address before this transaction is applied
+    /// the reward address before this transaction is applied
     pub reward_address: Address,
-    // the signal data before this transaction is applied
+    /// the signal data before this transaction is applied
     pub signal_data: Option<Blake2bHash>,
-    // the value of `inactive_since` before this transaction is applied
+    /// the value of `inactive_since` before this transaction is applied
     pub inactive_since: u32,
-    // the jail release before this transaction is applied
+    /// the jail release before this transaction is applied
     pub jail_release: Option<u32>,
 }
 convert_receipt!(DeleteValidatorReceipt);
@@ -115,11 +115,11 @@ convert_receipt!(DeleteValidatorReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct StakerReceipt {
-    // the delegation before this transaction is applied
+    /// the delegation before this transaction is applied
     pub delegation: Option<Address>,
-    // the active balance before this transaction is applied
+    /// the active balance before this transaction is applied
     pub active_balance: Coin,
-    // the inactive release before this transaction is applied
+    /// the inactive release before this transaction is applied
     pub inactive_release: Option<u32>,
 }
 convert_receipt!(StakerReceipt);
@@ -128,9 +128,9 @@ convert_receipt!(StakerReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SetInactiveStakeReceipt {
-    // the inactive release before this transaction is applied
+    /// the inactive release before this transaction is applied
     pub old_inactive_release: Option<u32>,
-    // the active balance before this transaction is applied
+    /// the active balance before this transaction is applied
     pub old_active_balance: Coin,
 }
 convert_receipt!(SetInactiveStakeReceipt);
@@ -139,9 +139,9 @@ convert_receipt!(SetInactiveStakeReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct RemoveStakeReceipt {
-    // the delegation before this transaction is applied
+    /// the delegation before this transaction is applied
     pub delegation: Option<Address>,
-    // the inactive release before this transaction is applied
+    /// the inactive release before this transaction is applied
     pub inactive_release: Option<u32>,
 }
 convert_receipt!(RemoveStakeReceipt);

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -177,7 +177,7 @@ impl AccountTransactionInteraction for StakingContract {
                 .map(|_| None),
             IncomingStakingTransactionData::UpdateStaker {
                 new_delegation,
-                new_inactive_balance,
+                reactivate_all_stake,
                 proof,
             } => {
                 // Get the staker address from the proof.
@@ -187,7 +187,7 @@ impl AccountTransactionInteraction for StakingContract {
                     &mut store,
                     &staker_address,
                     new_delegation,
-                    new_inactive_balance,
+                    reactivate_all_stake,
                     block_state.number,
                     tx_logger,
                 )

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -177,6 +177,7 @@ impl AccountTransactionInteraction for StakingContract {
                 .map(|_| None),
             IncomingStakingTransactionData::UpdateStaker {
                 new_delegation,
+                new_inactive_balance,
                 proof,
             } => {
                 // Get the staker address from the proof.
@@ -186,6 +187,7 @@ impl AccountTransactionInteraction for StakingContract {
                     &mut store,
                     &staker_address,
                     new_delegation,
+                    new_inactive_balance,
                     block_state.number,
                     tx_logger,
                 )

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -116,6 +116,10 @@ pub enum Log {
         staker_address: Address,
         old_validator_address: Option<Address>,
         new_validator_address: Option<Address>,
+        old_active_balance: Coin,
+        new_active_balance: Coin,
+        old_inactive_release: Option<u32>,
+        new_inactive_release: Option<u32>,
     },
 
     #[serde(rename_all = "camelCase")]
@@ -263,6 +267,10 @@ impl Log {
                 staker_address,
                 old_validator_address,
                 new_validator_address,
+                old_active_balance: _,
+                new_active_balance: _,
+                old_inactive_release: _,
+                new_inactive_release: _,
             } => {
                 staker_address == address
                     || old_validator_address

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -116,10 +116,8 @@ pub enum Log {
         staker_address: Address,
         old_validator_address: Option<Address>,
         new_validator_address: Option<Address>,
-        old_active_balance: Coin,
-        new_active_balance: Coin,
-        old_inactive_release: Option<u32>,
-        new_inactive_release: Option<u32>,
+        active_balance: Coin,
+        inactive_release: Option<u32>,
     },
 
     #[serde(rename_all = "camelCase")]
@@ -267,10 +265,7 @@ impl Log {
                 staker_address,
                 old_validator_address,
                 new_validator_address,
-                old_active_balance: _,
-                new_active_balance: _,
-                old_inactive_release: _,
-                new_inactive_release: _,
+                ..
             } => {
                 staker_address == address
                     || old_validator_address

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -74,6 +74,7 @@ pub enum IncomingStakingTransactionData {
     },
     UpdateStaker {
         new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
         proof: SignatureProof,
     },
     SetInactiveStake {

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -74,7 +74,7 @@ pub enum IncomingStakingTransactionData {
     },
     UpdateStaker {
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
         proof: SignatureProof,
     },
     SetInactiveStake {

--- a/primitives/transaction/tests/staking_contract_verify.rs
+++ b/primitives/transaction/tests/staking_contract_verify.rs
@@ -558,6 +558,7 @@ fn update_staker() {
     let mut tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::UpdateStaker {
             new_delegation: Some(VALIDATOR_ADDRESS.parse().unwrap()),
+            new_inactive_balance: None,
             proof: SignatureProof::default(),
         },
         0,
@@ -565,8 +566,8 @@ fn update_staker() {
         None,
     );
 
-    let tx_hex = "018c551fabc6e6e00c609c3f0313257ad7e835643c000000000000000000000000000000000000000000010377070183fa05dbe31f85e719f4c4fd67ebdba2e444d9f8b3adb13fe6887f6cdcb8c82c429f718fcdbbb27b2a19df7c1ea9814f19cd910500912d064ba2b1497656f34918ba0f1e4c005269dac08867f7b96c3b259372dd808b8f4b72fbfe582054424dba778f8f2fad73f0751d62afcf6b1922d5d8e825030000000000000000000000000000006400000001040261b3adb13fe6887f6cdcb8c82c429f718fcdbbb27b2a19df7c1ea9814f19cd91050002380c4c37062c8c753fd7993c50c8cbb67b58e9c4c78e4d1873aeb0fc1810c4428fe4748658bf22ceb965b14c4734543b8f771928bf5a5802d50e0c3be39509";
-    let tx_size = 284;
+    let tx_hex = "018c551fabc6e6e00c609c3f0313257ad7e835643c000000000000000000000000000000000000000000010378070183fa05dbe31f85e719f4c4fd67ebdba2e444d9f800b3adb13fe6887f6cdcb8c82c429f718fcdbbb27b2a19df7c1ea9814f19cd910500ae3042a470b6b3f63e3d8d6d628d7150747b22cb4124725de2e4a5ef7802d7228a77450dace2445885284a7c39a15699be76c99232d4defd733bc5e65015650d0000000000000000000000000000006400000001040261b3adb13fe6887f6cdcb8c82c429f718fcdbbb27b2a19df7c1ea9814f19cd910500c3ac6a608156ce6044a1f48b5c0d0fd58a794a5ab0e4a79f952a27ae52233e91771762dce7cb2f92382fcae6946ebf711dc5482698f56ad511ad81f3f80aa308";
+    let tx_size = 285;
 
     let mut ser_tx: Vec<u8> = Vec::with_capacity(tx_size);
     assert_eq!(tx_size, tx.serialized_size());
@@ -593,6 +594,7 @@ fn update_staker() {
     let tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::UpdateStaker {
             new_delegation: None,
+            new_inactive_balance: None,
             proof: SignatureProof::default(),
         },
         0,

--- a/primitives/transaction/tests/staking_contract_verify.rs
+++ b/primitives/transaction/tests/staking_contract_verify.rs
@@ -558,7 +558,7 @@ fn update_staker() {
     let mut tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::UpdateStaker {
             new_delegation: Some(VALIDATOR_ADDRESS.parse().unwrap()),
-            new_inactive_balance: None,
+            reactivate_all_stake: false,
             proof: SignatureProof::default(),
         },
         0,
@@ -594,7 +594,7 @@ fn update_staker() {
     let tx = make_signed_incoming_tx(
         IncomingStakingTransactionData::UpdateStaker {
             new_delegation: None,
-            new_inactive_balance: None,
+            reactivate_all_stake: false,
             proof: SignatureProof::default(),
         },
         0,

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -61,7 +61,7 @@ pub enum TransactionCommand {
         /// The stake will be sent from this wallet. The sender wallet must be unlocked prior to this action.
         sender_wallet: Address,
 
-        /// The staker address. This wallet must be unlocked prior to this action.        
+        /// The staker address. This wallet must be unlocked prior to this action.
         staker_wallet: Address,
 
         /// Validator address to delegate stake to. If empty, no delegation will occur.
@@ -100,6 +100,10 @@ pub enum TransactionCommand {
         /// The new address for the delegation.
         #[clap(long)]
         new_delegation: Option<Address>,
+
+        /// The new inactive balance to set for the new delegation.
+        #[clap(long)]
+        new_inactive_balance: Option<Coin>,
 
         #[clap(flatten)]
         tx_commons: TxCommon,
@@ -415,6 +419,7 @@ impl HandleSubcommand for TransactionCommand {
                 sender_wallet,
                 staker_wallet,
                 new_delegation,
+                new_inactive_balance,
                 tx_commons,
             } => {
                 if tx_commons.dry {
@@ -424,6 +429,7 @@ impl HandleSubcommand for TransactionCommand {
                             sender_wallet,
                             staker_wallet,
                             new_delegation,
+                            new_inactive_balance,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )
@@ -436,6 +442,7 @@ impl HandleSubcommand for TransactionCommand {
                             sender_wallet,
                             staker_wallet,
                             new_delegation,
+                            new_inactive_balance,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -101,9 +101,9 @@ pub enum TransactionCommand {
         #[clap(long)]
         new_delegation: Option<Address>,
 
-        /// The new inactive balance to set for the new delegation.
+        /// Activate all stake to the new delegation.
         #[clap(long)]
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
 
         #[clap(flatten)]
         tx_commons: TxCommon,
@@ -419,7 +419,7 @@ impl HandleSubcommand for TransactionCommand {
                 sender_wallet,
                 staker_wallet,
                 new_delegation,
-                new_inactive_balance,
+                reactivate_all_stake,
                 tx_commons,
             } => {
                 if tx_commons.dry {
@@ -429,7 +429,7 @@ impl HandleSubcommand for TransactionCommand {
                             sender_wallet,
                             staker_wallet,
                             new_delegation,
-                            new_inactive_balance,
+                            reactivate_all_stake,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )
@@ -442,7 +442,7 @@ impl HandleSubcommand for TransactionCommand {
                             sender_wallet,
                             staker_wallet,
                             new_delegation,
-                            new_inactive_balance,
+                            reactivate_all_stake,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -254,7 +254,7 @@ pub trait ConsensusInterface {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
@@ -264,7 +264,7 @@ pub trait ConsensusInterface {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -254,6 +254,7 @@ pub trait ConsensusInterface {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
@@ -263,6 +264,7 @@ pub trait ConsensusInterface {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -643,7 +643,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error> {
@@ -656,7 +656,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             sender_key.as_ref(),
             &self.get_wallet_keypair(&staker_wallet)?,
             new_delegation,
-            new_inactive_balance,
+            reactivate_all_stake,
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
@@ -673,7 +673,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error> {
@@ -682,7 +682,7 @@ impl ConsensusInterface for ConsensusDispatcher {
                 sender_wallet,
                 staker_wallet,
                 new_delegation,
-                new_inactive_balance,
+                reactivate_all_stake,
                 fee,
                 validity_start_height,
             )

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -643,6 +643,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error> {
@@ -655,6 +656,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             sender_key.as_ref(),
             &self.get_wallet_keypair(&staker_wallet)?,
             new_delegation,
+            new_inactive_balance,
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
@@ -671,6 +673,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error> {
@@ -679,6 +682,7 @@ impl ConsensusInterface for ConsensusDispatcher {
                 sender_wallet,
                 staker_wallet,
                 new_delegation,
+                new_inactive_balance,
                 fee,
                 validity_start_height,
             )

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -708,6 +708,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 IncomingAccountData::Staking {
                     parameters: IncomingStakingTransactionData::UpdateStaker {
                         new_delegation: Some(Address::from(&validator_key_pair)),
+                        new_inactive_balance: None,
                         proof: SignatureProof::default(),
                     },
                     validator_key_pair,

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -708,7 +708,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 IncomingAccountData::Staking {
                     parameters: IncomingStakingTransactionData::UpdateStaker {
                         new_delegation: Some(Address::from(&validator_key_pair)),
-                        new_inactive_balance: None,
+                        reactivate_all_stake: false,
                         proof: SignatureProof::default(),
                     },
                     validator_key_pair,

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -985,6 +985,7 @@ impl TransactionBuilder {
     ///  - `staker_key_pair`:       The key pair used to sign the incoming transaction. The staker
     ///                             address will be derived from this key pair.
     ///  - `delegation`:            The new delegation.
+    ///  - `reactivate_all_stake`:  If it should activate all inactive stake to the new delegation.
     ///  - `fee`:                   Transaction fee.
     ///  - `validity_start_height`: Block height from which this transaction is valid.
     ///  - `network_id`:            ID of network for which the transaction is meant.
@@ -1001,13 +1002,13 @@ impl TransactionBuilder {
         key_pair: Option<&KeyPair>,
         staker_key_pair: &KeyPair,
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
-        recipient.update_staker(new_delegation, new_inactive_balance);
+        recipient.update_staker(new_delegation, reactivate_all_stake);
 
         let mut builder = Self::new();
         builder

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -1001,12 +1001,13 @@ impl TransactionBuilder {
         key_pair: Option<&KeyPair>,
         staker_key_pair: &KeyPair,
         new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Result<Transaction, TransactionBuilderError> {
         let mut recipient = Recipient::new_staking_builder();
-        recipient.update_staker(new_delegation);
+        recipient.update_staker(new_delegation, new_inactive_balance);
 
         let mut builder = Self::new();
         builder

--- a/transaction-builder/src/recipient/staking_contract.rs
+++ b/transaction-builder/src/recipient/staking_contract.rs
@@ -138,11 +138,11 @@ impl StakingRecipientBuilder {
     pub fn update_staker(
         &mut self,
         new_delegation: Option<Address>,
-        new_inactive_balance: Option<Coin>,
+        reactivate_all_stake: bool,
     ) -> &mut Self {
         self.data = Some(IncomingStakingTransactionData::UpdateStaker {
             new_delegation,
-            new_inactive_balance,
+            reactivate_all_stake,
             proof: Default::default(),
         });
         self

--- a/transaction-builder/src/recipient/staking_contract.rs
+++ b/transaction-builder/src/recipient/staking_contract.rs
@@ -135,9 +135,14 @@ impl StakingRecipientBuilder {
 
     /// This method allows to change the delegation of a staker.
     /// It needs to be signed by the key pair corresponding to the staker address.
-    pub fn update_staker(&mut self, new_delegation: Option<Address>) -> &mut Self {
+    pub fn update_staker(
+        &mut self,
+        new_delegation: Option<Address>,
+        new_inactive_balance: Option<Coin>,
+    ) -> &mut Self {
         self.data = Some(IncomingStakingTransactionData::UpdateStaker {
             new_delegation,
+            new_inactive_balance,
             proof: Default::default(),
         });
         self

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -71,6 +71,7 @@ fn it_can_create_staker_transactions() {
     let tx = make_signed_incoming_transaction(
         IncomingStakingTransactionData::UpdateStaker {
             new_delegation: None,
+            new_inactive_balance: None,
             proof: Default::default(),
         },
         0,
@@ -80,6 +81,7 @@ fn it_can_create_staker_transactions() {
     let tx2 = TransactionBuilder::new_update_staker(
         Some(&key_pair),
         &key_pair,
+        None,
         None,
         100.try_into().unwrap(),
         1,
@@ -92,6 +94,7 @@ fn it_can_create_staker_transactions() {
     let tx2 = TransactionBuilder::new_update_staker(
         None,
         &key_pair,
+        None,
         None,
         100.try_into().unwrap(),
         1,

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -71,7 +71,7 @@ fn it_can_create_staker_transactions() {
     let tx = make_signed_incoming_transaction(
         IncomingStakingTransactionData::UpdateStaker {
             new_delegation: None,
-            new_inactive_balance: None,
+            reactivate_all_stake: false,
             proof: Default::default(),
         },
         0,
@@ -82,7 +82,7 @@ fn it_can_create_staker_transactions() {
         Some(&key_pair),
         &key_pair,
         None,
-        None,
+        false,
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
@@ -95,7 +95,7 @@ fn it_can_create_staker_transactions() {
         None,
         &key_pair,
         None,
-        None,
+        false,
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,

--- a/web-client/src/primitives/transaction_builder.rs
+++ b/web-client/src/primitives/transaction_builder.rs
@@ -161,12 +161,22 @@ impl TransactionBuilder {
     pub fn new_update_staker(
         sender: &Address,
         new_delegation: &Address,
+        new_inactive_balance: Option<u64>,
         fee: Option<u64>,
         validity_start_height: u32,
         network_id: u8,
     ) -> Result<Transaction, JsError> {
+        let new_inactive_balance = if let Some(new_inactive_balance) = new_inactive_balance {
+            Some(Coin::try_from(new_inactive_balance)?)
+        } else {
+            None
+        };
+
         let mut recipient = Recipient::new_staking_builder();
-        recipient.update_staker(Some(new_delegation.native_ref().clone()));
+        recipient.update_staker(
+            Some(new_delegation.native_ref().clone()),
+            new_inactive_balance,
+        );
 
         let mut builder = nimiq_transaction_builder::TransactionBuilder::new();
         builder

--- a/web-client/src/primitives/transaction_builder.rs
+++ b/web-client/src/primitives/transaction_builder.rs
@@ -161,21 +161,15 @@ impl TransactionBuilder {
     pub fn new_update_staker(
         sender: &Address,
         new_delegation: &Address,
-        new_inactive_balance: Option<u64>,
+        reactivate_all_stake: bool,
         fee: Option<u64>,
         validity_start_height: u32,
         network_id: u8,
     ) -> Result<Transaction, JsError> {
-        let new_inactive_balance = if let Some(new_inactive_balance) = new_inactive_balance {
-            Some(Coin::try_from(new_inactive_balance)?)
-        } else {
-            None
-        };
-
         let mut recipient = Recipient::new_staking_builder();
         recipient.update_staker(
             Some(new_delegation.native_ref().clone()),
-            new_inactive_balance,
+            reactivate_all_stake,
         );
 
         let mut builder = nimiq_transaction_builder::TransactionBuilder::new();


### PR DESCRIPTION
When changing delegation with `update_staker`, the pre-condition is that either the active balance delegated to the current validator is zero (and the inactive stake is released), or the current delegation is `None`. The first case is more common, as users mostly want to change delegation without unstaking first.

Currently, this process requires two consecutive transactions: `update_staker()` for changing delegation, then `set_inactive_balance()` to zero to activate the staking balance again.

For convenience, it will be good if the `update_staker()` function can just take care of both of these steps in one.

This PR includes an optional `reactivate_all_stake` parameter for the `update_staker()` method. When true, all previous inactive stake is activated.

This PR needs to be merged after #1765.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
