### PR TITLE
Expose policy info and utility methods to be available in the web-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+]
+
+[[package]]
 name = "chacha20"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4446,7 @@ dependencies = [
  "ark-mnt6-753",
  "ark-serialize",
  "byteorder",
+ "cfg_eval",
  "hex",
  "nimiq-bls",
  "nimiq-database-value",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -21,6 +21,7 @@ ark-ec = "0.4"
 ark-mnt6-753 = "0.4"
 ark-serialize = "0.4"
 byteorder = "1.2"
+cfg_eval = "0.1"
 hex = { version = "0.4", optional = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 num-traits = { version = "0.2", optional = true }

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -8,32 +8,34 @@ use wasm_bindgen::prelude::*;
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
 
-#[cfg_attr(
-    feature = "ts-types",
-    derive(nimiq_serde::Serialize),
-    serde(rename_all = "camelCase"),
-    wasm_bindgen::prelude::wasm_bindgen
-)]
+#[cfg_attr(feature = "ts-types", cfg_eval::cfg_eval, wasm_bindgen)]
 #[derive(Clone, Copy)]
 pub struct Policy {
     /// Length of a batch including the macro block
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub blocks_per_batch: u32,
     /// How many batches constitute an epoch
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub batches_per_epoch: u16,
     /// Tendermint's initial timeout, in milliseconds.
     ///
     /// See <https://arxiv.org/abs/1807.04938v3> for more information.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub tendermint_timeout_init: u64,
     /// Tendermint's timeout delta, in milliseconds.
     ///
     /// See <https://arxiv.org/abs/1807.04938v3> for more information.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub tendermint_timeout_delta: u64,
     /// Maximum size of accounts trie chunks.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub state_chunks_max_size: u32,
     /// Number of blocks a transaction is valid with Albatross consensus.
     /// This should be a multiple of `blocks_per_batch`.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub transaction_validity_window: u32,
     /// Genesis block number
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub genesis_block_number: u32,
 }
 

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -6,6 +6,12 @@ use once_cell::sync::OnceCell;
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
 
