### PR TITLE
`pow-migration`: Add some improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,7 +1680,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -4397,6 +4406,7 @@ name = "nimiq-pow-migration"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "convert_case 0.6.0",
  "hex",
  "humantime",
  "indicatif",
@@ -7518,6 +7528,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -18,6 +18,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 clap = { version = "4.3", features = ["derive"] }
+convert_case = "0.6"
 hex = "0.4"
 humantime = "2.1"
 indicatif = "0.17"

--- a/pow-migration/src/genesis/mod.rs
+++ b/pow-migration/src/genesis/mod.rs
@@ -1,6 +1,6 @@
 pub mod types;
 
-use std::{fs, str::FromStr, time::Instant};
+use std::{fs, path::PathBuf, str::FromStr, time::Instant};
 
 use nimiq_database::DatabaseProxy;
 use nimiq_genesis_builder::config::GenesisConfig;
@@ -119,6 +119,6 @@ pub async fn get_pos_genesis(
 }
 
 /// Write the genesis config file to a TOML file
-pub fn write_pos_genesis(file_path: &str, genesis_config: GenesisConfig) -> Result<(), Error> {
+pub fn write_pos_genesis(file_path: &PathBuf, genesis_config: GenesisConfig) -> Result<(), Error> {
     Ok(fs::write(file_path, toml::to_string(&genesis_config)?)?)
 }

--- a/pow-migration/src/genesis/types.rs
+++ b/pow-migration/src/genesis/types.rs
@@ -34,8 +34,11 @@ pub enum Error {
 /// The registration window is a set of blocks in the PoW chain that marks
 /// the start and end of different windows as follows:
 ///
+/// ```text
 ///     1                  2                  3                  4         5
 /// --- | ---------------- | ---------------- | ---------------- | ------- |
+///
+/// ```
 ///
 /// 1. Validator registration window start block.
 /// 2. Validator registration window end block. This block is also the pre-stake

--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -29,8 +29,12 @@ static MAINNET_BLOCK_WINDOWS: &BlockWindows = &BlockWindows {
 /// The registration window is a set of blocks in the PoW chain that marks
 /// the start and end of different windows as follows:
 ///
+/// ```text
+///
 ///     1              2              3              4              5        6
 /// --- | ------------ | ------------ | ------------ | ------------ |------- |
+///
+/// ```
 ///
 /// 1. Validator registration window start block.
 /// 2. Validator registration window end block.


### PR DESCRIPTION
- Remove the settings file.
- Make the client able to launch the PoS `nimiq-client`.
- Change the client to write the genesis file in the same location of the binary and such that it can be passed to launch the client.
- Fix `rustdoc` incorrectly being parsed as `doctest`.

Softly depends on #1781.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
