### PR TITLE
Use forked tsify branch to copy rustdoc comments over to web TS types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,19 +2148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-utils"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,13 +6448,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -7371,28 +7358,23 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "tsify"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+source = "git+https://github.com/sisou/tsify?branch=sisou/comments#e36e55bcf3c9ac7c1d8185e5ad994885f4a2eb46"
 dependencies = [
- "gloo-utils",
  "serde",
  "serde-wasm-bindgen",
- "serde_json",
  "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "tsify-macros"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d637b54262b1c6b8c2c88ce30fbef4e72613cb71c0e0b6fc09747052eb59a152"
+version = "0.4.5"
+source = "git+https://github.com/sisou/tsify?branch=sisou/comments#e36e55bcf3c9ac7c1d8185e5ad994885f4a2eb46"
 dependencies = [
- "darling 0.14.3",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", optional = true }
 serde_repr = { version = "0.1", optional = true }
 strum_macros = "0.25"
 thiserror = { version = "1.0", optional = true }
-tsify = { version = "0.4", optional = true }
+tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
 nimiq-bls = { workspace = true, features = ["lazy", "serde-derive"], optional = true }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0"
 strum_macros = "0.25"
 thiserror = "1.0"
-tsify = { version = "0.4", optional = true }
+tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
 nimiq-bls = { workspace = true, features = ["serde-derive"] }

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -26,7 +26,7 @@ js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
 serde-wasm-bindgen = "0.5"
-tsify = { version = "0.4", features= ["js"] }
+tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-derive = { version = "0.2", optional = true }


### PR DESCRIPTION
When generating the web-client Typescript type definitions, we use both `wasm-bindgen` and `tsify` for generating types. `wasm-bindgen`-annotated structs correctly carry their rustdoc comments over, but `tsify`-tagged ones were not.

[I added this functionality to tsify in my fork](https://github.com/madonoharu/tsify/pull/32), which the web-client switches to in this PR.

Having the comments in the generated type definitions benefits developers who can see the comments when hovering over the types in their TS projects in IDEs.