+#[cfg_attr(
+    feature = "ts-types",
+    derive(nimiq_serde::Serialize),
+    serde(rename_all = "camelCase"),
+    wasm_bindgen::prelude::wasm_bindgen
+)]
 #[derive(Clone, Copy)]
 pub struct Policy {
     /// Length of a batch including the macro block
@@ -180,8 +186,17 @@ impl Policy {
             .state_chunks_max_size
     }
 
+    #[inline]
+    pub fn get_or_init(policy: Policy) -> Policy {
+        *GLOBAL_POLICY.get_or_init(|| policy)
+    }
+}
+
+#[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen)]
+impl Policy {
     /// Returns the epoch number at a given block number (height).
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = epochAt))]
     pub fn epoch_at(block_number: u32) -> u32 {
         // If the block number is less than the genesis, we are at epoch 0
         if block_number <= Self::genesis_block_number() {
@@ -196,6 +211,7 @@ impl Policy {
     /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
     /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = epochIndexAt))]
     pub fn epoch_index_at(block_number: u32) -> u32 {
         // Any block before the genesis is considered to be part of epoch 0
         if block_number < Self::genesis_block_number() {
@@ -209,6 +225,7 @@ impl Policy {
 
     /// Returns the batch number at a given `block_number` (height)
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = batchAt))]
     pub fn batch_at(block_number: u32) -> u32 {
         // If the block number is less than the genesis, we are at batch 0
         if block_number <= Self::genesis_block_number() {
@@ -223,6 +240,7 @@ impl Policy {
     /// Returns the batch index at a given block number. The batch index is the number of a block relative
     /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = batchIndexAt))]
     pub fn batch_index_at(block_number: u32) -> u32 {
         // No batches before the genesis block number
         if block_number < Self::genesis_block_number() {
@@ -236,6 +254,7 @@ impl Policy {
 
     /// Returns the number (height) of the next election macro block after a given block number (height).
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = electionBlockAfter))]
     pub fn election_block_after(block_number: u32) -> u32 {
         // The next election block of any block before the genesis, is the genesis itself
         if block_number < Self::genesis_block_number() {
@@ -251,6 +270,7 @@ impl Policy {
     /// Returns the block number (height) of the preceding election macro block before a given block number (height).
     /// If the given block number is an election macro block, it returns the election macro block before it.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = electionBlockBefore))]
     pub fn election_block_before(block_number: u32) -> u32 {
         match block_number.cmp(&Self::genesis_block_number()) {
             std::cmp::Ordering::Less => {
@@ -272,6 +292,7 @@ impl Policy {
     /// Returns the block number (height) of the last election macro block at a given block number (height).
     /// If the given block number is an election macro block, then it returns that block number.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = lastElectionBlock))]
     pub fn last_election_block(block_number: u32) -> u32 {
         // The last election block of any block before the genesis, is the genesis itself
         if block_number < Self::genesis_block_number() {
@@ -285,12 +306,14 @@ impl Policy {
 
     /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = isElectionBlockAt))]
     pub fn is_election_block_at(block_number: u32) -> bool {
         Self::epoch_index_at(block_number) == Self::blocks_per_epoch() - 1
     }
 
     /// Returns the block number (height) of the next macro block after a given block number (height).
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = macroBlockAfter))]
     pub fn macro_block_after(block_number: u32) -> u32 {
         // The next macro block of any block before the genesis, is the genesis itself
         if block_number < Self::genesis_block_number() {
@@ -306,6 +329,7 @@ impl Policy {
     /// Returns the block number (height) of the preceding macro block before a given block number (height).
     /// If the given block number is a macro block, it returns the macro block before it.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = macroBlockBefore))]
     pub fn macro_block_before(block_number: u32) -> u32 {
         if block_number <= Self::genesis_block_number() {
             panic!("No macro blocks before genesis block");
@@ -320,6 +344,7 @@ impl Policy {
     /// Returns the block number (height) of the last macro block at a given block number (height).
     /// If the given block number is a macro block, then it returns that block number.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = lastMacroBlock))]
     pub fn last_macro_block(block_number: u32) -> u32 {
         // There is no macro block before the genesis
         if block_number < Self::genesis_block_number() {
@@ -333,6 +358,7 @@ impl Policy {
 
     /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = isMacroBlockAt))]
     pub fn is_macro_block_at(block_number: u32) -> bool {
         // No macro blocks before genesis
         if block_number < Self::genesis_block_number() {
@@ -344,6 +370,7 @@ impl Policy {
 
     /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = isMicroBlockAt))]
     pub fn is_micro_block_at(block_number: u32) -> bool {
         // No micro blocks before genesis
         if block_number < Self::genesis_block_number() {
@@ -355,6 +382,7 @@ impl Policy {
 
     /// Returns the block number of the first block of the given epoch (which is always a micro block).
     /// If the index is out of bounds, None is returned
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = firstBlockOf))]
     pub fn first_block_of(epoch: u32) -> Option<u32> {
         if epoch == 0 {
             panic!("Called first_block_of for epoch 0");
@@ -368,6 +396,7 @@ impl Policy {
 
     /// Returns the block number of the first block of the given batch (which is always a micro block).
     /// If the index is out of bounds, None is returned
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = firstBlockOfBatch))]
     pub fn first_block_of_batch(batch: u32) -> Option<u32> {
         if batch == 0 {
             panic!("Called first_block_of_batch for batch 0");
@@ -381,6 +410,7 @@ impl Policy {
 
     /// Returns the block number of the election macro block of the given epoch (which is always the last block).
     /// If the index is out of bounds, None is returned
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = electionBlockOf))]
     pub fn election_block_of(epoch: u32) -> Option<u32> {
         epoch
             .checked_mul(Self::blocks_per_epoch())?
@@ -390,6 +420,7 @@ impl Policy {
     /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
     /// is always the last block).
     /// If the index is out of bounds, None is returned
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = macroBlockOf))]
     pub fn macro_block_of(batch: u32) -> Option<u32> {
         batch
             .checked_mul(Self::blocks_per_batch())?
@@ -399,6 +430,7 @@ impl Policy {
     /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
     /// of the epoch.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = firstBatchOfEpoch))]
     pub fn first_batch_of_epoch(block_number: u32) -> bool {
         Self::epoch_index_at(block_number) < Self::blocks_per_batch()
     }
@@ -406,18 +438,21 @@ impl Policy {
     /// Returns the block height for the last block of the reporting window of a given block number.
     /// Note: This window is meant for reporting malicious behaviour (aka `jailable` behaviour).
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = lastBlockOfReportingWindow))]
     pub fn last_block_of_reporting_window(block_number: u32) -> u32 {
         block_number + Self::blocks_per_epoch()
     }
 
     /// Returns the first block after the reporting window of a given block number has ended.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = blockAfterReportingWindow))]
     pub fn block_after_reporting_window(block_number: u32) -> u32 {
         Self::last_block_of_reporting_window(block_number) + 1
     }
 
     /// Returns the first block after the jail period of a given block number has ended.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = blockAfterJail))]
     pub fn block_after_jail(block_number: u32) -> u32 {
         block_number + Self::blocks_per_epoch() * Self::JAIL_EPOCHS + 1
     }
@@ -427,6 +462,7 @@ impl Policy {
     /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
     /// Where e is the exponential function, t is the time in milliseconds since the genesis block and
     /// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = supplyAt))]
     pub fn supply_at(genesis_supply: u64, genesis_time: u64, current_time: u64) -> u64 {
         assert!(current_time >= genesis_time);
 
@@ -445,16 +481,12 @@ impl Policy {
     /// I.e 1 means that the full rewards should be given, whereas 0.5 means that half of the rewards should be given
     /// The input to this function is the batch delay, in milliseconds
     /// The function is: [(1 - MINIMUM_REWARDS_PERCENTAGE) * e ^(-BLOCKS_DELAY_DECAY * t^2)] + MINIMUM_REWARDS_PERCENTAGE
+    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = batchDelayPenalty))]
     pub fn batch_delay_penalty(delay: u64) -> f64 {
         let t = delay as f64;
         let exponent = -Self::BLOCKS_DELAY_DECAY * t * t;
 
         (1.0 - Self::MINIMUM_REWARDS_PERCENTAGE) * exponent.exp() + Self::MINIMUM_REWARDS_PERCENTAGE
-    }
-
-    #[inline]
-    pub fn get_or_init(policy: Policy) -> Policy {
-        *GLOBAL_POLICY.get_or_init(|| policy)
     }
 }
 

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -2,6 +2,8 @@ use std::cmp;
 
 use nimiq_keys::Address;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "ts-types")]
+use wasm_bindgen::prelude::*;
 
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
@@ -196,7 +198,7 @@ impl Policy {
 impl Policy {
     /// Returns the epoch number at a given block number (height).
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = epochAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = epochAt))]
     pub fn epoch_at(block_number: u32) -> u32 {
         // If the block number is less than the genesis, we are at epoch 0
         if block_number <= Self::genesis_block_number() {
@@ -211,7 +213,7 @@ impl Policy {
     /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
     /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = epochIndexAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = epochIndexAt))]
     pub fn epoch_index_at(block_number: u32) -> u32 {
         // Any block before the genesis is considered to be part of epoch 0
         if block_number < Self::genesis_block_number() {
@@ -225,7 +227,7 @@ impl Policy {
 
     /// Returns the batch number at a given `block_number` (height)
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = batchAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = batchAt))]
     pub fn batch_at(block_number: u32) -> u32 {
         // If the block number is less than the genesis, we are at batch 0
         if block_number <= Self::genesis_block_number() {
@@ -240,7 +242,7 @@ impl Policy {
     /// Returns the batch index at a given block number. The batch index is the number of a block relative
     /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = batchIndexAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = batchIndexAt))]
     pub fn batch_index_at(block_number: u32) -> u32 {
         // No batches before the genesis block number
         if block_number < Self::genesis_block_number() {
@@ -254,7 +256,7 @@ impl Policy {
 
     /// Returns the number (height) of the next election macro block after a given block number (height).
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = electionBlockAfter))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = electionBlockAfter))]
     pub fn election_block_after(block_number: u32) -> u32 {
         // The next election block of any block before the genesis, is the genesis itself
         if block_number < Self::genesis_block_number() {
@@ -270,7 +272,7 @@ impl Policy {
     /// Returns the block number (height) of the preceding election macro block before a given block number (height).
     /// If the given block number is an election macro block, it returns the election macro block before it.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = electionBlockBefore))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = electionBlockBefore))]
     pub fn election_block_before(block_number: u32) -> u32 {
         match block_number.cmp(&Self::genesis_block_number()) {
             std::cmp::Ordering::Less => {
@@ -292,7 +294,7 @@ impl Policy {
     /// Returns the block number (height) of the last election macro block at a given block number (height).
     /// If the given block number is an election macro block, then it returns that block number.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = lastElectionBlock))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastElectionBlock))]
     pub fn last_election_block(block_number: u32) -> u32 {
         // The last election block of any block before the genesis, is the genesis itself
         if block_number < Self::genesis_block_number() {
@@ -306,14 +308,14 @@ impl Policy {
 
     /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = isElectionBlockAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = isElectionBlockAt))]
     pub fn is_election_block_at(block_number: u32) -> bool {
         Self::epoch_index_at(block_number) == Self::blocks_per_epoch() - 1
     }
 
     /// Returns the block number (height) of the next macro block after a given block number (height).
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = macroBlockAfter))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = macroBlockAfter))]
     pub fn macro_block_after(block_number: u32) -> u32 {
         // The next macro block of any block before the genesis, is the genesis itself
         if block_number < Self::genesis_block_number() {
@@ -329,7 +331,7 @@ impl Policy {
     /// Returns the block number (height) of the preceding macro block before a given block number (height).
     /// If the given block number is a macro block, it returns the macro block before it.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = macroBlockBefore))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = macroBlockBefore))]
     pub fn macro_block_before(block_number: u32) -> u32 {
         if block_number <= Self::genesis_block_number() {
             panic!("No macro blocks before genesis block");
@@ -344,7 +346,7 @@ impl Policy {
     /// Returns the block number (height) of the last macro block at a given block number (height).
     /// If the given block number is a macro block, then it returns that block number.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = lastMacroBlock))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastMacroBlock))]
     pub fn last_macro_block(block_number: u32) -> u32 {
         // There is no macro block before the genesis
         if block_number < Self::genesis_block_number() {
@@ -358,7 +360,7 @@ impl Policy {
 
     /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = isMacroBlockAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = isMacroBlockAt))]
     pub fn is_macro_block_at(block_number: u32) -> bool {
         // No macro blocks before genesis
         if block_number < Self::genesis_block_number() {
@@ -370,7 +372,7 @@ impl Policy {
 
     /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = isMicroBlockAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = isMicroBlockAt))]
     pub fn is_micro_block_at(block_number: u32) -> bool {
         // No micro blocks before genesis
         if block_number < Self::genesis_block_number() {
@@ -382,7 +384,7 @@ impl Policy {
 
     /// Returns the block number of the first block of the given epoch (which is always a micro block).
     /// If the index is out of bounds, None is returned
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = firstBlockOf))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = firstBlockOf))]
     pub fn first_block_of(epoch: u32) -> Option<u32> {
         if epoch == 0 {
             panic!("Called first_block_of for epoch 0");
@@ -396,7 +398,7 @@ impl Policy {
 
     /// Returns the block number of the first block of the given batch (which is always a micro block).
     /// If the index is out of bounds, None is returned
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = firstBlockOfBatch))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = firstBlockOfBatch))]
     pub fn first_block_of_batch(batch: u32) -> Option<u32> {
         if batch == 0 {
             panic!("Called first_block_of_batch for batch 0");
@@ -410,7 +412,7 @@ impl Policy {
 
     /// Returns the block number of the election macro block of the given epoch (which is always the last block).
     /// If the index is out of bounds, None is returned
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = electionBlockOf))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = electionBlockOf))]
     pub fn election_block_of(epoch: u32) -> Option<u32> {
         epoch
             .checked_mul(Self::blocks_per_epoch())?
@@ -420,7 +422,7 @@ impl Policy {
     /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
     /// is always the last block).
     /// If the index is out of bounds, None is returned
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = macroBlockOf))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = macroBlockOf))]
     pub fn macro_block_of(batch: u32) -> Option<u32> {
         batch
             .checked_mul(Self::blocks_per_batch())?
@@ -430,7 +432,7 @@ impl Policy {
     /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
     /// of the epoch.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = firstBatchOfEpoch))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = firstBatchOfEpoch))]
     pub fn first_batch_of_epoch(block_number: u32) -> bool {
         Self::epoch_index_at(block_number) < Self::blocks_per_batch()
     }
@@ -438,21 +440,21 @@ impl Policy {
     /// Returns the block height for the last block of the reporting window of a given block number.
     /// Note: This window is meant for reporting malicious behaviour (aka `jailable` behaviour).
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = lastBlockOfReportingWindow))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastBlockOfReportingWindow))]
     pub fn last_block_of_reporting_window(block_number: u32) -> u32 {
         block_number + Self::blocks_per_epoch()
     }
 
     /// Returns the first block after the reporting window of a given block number has ended.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = blockAfterReportingWindow))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = blockAfterReportingWindow))]
     pub fn block_after_reporting_window(block_number: u32) -> u32 {
         Self::last_block_of_reporting_window(block_number) + 1
     }
 
     /// Returns the first block after the jail period of a given block number has ended.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = blockAfterJail))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = blockAfterJail))]
     pub fn block_after_jail(block_number: u32) -> u32 {
         block_number + Self::blocks_per_epoch() * Self::JAIL_EPOCHS + 1
     }
