### PR TITLE
Make jail, stake and validator inactivation block heights more consistent

### DIFF
--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -1268,8 +1268,10 @@ fn it_can_revert_failed_delete_validator() {
 
         // Now the validator should be inactive because of the failing txn.
         assert_eq!(
-            validator.inactive_since,
-            Some(1 + Policy::genesis_block_number())
+            validator.inactive_from,
+            Some(Policy::election_block_after(
+                1 + Policy::genesis_block_number()
+            ))
         );
     }
 

--- a/primitives/account/src/account/staking_contract/receipts.rs
+++ b/primitives/account/src/account/staking_contract/receipts.rs
@@ -34,8 +34,8 @@ pub struct JailReceipt {
     pub old_previous_batch_punished_slots: BitSet,
     /// the current batch punished slots of the affected validator before this jail is applied
     pub old_current_batch_punished_slots: Option<BTreeSet<u16>>,
-    /// the jail release before this jail is applied
-    pub old_jail_release: Option<u32>,
+    /// the jailed block height before this jail is applied
+    pub old_jailed_since: Option<u32>,
 }
 convert_receipt!(JailReceipt);
 
@@ -60,8 +60,8 @@ convert_receipt!(UpdateValidatorReceipt);
 pub struct JailValidatorReceipt {
     /// true if corresponding validator was deactivated by this jail
     pub newly_deactivated: bool,
-    /// the jail release before this jail is applied
-    pub old_jail_release: Option<u32>,
+    /// the jail block height before this jail is applied
+    pub old_jailed_since: Option<u32>,
 }
 convert_receipt!(JailValidatorReceipt);
 
@@ -69,7 +69,7 @@ impl From<&JailReceipt> for JailValidatorReceipt {
     fn from(value: &JailReceipt) -> Self {
         Self {
             newly_deactivated: value.newly_deactivated,
-            old_jail_release: value.old_jail_release,
+            old_jailed_since: value.old_jailed_since,
         }
     }
 }
@@ -107,7 +107,7 @@ pub struct DeleteValidatorReceipt {
     /// the value of `inactive_since` before this transaction is applied
     pub inactive_since: u32,
     /// the jail release before this transaction is applied
-    pub jail_release: Option<u32>,
+    pub jailed_since: Option<u32>,
 }
 convert_receipt!(DeleteValidatorReceipt);
 

--- a/primitives/account/src/account/staking_contract/receipts.rs
+++ b/primitives/account/src/account/staking_contract/receipts.rs
@@ -35,7 +35,7 @@ pub struct JailReceipt {
     /// the current batch punished slots of the affected validator before this jail is applied
     pub old_current_batch_punished_slots: Option<BTreeSet<u16>>,
     /// the jailed block height before this jail is applied
-    pub old_jailed_since: Option<u32>,
+    pub old_jailed_from: Option<u32>,
 }
 convert_receipt!(JailReceipt);
 
@@ -61,7 +61,7 @@ pub struct JailValidatorReceipt {
     /// true if corresponding validator was deactivated by this jail
     pub newly_deactivated: bool,
     /// the jail block height before this jail is applied
-    pub old_jailed_since: Option<u32>,
+    pub old_jailed_from: Option<u32>,
 }
 convert_receipt!(JailValidatorReceipt);
 
@@ -69,7 +69,7 @@ impl From<&JailReceipt> for JailValidatorReceipt {
     fn from(value: &JailReceipt) -> Self {
         Self {
             newly_deactivated: value.newly_deactivated,
-            old_jailed_since: value.old_jailed_since,
+            old_jailed_from: value.old_jailed_from,
         }
     }
 }
@@ -78,8 +78,8 @@ impl From<&JailReceipt> for JailValidatorReceipt {
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ReactivateValidatorReceipt {
-    /// the value of `inactive_since` before this transaction is applied
-    pub was_inactive_since: u32,
+    /// the value of `inactive_from` before this transaction is applied
+    pub was_inactive_from: u32,
 }
 convert_receipt!(ReactivateValidatorReceipt);
 
@@ -104,10 +104,10 @@ pub struct DeleteValidatorReceipt {
     pub reward_address: Address,
     /// the signal data before this transaction is applied
     pub signal_data: Option<Blake2bHash>,
-    /// the value of `inactive_since` before this transaction is applied
-    pub inactive_since: u32,
+    /// the value of `inactive_from` before this transaction is applied
+    pub inactive_from: u32,
     /// the jail release before this transaction is applied
-    pub jailed_since: Option<u32>,
+    pub jailed_from: Option<u32>,
 }
 convert_receipt!(DeleteValidatorReceipt);
 
@@ -119,8 +119,8 @@ pub struct StakerReceipt {
     pub delegation: Option<Address>,
     /// the active balance before this transaction is applied
     pub active_balance: Coin,
-    /// the inactive release before this transaction is applied
-    pub inactive_release: Option<u32>,
+    /// the inactivation block height before this transaction is applied
+    pub inactive_from: Option<u32>,
 }
 convert_receipt!(StakerReceipt);
 
@@ -128,8 +128,8 @@ convert_receipt!(StakerReceipt);
 /// these transactions.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SetInactiveStakeReceipt {
-    /// the inactive release before this transaction is applied
-    pub old_inactive_release: Option<u32>,
+    /// the inactivation block height before this transaction is applied
+    pub old_inactive_from: Option<u32>,
     /// the active balance before this transaction is applied
     pub old_active_balance: Coin,
 }
