### PR TITLE
Fixing the validator's counters for number of stakers

### DIFF
--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -129,7 +129,7 @@ impl StakingContract {
 
         // If we are delegating to a validator, we need to update it.
         if let Some(validator_address) = &staker.delegation {
-            self.decrease_stake_from_validator(store, &validator_address, staker.balance);
+            self.decrease_stake_from_validator(store, validator_address, staker.balance);
             self.unregister_staker_from_validator(store, validator_address);
         }
 


### PR DESCRIPTION
This fixes the stall of yesterday.

Changes:
- Made the validator counter increase and decrease only when removing a staker or changing delegation.
- When we inactivate stake we only change the validators balance, not the counter. 
- Added a test of updating the staker with the same delegation.
- Added tests for the validator's staker counter.

The validator's counter for the number of stakers represents the number of stakers that have delegation set to that address.
The validator's stake balance represents the sum of the current active stake its stakers have delegated to the validator.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
