### PR TITLE
ci: Run doctest

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -74,6 +74,9 @@ jobs:
     #    verbose: true
     - name: Run tests
       run: cargo nextest run --all-features
+    # Currently `nextest` doesn't support doctest so we have to run them apart
+    - name: Run doctest
+      run: cargo test --doc
 
   clippy:
     if: github.event_name != 'push' || github.event.pusher.name != 'dependabot[bot]'


### PR DESCRIPTION
Run `doctest` in the `build+test` GH workflow. A manual run of `doctests` is required since `nextest` as of now doesn't support `doctest`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
