### PR TITLE
ci: Upgrade GH actions docker dependencies

### DIFF
--- a/.github/workflows/github_release_docker.yml
+++ b/.github/workflows/github_release_docker.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Download nimiq client artifact from previous job
         uses: actions/download-artifact@v3
         with:
@@ -53,21 +53,21 @@ jobs:
           chmod -R +x target/release/
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: latest=true
 
       - name: Login to image repository
         if: github.ref_type == 'tag'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
         with:
           context: .
           file: Dockerfile.prod


### PR DESCRIPTION
- Bumps [docker/metadata-action](https://github.com/docker/metadata-action) from 4 to 5.
  - [Release notes](https://github.com/docker/metadata-action/releases)
  - [Upgrade guide](https://github.com/docker/metadata-action/blob/master/UPGRADE.md)
  - [Commits](https://github.com/docker/metadata-action/compare/v4...v5)
- Bumps [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) from 2 to 3.
  - [Release notes](https://github.com/docker/setup-buildx-action/releases)
  - [Commits](https://github.com/docker/setup-buildx-action/compare/v2...v3)
- Bumps [docker/login-action](https://github.com/docker/login-action) from 2 to 3.
  - [Release notes](https://github.com/docker/login-action/releases)
  - [Commits](https://github.com/docker/login-action/compare/v2...v3)
- Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 4.2.1 to 5.0.0.
  - [Release notes](https://github.com/docker/build-push-action/releases)
  - [Commits](https://github.com/docker/build-push-action/compare/0a97817b6ade9f46837855d676c4cca3a2471fc9...0565240e2d4ab88bba5387d719585280857ece09)

This closes #1850, closes #1849, closes #1848 and closes #1847.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
