### PR TITLE
web-client: Fix clippy warning

### DIFF
--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -186,9 +186,10 @@ impl Transaction {
                 // It is possible to add an additional argument `secondary_key_pair: Option<&KeyPair>` with
                 // https://docs.rs/wasm-bindgen-derive/latest/wasm_bindgen_derive/#optional-arguments.
                 // TODO: Support signing for differing staker and validator signing & cold keys.
-                let secondary_key_pair: Option<&KeyPair> = None;
+                // let secondary_key_pair: Option<&KeyPair> = None;
+                // builder.sign_with_key_pair(secondary_key_pair.unwrap_or(key_pair).native_ref());
 
-                builder.sign_with_key_pair(secondary_key_pair.unwrap_or(key_pair).native_ref());
+                builder.sign_with_key_pair(key_pair.native_ref());
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair.native_ref());
                 builder.generate().unwrap()


### PR DESCRIPTION
Fix clippy warning in the `web-client` subcrate related to unnecessary literal unwrapping that started to show up with rust 1.72.0.


## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
