### PR TITLE
Inferior chain macro block verification

### DIFF
--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -99,6 +99,8 @@ pub enum PushError {
     InvalidHistoricTransaction,
     #[error("Proof for equivocation already included")]
     EquivocationAlreadyIncluded(EquivocationLocator),
+    #[error("Accounts trie is incomplete and thus cannot be verified.")]
+    IncompleteAccountsTrie,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]

--- a/blockchain/src/blockchain/mod.rs
+++ b/blockchain/src/blockchain/mod.rs
@@ -5,6 +5,7 @@ pub mod blockchain;
 pub mod history_sync;
 pub mod inherents;
 pub mod push;
+pub(super) mod rebranch_utils;
 pub mod slots;
 pub mod verify;
 pub mod wrappers;

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -519,8 +519,11 @@ impl Blockchain {
         let mut fork_iter = fork_chain.iter().rev();
 
         while let Some(fork_block) = fork_iter.next() {
-            let mut block_logger =
-                BlockLogger::new_reverted(fork_block.0.clone(), fork_block.1.head.block_number());
+            let mut block_logger = BlockLogger::new_applied(
+                fork_block.0.clone(),
+                fork_block.1.head.block_number(),
+                fork_block.1.head.timestamp(),
+            );
 
             match this.check_and_commit(
                 &this.state,

--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -1,0 +1,261 @@
+use std::error::Error;
+
+use nimiq_account::{BlockLog, BlockLogger};
+use nimiq_blockchain_interface::{ChainInfo, PushError};
+use nimiq_database::{TransactionProxy, WriteTransactionProxy};
+use nimiq_hash::Blake2bHash;
+use nimiq_primitives::trie::trie_diff::TrieDiff;
+
+use crate::Blockchain;
+
+impl Blockchain {
+    /// Finds the common ancestor between the current main chain in the context of `txn` and the fork chain given by
+    /// its chain info and the block hash.
+    ///
+    /// Returns the common ancestor as .0 and the chain leading to the common ancestor backwards from `block_hash` as .1
+    /// The block with `block_hash` is included.
+    pub(super) fn find_common_ancestor(
+        &self,
+        block_hash: Blake2bHash,
+        chain_info: ChainInfo,
+        diff: Option<TrieDiff>,
+        txn: &TransactionProxy,
+    ) -> Result<
+        (
+            (Blake2bHash, ChainInfo, Option<TrieDiff>),
+            Vec<(Blake2bHash, ChainInfo, Option<TrieDiff>)>,
+        ),
+        PushError,
+    > {
+        // Walk up the fork chain until we find a block that is part of the main chain.
+        // Store the chain along the way
+        let target = chain_info.head.header();
+
+        // Collects the chain on the way back to the common ancestor
+        let mut fork_chain = vec![];
+
+        // Keeps track of the currently investigated block
+        let mut current: (Blake2bHash, ChainInfo, Option<TrieDiff>) =
+            (block_hash, chain_info, diff);
+
+        // Check if the currently checked block is on main chain. If so it is the common ancestor.
+        while !current.1.on_main_chain {
+            // If not keep on moving backwards so get the prev hash
+            let prev_hash = current.1.head.parent_hash().clone();
+
+            // Using the prev hash get the chain info of the previous block
+            let prev_info = self
+                .chain_store
+                .get_chain_info(&prev_hash, true, Some(txn))
+                .expect("Corrupted store: Failed to find fork predecessor while rebranching");
+
+            // Get the prev diff for that block as well.
+            let prev_diff = self
+                .chain_store
+                .get_accounts_diff(&prev_hash, Some(txn))
+                .ok();
+
+            // Store the current block as part of the fork
+            fork_chain.push(current);
+
+            // Update with the information regarding the previous block
+            current = (prev_hash, prev_info, prev_diff);
+        }
+
+        // Check if ancestor is in current batch.
+        if current.1.head.block_number() < self.state.macro_info.head.block_number() {
+            warn!(
+                block = %target,
+                reason = "ancestor block already finalized",
+                ancestor_block = %current.1.head,
+                "Rejecting block",
+            );
+            return Err(PushError::InvalidFork);
+        }
+
+        // Return the ancestor and the part of the chain used to get there.
+        Ok((current, fork_chain))
+    }
+
+    /// Reverts all blocks until the common ancestor given as an argument is reached.
+    /// After that applies all blocks given as target_chain in reverse order or until a block fails
+    /// to be applied.
+    ///
+    /// Returns the reverted chain as `.1` and the block logs as `.2` or the blocks which are on a faulty fork.
+    /// It does _not_ deal with the faulty blocks.
+    pub(super) fn rebranch_to(
+        &self,
+        target_chain: &mut Vec<(Blake2bHash, ChainInfo, Option<TrieDiff>)>,
+        ancestor: &mut (Blake2bHash, ChainInfo, Option<TrieDiff>),
+        write_txn: &mut WriteTransactionProxy,
+    ) -> Result<
+        (Vec<(Blake2bHash, ChainInfo)>, Vec<BlockLog>),
+        Vec<(Blake2bHash, ChainInfo, Option<TrieDiff>)>,
+    > {
+        // Keeps track of the currently investigated block
+        let mut current = (self.state.head_hash.clone(), self.state.main_chain.clone());
+        // Collects the reverted blocks
+        let mut revert_chain: Vec<(Blake2bHash, ChainInfo)> = vec![];
+        // Keep track of block logs
+        let mut block_logs = vec![];
+
+        // Start reverting blocks until the common ancestor is reached.
+        while current.0 != ancestor.0 {
+            let block = current.1.head.clone();
+
+            // Macro blocks cannot be reverted.
+            if block.is_macro() {
+                panic!("Trying to rebranch across macro block {block}");
+            }
+
+            // Retrieve the predecessor for later use.
+            let prev_hash = block.parent_hash().clone();
+            let prev_info = self
+                .chain_store
+                .get_chain_info(&prev_hash, true, Some(write_txn))
+                .expect("Corrupted store: Failed to find main chain predecessor while rebranching");
+
+            // If previously a part of the accounts tree was missing the corresponding chunk must be reverted as well.
+            if let Some(ref prev_missing_range) = current.1.prev_missing_range {
+                self.state
+                    .accounts
+                    .revert_chunk(&mut write_txn.into(), prev_missing_range.start.clone())
+                    .map_err(|error| {
+                        warn!(
+                            %block,
+                            chain_info = ?current.1,
+                            ?error,
+                            "Failed to revert chunk while rebranching",
+                        );
+                        // The revert failed, but there are no blocks to remove.
+                        vec![]
+                    })?;
+            }
+
+            // Keep track of the logs for the upcoming revert
+            let mut block_logger = BlockLogger::new_reverted(block.hash(), block.block_number());
+            // Revert the accounts
+            let total_tx_size = self
+                .revert_accounts(
+                    &self.state.accounts,
+                    &mut write_txn.into(),
+                    &block,
+                    &mut block_logger,
+                )
+                .map_err(|error| {
+                    warn!(
+                        %block,
+                        chain_info = ?current.1,
+                        ?error,
+                        "Failed to revert accounts while rebranching",
+                    );
+                    // The revert failed, but there are no blocks to remove.
+                    vec![]
+                })?;
+            // Push the collected revert logs into the block logs collection.
+            block_logs.push(block_logger.build(total_tx_size));
+
+            // Verify accounts hash if the tree is complete or changes only happened in the complete part.
+            if let Some(accounts_hash) = self.state.accounts.get_root_hash(Some(write_txn)) {
+                assert_eq!(
+                    prev_info.head.state_root(),
+                    &accounts_hash,
+                    "Inconsistent state after reverting block {} - {:?}",
+                    block,
+                    block,
+                );
+            }
+
+            // Block was reverted, add it to the reverted chain collection.
+            revert_chain.push(current);
+
+            // Continue with the predecessor.
+            current = (prev_hash, prev_info);
+        }
+        // Revert to common ancestor is done.
+
+        // Next, push each block of the target chain.
+
+        // Pushing must happen in reverse.
+        let mut target_chain_iter = target_chain.iter().rev();
+
+        while let Some(block) = target_chain_iter.next() {
+            // Collect logs for the upcoming push.
+            let mut block_logger = BlockLogger::new_applied(
+                block.0.clone(),
+                block.1.head.block_number(),
+                block.1.head.timestamp(),
+            );
+
+            // Push the block
+            match self.check_and_commit(
+                &self.state,
+                &block.1.head,
+                block.2.clone(),
+                write_txn,
+                &mut block_logger,
+            ) {
+                Ok(total_tx_size)
+                    // push the logs into the logs collection
+                    => block_logs.push(block_logger.build(total_tx_size)),
+                Err(e) => {
+                    // If a block fails to apply here it does not verify fully.
+                    // This block and all blocks after this thus should be removed from the store
+                    // as they are not verifying. 
+                    warn!(
+                        block = %block.1.head,
+                        reason = "failed to apply fork block while rebranching",
+                        fork_block = %block.1.head,
+                        error = &e as &dyn Error,
+                        "Rejecting block",
+                    );
+
+                    // Since a write txn is open which cannot be closed the vec of the to-be-removed
+                    // blocks is returned so the caller side can deal with it.
+                    let remove_chain = vec![block.clone()]
+                        .into_iter()
+                        .chain(target_chain_iter.cloned())
+                        .collect();
+                    return Err(remove_chain);
+                }
+            }
+        }
+
+        // Unset on_main_chain flag / main_chain_successor on the current main chain up to (excluding) the common ancestor.
+        for reverted_block in revert_chain.iter_mut() {
+            reverted_block.1.on_main_chain = false;
+            reverted_block.1.main_chain_successor = None;
+
+            self.chain_store
+                .put_chain_info(write_txn, &reverted_block.0, &reverted_block.1, false);
+        }
+
+        // Update the main_chain_successor of the common ancestor block.
+        ancestor.1.main_chain_successor = Some(target_chain.last().unwrap().0.clone());
+        self.chain_store
+            .put_chain_info(write_txn, &ancestor.0, &ancestor.1, false);
+
+        // Set on_main_chain flag / main_chain_successor on the fork.
+        for i in (0..target_chain.len()).rev() {
+            let main_chain_successor = if i > 0 {
+                Some(target_chain[i - 1].0.clone())
+            } else {
+                None
+            };
+
+            let fork_block = &mut target_chain[i];
+            fork_block.1.on_main_chain = true;
+            fork_block.1.main_chain_successor = main_chain_successor;
+
+            // Include the body of the new block (at position 0).
+            self.chain_store
+                .put_chain_info(write_txn, &fork_block.0, &fork_block.1, i == 0);
+        }
+
+        // Update the head.
+        let new_head_hash = &target_chain[0].0;
+        self.chain_store.set_head(write_txn, new_head_hash);
+
+        Ok((revert_chain, block_logs))
+    }
+}

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -102,7 +102,7 @@ pub trait Protocol: Clone + Send + Sync + Unpin + Sized + 'static {
     ) -> Self::ProposalSignature;
 
     /// Verifies a given `proposal`. Optionally a precomputed `precalculated_inherent` can be provided if the inherent has been computed before.
-    /// as well as all checks can be skipped except for the signature verification.
+    /// All checks except for the signature verification can be skipped using the `signature_only` flag
     fn verify_proposal(
         &self,
         proposal: &SignedProposalMessage<Self::Proposal, Self::ProposalSignature>,

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -5,5 +5,5 @@ pub mod aggregation;
 mod jail;
 mod r#macro;
 mod micro;
-mod tendermint;
+pub mod tendermint;
 pub mod validator;

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_network_libp2p::Network;
+use nimiq_network_mock::MockHub;
+use nimiq_primitives::policy::Policy;
+use nimiq_tendermint::{ProposalMessage, Protocol, SignedProposalMessage};
+use nimiq_test_log::test;
+use nimiq_test_utils::{block_production::TemporaryBlockProducer, test_network::TestNetwork};
+use nimiq_validator::{aggregation::tendermint::proposal::Header, tendermint::TendermintProtocol};
+use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
+
+#[test(tokio::test)]
+async fn it_verifies_inferior_chain_proposals() {
+    let temp_producer1 = TemporaryBlockProducer::default();
+    let temp_producer2 = TemporaryBlockProducer::default();
+    let blockchain1 = Arc::clone(&temp_producer1.blockchain);
+    let blockchain2 = Arc::clone(&temp_producer2.blockchain);
+
+    // Progress until there are 2 micro blocks left before the macro block
+    for _ in 0..Policy::blocks_per_batch() - 3 {
+        let block = temp_producer1.next_block(vec![], false);
+        temp_producer2
+            .push(block)
+            .expect("Should be able to push block");
+    }
+
+    assert_eq!(
+        Policy::macro_block_after(blockchain1.read().head().block_number()),
+        blockchain1.read().head().block_number() + 3,
+    );
+    assert_eq!(
+        Policy::macro_block_after(blockchain2.read().head().block_number()),
+        blockchain2.read().head().block_number() + 3,
+    );
+
+    // create but do not push a skip block to move all subsequent micro blocks to inferior chain.
+    let first_skip_block = temp_producer1.next_block_no_push(vec![], true);
+    // produce the next 2 micro blocks and push them such that the next block is a macro block.
+    let second_to_last1 = temp_producer1.next_block(vec![], false);
+    let second_to_last2 = temp_producer1.next_block(vec![], false);
+    // create a proposal for the macro block, but do not produce a block.
+    let inf_proposal1 = {
+        let b = blockchain1.read();
+        temp_producer1.producer.next_macro_block_proposal(
+            &*b,
+            b.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            0,
+            vec![],
+        )
+    };
+    // Use the skip block to rebranch the micro blocks away, effectively leaving the proposal on an inferior chain.
+    // This chain has 2 blocks differ from the main chain preceding the macro block.
+    temp_producer1
+        .push(first_skip_block.clone())
+        .expect("Pushing skip block should succeed.");
+    temp_producer2
+        .push(first_skip_block)
+        .expect("Pushing skip block should succeed.");
+
+    assert_eq!(
+        Policy::macro_block_after(blockchain1.read().head().block_number()),
+        blockchain1.read().head().block_number() + 2,
+    );
+    assert_eq!(
+        Policy::macro_block_after(blockchain2.read().head().block_number()),
+        blockchain2.read().head().block_number() + 2,
+    );
+
+    // Create but don't push another skip block to move the subsequent micro block to an inferior chain
+    let second_skip_block = temp_producer1.next_block_no_push(vec![], true);
+    // create the micro block and push it such that the next block is a macro block.
+    let last = temp_producer1.next_block(vec![], false);
+    // create a macro block proposal, but do not produce a block.
+    let inf_proposal2 = {
+        let b = blockchain1.read();
+        temp_producer1.producer.next_macro_block_proposal(
+            &*b,
+            b.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            0,
+            vec![],
+        )
+    };
+
+    // use the skip block to move the proposal to inferior chain.
+    temp_producer1
+        .push(second_skip_block.clone())
+        .expect("Pushing skip block should succeed.");
+    temp_producer2
+        .push(second_skip_block)
+        .expect("Pushing skip block should succeed.");
+
+    assert_eq!(
+        Policy::macro_block_after(blockchain1.read().head().block_number()),
+        blockchain1.read().head().block_number() + 1,
+    );
+    assert_eq!(
+        Policy::macro_block_after(blockchain2.read().head().block_number()),
+        blockchain2.read().head().block_number() + 1,
+    );
+
+    // Finally create a proposal on main chain
+    let main_chain_proposal = {
+        let b = blockchain1.read();
+        temp_producer1.producer.next_macro_block_proposal(
+            &*b,
+            b.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            0,
+            vec![],
+        )
+    };
+
+    // blockchain2 here has not seen any of the inferior micro blocks nor any of the proposals.
+
+    // Create TendermintProtocol for blockchain2
+    let current_validators = blockchain1.read().current_validators().unwrap();
+    let hub = MockHub::default();
+    let nw: Arc<Network> = TestNetwork::build_network(0, Default::default(), &mut Some(hub)).await;
+    let val_net = Arc::new(ValidatorNetworkImpl::new(nw));
+    let interface = TendermintProtocol::new(
+        Arc::clone(&blockchain2),
+        val_net,
+        temp_producer2.producer.clone(),
+        current_validators,
+        0,
+        blockchain2.read().head().block_number() + 1,
+    );
+
+    // Make sure the main chain proposal is acceptable.
+    let main_chain_msg = ProposalMessage {
+        round: 0,
+        valid_round: None,
+        proposal: Header(main_chain_proposal.header, None),
+    };
+    let main_chain_sig = interface.sign_proposal(&main_chain_msg);
+    let message = SignedProposalMessage {
+        message: main_chain_msg,
+        signature: main_chain_sig,
+    };
+
+    assert!(interface.verify_proposal(&message, None, false).is_ok());
+
+    // Make sure the second inferior chain proposal is not acceptable without the micro block
+    let inf_chain2 = ProposalMessage {
+        round: 0,
+        valid_round: None,
+        proposal: Header(inf_proposal2.header, None),
+    };
+    let inf_chain2_sig = interface.sign_proposal(&inf_chain2);
+    let message: SignedProposalMessage<Header<_>, _> = SignedProposalMessage {
+        message: inf_chain2,
+        signature: inf_chain2_sig,
+    };
+    assert!(interface.verify_proposal(&message, None, false).is_err());
+
+    // push the micro block and then make sure the proposal is ok
+    temp_producer2
+        .push(last)
+        .expect("Pushing inferior micro block should succeed.");
+    let body = interface
+        .verify_proposal(&message, None, false)
+        .expect("Verification must succeed.");
+
+    assert_eq!(inf_proposal2.body.expect(""), body.0);
+
+    // Make sure the first inferior chain proposal is not acceptable without both the micro blocks
+    let inf_chain1 = ProposalMessage {
+        round: 0,
+        valid_round: None,
+        proposal: Header(inf_proposal1.header.clone(), None),
+    };
+    let inf_chain1_sig = interface.sign_proposal(&inf_chain1);
+    let message: SignedProposalMessage<Header<_>, _> = SignedProposalMessage {
+        message: inf_chain1.clone(),
+        signature: inf_chain1_sig,
+    };
+    assert!(interface.verify_proposal(&message, None, false).is_err());
+
+    temp_producer2
+        .push(second_to_last1)
+        .expect("Pushing inferior micro block should succeed.");
+    assert!(interface.verify_proposal(&message, None, false).is_err());
+
+    temp_producer2
+        .push(second_to_last2)
+        .expect("Pushing inferior micro block should succeed.");
+
+    // After the last micro block is pushed the proposal should verify
+    // The calculated body should match the one given by block production itself.
+    let body = interface
+        .verify_proposal(&message, None, false)
+        .expect("Verification must succeed.");
+    assert_eq!(inf_proposal1.body.clone().expect(""), body.0);
+}


### PR DESCRIPTION
This PR adds the ability to verify a macro block proposal whose predecessor is no longer on the main chain (i.e it was rebranched by a skip block in its place). Prior to this the state verification would fail, as the state was not altered from main chain head to the actual predecessor of the macro block.

Macro blocks with a non main chain predecessor are not invalid and thus their verification must succeed, given the micro blocks leading up to it.