### PR TITLE
Allow to define inactive validators and stake

### DIFF
--- a/consensus/tests/request_component.rs
+++ b/consensus/tests/request_component.rs
@@ -32,6 +32,9 @@ async fn test_request_component() {
             sgn_key.public,
             vtn_key.public_key,
             Address::default(),
+            None,
+            None,
+            false,
         )
         .generate(env)
         .unwrap();

--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -62,6 +62,10 @@ pub struct GenesisValidator {
     pub signing_key: SchnorrPublicKey,
     pub voting_key: BlsPublicKey,
     pub reward_address: Address,
+    pub inactive_from: Option<u32>,
+    pub jailed_from: Option<u32>,
+    #[serde(default)]
+    pub retired: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -69,6 +73,9 @@ pub struct GenesisStaker {
     pub staker_address: Address,
     pub balance: Coin,
     pub delegation: Address,
+    #[serde(default)]
+    pub inactive_balance: Coin,
+    pub inactive_from: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -165,12 +165,18 @@ impl GenesisBuilder {
         signing_key: SchnorrPublicKey,
         voting_key: BlsPublicKey,
         reward_address: Address,
+        inactive_from: Option<u32>,
+        jailed_from: Option<u32>,
+        retired: bool,
     ) -> &mut Self {
         self.validators.push(config::GenesisValidator {
             validator_address,
             signing_key,
             voting_key,
             reward_address,
+            inactive_from,
+            jailed_from,
+            retired,
         });
         self
     }
@@ -180,11 +186,15 @@ impl GenesisBuilder {
         staker_address: Address,
         validator_address: Address,
         balance: Coin,
+        inactive_balance: Coin,
+        inactive_from: Option<u32>,
     ) -> &mut Self {
         self.stakers.push(config::GenesisStaker {
             staker_address,
             balance,
             delegation: validator_address,
+            inactive_balance,
+            inactive_from,
         });
         self
     }
@@ -402,6 +412,9 @@ impl GenesisBuilder {
                 validator.reward_address.clone(),
                 None,
                 deposit,
+                validator.inactive_from,
+                validator.jailed_from,
+                validator.retired,
                 &mut TransactionLog::empty(),
             )?;
         }
@@ -412,6 +425,8 @@ impl GenesisBuilder {
                 &staker.staker_address,
                 staker.balance,
                 Some(staker.delegation.clone()),
+                staker.inactive_balance,
+                staker.inactive_from,
                 &mut TransactionLog::empty(),
             )?;
         }

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -322,6 +322,9 @@ async fn push_same_tx_twice() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -440,6 +443,9 @@ async fn push_tx_with_wrong_signature() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -511,6 +517,9 @@ async fn mempool_get_txn_max_size() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -592,6 +601,9 @@ async fn mempool_get_txn_ordered() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -674,6 +686,9 @@ async fn push_tx_with_insufficient_balance() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -746,6 +761,9 @@ async fn multiple_transactions_multiple_senders() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -828,6 +846,9 @@ async fn mempool_tps() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     // Generate the genesis and blockchain
@@ -916,6 +937,9 @@ async fn multiple_start_stop() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     // Generate the genesis and blockchain
@@ -1062,6 +1086,9 @@ async fn mempool_update() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     // Generate the genesis and blockchain
@@ -1189,6 +1216,9 @@ async fn mempool_update_aged_transaction() {
         signing_key().public,
         voting_key().public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     // Generate the genesis and blockchain
@@ -1336,6 +1366,9 @@ async fn mempool_update_not_enough_balance() {
         signing_key().public,
         voting_key().public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     // Generate the genesis and blockchain
@@ -1492,6 +1525,9 @@ async fn mempool_update_pruned_account() {
         signing_key().public,
         voting_key().public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     // Generate the genesis and blockchain
@@ -1699,6 +1735,9 @@ async fn mempool_regular_and_control_tx() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -1836,6 +1875,9 @@ async fn applies_total_tx_size_limits() {
         SchnorrPublicKey::from([0u8; 32]),
         BlsKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();

--- a/pow-migration/src/state/mod.rs
+++ b/pow-migration/src/state/mod.rs
@@ -246,6 +246,9 @@ pub async fn get_validators(
                         signing_key,
                         voting_key,
                         reward_address: address.clone(),
+                        inactive_from: None,
+                        jailed_from: None,
+                        retired: false,
                     },
                 };
                 log::debug!(%address, "Found possible validator");
@@ -315,6 +318,8 @@ pub async fn get_stakers(
                 staker_address: validator.validator.validator_address.clone(),
                 balance: validator.balance - Coin::from_u64_unchecked(VALIDATOR_DEPOSIT),
                 delegation: validator.validator.validator_address.clone(),
+                inactive_balance: Coin::ZERO,
+                inactive_from: None,
             })
         }
     }
