### PR TITLE
Fix clippy warnings

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -219,7 +219,7 @@ impl Blockchain {
             .expect("Block body must be present");
 
         for equivocation_proof in &body.equivocation_proofs {
-            let validators = &self
+            let validators = self
                 .get_validators_for_epoch(
                     Policy::epoch_at(equivocation_proof.block_number()),
                     Some(txn),

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -482,6 +482,7 @@ impl DoubleVoteProof {
         }
 
         // Check that at least one of the validator's slots is actually contained in both signer sets.
+        #[allow(clippy::redundant_clone)]
         if !validator_slots
             .clone()
             .any(|s| self.signers1.contains(s as usize) && self.signers2.contains(s as usize))


### PR DESCRIPTION
Ignore the unnecessary clone warning because adhering to it would make the code more dangerous. `ops::Range` would be modified by the `any` call, making further operations on it work on a modified range.