### PR TITLE
Deduplicate equivocation proofs by block height etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,6 +4185,7 @@ dependencies = [
  "nimiq-collections",
  "nimiq-genesis",
  "nimiq-hash",
+ "nimiq-keys",
  "nimiq-primitives",
  "nimiq-test-log",
  "nimiq-test-utils",

--- a/block-production/tests/mod.rs
+++ b/block-production/tests/mod.rs
@@ -19,7 +19,7 @@ use nimiq_test_utils::{
     block_production::TemporaryBlockProducer,
     blockchain::{
         fill_micro_blocks, fill_micro_blocks_with_txns, produce_macro_blocks, sign_macro_block,
-        signing_key, voting_key,
+        signing_key, validator_address, voting_key,
     },
     test_rng::test_rng,
 };
@@ -55,9 +55,6 @@ fn it_can_produce_micro_blocks() {
 
     let bc = blockchain.upgradable_read();
 
-    // Store seed before pushing a block as it is needed for the fork proof.
-    let prev_vrf_seed = bc.head().seed().clone();
-
     // #1.0: Empty standard micro block
     let block = producer.next_micro_block(
         &bc,
@@ -92,11 +89,11 @@ fn it_can_produce_micro_blocks() {
         let hash2 = header2.hash::<Blake2bHash>();
         let justification2 = signing_key().sign(hash2.as_slice());
         ForkProof::new(
+            validator_address(),
             header1,
             justification1,
             header2,
             justification2,
-            prev_vrf_seed,
         )
     };
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -11,6 +11,7 @@ use nimiq_database::{
     TransactionProxy, WriteTransactionProxy,
 };
 use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_keys::Address;
 use nimiq_primitives::{
     policy::Policy,
     trie::{
@@ -19,7 +20,6 @@ use nimiq_primitives::{
     },
 };
 use nimiq_trie::WriteTransactionProxy as TrieWriteTransactionProxy;
-use nimiq_vrf::VrfSeed;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 use tokio::sync::broadcast::Sender as BroadcastSender;
 
@@ -95,7 +95,16 @@ impl Blockchain {
 
         // Detect forks in non-skip micro blocks.
         if block.is_micro() && !block.is_skip() {
-            this.detect_forks(&read_txn, block.unwrap_micro_ref(), prev_info.head.seed());
+            let validator = this
+                .get_proposer_at(
+                    block.block_number(),
+                    block.block_number(),
+                    prev_info.head.seed().entropy(),
+                    Some(&read_txn),
+                )
+                .expect("Couldn't find slot owner")
+                .validator;
+            this.detect_forks(&read_txn, block.unwrap_micro_ref(), &validator.address);
         }
 
         // Calculate chain ordering.
@@ -733,7 +742,12 @@ impl Blockchain {
         Ok(total_tx_size)
     }
 
-    fn detect_forks(&self, txn: &TransactionProxy, block: &MicroBlock, prev_vrf_seed: &VrfSeed) {
+    fn detect_forks(
+        &self,
+        txn: &TransactionProxy,
+        block: &MicroBlock,
+        validator_address: &Address,
+    ) {
         assert!(!block.is_skip_block());
 
         // Check if there are two blocks in the same slot and with the same height. Since we already
@@ -770,11 +784,11 @@ impl Blockchain {
                     .unwrap_micro();
 
                 let proof = ForkProof::new(
+                    validator_address.clone(),
                     block.header.clone(),
                     justification1,
                     micro_block.header,
                     justification2,
-                    prev_vrf_seed.clone(),
                 );
 
                 // We shouldn't log errors if there are no listeners.

--- a/blockchain/src/blockchain/slots.rs
+++ b/blockchain/src/blockchain/slots.rs
@@ -1,4 +1,3 @@
-use nimiq_block::{DoubleProposalProof, DoubleVoteProof, ForkProof};
 use nimiq_blockchain_interface::BlockchainError;
 use nimiq_collections::BitSet;
 use nimiq_database::TransactionProxy;
@@ -96,48 +95,6 @@ impl Blockchain {
             band: slot_band,
             validator: validator.clone(),
         })
-    }
-
-    /// Get the proposer slot for a given fork proof.
-    pub fn get_proposer_for_fork_proof(
-        &self,
-        fork_proof: &ForkProof,
-        txn_option: Option<&TransactionProxy>,
-    ) -> Result<Slot, BlockchainError> {
-        self.get_proposer_at(
-            fork_proof.block_number(),
-            fork_proof.block_number(),
-            fork_proof.prev_vrf_seed().entropy(),
-            txn_option,
-        )
-    }
-
-    /// Get the proposer slot for a given double proposal proof.
-    pub fn get_proposer_for_double_proposal_proof(
-        &self,
-        double_proposal_proof: &DoubleProposalProof,
-        txn_option: Option<&TransactionProxy>,
-    ) -> Result<Slot, BlockchainError> {
-        self.get_proposer_at(
-            double_proposal_proof.block_number(),
-            double_proposal_proof.round(),
-            // It doesn't matter which VRF seed we choose, in the validation
-            // it will be checked that the validator has actually signed both.
-            double_proposal_proof.prev_vrf_seed1().entropy(),
-            txn_option,
-        )
-    }
-
-    /// Get the validators currently active for a given double vote proof.
-    pub fn get_validators_for_double_vote_proof(
-        &self,
-        double_vote_proof: &DoubleVoteProof,
-        txn_option: Option<&TransactionProxy>,
-    ) -> Result<Validators, BlockchainError> {
-        self.get_validators_for_epoch(
-            Policy::epoch_at(double_vote_proof.block_number()),
-            txn_option,
-        )
     }
 
     fn compute_slot_number(offset: u32, vrf_entropy: VrfEntropy, disabled_slots: BitSet) -> u16 {

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -20,6 +20,7 @@ use nimiq_primitives::{key_nibbles::KeyNibbles, policy::Policy};
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     block_production::TemporaryBlockProducer,
+    blockchain::validator_address,
     test_rng::test_rng,
     zkp_test_data::{get_base_seed, simulate_merger_wrapper, ZKP_TEST_KEYS_PATH},
 };
@@ -444,11 +445,11 @@ fn it_validates_fork_proofs() {
     expect_push_micro_block(
         BlockConfig {
             equivocation_proofs: vec![ForkProof::new(
+                validator_address(),
                 header1,
                 justification1,
                 header2,
                 justification2,
-                VrfSeed::default(),
             )
             .into()],
             test_macro: false,
@@ -485,12 +486,11 @@ fn it_validates_double_proposal_proofs() {
     expect_push_micro_block(
         BlockConfig {
             equivocation_proofs: vec![DoubleProposalProof::new(
+                validator_address(),
                 header1,
                 justification1,
-                VrfSeed::default(),
                 header2,
                 justification2,
-                VrfSeed::default(),
             )
             .into()],
             test_macro: false,
@@ -531,10 +531,10 @@ fn it_validates_double_vote_proofs() {
                 },
                 validator.address,
                 None,
-                Some(Blake2sHash::default()),
-                AggregateSignature::new(),
                 AggregateSignature::new(),
                 validator.slots.clone().map(|i| i.into()).collect(),
+                Some(Blake2sHash::default()),
+                AggregateSignature::new(),
                 validator.slots.clone().map(|i| i.into()).collect(),
             )
             .into()],

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -13,7 +13,7 @@ use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     blockchain::{
-        fill_micro_blocks_with_txns, produce_macro_blocks, signing_key, voting_key, UNIT_KEY,
+        fill_micro_blocks_with_txns, produce_macro_blocks, signing_key, voting_key, REWARD_KEY,
     },
     node::TESTING_BLS_CACHE_MAX_CAPACITY,
 };
@@ -96,7 +96,7 @@ async fn test_request_transactions_by_address() {
     let consensus_proxy = consensus2.proxy();
     net1.dial_mock(&net2);
 
-    let key_pair = KeyPair::from(PrivateKey::from_str(UNIT_KEY).unwrap());
+    let key_pair = KeyPair::from(PrivateKey::from_str(REWARD_KEY).unwrap());
 
     let res = consensus_proxy
         .request_transactions_by_address(Address::from(&key_pair.public), 0, vec![], 1, None)

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -23,6 +23,7 @@ nimiq-blockchain-interface = { workspace = true }
 nimiq-collections = { workspace = true }
 nimiq-genesis = { workspace = true, default-features = false }
 nimiq-hash = { workspace = true }
+nimiq-keys = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["policy"] }
 nimiq-utils = { workspace = true, features = ["time"] }
 nimiq-vrf = { workspace = true }

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -5,8 +5,8 @@ use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, ChainOrdering, ForkEvent, PushError, PushResult,
 };
 use nimiq_hash::{Blake2bHash, Hash};
+use nimiq_keys::Address;
 use nimiq_primitives::policy::Policy;
-use nimiq_vrf::VrfSeed;
 use parking_lot::RwLockUpgradableReadGuard;
 
 use crate::blockchain::LightBlockchain;
@@ -118,7 +118,14 @@ impl LightBlockchain {
 
         // Detect forks in non-skip micro blocks.
         if block.is_micro() && !block.is_skip() {
-            this.detect_forks(block.unwrap_micro_ref(), prev_info.head.seed());
+            let (validator, _) = this
+                .get_proposer_at(
+                    block.block_number(),
+                    block.block_number(),
+                    prev_info.head.seed().entropy(),
+                )
+                .expect("Couldn't find slot owner");
+            this.detect_forks(block.unwrap_micro_ref(), &validator.address);
         }
 
         // Create the chain info for the new block.
@@ -394,7 +401,7 @@ impl LightBlockchain {
         Ok(PushResult::Extended)
     }
 
-    fn detect_forks(&self, block: &MicroBlock, prev_vrf_seed: &VrfSeed) {
+    fn detect_forks(&self, block: &MicroBlock, validator_address: &Address) {
         assert!(!block.is_skip_block());
 
         // Check if there are two blocks in the same slot and with the same height. Since we already
@@ -425,11 +432,11 @@ impl LightBlockchain {
                     .unwrap_micro();
 
                 let proof = ForkProof::new(
+                    validator_address.clone(),
                     block.header.clone(),
                     justification1,
                     micro_block.header,
                     justification2,
-                    prev_vrf_seed.clone(),
                 );
 
                 // We shouldn't log errors if there are no listeners.

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -1,22 +1,24 @@
-use std::{cmp::Ordering, hash::Hasher, mem};
+use std::{cmp::Ordering, hash::Hasher, io, mem, ops::Range};
 
+use byteorder::WriteBytesExt;
 use nimiq_bls::{AggregatePublicKey, AggregateSignature};
 use nimiq_collections::BitSet;
-use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput};
-use nimiq_hash_derive::SerializeContent;
+use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput, SerializeContent};
 use nimiq_keys::{Address, PublicKey as SchnorrPublicKey, Signature as SchnorrSignature};
-use nimiq_primitives::{policy::Policy, slots_allocation::Validators};
+use nimiq_primitives::{
+    policy::Policy,
+    slots_allocation::{Validator, Validators},
+};
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_vrf::VrfSeed;
 use thiserror::Error;
 
-use crate::{MacroHeader, MicroHeader, TendermintIdentifier, TendermintVote};
+use crate::{MacroHeader, MicroHeader, TendermintIdentifier, TendermintStep, TendermintVote};
 
 /// An equivocation proof proves that a validator misbehaved.
 ///
 /// This can come in several forms, but e.g. producing two blocks in a single slot or voting twice
 /// in the same round.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, SerializeContent)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum EquivocationProof {
     Fork(ForkProof),
     DoubleProposal(DoubleProposalProof),
@@ -33,6 +35,15 @@ const fn max3(a: usize, b: usize, c: usize) -> usize {
     }
 }
 
+fn get_validator<'a>(
+    validators: &'a Validators,
+    address: &Address,
+) -> Result<&'a Validator, EquivocationProofError> {
+    validators
+        .get_validator_by_address(address)
+        .ok_or(EquivocationProofError::InvalidValidatorAddress)
+}
+
 impl EquivocationProof {
     /// The size of a single equivocation proof. This is the maximum possible size.
     pub const MAX_SIZE: usize = 1 + max3(
@@ -40,6 +51,16 @@ impl EquivocationProof {
         DoubleProposalProof::MAX_SIZE,
         DoubleVoteProof::MAX_SIZE,
     );
+
+    /// Address of the offending validator.
+    pub fn validator_address(&self) -> &Address {
+        use self::EquivocationProof::*;
+        match self {
+            Fork(proof) => proof.validator_address(),
+            DoubleProposal(proof) => proof.validator_address(),
+            DoubleVote(proof) => proof.validator_address(),
+        }
+    }
 
     /// Returns the block number of an equivocation proof. This assumes that the equivocation proof
     /// is valid.
@@ -49,6 +70,33 @@ impl EquivocationProof {
             Fork(proof) => proof.block_number(),
             DoubleProposal(proof) => proof.block_number(),
             DoubleVote(proof) => proof.block_number(),
+        }
+    }
+
+    /// Check if an equivocation proof contains a valid offense.
+    ///
+    /// The parameter `validators` must be the historic validators at the time of the offense.
+    pub fn verify(&self, validators: &Validators) -> Result<(), EquivocationProofError> {
+        self.verify_excluding_address(
+            validators,
+            get_validator(validators, self.validator_address())?,
+        )
+    }
+
+    /// Check if an equivocation proof contains a valid offense, but do not check attribution to
+    /// the `validator_address`.
+    pub fn verify_excluding_address(
+        &self,
+        validators: &Validators,
+        validator: &Validator,
+    ) -> Result<(), EquivocationProofError> {
+        use self::EquivocationProof::*;
+        match self {
+            Fork(proof) => proof.verify_excluding_address(&validator.signing_key),
+            DoubleProposal(proof) => proof.verify_excluding_address(&validator.signing_key),
+            DoubleVote(proof) => {
+                proof.verify_excluding_address(validators, validator.slots.clone())
+            }
         }
     }
 
@@ -83,11 +131,33 @@ impl From<DoubleVoteProof> for EquivocationProof {
     }
 }
 
+impl SerializeContent for EquivocationProof {
+    fn serialize_content<W: io::Write, H: HashOutput>(&self, writer: &mut W) -> io::Result<()> {
+        use self::EquivocationProof::*;
+        match self {
+            Fork(proof) => {
+                writer.write_u8(0)?;
+                proof.serialize_content::<_, H>(writer)
+            }
+            DoubleProposal(proof) => {
+                writer.write_u8(1)?;
+                proof.serialize_content::<_, H>(writer)
+            }
+            DoubleVote(proof) => {
+                writer.write_u8(2)?;
+                proof.serialize_content::<_, H>(writer)
+            }
+        }
+    }
+}
+
 /// Struct representing a fork proof. A fork proof proves that a given validator created or
 /// continued a fork. For this it is enough to provide two different headers, with the same block
 /// number, signed by the same validator.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ForkProof {
+    /// Address of the offending validator.
+    validator_address: Address,
     /// Header number 1.
     header1: MicroHeader,
     /// Header number 2.
@@ -96,8 +166,6 @@ pub struct ForkProof {
     justification1: SchnorrSignature,
     /// Justification for header number 2.
     justification2: SchnorrSignature,
-    /// VRF seed of the previous block. Used to determine the slot.
-    prev_vrf_seed: VrfSeed,
 }
 
 impl ForkProof {
@@ -105,14 +173,14 @@ impl ForkProof {
     /// has a variable size (because of the extra data field) and here we assume that the header
     /// has the maximum size.
     pub const MAX_SIZE: usize =
-        2 * MicroHeader::MAX_SIZE + 2 * SchnorrSignature::SIZE + VrfSeed::SIZE;
+        Address::SIZE + 2 * MicroHeader::MAX_SIZE + 2 * SchnorrSignature::SIZE;
 
     pub fn new(
+        validator_address: Address,
         mut header1: MicroHeader,
         mut justification1: SchnorrSignature,
         mut header2: MicroHeader,
         mut justification2: SchnorrSignature,
-        prev_vrf_seed: VrfSeed,
     ) -> ForkProof {
         let hash1: Blake2bHash = header1.hash();
         let hash2: Blake2bHash = header2.hash();
@@ -121,14 +189,22 @@ impl ForkProof {
             mem::swap(&mut justification1, &mut justification2);
         }
         ForkProof {
+            validator_address,
             header1,
             header2,
             justification1,
             justification2,
-            prev_vrf_seed,
         }
     }
 
+    /// Address of the offending validator.
+    pub fn validator_address(&self) -> &Address {
+        &self.validator_address
+    }
+    /// Block number at which the offense occurred.
+    pub fn block_number(&self) -> u32 {
+        self.header1.block_number
+    }
     /// Hash of header number 1.
     pub fn header1_hash(&self) -> Blake2bHash {
         self.header1.hash()
@@ -137,17 +213,14 @@ impl ForkProof {
     pub fn header2_hash(&self) -> Blake2bHash {
         self.header2.hash()
     }
-    /// Block number.
-    pub fn block_number(&self) -> u32 {
-        self.header1.block_number
-    }
-    /// VRF seed of the previous blocks. Used to determine the slot.
-    pub fn prev_vrf_seed(&self) -> &VrfSeed {
-        &self.prev_vrf_seed
-    }
 
     /// Verify the validity of a fork proof.
-    pub fn verify(&self, signing_key: &SchnorrPublicKey) -> Result<(), EquivocationProofError> {
+    ///
+    /// Does not verify the validator address.
+    pub fn verify_excluding_address(
+        &self,
+        signing_key: &SchnorrPublicKey,
+    ) -> Result<(), EquivocationProofError> {
         let hash1: Blake2bHash = self.header1.hash();
         let hash2: Blake2bHash = self.header2.hash();
 
@@ -165,11 +238,6 @@ impl ForkProof {
             return Err(EquivocationProofError::SlotMismatch);
         }
 
-        if let Err(error) = self.header1.seed.verify(&self.prev_vrf_seed, signing_key) {
-            error!(?error, "ForkProof: VrfSeed failed to verify");
-            return Err(EquivocationProofError::InvalidJustification);
-        }
-
         // Check that the justifications are valid.
         if !signing_key.verify(&self.justification1, hash1.as_slice())
             || !signing_key.verify(&self.justification2, hash2.as_slice())
@@ -185,6 +253,14 @@ impl std::hash::Hash for ForkProof {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(self.header1.hash::<Blake2bHash>().as_bytes());
         state.write(self.header2.hash::<Blake2bHash>().as_bytes());
+    }
+}
+
+impl SerializeContent for ForkProof {
+    fn serialize_content<W: io::Write, H: HashOutput>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(self.validator_address().as_bytes())?;
+        self.block_number().serialize_to_writer(writer)?;
+        Ok(())
     }
 }
 
@@ -207,8 +283,10 @@ pub enum EquivocationProofError {
 
 /// Struct representing a double proposal proof. A double proposal proof proves that a given
 /// validator created two macro block proposals at the same height, in the same round.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DoubleProposalProof {
+    /// Address of the offending validator.
+    validator_address: Address,
     /// Header number 1.
     header1: MacroHeader,
     /// Header number 2.
@@ -217,43 +295,40 @@ pub struct DoubleProposalProof {
     justification1: SchnorrSignature,
     /// Justification for header number 2.
     justification2: SchnorrSignature,
-    /// VRF seed of the previous block for header 1. Used to determine the slot.
-    prev_vrf_seed1: VrfSeed,
-    /// VRF seed of the previous block for header 2. Used to determine the slot.
-    prev_vrf_seed2: VrfSeed,
 }
 
 impl DoubleProposalProof {
     /// The maximum size of a double proposal proof.
     pub const MAX_SIZE: usize =
-        2 * MacroHeader::MAX_SIZE + 2 * SchnorrSignature::SIZE + 2 * VrfSeed::SIZE;
+        Address::SIZE + 2 * MacroHeader::MAX_SIZE + 2 * SchnorrSignature::SIZE;
 
     pub fn new(
+        validator_address: Address,
         mut header1: MacroHeader,
         mut justification1: SchnorrSignature,
-        mut prev_vrf_seed1: VrfSeed,
         mut header2: MacroHeader,
         mut justification2: SchnorrSignature,
-        mut prev_vrf_seed2: VrfSeed,
     ) -> DoubleProposalProof {
         let hash1: Blake2bHash = header1.hash();
         let hash2: Blake2bHash = header2.hash();
         if hash1 > hash2 {
             mem::swap(&mut header1, &mut header2);
             mem::swap(&mut justification1, &mut justification2);
-            mem::swap(&mut prev_vrf_seed1, &mut prev_vrf_seed2);
         }
         DoubleProposalProof {
+            validator_address,
             header1,
             header2,
             justification1,
             justification2,
-            prev_vrf_seed1,
-            prev_vrf_seed2,
         }
     }
 
-    /// Block number.
+    /// Address of the offending validator.
+    pub fn validator_address(&self) -> &Address {
+        &self.validator_address
+    }
+    /// Block number at which the offense occurred.
     pub fn block_number(&self) -> u32 {
         self.header1.block_number
     }
@@ -269,17 +344,12 @@ impl DoubleProposalProof {
     pub fn header2_hash(&self) -> Blake2bHash {
         self.header2.hash()
     }
-    /// VRF seed of the previous block for header 1. Used to determine the slot.
-    pub fn prev_vrf_seed1(&self) -> &VrfSeed {
-        &self.prev_vrf_seed1
-    }
-    /// VRF seed of the previous block for header 2. Used to determine the slot.
-    pub fn prev_vrf_seed2(&self) -> &VrfSeed {
-        &self.prev_vrf_seed2
-    }
 
     /// Verify the validity of a double proposal proof.
-    pub fn verify(&self, signing_key: &SchnorrPublicKey) -> Result<(), EquivocationProofError> {
+    pub fn verify_excluding_address(
+        &self,
+        signing_key: &SchnorrPublicKey,
+    ) -> Result<(), EquivocationProofError> {
         let hash1: Blake2bHash = self.header1.hash();
         let hash2: Blake2bHash = self.header2.hash();
 
@@ -294,16 +364,6 @@ impl DoubleProposalProof {
             || self.header1.round != self.header2.round
         {
             return Err(EquivocationProofError::SlotMismatch);
-        }
-
-        if let Err(error) = self.header1.seed.verify(&self.prev_vrf_seed1, signing_key) {
-            error!(?error, "DoubleProposalProof: VrfSeed 1 failed to verify");
-            return Err(EquivocationProofError::InvalidJustification);
-        }
-
-        if let Err(error) = self.header2.seed.verify(&self.prev_vrf_seed2, signing_key) {
-            error!(?error, "DoubleProposalProof: VrfSeed 2 failed to verify");
-            return Err(EquivocationProofError::InvalidJustification);
         }
 
         // Check that the justifications are valid.
@@ -323,14 +383,23 @@ impl std::hash::Hash for DoubleProposalProof {
     }
 }
 
+impl SerializeContent for DoubleProposalProof {
+    fn serialize_content<W: io::Write, H: HashOutput>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(self.validator_address().as_bytes())?;
+        self.block_number().serialize_to_writer(writer)?;
+        self.round().serialize_to_writer(writer)?;
+        Ok(())
+    }
+}
+
 /// Struct representing a double vote proof. A double vote proof proves that a given
 /// validator voted twice at same height, in the same round.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DoubleVoteProof {
-    /// Round and block height information.
-    tendermint_id: TendermintIdentifier,
     /// Address of the offending validator.
     validator_address: Address,
+    /// Round and block height information.
+    tendermint_id: TendermintIdentifier,
     /// Hash of proposal number 1.
     proposal_hash1: Option<Blake2sHash>,
     /// Hash of proposal number 2.
@@ -356,10 +425,10 @@ impl DoubleVoteProof {
         tendermint_id: TendermintIdentifier,
         validator_address: Address,
         mut proposal_hash1: Option<Blake2sHash>,
-        mut proposal_hash2: Option<Blake2sHash>,
         mut signature1: AggregateSignature,
-        mut signature2: AggregateSignature,
         mut signers1: BitSet,
+        mut proposal_hash2: Option<Blake2sHash>,
+        mut signature2: AggregateSignature,
         mut signers2: BitSet,
     ) -> DoubleVoteProof {
         if proposal_hash1 > proposal_hash2 {
@@ -379,20 +448,32 @@ impl DoubleVoteProof {
         }
     }
 
-    /// Block number.
-    pub fn block_number(&self) -> u32 {
-        self.tendermint_id.block_number
-    }
     /// Address of the offending validator.
     pub fn validator_address(&self) -> &Address {
         &self.validator_address
+    }
+    /// Block number at which the offense occurred.
+    pub fn block_number(&self) -> u32 {
+        self.tendermint_id.block_number
+    }
+    /// Round number in which the offense occurred.
+    pub fn round(&self) -> u32 {
+        self.tendermint_id.round_number
+    }
+    /// Tendermint step in which the offense occurred.
+    pub fn step(&self) -> TendermintStep {
+        self.tendermint_id.step
     }
 
     /// Verify the validity of a double vote proof.
     ///
     /// The parameter `validators` must be the historic validators of that
     /// macro block production.
-    pub fn verify(&self, validators: &Validators) -> Result<(), EquivocationProofError> {
+    pub fn verify_excluding_address(
+        &self,
+        validators: &Validators,
+        validator_slots: Range<u16>,
+    ) -> Result<(), EquivocationProofError> {
         // Check that the proposals are not equal and in the right order:
         match self.proposal_hash1.cmp(&self.proposal_hash2) {
             Ordering::Less => {}
@@ -400,14 +481,8 @@ impl DoubleVoteProof {
             Ordering::Greater => return Err(EquivocationProofError::WrongOrder),
         }
 
-        let validator = match validators.get_validator_by_address(&self.validator_address) {
-            None => return Err(EquivocationProofError::InvalidValidatorAddress),
-            Some(v) => v,
-        };
-
         // Check that at least one of the validator's slots is actually contained in both signer sets.
-        if !validator
-            .slots
+        if !validator_slots
             .clone()
             .any(|s| self.signers1.contains(s as usize) && self.signers2.contains(s as usize))
         {
@@ -451,5 +526,436 @@ impl DoubleVoteProof {
 impl std::hash::Hash for DoubleVoteProof {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(Hash::hash::<Blake2bHash>(self).as_bytes());
+    }
+}
+
+impl SerializeContent for DoubleVoteProof {
+    fn serialize_content<W: io::Write, H: HashOutput>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(self.validator_address().as_bytes())?;
+        self.block_number().serialize_to_writer(writer)?;
+        self.round().serialize_to_writer(writer)?;
+        self.step().serialize_to_writer(writer)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use nimiq_bls::{AggregateSignature, SecretKey};
+    use nimiq_collections::BitSet;
+    use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput};
+    use nimiq_keys::{Address, KeyPair, PrivateKey};
+    use nimiq_primitives::policy::Policy;
+    use nimiq_serde::Deserialize;
+    use nimiq_vrf::VrfSeed;
+
+    use crate::{
+        DoubleProposalProof, DoubleVoteProof, EquivocationProof, ForkProof, MacroHeader,
+        MicroHeader, TendermintIdentifier, TendermintStep, TendermintVote,
+    };
+
+    #[test]
+    fn fork_proof_sort_key() {
+        let key = KeyPair::from(
+            PrivateKey::from_bytes(
+                &hex::decode(&"8a535c4be49186007503231c8569f873eb512eae308d9be7e7de20af1ddc1663")
+                    .unwrap(),
+            )
+            .unwrap(),
+        );
+
+        let header1 = MicroHeader {
+            version: Policy::VERSION,
+            block_number: Policy::genesis_block_number(),
+            timestamp: 0,
+            parent_hash: Blake2bHash::default(),
+            seed: VrfSeed::default(),
+            extra_data: vec![],
+            state_root: Blake2bHash::default(),
+            body_root: Blake2sHash::default(),
+            diff_root: Blake2bHash::default(),
+            history_root: Blake2bHash::default(),
+        };
+        let header2 = MicroHeader {
+            version: 1234,
+            block_number: Policy::genesis_block_number(),
+            timestamp: 1,
+            parent_hash: "".hash(),
+            seed: VrfSeed::default().sign_next(&key),
+            extra_data: vec![1],
+            state_root: "".hash(),
+            body_root: "".hash(),
+            diff_root: "".hash(),
+            history_root: "".hash(),
+        };
+        let header3 = MicroHeader {
+            version: 4321,
+            block_number: Policy::genesis_block_number(),
+            timestamp: 2,
+            parent_hash: "1".hash(),
+            seed: VrfSeed::default().sign_next(&key).sign_next(&key),
+            extra_data: vec![2],
+            state_root: "1".hash(),
+            body_root: "1".hash(),
+            diff_root: "1".hash(),
+            history_root: "1".hash(),
+        };
+
+        // Headers from a different block height.
+        let mut header4 = header1.clone();
+        header4.block_number += 1;
+        let mut header5 = header2.clone();
+        header5.block_number += 1;
+
+        let justification1 = key.sign(header1.hash::<Blake2bHash>().as_bytes());
+        let justification2 = key.sign(header2.hash::<Blake2bHash>().as_bytes());
+        let justification3 = key.sign(header3.hash::<Blake2bHash>().as_bytes());
+        let justification4 = key.sign(header4.hash::<Blake2bHash>().as_bytes());
+        let justification5 = key.sign(header5.hash::<Blake2bHash>().as_bytes());
+
+        let proof1: EquivocationProof = ForkProof::new(
+            Address::burn_address(),
+            header1.clone(),
+            justification1.clone(),
+            header2.clone(),
+            justification2.clone(),
+        )
+        .into();
+        let proof2: EquivocationProof = ForkProof::new(
+            Address::burn_address(),
+            header2.clone(),
+            justification2.clone(),
+            header3.clone(),
+            justification3.clone(),
+        )
+        .into();
+        let proof3: EquivocationProof = ForkProof::new(
+            Address::burn_address(),
+            header3.clone(),
+            justification3.clone(),
+            header1.clone(),
+            justification1.clone(),
+        )
+        .into();
+        // Different block height.
+        let proof4: EquivocationProof = ForkProof::new(
+            Address::burn_address(),
+            header4.clone(),
+            justification4.clone(),
+            header5.clone(),
+            justification5.clone(),
+        )
+        .into();
+
+        assert_eq!(proof1.sort_key(), proof2.sort_key());
+        assert_eq!(proof1.sort_key(), proof3.sort_key());
+        assert_ne!(proof1.sort_key(), proof4.sort_key());
+    }
+
+    #[test]
+    fn double_proposal_proof_sort_key() {
+        let key = KeyPair::from(
+            PrivateKey::from_bytes(
+                &hex::decode(&"8a535c4be49186007503231c8569f873eb512eae308d9be7e7de20af1ddc1663")
+                    .unwrap(),
+            )
+            .unwrap(),
+        );
+
+        let header1 = MacroHeader {
+            version: Policy::VERSION,
+            block_number: Policy::genesis_block_number(),
+            round: 0,
+            timestamp: 0,
+            parent_hash: Blake2bHash::default(),
+            parent_election_hash: Blake2bHash::default(),
+            interlink: None,
+            seed: VrfSeed::default(),
+            extra_data: vec![],
+            state_root: Blake2bHash::default(),
+            body_root: Blake2sHash::default(),
+            diff_root: Blake2bHash::default(),
+            history_root: Blake2bHash::default(),
+        };
+        let header2 = MacroHeader {
+            version: 1234,
+            block_number: Policy::genesis_block_number(),
+            round: 0,
+            timestamp: 1,
+            parent_hash: "".hash(),
+            parent_election_hash: "".hash(),
+            interlink: Some(vec![]),
+            seed: VrfSeed::default().sign_next(&key),
+            extra_data: vec![1],
+            state_root: "".hash(),
+            body_root: "".hash(),
+            diff_root: "".hash(),
+            history_root: "".hash(),
+        };
+        let header3 = MacroHeader {
+            version: 4321,
+            block_number: Policy::genesis_block_number(),
+            round: 0,
+            timestamp: 2,
+            parent_hash: "1".hash(),
+            parent_election_hash: "1".hash(),
+            interlink: Some(vec![Blake2bHash::default()]),
+            seed: VrfSeed::default().sign_next(&key).sign_next(&key),
+            extra_data: vec![2],
+            state_root: "1".hash(),
+            body_root: "1".hash(),
+            diff_root: "1".hash(),
+            history_root: "1".hash(),
+        };
+
+        // Headers from a different block height.
+        let mut header4 = header1.clone();
+        header4.block_number += 1;
+        let mut header5 = header2.clone();
+        header5.block_number += 1;
+
+        // Headers from a different round.
+        let mut header6 = header1.clone();
+        header6.round += 1;
+        let mut header7 = header2.clone();
+        header7.round += 1;
+
+        let justification1 = key.sign(header1.hash::<Blake2bHash>().as_bytes());
+        let justification2 = key.sign(header2.hash::<Blake2bHash>().as_bytes());
+        let justification3 = key.sign(header3.hash::<Blake2bHash>().as_bytes());
+        let justification4 = key.sign(header4.hash::<Blake2bHash>().as_bytes());
+        let justification5 = key.sign(header5.hash::<Blake2bHash>().as_bytes());
+        let justification6 = key.sign(header6.hash::<Blake2bHash>().as_bytes());
+        let justification7 = key.sign(header7.hash::<Blake2bHash>().as_bytes());
+
+        let proof1: EquivocationProof = DoubleProposalProof::new(
+            Address::burn_address(),
+            header1.clone(),
+            justification1.clone(),
+            header2.clone(),
+            justification2.clone(),
+        )
+        .into();
+        let proof2: EquivocationProof = DoubleProposalProof::new(
+            Address::burn_address(),
+            header2.clone(),
+            justification2.clone(),
+            header3.clone(),
+            justification3.clone(),
+        )
+        .into();
+        let proof3: EquivocationProof = DoubleProposalProof::new(
+            Address::burn_address(),
+            header3.clone(),
+            justification3.clone(),
+            header1.clone(),
+            justification1.clone(),
+        )
+        .into();
+        // Different block height.
+        let proof4: EquivocationProof = DoubleProposalProof::new(
+            Address::burn_address(),
+            header4.clone(),
+            justification4.clone(),
+            header5.clone(),
+            justification5.clone(),
+        )
+        .into();
+        // Different round.
+        let proof5: EquivocationProof = DoubleProposalProof::new(
+            Address::burn_address(),
+            header6.clone(),
+            justification6.clone(),
+            header7.clone(),
+            justification7.clone(),
+        )
+        .into();
+
+        assert_eq!(proof1.sort_key(), proof2.sort_key());
+        assert_eq!(proof1.sort_key(), proof3.sort_key());
+        assert_ne!(proof1.sort_key(), proof4.sort_key());
+        assert_ne!(proof1.sort_key(), proof5.sort_key());
+        assert_ne!(proof4.sort_key(), proof5.sort_key());
+    }
+
+    #[test]
+    fn double_vote_proof_sort_key() {
+        let key = SecretKey::deserialize_from_vec(&hex::decode(&"f82ec9bb46d94c6bd6272d55e08fa5bfb911257136d205d7ee41c4f8fd839cf7a38e156c23d03c10597a4faa52a28a638756cdd83355db3eaafe37c5a94cc5c062f6de73890a6387175e579ef0083e3fe516dc61c2fab73e2183ea58a0b700").unwrap()).unwrap();
+
+        let signers: BitSet = [0].into_iter().collect();
+
+        let proposal1 = None;
+        let proposal2 = Some(Blake2sHash::default());
+        let proposal3 = Some("".hash());
+
+        let id = TendermintIdentifier {
+            block_number: 1,
+            round_number: 2,
+            step: TendermintStep::PreVote,
+        };
+
+        let other_id1 = TendermintIdentifier {
+            block_number: 2,
+            round_number: 2,
+            step: TendermintStep::PreVote,
+        };
+
+        let other_id2 = TendermintIdentifier {
+            block_number: 1,
+            round_number: 3,
+            step: TendermintStep::PreVote,
+        };
+
+        let other_id3 = TendermintIdentifier {
+            block_number: 1,
+            round_number: 2,
+            step: TendermintStep::PreCommit,
+        };
+
+        let other_id4 = TendermintIdentifier {
+            block_number: 1,
+            round_number: 2,
+            step: TendermintStep::Propose,
+        };
+
+        let signature1 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal1.clone(),
+            id: id.clone(),
+        })]);
+        let signature2 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal2.clone(),
+            id: id.clone(),
+        })]);
+        let signature3 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal3.clone(),
+            id: id.clone(),
+        })]);
+        let signature4 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal1.clone(),
+            id: other_id1.clone(),
+        })]);
+        let signature5 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal2.clone(),
+            id: other_id1.clone(),
+        })]);
+        let signature6 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal1.clone(),
+            id: other_id2.clone(),
+        })]);
+        let signature7 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal2.clone(),
+            id: other_id2.clone(),
+        })]);
+        let signature8 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal1.clone(),
+            id: other_id3.clone(),
+        })]);
+        let signature9 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal2.clone(),
+            id: other_id3.clone(),
+        })]);
+        let signature10 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal1.clone(),
+            id: other_id4.clone(),
+        })]);
+        let signature11 = AggregateSignature::from_signatures(&[key.sign(&TendermintVote {
+            proposal_hash: proposal2.clone(),
+            id: other_id4.clone(),
+        })]);
+
+        let proof1: EquivocationProof = DoubleVoteProof::new(
+            id.clone(),
+            Address::burn_address(),
+            proposal1.clone(),
+            signature1,
+            signers.clone(),
+            proposal2.clone(),
+            signature2.clone(),
+            signers.clone(),
+        )
+        .into();
+        let proof2: EquivocationProof = DoubleVoteProof::new(
+            id.clone(),
+            Address::burn_address(),
+            proposal2.clone(),
+            signature2,
+            signers.clone(),
+            proposal3.clone(),
+            signature3.clone(),
+            signers.clone(),
+        )
+        .into();
+        let proof3: EquivocationProof = DoubleVoteProof::new(
+            id.clone(),
+            Address::burn_address(),
+            proposal3.clone(),
+            signature3,
+            signers.clone(),
+            proposal1.clone(),
+            signature1.clone(),
+            signers.clone(),
+        )
+        .into();
+        // Different block height.
+        let proof4: EquivocationProof = DoubleVoteProof::new(
+            other_id1,
+            Address::burn_address(),
+            proposal1.clone(),
+            signature4,
+            signers.clone(),
+            proposal2.clone(),
+            signature5.clone(),
+            signers.clone(),
+        )
+        .into();
+        // Different round.
+        let proof5: EquivocationProof = DoubleVoteProof::new(
+            other_id2,
+            Address::burn_address(),
+            proposal1.clone(),
+            signature6,
+            signers.clone(),
+            proposal2.clone(),
+            signature7.clone(),
+            signers.clone(),
+        )
+        .into();
+        // Different step, 1.
+        let proof6: EquivocationProof = DoubleVoteProof::new(
+            other_id3,
+            Address::burn_address(),
+            proposal1.clone(),
+            signature8,
+            signers.clone(),
+            proposal2.clone(),
+            signature9.clone(),
+            signers.clone(),
+        )
+        .into();
+        // Different step, 2.
+        let proof7: EquivocationProof = DoubleVoteProof::new(
+            other_id4,
+            Address::burn_address(),
+            proposal1.clone(),
+            signature10,
+            signers.clone(),
+            proposal2.clone(),
+            signature11.clone(),
+            signers.clone(),
+        )
+        .into();
+
+        assert_eq!(proof1.sort_key(), proof2.sort_key());
+        assert_eq!(proof1.sort_key(), proof3.sort_key());
+        assert_ne!(proof1.sort_key(), proof4.sort_key());
+        assert_ne!(proof1.sort_key(), proof5.sort_key());
+        assert_ne!(proof1.sort_key(), proof6.sort_key());
+        assert_ne!(proof1.sort_key(), proof7.sort_key());
+
+        let mut different = vec![proof4, proof5, proof6, proof7];
+        let num_different = different.len();
+        different.sort_by(|p1, p2| p1.sort_key().cmp(&p2.sort_key()));
+        different.dedup_by(|p1, p2| p1.sort_key() == p2.sort_key());
+        assert_eq!(different.len(), num_different);
     }
 }

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -10,7 +10,7 @@ use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
 use nimiq_keys::{Address, KeyPair, PublicKey as SchnorrPublicKey, Signature};
 use nimiq_primitives::{networks::NetworkId, policy::Policy, slots_allocation::ValidatorsBuilder};
 use nimiq_test_log::test;