@@ -346,6 +351,8 @@ pub async fn get_stakers(
                                         staker_address,
                                         balance: stake,
                                         delegation: validator.validator.validator_address.clone(),
+                                        inactive_balance: Coin::ZERO,
+                                        inactive_from: None,
                                     });
                                 } else {
                                     log::error!(

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -75,6 +75,8 @@ impl StakingContract {
         staker_address: &Address,
         value: Coin,
         delegation: Option<Address>,
+        inactive_balance: Coin,
+        inactive_from: Option<u32>,
         tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         // See if the staker already exists.
@@ -93,8 +95,8 @@ impl StakingContract {
         let staker = Staker {
             address: staker_address.clone(),
             balance: value,
-            inactive_balance: Coin::ZERO,
-            inactive_from: None,
+            inactive_balance,
+            inactive_from,
             delegation,
         };
 

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -88,6 +88,9 @@ impl AccountTransactionInteraction for StakingContract {
                     reward_address,
                     signal_data,
                     transaction.value,
+                    None,
+                    None,
+                    false,
                     tx_logger,
                 )
                 .map(|_| None)
@@ -167,6 +170,8 @@ impl AccountTransactionInteraction for StakingContract {
                     &staker_address,
                     transaction.value,
                     delegation,
+                    Coin::ZERO,
+                    None,
                     tx_logger,
                 )
                 .map(|_| None)

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -121,6 +121,9 @@ impl StakingContract {
         reward_address: Address,
         signal_data: Option<Blake2bHash>,
         deposit: Coin,
+        inactive_from: Option<u32>,
+        jailed_from: Option<u32>,
+        retired: bool,
         tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         // Fail if the validator already exists.
@@ -147,16 +150,18 @@ impl StakingContract {
             total_stake: deposit,
             deposit,
             num_stakers: 0,
-            inactive_from: None,
-            jailed_from: None,
-            retired: false,
+            inactive_from,
+            jailed_from,
+            retired,
         };
 
         // Update our balance.
         self.balance += deposit;
 
-        self.active_validators
-            .insert(validator_address.clone(), validator.total_stake);
+        if !retired && inactive_from.is_none() {
+            self.active_validators
+                .insert(validator_address.clone(), validator.total_stake);
+        }
 
         tx_logger.push_log(Log::CreateValidator {
             validator_address: validator_address.clone(),

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -447,6 +447,9 @@ fn accounts_performance() {
         PublicKey::from([0u8; 32]),
         BLSKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -566,6 +569,9 @@ fn accounts_performance_history_sync_batches_single_sender() {
         PublicKey::from([0u8; 32]),
         BLSKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
@@ -691,6 +697,9 @@ fn accounts_performance_history_sync_batches_many_to_many() {
         PublicKey::from([0u8; 32]),
         BLSKeyPair::generate(&mut rng).public_key,
         Address::default(),
+        None,
+        None,
+        false,
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -183,6 +183,9 @@ fn make_sample_contract(
             validator_address.clone(),
             None,
             Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+            None,
+            None,
+            false,
             &mut TransactionLog::empty(),
         )
         .unwrap();
@@ -194,6 +197,8 @@ fn make_sample_contract(
                 &staker_address,
                 Coin::from_u64_unchecked(staker_active_balance),
                 Some(validator_address.clone()),
+                Coin::ZERO,
+                None,
                 &mut TransactionLog::empty(),
             )
             .unwrap();

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -380,6 +380,9 @@ fn update_staker_works() {
             validator_address2.clone(),
             None,
             Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+            None,
+            None,
+            false,
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");
@@ -701,6 +704,9 @@ fn update_staker_with_stake_reactivation_works() {
             validator_address2.clone(),
             None,
             Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+            None,
+            None,
+            false,
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");
@@ -1826,6 +1832,9 @@ fn update_staker_jail_interaction() {
             validator_address2.clone(),
             None,
             Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+            None,
+            None,
+            false,
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");
@@ -1946,6 +1955,9 @@ fn can_only_redelegate_after_release() {
             validator_address2.clone(),
             None,
             Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+            None,
+            None,
+            false,
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");
@@ -2024,6 +2036,9 @@ fn cannot_redelegate_while_having_active_stake() {
             validator_address2.clone(),
             None,
             Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+            None,
+            None,
+            false,
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -760,6 +760,9 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 Address::from(&validator_key_pair),
                 None,
                 deposit,
+                None,
+                None,
+                false,
                 &mut TransactionLog::empty(),
             )
             .expect("Failed to create validator");
@@ -797,6 +800,8 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 &Address::from(&staker_key_pair),
                 balance,
                 Some(Address::from(&validator_key_pair)),
+                Coin::ZERO,
+                None,
                 &mut TransactionLog::empty(),
             )
             .expect("Failed to create staker");

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -92,6 +92,9 @@ where
             signing_keys[i].public,
             voting_keys[i].public_key,
             Address::default(),
+            None,
+            None,
+            false,
         );
     }
     let genesis = genesis_builder.generate(env).unwrap();

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -53,6 +53,9 @@ async fn one_validator_can_create_micro_blocks() {
             signing_key.public,
             voting_key.public_key,
             Address::default(),
+            None,
+            None,
+            false,
         )
         .generate(env)
         .unwrap();


### PR DESCRIPTION
- Change the `genesis-builder` types to be able to extract extra data from the TOML file for validators and stakers.
- Change the signature of the staking contract for validator and staker creation such that it can receive extra parameters to create inactive validators and stake.

This closes #1852.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