@@ -141,7 +141,7 @@ convert_receipt!(SetInactiveStakeReceipt);
 pub struct RemoveStakeReceipt {
     /// the delegation before this transaction is applied
     pub delegation: Option<Address>,
-    /// the inactive release before this transaction is applied
-    pub inactive_release: Option<u32>,
+    /// the inactivation block height before this transaction is applied
+    pub inactive_from: Option<u32>,
 }
 convert_receipt!(RemoveStakeReceipt);

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -48,10 +48,16 @@ pub struct Staker {
     pub address: Address,
     /// The staker's active balance.
     pub balance: Coin,
-    /// The staker's inactive balance.
+    /// The staker's inactive balance. Only released inactive balance can be withdrawn from the staking contract.
+    /// Stake can only be re-delegated if the whole balance of the staker is inactive and released
+    /// (or if there was no prior delegation). For inactive balance to be released, the maximum of
+    /// the inactive and the validator's jailed periods must have passed.
     pub inactive_balance: Coin,
-    /// An option indicating the last stake inactivation. The stake can only effectively become inactive
-    /// on the next election block. Thus, this may contain a block height in the future.
+    /// The block number at which the inactive balance was last inactivated for withdrawal or re-delegation.
+    /// If the stake is currently delegated to a jailed validator, the maximum of its jail release
+    /// and the inactive release is taken. Re-delegation requires the whole balance of the staker to be inactive.
+    /// The stake can only effectively become inactive on the next election block. Thus, this may contain a
+    /// future block height.
     pub inactive_from: Option<u32>,
     /// The address of the validator for which the staker is delegating its stake for. If it is not
     /// delegating to any validator, this will be set to None.

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -666,7 +666,7 @@ impl AccountInherentInteraction for StakingContract {
                 inherent_logger.push_tx_logger(tx_logger);
 
                 let newly_deactivated = receipt.newly_deactivated;
-                let newly_jailed = receipt.old_jailed_since.is_none();
+                let newly_jailed = receipt.old_jailed_from.is_none();
 
                 // Register the validator slots as punished
                 let (old_previous_batch_punished_slots, old_current_batch_punished_slots) =
@@ -687,7 +687,7 @@ impl AccountInherentInteraction for StakingContract {
                         newly_deactivated,
                         old_previous_batch_punished_slots,
                         old_current_batch_punished_slots,
-                        old_jailed_since: receipt.old_jailed_since,
+                        old_jailed_from: receipt.old_jailed_from,
                     }
                     .into(),
                 ))