-use nimiq_test_utils::blockchain::generate_transactions;
+use nimiq_test_utils::blockchain::{generate_transactions, validator_address};
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_vrf::VrfSeed;
 
@@ -291,33 +291,37 @@ fn test_verify_micro_block_body_fork_proofs() {
     };
 
     let mut micro_header_1 = micro_header.clone();
-    micro_header_1.block_number += 1;
-
-    let mut micro_header_2 = micro_header_1.clone();
-    micro_header_2.block_number += 1;
+    let mut micro_header_2 = micro_header.clone();
+    micro_header_2.timestamp += 1;
 
     let fork_proof_1 = ForkProof::new(
-        micro_header.clone(),
-        Signature::default(),
+        validator_address(),
         micro_header_1.clone(),
         Signature::default(),
-        VrfSeed::default(),
+        micro_header_2.clone(),
+        Signature::default(),
     );
+
+    micro_header_1.block_number += 1;
+    micro_header_2.block_number += 1;
 
     let fork_proof_2 = ForkProof::new(
+        validator_address(),
         micro_header_1.clone(),
         Signature::default(),
         micro_header_2.clone(),
         Signature::default(),
-        VrfSeed::default(),
     );
 
+    micro_header_1.block_number += 1;
+    micro_header_2.block_number += 1;
+
     let fork_proof_3 = ForkProof::new(
-        micro_header.clone(),
+        validator_address(),
+        micro_header_1.clone(),
         Signature::default(),
         micro_header_2.clone(),
         Signature::default(),
-        VrfSeed::default(),
     );
 
     let micro_justification = MicroJustification::Micro(Signature::default());
