### PR TITLE
Fix feature compilation for some crates

### DIFF
--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -23,6 +23,9 @@ pub struct Signature {
 }
 
 impl Signature {
+    /// Maximum size in bytes for a single `Signature` in binary serialization.
+    pub const SIZE: usize = CompressedSignature::SIZE;
+
     /// Maps an hash to a elliptic curve point in the G1 group, it is known as
     /// "hash-to-curve". It is required to create signatures. We use the
     /// try-and-increment method to create the EC point.
@@ -142,11 +145,6 @@ mod serde_derive {
     };
 
     use super::{CompressedSignature, Signature};
-
-    impl Signature {
-        /// Maximum size in bytes for a single `Signature` in binary serialization.
-        pub const SIZE: usize = CompressedSignature::SIZE;
-    }
 
     impl Serialize for Signature {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/collections/Cargo.toml
+++ b/collections/Cargo.toml
@@ -26,5 +26,4 @@ hex = "0.4"
 rand = "0.8"
 serde_json = "1.0"
 
-nimiq-serde = { workspace = true }
 nimiq-test-log = { workspace = true }

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "interaction-traits")]
 use std::cmp::Ordering;
 
 use nimiq_keys::Address;
 #[cfg(feature = "interaction-traits")]
 use nimiq_primitives::account::AccountError;
-use nimiq_primitives::{coin::Coin, policy::Policy};
+use nimiq_primitives::coin::Coin;
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::policy::Policy;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "interaction-traits")]
@@ -14,9 +17,8 @@ use crate::{
         },
         StakerReceipt, StakingContract, Tombstone,
     },
-    Log, TransactionLog,
+    Log, RemoveStakeReceipt, SetInactiveStakeReceipt, TransactionLog,
 };
-use crate::{RemoveStakeReceipt, SetInactiveStakeReceipt};
 
 /// Struct representing a staker in the staking contract.
 /// The staker's balance is divided into active and inactive stake.

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -6,7 +6,6 @@ use nimiq_primitives::coin::Coin;
 use nimiq_primitives::{account::AccountError, policy::Policy};
 use serde::{Deserialize, Serialize};
 
-use crate::JailValidatorReceipt;
 #[cfg(feature = "interaction-traits")]
 use crate::{
     account::staking_contract::{
@@ -16,7 +15,7 @@ use crate::{
         },
         StakingContract,
     },
-    Log, RetireValidatorReceipt, TransactionLog,
+    JailValidatorReceipt, Log, RetireValidatorReceipt, TransactionLog,
 };
 
 /// Struct representing a validator in the staking contract.

--- a/primitives/mmr/src/mmr/proof.rs
+++ b/primitives/mmr/src/mmr/proof.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
 
-use nimiq_serde::{Deserialize, Serialize};
-
 use crate::{
     error::Error,
     hash::{Hash, Merge},
@@ -12,7 +10,11 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde-derive",
+    derive(nimiq_serde::Serialize, nimiq_serde::Deserialize)
+)]
 pub enum SizeProof<H: Merge, T: Hash<H>> {
     EmptyTree,
     SingleElement(u64, T),


### PR DESCRIPTION
- Fix feature compilation for the following crates:
  - `bls`
  - `mmr` primitives.
- Remove a duplicate dev dependency in the `collections` crate.
- Fix some compilation warnings in the `accounts` primitives crate when the `interaction-traits` feature is disabled.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