@@ -462,7 +464,7 @@ impl Policy {
     /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
     /// Where e is the exponential function, t is the time in milliseconds since the genesis block and
     /// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = supplyAt))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = supplyAt))]
     pub fn supply_at(genesis_supply: u64, genesis_time: u64, current_time: u64) -> u64 {
         assert!(current_time >= genesis_time);
 
@@ -481,7 +483,7 @@ impl Policy {
     /// I.e 1 means that the full rewards should be given, whereas 0.5 means that half of the rewards should be given
     /// The input to this function is the batch delay, in milliseconds
     /// The function is: [(1 - MINIMUM_REWARDS_PERCENTAGE) * e ^(-BLOCKS_DELAY_DECAY * t^2)] + MINIMUM_REWARDS_PERCENTAGE
-    #[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen(js_name = batchDelayPenalty))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = batchDelayPenalty))]
     pub fn batch_delay_penalty(delay: u64) -> f64 {
         let t = delay as f64;
         let exponent = -Self::BLOCKS_DELAY_DECAY * t * t;

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -132,70 +132,86 @@ impl Policy {
     }
 
     #[inline]
-    fn get_genesis_block_number(&self) -> u32 {
-        self.genesis_block_number
+    pub fn get_or_init(policy: Policy) -> Policy {
+        *GLOBAL_POLICY.get_or_init(|| policy)
     }
+}
 
+#[cfg_attr(feature = "ts-types", wasm_bindgen)]
+impl Policy {
+    /// Number of blocks a transaction is valid with Albatross consensus.
+    /// This should be a multiple of `blocks_per_batch`.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = transactionValidityWindow))]
     pub fn transaction_validity_window() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
             .transaction_validity_window
     }
 
+    /// How many batches constitute an epoch
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = batchesPerEpoch))]
     pub fn batches_per_epoch() -> u16 {
         GLOBAL_POLICY.get_or_init(Self::default).batches_per_epoch
     }
 
+    /// Length of a batch including the macro block
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = blocksPerBatch))]
     pub fn blocks_per_batch() -> u32 {
         GLOBAL_POLICY.get_or_init(Self::default).blocks_per_batch
     }
 
