### PR TITLE
Add option to override the testnet genesis

### DIFF
--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -111,6 +111,22 @@ fn network(network_id: NetworkId) -> Option<&'static NetworkInfo> {
             &INFO
         }
         NetworkId::TestAlbatross => {
+            #[cfg(feature = "genesis-override")]
+            {
+                use std::sync::OnceLock;
+                static OVERRIDE: OnceLock<Option<NetworkInfo>> = OnceLock::new();
+                if let Some(info) = OVERRIDE.get_or_init(|| {
+                    let override_path = env::var_os("NIMIQ_OVERRIDE_TESTNET_CONFIG");
+                    override_path.map(|p| NetworkInfo {
+                        network_id: NetworkId::TestAlbatross,
+                        name: "test-albatross",
+                        genesis: read_genesis_config(Path::new(&p))
+                            .expect("failure reading provided NIMIQ_OVERRIDE_TESTNET_CONFIG"),
+                    })
+                }) {
+                    return Some(info);
+                }
+            }
             static INFO: NetworkInfo = NetworkInfo {
                 network_id: NetworkId::TestAlbatross,
                 name: "test-albatross",


### PR DESCRIPTION
- Add option to override the testnet genesis with an environment variable: `NIMIQ_OVERRIDE_TESTNET_CONFIG`.
- Add logic inside the `pow-migration` tool to set the environment variable to override the genesis according to the `networkId` that is set in the configuration file.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
