### PR TITLE
`pow-migration`: Add several improvements

### DIFF
--- a/pow-migration/src/config.toml
+++ b/pow-migration/src/config.toml
@@ -1,1 +1,0 @@
-genesis = "output.toml"

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -346,7 +346,12 @@ async fn main() {
         }
 
         // Check if we have enough validators ready at this point
-        let validators_status = check_validators_ready(&client, validators.clone()).await;
+        let validators_status = check_validators_ready(
+            &client,
+            validators.clone(),
+            previous_election_block..next_election_block,
+        )
+        .await;
         match validators_status {
             ValidatorsReadiness::NotReady(stake) => {
                 info!(stake_ready = %stake, "Not enough validators are ready yet",);

--- a/pow-migration/src/monitor/mod.rs
+++ b/pow-migration/src/monitor/mod.rs
@@ -1,6 +1,6 @@
 pub mod types;
 
-use std::{collections::HashMap, ops::Range};
+use std::ops::Range;
 
 use log::{error, info};
 use nimiq_keys::Address;
@@ -87,21 +87,6 @@ pub async fn check_validators_ready(
     let total_stake: Coin = validators.iter().map(|validator| validator.balance).sum();
 
     log::debug!(registered_stake = %total_stake);
-
-    // First we need to obtain the validator list, along with the slot allocation for the first epoch.
-    let mut validator_list = HashMap::new();
-
-    // This is a mock list for testing purposes(for now)
-    // The validator address and the slots assigned to each address
-    validator_list.insert(
-        "NQ28 GSPY V07Q DJTK Y8TG DFYD KR5Q 9KBF HV5A".to_string(),
-        100u16,
-    );
-
-    validator_list.insert(
-        "NQ56 7L0M GQPS GNCU VGGT LV4S 4HHN F701 2DEF".to_string(),
-        412u16,
-    );
 
     let mut ready_validators = Vec::new();
 

--- a/pow-migration/src/monitor/mod.rs
+++ b/pow-migration/src/monitor/mod.rs
@@ -71,7 +71,7 @@ pub async fn send_tx(client: &Client, transaction: OutgoingTransaction) -> Resul
         }
         Err(error) => {
             error!(?error, "Failed sending transaction");
-            Err(Error::Rpc)
+            Err(Error::Rpc(error))
         }
     }
 }

--- a/pow-migration/src/monitor/types.rs
+++ b/pow-migration/src/monitor/types.rs
@@ -1,15 +1,24 @@
 use nimiq_primitives::coin::Coin;
 use thiserror::Error;
 
+/// Block height of the validator activation window start
+/// Fixme: This shouldn't be hardwired.
 pub const ACTIVATION_HEIGHT: u32 = 100;
+
+/// Readiness state of all of the validators registered in the PoW chain
 pub enum ValidatorsReadiness {
+    /// Validators are not ready.
+    /// Encodes the stake that is ready in the inner type.
     NotReady(Coin),
+    /// Validators are ready.
+    /// Encodes the stake that is ready in the inner type.
     Ready(Coin),
 }
 
+/// Error types that can be returned by the monitor
 #[derive(Error, Debug)]
 pub enum Error {
     /// RPC error
-    #[error("RPC error")]
-    Rpc,
+    #[error("RPC error: {0}")]
+    Rpc(#[from] jsonrpsee::core::Error),
 }

--- a/pow-migration/src/monitor/types.rs
+++ b/pow-migration/src/monitor/types.rs
@@ -1,10 +1,6 @@
 use nimiq_primitives::coin::Coin;
 use thiserror::Error;
 
-/// Block height of the validator activation window start
-/// Fixme: This shouldn't be hardwired.
-pub const ACTIVATION_HEIGHT: u32 = 100;
-
 /// Readiness state of all of the validators registered in the PoW chain
 pub enum ValidatorsReadiness {
     /// Validators are not ready.


### PR DESCRIPTION
- Remove the no longer needed configuration file in the `pow-migration` subcrate.
- Remove mock list of validators from the monitor within the `pow-migration` subcrate.
- Improve the monitor types documentation and make a better use of `thiserror`.
- Remove mock list of validators from the monitor within the `pow-migration` subcrate.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