+    /// Length of an epoch including the election block
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = blocksPerEpoch))]
     pub fn blocks_per_epoch() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
             .get_blocks_per_epoch()
     }
 
+    /// Genesis block number
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = genesisBlockNumber))]
     pub fn genesis_block_number() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
-            .get_genesis_block_number()
+            .genesis_block_number
     }
 
+    /// Tendermint's initial timeout, in milliseconds.
+    ///
+    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = tendermintTimeoutInit))]
     pub fn tendermint_timeout_init() -> u64 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
             .tendermint_timeout_init
     }
 
+    /// Tendermint's timeout delta, in milliseconds.
+    ///
+    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = tendermintTimeoutDelta))]
     pub fn tendermint_timeout_delta() -> u64 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
             .tendermint_timeout_delta
     }
 
+    /// Maximum size of accounts trie chunks.
     #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = stateChunksMaxSize))]
     pub fn state_chunks_max_size() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Policy::default)
             .state_chunks_max_size
     }
 
-    #[inline]
-    pub fn get_or_init(policy: Policy) -> Policy {
-        *GLOBAL_POLICY.get_or_init(|| policy)
-    }
-}
-
-#[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen)]
-impl Policy {
     /// Returns the epoch number at a given block number (height).
     #[inline]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = epochAt))]

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -144,7 +144,7 @@ impl Policy {
     /// Number of blocks a transaction is valid with Albatross consensus.
     /// This should be a multiple of `blocks_per_batch`.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = transactionValidityWindow))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TRANSACTION_VALIDITY_WINDOW))]
     pub fn transaction_validity_window() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
@@ -153,21 +153,21 @@ impl Policy {
 
     /// How many batches constitute an epoch
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = batchesPerEpoch))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BATCHES_PER_EPOCH))]
     pub fn batches_per_epoch() -> u16 {
         GLOBAL_POLICY.get_or_init(Self::default).batches_per_epoch
     }
 
     /// Length of a batch including the macro block
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = blocksPerBatch))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLOCKS_PER_BATCH))]
     pub fn blocks_per_batch() -> u32 {
         GLOBAL_POLICY.get_or_init(Self::default).blocks_per_batch
     }
 
     /// Length of an epoch including the election block
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = blocksPerEpoch))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLOCKS_PER_EPOCH))]
     pub fn blocks_per_epoch() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