@@ -378,14 +382,14 @@ fn test_verify_micro_block_body_fork_proofs() {
     micro_header_large_block_number_1.block_number =
         Policy::blocks_per_epoch() + genesis_block_number;
     let mut micro_header_large_block_number_2 = micro_header_large_block_number_1.clone();
-    micro_header_large_block_number_2.block_number += 1;
+    micro_header_large_block_number_2.timestamp += 1;
     fork_proofs.pop().unwrap();
     fork_proofs.push(ForkProof::new(
+        validator_address(),
         micro_header_large_block_number_1,
         Signature::default(),
         micro_header_large_block_number_2,
         Signature::default(),
-        VrfSeed::default(),
     ));
     fork_proofs.sort_by_key(|p| EquivocationProof::from(p.clone()).sort_key());
 

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -25,7 +25,8 @@ use crate::{blockchain_with_rng::*, test_rng::test_rng};
 /// Secret keys of validator. Tests run with `genesis/src/genesis/unit-albatross.toml`
 pub const SIGNING_KEY: &str = "041580cc67e66e9e08b68fd9e4c9deb68737168fbe7488de2638c2e906c2f5ad";
 pub const VOTING_KEY: &str = "99237809f3b37bd0878854d2b5b66e4cc00ba1a1d64377c374f2b6d1bf3dec7835bfae3e7ab89b6d331b3ef7d1e9a06a7f6967bf00edf9e0bcfe34b58bd1260e96406e09156e4c190ff8f69a9ce1183b4289383e6d798fd5104a3800fabd00";
-pub const UNIT_KEY: &str = "6c9320ac201caf1f8eaa5b05f5d67a9e77826f3f6be266a0ecccc20416dc6587";
+pub const REWARD_KEY: &str = "6c9320ac201caf1f8eaa5b05f5d67a9e77826f3f6be266a0ecccc20416dc6587";
+pub const VALIDATOR_KEY: &str = "6927eb8de74e8ea06a8afae5a66db176a7031f742b656651ac53bddb8a4ad3f3";
 
 pub fn generate_transactions(
     key_pair: &KeyPair,
@@ -122,7 +123,7 @@ pub fn fill_micro_blocks_with_txns(
     rng_seed: u64,
 ) {
     let init_height = blockchain.read().block_number();
-    let key_pair = KeyPair::from(PrivateKey::from_str(UNIT_KEY).unwrap());
+    let key_pair = KeyPair::from(PrivateKey::from_str(REWARD_KEY).unwrap());
     assert!(Policy::is_macro_block_at(init_height));
 
     let macro_block_number = init_height + Policy::blocks_per_batch();
@@ -242,6 +243,16 @@ pub fn sign_skip_block_info(
     SkipBlockProof {
         sig: MultiSignature::new(signature, signers),
     }
+}
+
+pub fn validator_key() -> SchnorrKeyPair {
+    SchnorrKeyPair::from(
+        SchnorrPrivateKey::deserialize_from_vec(&hex::decode(VALIDATOR_KEY).unwrap()).unwrap(),
+    )
+}
+
+pub fn validator_address() -> Address {
+    Address::from(&validator_key())
 }
 
 pub fn voting_key() -> BlsKeyPair {


### PR DESCRIPTION
As an example, this means that if a validator produces 5 fork blocks at a given height, only one fork proof can be included in a subsequent block, not 5*4/2 proofs as before.

CC #1481.