### PR TITLE
Fix code coverage errors when freeing up space

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -39,7 +39,6 @@ jobs:
         swap-storage: true
     - name: Remove large packages
       run: |
-        sudo apt-get remove -y '^dotnet-.*'
         sudo apt-get remove -y 'php.*'
         sudo apt-get remove -y '^mongodb-.*'
         sudo apt-get remove -y '^mysql-.*'


### PR DESCRIPTION
## What's in this pull request?
The code coverage started failing after the second removal of dotnet (the "Free disk space" step removes dotnet already). This second removal was triggering a series of aspnet related upgrades and installations that were unnecessary and failing on our workflow.

This PR simply removes the 2nd removal of dotnet from the workflow and solves the error. 


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