@@ -176,7 +176,7 @@ impl Policy {
 
     /// Genesis block number
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = genesisBlockNumber))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = GENESIS_BLOCK_NUMBER))]
     pub fn genesis_block_number() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
@@ -187,7 +187,7 @@ impl Policy {
     ///
     /// See <https://arxiv.org/abs/1807.04938v3> for more information.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = tendermintTimeoutInit))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TENDERMINT_TIMEOUT_INIT))]
     pub fn tendermint_timeout_init() -> u64 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
@@ -198,7 +198,7 @@ impl Policy {
     ///
     /// See <https://arxiv.org/abs/1807.04938v3> for more information.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = tendermintTimeoutDelta))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TENDERMINT_TIMEOUT_DELTA))]
     pub fn tendermint_timeout_delta() -> u64 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
@@ -207,7 +207,7 @@ impl Policy {
 
     /// Maximum size of accounts trie chunks.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = stateChunksMaxSize))]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = STATE_CHUNKS_MAX_SIZE))]
     pub fn state_chunks_max_size() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Policy::default)

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -510,6 +510,152 @@ impl Policy {
     }
 }
 
+// wasm_bindgen does not support exposing `pub const` struct fields, so we reimplement those consts
+// as getters when compiling for WASM.
+#[cfg(feature = "ts-types")]
+#[wasm_bindgen]
+impl Policy {
+    /// This is the address for the staking contract.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = STAKING_CONTRACT_ADDRESS))]
+    pub fn wasm_staking_contract_address() -> String {
+        Self::STAKING_CONTRACT_ADDRESS.to_user_friendly_address()
+    }
+
+    /// This is the address for the coinbase. Note that this is not a real account, it is just the
+    /// address we use to denote that some coins originated from a coinbase event.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = COINBASE_ADDRESS))]
+    pub fn wasm_coinbase_address() -> String {
+        Self::COINBASE_ADDRESS.to_user_friendly_address()
+    }
+
+    /// The maximum allowed size, in bytes, for a micro block body.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = MAX_SIZE_MICRO_BODY))]
+    pub fn wasm_max_size_micro_body() -> usize {
+        Self::MAX_SIZE_MICRO_BODY
+    }
+
+    /// The current version number of the protocol. Changing this always results in a hard fork.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = VERSION))]
+    pub fn wasm_version() -> u16 {
+        Self::VERSION
+    }
+
+    /// Number of available validator slots. Note that a single validator may own several validator slots.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = SLOTS))]
+    pub fn wasm_slots() -> u16 {
+        Self::SLOTS
+    }
+
+    /// Calculates 2f+1 slots which is the minimum number of slots necessary to produce a macro block,
+    /// a skip block and other actions.
+    /// It is also the minimum number of slots necessary to be guaranteed to have a majority of honest
+    /// slots. That's because from a total of 3f+1 slots at most f will be malicious. If in a group of
+    /// 2f+1 slots we have f malicious ones (which is the worst case scenario), that still leaves us
+    /// with f+1 honest slots. Which is more than the f slots that are not in this group (which must all
+    /// be honest).
+    /// It is calculated as `ceil(SLOTS*2/3)` and we use the formula `ceil(x/y) = (x+y-1)/y` for the
+    /// ceiling division.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TWO_F_PLUS_ONE))]
+    pub fn wasm_two_f_plus_one() -> u16 {
+        Self::TWO_F_PLUS_ONE
+    }
+
+    /// Calculates f+1 slots which is the minimum number of slots necessary to be guaranteed to have at
+    /// least one honest slots. That's because from a total of 3f+1 slots at most f will be malicious.
+    /// It is calculated as `ceil(SLOTS/3)` and we use the formula `ceil(x/y) = (x+y-1)/y` for the
+    /// ceiling division.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = F_PLUS_ONE))]
+    pub fn wasm_f_plus_one() -> u16 {
+        Self::F_PLUS_ONE
+    }
+
+    /// The timeout in milliseconds for a validator to produce a block (2s)
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLOCK_PRODUCER_TIMEOUT))]
+    pub fn wasm_block_producer_timeout() -> u64 {
+        Self::BLOCK_PRODUCER_TIMEOUT
+    }
+
+    /// The optimal time in milliseconds between blocks (1s)
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLOCK_SEPARATION_TIME))]
+    pub fn wasm_block_separation_time() -> u64 {
+        Self::BLOCK_SEPARATION_TIME
+    }
+
+    /// Minimum number of epochs that the ChainStore will store fully
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = MIN_EPOCHS_STORED))]
+    pub fn wasm_min_epochs_stored() -> u32 {
+        Self::MIN_EPOCHS_STORED
+    }
+
+    /// The maximum drift, in milliseconds, that is allowed between any block's timestamp and the node's
+    /// system time. We only care about drifting to the future.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TIMESTAMP_MAX_DRIFT))]
+    pub fn wasm_timestamp_max_drift() -> u64 {
+        Self::TIMESTAMP_MAX_DRIFT
+    }
+
+    /// The slope of the exponential decay used to punish validators for not producing block in time
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLOCKS_DELAY_DECAY))]
+    pub fn wasm_blocks_delay_decay() -> f64 {
+        Self::BLOCKS_DELAY_DECAY
+    }
+
+    /// The minimum rewards percentage that we allow
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = MINIMUM_REWARDS_PERCENTAGE))]
+    pub fn wasm_minimum_rewards_percentage() -> f64 {
+        Self::MINIMUM_REWARDS_PERCENTAGE
+    }
+
+    /// The deposit necessary to create a validator in Lunas (1 NIM = 100,000 Lunas).
+    /// A validator is someone who actually participates in block production. They are akin to miners
+    /// in proof-of-work.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = VALIDATOR_DEPOSIT))]
+    pub fn wasm_validator_deposit() -> u64 {
+        Self::VALIDATOR_DEPOSIT
+    }
+
+    /// The number of epochs a validator is put in jail for. The jailing only happens for severe offenses.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = JAIL_EPOCHS))]
+    pub fn wasm_jail_epochs() -> u32 {
+        Self::JAIL_EPOCHS
+    }
+
+    /// Total supply in units.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TOTAL_SUPPLY))]
+    pub fn wasm_total_supply() -> u64 {
+        Self::TOTAL_SUPPLY
+    }
+
+    /// This is the number of Lunas (1 NIM = 100,000 Lunas) created by millisecond at the genesis of the
+    /// Nimiq 2.0 chain. The velocity then decreases following the formula:
+    /// Supply_velocity (t) = Initial_supply_velocity * e^(- Supply_decay * t)
+    /// Where e is the exponential function and t is the time in milliseconds since the genesis block.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = INITIAL_SUPPLY_VELOCITY))]
+    pub fn wasm_initial_supply_velocity() -> f64 {
+        Self::INITIAL_SUPPLY_VELOCITY
+    }
+
+    /// The supply decay is a constant that is calculated so that the supply velocity decreases at a
+    /// steady 1.47% per year.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = SUPPLY_DECAY))]
+    pub fn wasm_supply_decay() -> f64 {
+        Self::SUPPLY_DECAY
+    }
+
+    /// The maximum size of the BLS public key cache.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLS_CACHE_MAX_CAPACITY))]
+    pub fn wasm_bls_cache_max_capacity() -> usize {
+        Self::BLS_CACHE_MAX_CAPACITY
+    }
+
+    /// Maximum size of history chunks.
+    /// 25 MB.
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = HISTORY_CHUNKS_MAX_SIZE))]
+    pub fn wasm_history_chunks_max_size() -> u64 {
+        Self::HISTORY_CHUNKS_MAX_SIZE
+    }
+}
+
 impl Default for Policy {
     fn default() -> Self {
         Policy {

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -387,6 +387,14 @@ impl Client {
         self.inner.blockchain_head().block_number()
     }
 
+    /// Returns the policy information.
+    #[wasm_bindgen(js_name = policy)]
+    pub async fn policy(&self) -> Result<JsValue, JsError> {
+        Ok(serde_wasm_bindgen::to_value(&Policy::get_or_init(
+            Policy::default(),
+        ))?)
+    }
+
     /// Returns the current blockchain head block.
     /// Note that the web client is a light client and does not have block bodies, i.e. no transactions.
     #[wasm_bindgen(js_name = getHeadBlock)]

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -387,14 +387,6 @@ impl Client {
         self.inner.blockchain_head().block_number()
     }
 
-    /// Returns the policy information.
-    #[wasm_bindgen(js_name = policy)]
-    pub async fn policy(&self) -> Result<JsValue, JsError> {
-        Ok(serde_wasm_bindgen::to_value(&Policy::get_or_init(
-            Policy::default(),
-        ))?)
-    }
-
     /// Returns the current blockchain head block.
     /// Note that the web client is a light client and does not have block bodies, i.e. no transactions.
     #[wasm_bindgen(js_name = getHeadBlock)]


### PR DESCRIPTION
## What's in this pull request?
Annotate Policy primitives including the static utility functions with `wasm-bindgen` so they can be used by the `web-client`.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