@@ -762,7 +762,7 @@ impl AccountInherentInteraction for StakingContract {
             } => {
                 let receipt: JailReceipt =
                     receipt.ok_or(AccountError::InvalidReceipt)?.try_into()?;
-                let newly_jailed = receipt.old_jailed_since.is_none();
+                let newly_jailed = receipt.old_jailed_from.is_none();
                 let jail_receipt = JailValidatorReceipt::from(&receipt);
 
                 self.punished_slots.revert_register_jail(

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -2,7 +2,6 @@ use nimiq_keys::Address;
 use nimiq_primitives::{
     account::{AccountError, AccountType},
     coin::Coin,
-    policy::Policy,
 };
 use nimiq_serde::Deserialize;
 use nimiq_transaction::{
@@ -662,13 +661,12 @@ impl AccountInherentInteraction for StakingContract {
                     &mut store,
                     &jailed_validator.validator_address,
                     block_state.number,
-                    Policy::block_after_jail(block_state.number),
                     &mut tx_logger,
                 )?;
                 inherent_logger.push_tx_logger(tx_logger);
 
                 let newly_deactivated = receipt.newly_deactivated;
-                let newly_jailed = receipt.old_jail_release.is_none();
+                let newly_jailed = receipt.old_jailed_since.is_none();
 
                 // Register the validator slots as punished
                 let (old_previous_batch_punished_slots, old_current_batch_punished_slots) =
@@ -689,7 +687,7 @@ impl AccountInherentInteraction for StakingContract {
                         newly_deactivated,
                         old_previous_batch_punished_slots,
                         old_current_batch_punished_slots,
-                        old_jail_release: receipt.old_jail_release,
+                        old_jailed_since: receipt.old_jailed_since,
                     }
                     .into(),
                 ))
@@ -764,7 +762,7 @@ impl AccountInherentInteraction for StakingContract {
             } => {
                 let receipt: JailReceipt =
                     receipt.ok_or(AccountError::InvalidReceipt)?.try_into()?;
-                let newly_jailed = receipt.old_jail_release.is_none();
+                let newly_jailed = receipt.old_jailed_since.is_none();
                 let jail_receipt = JailValidatorReceipt::from(&receipt);
 
                 self.punished_slots.revert_register_jail(

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -88,7 +88,7 @@ pub enum Log {
     #[serde(rename_all = "camelCase")]
     JailValidator {
         validator_address: Address,
-        jail_release: u32,
+        jailed_since: u32,
     },
 
     #[serde(rename_all = "camelCase")]

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -82,12 +82,16 @@ pub enum Log {
         fee: Coin,
     },
 
+    /// The validator with the given address has been marked for deactivation.
+    /// It will be inactive from the given block number.
     #[serde(rename_all = "camelCase")]
     DeactivateValidator {
         validator_address: Address,
         inactive_from: u32,
     },
 
+    /// The validator with the given address has been jailed.
+    /// It is jailed from the given block number.
     #[serde(rename_all = "camelCase")]
     JailValidator {
         validator_address: Address,

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -83,12 +83,15 @@ pub enum Log {
     },
 
     #[serde(rename_all = "camelCase")]
-    DeactivateValidator { validator_address: Address },
+    DeactivateValidator {
+        validator_address: Address,
+        inactive_from: u32,
+    },
 
     #[serde(rename_all = "camelCase")]
     JailValidator {
         validator_address: Address,
-        jailed_since: u32,
+        jailed_from: u32,
     },
 
     #[serde(rename_all = "camelCase")]
@@ -117,7 +120,7 @@ pub enum Log {
         old_validator_address: Option<Address>,
         new_validator_address: Option<Address>,
         active_balance: Coin,
-        inactive_release: Option<u32>,
+        inactive_from: Option<u32>,
     },
 
     #[serde(rename_all = "camelCase")]
@@ -134,7 +137,7 @@ pub enum Log {
         staker_address: Address,
         validator_address: Option<Address>,
         value: Coin,
-        inactive_release: Option<u32>,
+        inactive_from: Option<u32>,
     },
 
     #[serde(rename_all = "camelCase")]

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -213,6 +213,7 @@ struct ValidatorSetup {
     env: DatabaseProxy,
     accounts: Accounts,
     staking_contract: StakingContract,
+    effective_state_block_state: BlockState,
     before_state_release_block_state: BlockState,
     state_release_block_state: BlockState,
     validator_address: Address,
@@ -221,6 +222,7 @@ struct ValidatorSetup {
 
 impl ValidatorSetup {
     fn setup(
+        state_block_height: BlockState,
         before_state_release_block_state: BlockState,
         state_release_block_state: BlockState,
         staker_active_balance: Option<u64>,
@@ -240,6 +242,7 @@ impl ValidatorSetup {
             env,
             accounts,
             staking_contract,
+            effective_state_block_state: state_block_height,
             before_state_release_block_state,
             state_release_block_state,
             validator_address,
@@ -249,6 +252,7 @@ impl ValidatorSetup {
 
     fn new(staker_active_balance: Option<u64>) -> ValidatorSetup {
         Self::setup(
+            BlockState::default(),
             BlockState::default(),
             BlockState::default(),
             staker_active_balance,
@@ -283,14 +287,21 @@ impl ValidatorSetup {
             )
             .expect("Failed to commit transaction");
 
-        let after_cooldown =
-            Policy::block_after_reporting_window(Policy::election_block_after(block_state.number));
+        let effective_state_block_state =
+            BlockState::new(Policy::election_block_after(block_state.number), 2);
+        let after_cooldown = Policy::block_after_reporting_window(Policy::election_block_after(
+            effective_state_block_state.number,
+        ));
         let after_cooldown = BlockState::new(after_cooldown, 1000);
         let before_cooldown = BlockState::new(after_cooldown.number - 1, 9000);
 
         db_txn_og.commit();
 
-        validator_setup.set_block_state(before_cooldown, after_cooldown);
+        validator_setup.set_block_state(
+            effective_state_block_state,
+            before_cooldown,
+            after_cooldown,
+        );
         validator_setup
     }
 
@@ -318,21 +329,13 @@ impl ValidatorSetup {
 
         db_txn_og.commit();
 
-        validator_setup.set_block_state(BlockState::default(), BlockState::default());
+        validator_setup.set_block_state(block_state, BlockState::default(), BlockState::default());
         validator_setup
     }
 
     fn setup_jailed_validator(staker_active_balance: Option<u64>) -> ValidatorSetup {
         let jailing_inherent_block_state = BlockState::new(2, 2);
-        let jail_release_block_state = BlockState::new(
-            Policy::block_after_jail(jailing_inherent_block_state.number),
-            2,
-        );
-        let before_release_block_state = BlockState::new(jail_release_block_state.number - 1, 2);
 
-        // -----------------------------------
-        // Test setup:
-        // -----------------------------------
         let mut validator_setup = ValidatorSetup::new(staker_active_balance);
         let data_store = validator_setup
             .accounts
@@ -340,7 +343,7 @@ impl ValidatorSetup {
         let mut db_txn_og = validator_setup.env.write_transaction();
         let mut db_txn = (&mut db_txn_og).into();
 
-        // 2. Jail validator
+        // Jail validator
         let mut data_store_write = data_store.write(&mut db_txn);
         let mut staking_contract_store = StakingContractStoreWrite::new(&mut data_store_write);
         let _result = validator_setup
@@ -349,22 +352,37 @@ impl ValidatorSetup {
                 &mut staking_contract_store,
                 &validator_setup.validator_address,
                 jailing_inherent_block_state.number,
-                jail_release_block_state.number,
                 &mut TransactionLog::empty(),
             )
             .unwrap();
 
         db_txn_og.commit();
-        validator_setup.set_block_state(before_release_block_state, jail_release_block_state);
 
+        let effective_state_block_state = BlockState::new(
+            Policy::election_block_after(jailing_inherent_block_state.number),
+            2,
+        );
+        let jail_release_block_state = BlockState::new(
+            Policy::block_after_jail(effective_state_block_state.number),
+            2,
+        );
+        let before_release_block_state = BlockState::new(jail_release_block_state.number - 1, 2);
+
+        validator_setup.set_block_state(
+            effective_state_block_state,
+            before_release_block_state,
+            jail_release_block_state,
+        );
         validator_setup
     }
 
     fn set_block_state(
         &mut self,
+        state_block_height: BlockState,
         before_state_release_block_state: BlockState,
         state_release_block_state: BlockState,
     ) {
+        self.effective_state_block_state = state_block_height;
         self.before_state_release_block_state = before_state_release_block_state;
         self.state_release_block_state = state_release_block_state;
     }

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -358,10 +358,7 @@ impl ValidatorSetup {
 
         db_txn_og.commit();
 
-        let effective_state_block_state = BlockState::new(
-            Policy::election_block_after(jailing_inherent_block_state.number),
-            2,
-        );
+        let effective_state_block_state = BlockState::new(jailing_inherent_block_state.number, 2);
         let jail_release_block_state = BlockState::new(
             Policy::block_after_jail(effective_state_block_state.number),
             2,

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -392,6 +392,7 @@ struct StakerSetup {
     env: DatabaseProxy,
     accounts: Accounts,
     staking_contract: StakingContract,
+    effective_inactivation_block_state: BlockState,
     before_release_block_state: BlockState,
     inactive_release_block_state: BlockState,
     validator_address: Address,
@@ -442,8 +443,11 @@ impl StakerSetup {
         let inactive_stake = Coin::from_u64_unchecked(inactive_stake);
         let staker_address = validator_setup.staker_address.unwrap();
         let deactivation_block = 2;
+
+        let effective_inactivation_block_state =
+            BlockState::new(Policy::election_block_after(deactivation_block), 2);
         let inactive_release_block_state = BlockState::new(
-            Policy::block_after_reporting_window(Policy::election_block_after(deactivation_block)),
+            Policy::block_after_reporting_window(effective_inactivation_block_state.number),
             2,
         );
         let before_release_block_state =
@@ -467,6 +471,7 @@ impl StakerSetup {
             env: validator_setup.env,
             accounts: validator_setup.accounts,
             staking_contract: validator_setup.staking_contract,
+            effective_inactivation_block_state,
             before_release_block_state,
             inactive_release_block_state,
             validator_address: validator_setup.validator_address,

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -421,7 +421,7 @@ fn update_staker_works() {
     let expected_receipt = StakerReceipt {
         delegation: Some(validator_address1.clone()),
         active_balance: staker.balance,
-        inactive_release: staker.inactive_release,
+        inactive_from: staker.inactive_from,
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
@@ -434,7 +434,7 @@ fn update_staker_works() {
 
             active_balance: staker.balance,
 
-            inactive_release: staker.inactive_release,
+            inactive_from: staker.inactive_from,
         }]
     );
 
@@ -542,7 +542,7 @@ fn update_staker_works() {
     let expected_receipt = StakerReceipt {
         delegation: Some(validator_address2.clone()),
         active_balance: staker.balance,
-        inactive_release: staker.inactive_release,
+        inactive_from: staker.inactive_from,
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
@@ -555,7 +555,7 @@ fn update_staker_works() {
 
             active_balance: staker.balance,
 
-            inactive_release: staker.inactive_release,
+            inactive_from: staker.inactive_from,
         }]
     );
 
@@ -618,7 +618,7 @@ fn update_staker_works() {
 
             active_balance: staker.balance,
 
-            inactive_release: staker.inactive_release,
+            inactive_from: staker.inactive_from,
         }]
     );
 
@@ -737,7 +737,7 @@ fn update_staker_with_stake_reactivation_works() {
     let expected_receipt = StakerReceipt {
         delegation: Some(validator_address1.clone()),
         active_balance: Coin::ZERO,
-        inactive_release: Some(block_state.number),
+        inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
@@ -753,11 +753,11 @@ fn update_staker_with_stake_reactivation_works() {
             old_validator_address: Some(validator_address1.clone()),
             new_validator_address: Some(validator_address2.clone()),
             active_balance: staker_after.balance,
-            inactive_release: staker_after.inactive_release,
+            inactive_from: staker_after.inactive_from,
         }]
     );
 
-    assert!(staker_after.inactive_release.is_none());
+    assert!(staker_after.inactive_from.is_none());
     assert_eq!(staker_after.address, staker_address);
     assert_eq!(staker_after.inactive_balance, Coin::ZERO);
     assert_eq!(staker_after.balance, Coin::from_u64_unchecked(150_000_000));
@@ -821,7 +821,7 @@ fn update_staker_with_stake_reactivation_works() {
             old_validator_address: Some(validator_address1.clone()),
             new_validator_address: Some(validator_address2.clone()),
             active_balance: staker_after.balance,
-            inactive_release: staker_after.inactive_release,
+            inactive_from: staker_after.inactive_from,
         }]
     );
 
@@ -914,7 +914,7 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
     let expected_receipt = StakerReceipt {
         delegation: Some(validator_address1.clone()),
         active_balance: Coin::ZERO,
-        inactive_release: Some(block_state.number),
+        inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
@@ -930,7 +930,7 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
             old_validator_address: Some(validator_address1.clone()),
             new_validator_address: None,
             active_balance: staker_after.balance,
-            inactive_release: staker_after.inactive_release,
+            inactive_from: staker_after.inactive_from,
         }]
     );
 
@@ -938,7 +938,7 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
     assert_eq!(staker_after.inactive_balance, Coin::ZERO);
     assert_eq!(staker_after.balance, Coin::from_u64_unchecked(150_000_000));
     assert_eq!(staker_after.delegation, None);
-    assert!(staker_after.inactive_release.is_none());
+    assert!(staker_after.inactive_from.is_none());
 
     let validator2 = staker_setup
         .staking_contract
@@ -981,7 +981,7 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
 
             active_balance: staker_after.balance,
 
-            inactive_release: staker_after.inactive_release,
+            inactive_from: staker_after.inactive_from,
         }]
     );
 
@@ -1075,7 +1075,7 @@ fn update_staker_with_no_delegation_no_reactivation() {
     let expected_receipt = StakerReceipt {
         delegation: None,
         active_balance: Coin::from_u64_unchecked(150_000_000),
-        inactive_release: None,
+        inactive_from: None,
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
@@ -1091,7 +1091,7 @@ fn update_staker_with_no_delegation_no_reactivation() {
             old_validator_address: None,
             new_validator_address: Some(validator_address1.clone()),
             active_balance: staker_after.balance,
-            inactive_release: staker_after.inactive_release,
+            inactive_from: staker_after.inactive_from,
         }]
     );
 
@@ -1099,7 +1099,7 @@ fn update_staker_with_no_delegation_no_reactivation() {
     assert_eq!(staker_after.inactive_balance, Coin::ZERO);
     assert_eq!(staker_after.balance, Coin::from_u64_unchecked(150_000_000));
     assert_eq!(staker_after.delegation, Some(validator_address1.clone()));
-    assert!(staker_after.inactive_release.is_none());
+    assert!(staker_after.inactive_from.is_none());
 
     let validator1 = validator_setup
         .staking_contract
@@ -1142,7 +1142,7 @@ fn update_staker_with_no_delegation_no_reactivation() {
             old_validator_address: None,
             new_validator_address: Some(validator_address1.clone()),
             active_balance: staker_after.balance,
-            inactive_release: staker_after.inactive_release,
+            inactive_from: staker_after.inactive_from,
         }]
     );
 
@@ -1228,7 +1228,7 @@ fn update_staker_same_validator() {
     let expected_receipt = StakerReceipt {
         delegation: Some(validator_address.clone()),
         active_balance: Coin::ZERO,
-        inactive_release: Some(block_state.number),
+        inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
     };
     assert_eq!(receipt, Some(expected_receipt.into()));
 
@@ -1239,7 +1239,7 @@ fn update_staker_same_validator() {
             old_validator_address: Some(validator_address.clone()),
             new_validator_address: Some(validator_address.clone()),
             active_balance: Coin::ZERO,
-            inactive_release: Some(block_state.number),
+            inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
         }]
     );
 
@@ -1304,7 +1304,7 @@ fn update_staker_same_validator() {
             old_validator_address: Some(validator_address.clone()),
             new_validator_address: Some(validator_address.clone()),
             active_balance: Coin::ZERO,
-            inactive_release: Some(block_state.number),
+            inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
         }]
     );
 
@@ -1384,7 +1384,7 @@ fn unstake_works() {
 
     let expected_receipt = RemoveStakeReceipt {
         delegation: Some(validator_address.clone()),
-        inactive_release: Some(block_state.number),
+        inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
     };
 
     assert_eq!(receipt, Some(expected_receipt.into()));
@@ -1467,7 +1467,7 @@ fn unstake_works() {
 
     let expected_receipt = RemoveStakeReceipt {
         delegation: Some(validator_address.clone()),
-        inactive_release: Some(block_state.number),
+        inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
     };
 
     assert_eq!(receipt, Some(expected_receipt.into()));
@@ -1632,7 +1632,7 @@ fn unstake_from_tombstone_works() {
 
     let expected_receipt = RemoveStakeReceipt {
         delegation: Some(validator_address.clone()),
-        inactive_release: Some(unstake_block_state.number),
+        inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
     };
     assert_eq!(unstake_receipt, Some(expected_receipt.into()));
 
@@ -2104,7 +2104,7 @@ fn can_update_inactive_balance() {
         receipt,
         Some(
             SetInactiveStakeReceipt {
-                old_inactive_release: Some(staker_setup.inactive_release_block_state.number),
+                old_inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
                 old_active_balance: staker_setup.active_stake,
             }
             .into()
@@ -2117,8 +2117,8 @@ fn can_update_inactive_balance() {
             staker_address: staker_setup.staker_address.clone(),
             validator_address: Some(staker_setup.validator_address.clone()),
             value: Coin::from_u64_unchecked(100_000_000),
-            inactive_release: Some(Policy::block_after_reporting_window(
-                Policy::election_block_after(staker_setup.before_release_block_state.number)
+            inactive_from: Some(Policy::election_block_after(
+                staker_setup.before_release_block_state.number
             ))
         }]
     );
@@ -2134,9 +2134,9 @@ fn can_update_inactive_balance() {
         Coin::from_u64_unchecked(100_000_000)
     );
     assert_eq!(
-        staker.inactive_release,
-        Some(Policy::block_after_reporting_window(
-            Policy::election_block_after(staker_setup.before_release_block_state.number)
+        staker.inactive_from,
+        Some(Policy::election_block_after(
+            staker_setup.before_release_block_state.number
         ))
     );
 
@@ -2171,8 +2171,8 @@ fn can_update_inactive_balance() {
     assert_eq!(staker.balance, staker_setup.active_stake);
     assert_eq!(staker.inactive_balance, staker_setup.inactive_stake);
     assert_eq!(
-        staker.inactive_release,
-        Some(staker_setup.inactive_release_block_state.number)
+        staker.inactive_from,
+        Some(staker_setup.effective_inactivation_block_state.number)
     );
 
     let validator = staker_setup
@@ -2202,7 +2202,7 @@ fn can_update_inactive_balance() {
         receipt,
         Some(
             SetInactiveStakeReceipt {
-                old_inactive_release: Some(staker_setup.inactive_release_block_state.number),
+                old_inactive_from: Some(staker_setup.effective_inactivation_block_state.number),
                 old_active_balance: staker_setup.active_stake,
             }
             .into()
@@ -2216,7 +2216,7 @@ fn can_update_inactive_balance() {
 
     assert_eq!(staker.balance, Coin::from_u64_unchecked(100_000_000));
     assert_eq!(staker.inactive_balance, Coin::ZERO);
-    assert_eq!(staker.inactive_release, None);
+    assert_eq!(staker.inactive_from, None);
 
     let validator = staker_setup
         .staking_contract
@@ -2248,8 +2248,8 @@ fn can_update_inactive_balance() {
     assert_eq!(staker.balance, staker_setup.active_stake);
     assert_eq!(staker.inactive_balance, staker_setup.inactive_stake);
     assert_eq!(
-        staker.inactive_release,
-        Some(staker_setup.inactive_release_block_state.number)
+        staker.inactive_from,
+        Some(staker_setup.effective_inactivation_block_state.number)
     );
 
     let validator = staker_setup

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -731,7 +731,7 @@ pub struct Validator {
     pub inactivity_flag: Option<u32>,
     pub retired: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jail_release: Option<u32>,
+    pub jailed_since: Option<u32>,
 }
 
 impl Validator {
@@ -746,7 +746,7 @@ impl Validator {
             num_stakers: validator.num_stakers,
             inactivity_flag: validator.inactive_since,
             retired: validator.retired,
-            jail_release: validator.jail_release,
+            jailed_since: validator.jailed_since,
         }
     }
 }

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -701,7 +701,7 @@ pub struct Staker {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation: Option<Address>,
     pub inactive_balance: Coin,
-    pub inactive_release: Option<u32>,
+    pub inactive_from: Option<u32>,
 }
 
 impl Staker {
@@ -711,7 +711,7 @@ impl Staker {
             balance: staker.balance,
             delegation: staker.delegation.clone(),
             inactive_balance: staker.inactive_balance,
-            inactive_release: staker.inactive_release,
+            inactive_from: staker.inactive_from,
         }
     }
 }
@@ -731,7 +731,7 @@ pub struct Validator {
     pub inactivity_flag: Option<u32>,
     pub retired: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jailed_since: Option<u32>,
+    pub jailed_from: Option<u32>,
 }
 
 impl Validator {
@@ -744,9 +744,9 @@ impl Validator {
             signal_data: validator.signal_data.clone(),
             balance: validator.total_stake,
             num_stakers: validator.num_stakers,
-            inactivity_flag: validator.inactive_since,
+            inactivity_flag: validator.inactive_from,
             retired: validator.retired,
-            jailed_since: validator.jailed_since,
+            jailed_from: validator.jailed_from,
         }
     }
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -699,8 +699,8 @@ where
             .get_validator(&data_store.read(&txn), &validator_address)
             .map_or(
                 ValidatorStakingState::NoStake,
-                |validator| match validator.inactive_since {
-                    Some(_) => ValidatorStakingState::Inactive(validator.jailed_since),
+                |validator| match validator.inactive_from {
+                    Some(_) => ValidatorStakingState::Inactive(validator.jailed_from),
                     None => ValidatorStakingState::Active,
                 },
             )
@@ -860,11 +860,11 @@ where
                         info!("Automatically reactivated.");
                     }
                 }
-                ValidatorStakingState::Inactive(jailed_since) => {
+                ValidatorStakingState::Inactive(jailed_from) => {
                     if self.validator_state.is_none()
-                        && jailed_since
-                            .map(|jailed_since| {
-                                blockchain.block_number() >= Policy::block_after_jail(jailed_since)
+                        && jailed_from
+                            .map(|jailed_from| {
+                                blockchain.block_number() >= Policy::block_after_jail(jailed_from)
                             })
                             .unwrap_or(true)
                         && self.automatic_reactivate.load(Ordering::Acquire)

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -142,9 +142,11 @@ pub struct PlainStaker {
     /// (or if there was no prior delegation). For inactive balance to be released, the maximum of
     /// the inactive and the validator's jailed periods must have passed.
     inactive_balance: u64,
-    /// The block number at which the inactive balance was inactivated for withdrawal or re-delegation.
+    /// The block number at which the inactive balance was last inactivated for withdrawal or re-delegation.
     /// If the stake is currently delegated to a jailed validator, the maximum of its jail release
     /// and the inactive release is taken. Re-delegation requires the whole balance of the staker to be inactive.
+    /// The stake can only effectively become inactive on the next election block. Thus, this may contain a
+    /// future block height.
     inactive_from: Option<u32>,
 }
 
@@ -184,13 +186,17 @@ pub struct PlainValidator {
     pub deposit: u64,
     /// The number of stakers that are delegating to this validator.
     pub num_stakers: u64,
-    /// An option indicating if the validator is inactive. If it is inactive, then it contains the
-    /// block height at which it became inactive.
+    /// An option indicating if the validator is marked as inactive. If it is, then it contains the
+    /// block height at which it becomes inactive.
+    /// A validator can only effectively become inactive on the next election block. Thus, this may
+    /// contain a block height in the future.
     pub inactive_from: Option<u32>,
     /// A flag indicating if the validator is retired.
     pub retired: bool,
-    /// An option indication if the validator is jailed. If it is jailed, then it contains the
+    /// An option indicating if the validator is jailed. If it is, then it contains the
     /// block height at which it became jailed.
+    /// Opposed to the inactive_from, the jailing can and should take effect immediately to prevent
+    /// the validator and its stakers from modifying their funds and or delegation.
     pub jailed_from: Option<u32>,
 }
 

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -140,7 +140,7 @@ pub struct PlainStaker {
     /// The staker's inactive balance. Only released inactive balance can be withdrawn from the staking contract.
     /// Stake can only be re-delegated if the whole balance of the staker is inactive and released
     /// (or if there was no prior delegation). For inactive balance to be released, the maximum of
-    /// the `inactive_release` and the validator's `jail_release` must have passed.
+    /// the `inactive_release` and the validator's `jailed_since` must have passed.
     inactive_balance: u64,
     /// The earliest block number at which the inactive balance is released for withdrawal or re-delegation.
     /// If the stake is currently delegated to a jailed validator, the maximum of its jail release
@@ -190,8 +190,8 @@ pub struct PlainValidator {
     /// A flag indicating if the validator is retired.
     pub retired: bool,
     /// An option indication if the validator is jailed. If it is jailed, then it contains the
-    /// block height at which the jail period ends.
-    pub jail_release: Option<u32>,
+    /// block height at which it became jailed.
+    pub jailed_since: Option<u32>,
 }
 
 impl PlainValidator {
@@ -206,7 +206,7 @@ impl PlainValidator {
             num_stakers: validator.num_stakers,
             inactive_since: validator.inactive_since,
             retired: validator.retired,
-            jail_release: validator.jail_release,
+            jailed_since: validator.jailed_since,
         }
     }
 }

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -206,7 +206,7 @@ pub struct PlainValidator {
     pub retired: bool,
     /// An option indicating if the validator is jailed. If it is, then it contains the
     /// block height at which it became jailed.
-    /// Opposed to the inactive_from, the jailing can and should take effect immediately to prevent
+    /// Opposed to `inactive_from`, jailing can and should take effect immediately to prevent
     /// the validator and its stakers from modifying their funds and or delegation.
     pub jailed_from: Option<u32>,
     /// An option indicating if the validator is jailed. If it is, then it contains the

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -140,12 +140,12 @@ pub struct PlainStaker {
     /// The staker's inactive balance. Only released inactive balance can be withdrawn from the staking contract.
     /// Stake can only be re-delegated if the whole balance of the staker is inactive and released
     /// (or if there was no prior delegation). For inactive balance to be released, the maximum of
-    /// the `inactive_release` and the validator's `jailed_since` must have passed.
+    /// the inactive and the validator's jailed periods must have passed.
     inactive_balance: u64,
-    /// The earliest block number at which the inactive balance is released for withdrawal or re-delegation.
+    /// The block number at which the inactive balance was inactivated for withdrawal or re-delegation.
     /// If the stake is currently delegated to a jailed validator, the maximum of its jail release
     /// and the inactive release is taken. Re-delegation requires the whole balance of the staker to be inactive.
-    inactive_release: Option<u32>,
+    inactive_from: Option<u32>,
 }
 
 impl PlainStaker {
@@ -157,7 +157,7 @@ impl PlainStaker {
                 .map(|address| address.to_user_friendly_address()),
             balance: staker.balance.into(),
             inactive_balance: staker.inactive_balance.into(),
-            inactive_release: staker.inactive_release,
+            inactive_from: staker.inactive_from,
         }
     }
 }
@@ -186,12 +186,12 @@ pub struct PlainValidator {
     pub num_stakers: u64,
     /// An option indicating if the validator is inactive. If it is inactive, then it contains the
     /// block height at which it became inactive.
-    pub inactive_since: Option<u32>,
+    pub inactive_from: Option<u32>,
     /// A flag indicating if the validator is retired.
     pub retired: bool,
     /// An option indication if the validator is jailed. If it is jailed, then it contains the
     /// block height at which it became jailed.
-    pub jailed_since: Option<u32>,
+    pub jailed_from: Option<u32>,
 }
 
 impl PlainValidator {
@@ -204,9 +204,9 @@ impl PlainValidator {
             total_stake: validator.total_stake.into(),
             deposit: validator.deposit.into(),
             num_stakers: validator.num_stakers,
-            inactive_since: validator.inactive_since,
+            inactive_from: validator.inactive_from,
             retired: validator.retired,
-            jailed_since: validator.jailed_since,
+            jailed_from: validator.jailed_from,
         }
     }
 }


### PR DESCRIPTION
## What's in this pull request?

- Change inactive_release and jailed_release to inactive_from and jailed_from. This standardizes the representation of the information regarding state changes for the validators and stakers.
- Validator inactivation and stake inactivation only become effective on the next election block. This PR sets the inactive stake and validator inactivation block height to the next election block.


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
