### PR TITLE
Fix signing of InStaking transaction with web-client's WASM API

### DIFF
--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -10,58 +10,56 @@ mod transaction;
 mod utils;
 
 #[cfg(test)]
-use wasm_bindgen::JsValue;
-#[cfg(test)]
-use wasm_bindgen_test::wasm_bindgen_test;
+mod tests {
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
-#[cfg(test)]
-use crate::{
-    address::Address,
-    primitives::{
-        bls_key_pair::BLSKeyPair, key_pair::KeyPair, transaction_builder::TransactionBuilder,
-    },
-};
+    use crate::{
+        address::Address,
+        primitives::{
+            bls_key_pair::BLSKeyPair, key_pair::KeyPair, transaction_builder::TransactionBuilder,
+        },
+    };
 
-#[cfg(test)]
-#[wasm_bindgen_test]
-pub fn it_can_create_and_sign_basic_transactions() {
-    let keypair = KeyPair::generate();
+    #[wasm_bindgen_test]
+    pub fn it_can_create_and_sign_basic_transactions() {
+        let keypair = KeyPair::generate();
 
-    let mut tx = TransactionBuilder::new_basic(
-        &keypair.to_address(),
-        &Address::from_string("0000000000000000000000000000000000000000")
-            .map_err(JsValue::from)
-            .unwrap(),
-        100_00000,
-        None,
-        1,
-        5,
-    )
-    .map_err(JsValue::from)
-    .unwrap();
+        let mut tx = TransactionBuilder::new_basic(
+            &keypair.to_address(),
+            &Address::from_string("0000000000000000000000000000000000000000")
+                .map_err(JsValue::from)
+                .unwrap(),
+            100_00000,
+            None,
+            1,
+            5,
+        )
+        .map_err(JsValue::from)
+        .unwrap();
 
-    tx.sign(&keypair).map_err(JsValue::from).unwrap();
-    assert_eq!(tx.verify(None).map_err(JsValue::from), Ok(()))
-}
+        tx.sign(&keypair).map_err(JsValue::from).unwrap();
+        assert_eq!(tx.verify(None).map_err(JsValue::from), Ok(()))
+    }
 
-#[cfg(test)]
-#[wasm_bindgen_test]
-pub fn it_can_create_and_sign_validator_transactions() {
-    let keypair = KeyPair::generate();
+    #[wasm_bindgen_test]
+    pub fn it_can_create_and_sign_validator_transactions() {
+        let keypair = KeyPair::generate();
 
-    let mut tx = TransactionBuilder::new_create_validator(
-        &keypair.to_address(),
-        &keypair.to_address(),
-        &keypair.public_key(),
-        &BLSKeyPair::generate(),
-        None,
-        None,
-        1,
-        5,
-    )
-    .map_err(JsValue::from)
-    .unwrap();
+        let mut tx = TransactionBuilder::new_create_validator(
+            &keypair.to_address(),
+            &keypair.to_address(),
+            &keypair.public_key(),
+            &BLSKeyPair::generate(),
+            None,
+            None,
+            1,
+            5,
+        )
+        .map_err(JsValue::from)
+        .unwrap();
 
-    tx.sign(&keypair).map_err(JsValue::from).unwrap();
-    assert_eq!(tx.verify(None).map_err(JsValue::from), Ok(()))
+        tx.sign(&keypair).map_err(JsValue::from).unwrap();
+        assert_eq!(tx.verify(None).map_err(JsValue::from), Ok(()))
+    }
 }

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -8,3 +8,60 @@ mod client_configuration;
 mod primitives;
 mod transaction;
 mod utils;
+
+#[cfg(test)]
+use wasm_bindgen::JsValue;
+#[cfg(test)]
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[cfg(test)]
+use crate::{
+    address::Address,
+    primitives::{
+        bls_key_pair::BLSKeyPair, key_pair::KeyPair, transaction_builder::TransactionBuilder,
+    },
+};
+
+#[cfg(test)]
+#[wasm_bindgen_test]
+pub fn it_can_create_and_sign_basic_transactions() {
+    let keypair = KeyPair::generate();
+
+    let mut tx = TransactionBuilder::new_basic(
+        &keypair.to_address(),
+        &Address::from_string("0000000000000000000000000000000000000000")
+            .map_err(JsValue::from)
+            .unwrap(),
+        100_00000,
+        None,
+        1,
+        5,
+    )
+    .map_err(JsValue::from)
+    .unwrap();
+
+    tx.sign(&keypair).map_err(JsValue::from).unwrap();
+    assert_eq!(tx.verify(None).map_err(JsValue::from), Ok(()))
+}
+
+#[cfg(test)]
+#[wasm_bindgen_test]
+pub fn it_can_create_and_sign_validator_transactions() {
+    let keypair = KeyPair::generate();
+
+    let mut tx = TransactionBuilder::new_create_validator(
+        &keypair.to_address(),
+        &keypair.to_address(),
+        &keypair.public_key(),
+        &BLSKeyPair::generate(),
+        None,
+        None,
+        1,
+        5,
+    )
+    .map_err(JsValue::from)
+    .unwrap();
+
+    tx.sign(&keypair).map_err(JsValue::from).unwrap();
+    assert_eq!(tx.verify(None).map_err(JsValue::from), Ok(()))
+}

--- a/web-client/src/primitives/transaction_builder.rs
+++ b/web-client/src/primitives/transaction_builder.rs
@@ -268,8 +268,8 @@ impl TransactionBuilder {
     pub fn new_create_validator(
         sender: &Address,
         reward_address: &Address,
-        signing_key: PublicKey,
-        voting_key_pair: BLSKeyPair,
+        signing_key: &PublicKey,
+        voting_key_pair: &BLSKeyPair,
         signal_data: Option<String>,
         fee: Option<u64>,
         validity_start_height: u32,
@@ -280,7 +280,7 @@ impl TransactionBuilder {
         let mut recipient = Recipient::new_staking_builder();
         recipient.create_validator(
             *signing_key.native_ref(),
-            &voting_key_pair.native_ref().clone(),
+            voting_key_pair.native_ref(),
             reward_address.native_ref().clone(),
             native_signal_data,
         );
@@ -377,8 +377,6 @@ impl TransactionBuilder {
     }
 
     // pub fn new_reactivate_validator()
-
-    // pub fn new_unpark_validator()
 
     /// Deleted a validator the staking contract. The deposit is returned to the Sender
     ///

--- a/web-client/src/primitives/transaction_builder.rs
+++ b/web-client/src/primitives/transaction_builder.rs
@@ -275,8 +275,7 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: u8,
     ) -> Result<Transaction, JsError> {
-        let native_signal_data: Option<Blake2bHash> =
-            signal_data.map(|r| Blake2bHash::from_str(&r).unwrap());
+        let native_signal_data = signal_data.map(|r| Blake2bHash::from_str(&r).unwrap());
         let mut recipient = Recipient::new_staking_builder();
         recipient.create_validator(
             *signing_key.native_ref(),
@@ -315,15 +314,11 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: u8,
     ) -> Result<Transaction, JsError> {
-        let native_signal_data: Option<Option<Blake2bHash>> =
-            signal_data.map(|r| Some(Blake2bHash::from_str(&r).unwrap()));
+        let native_signal_data = signal_data.map(|r| Some(Blake2bHash::from_str(&r).unwrap()));
         let mut recipient = Recipient::new_staking_builder();
-        let native_signing_key: Option<nimiq_keys::PublicKey> =
-            signing_key.map(|r| *r.native_ref());
-        let native_voting_key_pair: Option<nimiq_bls::KeyPair> =
-            voting_key_pair.map(|r| r.native_ref().clone());
-        let native_reward_address: Option<nimiq_keys::Address> =
-            reward_address.map(|r| r.native_ref().clone());
+        let native_signing_key = signing_key.map(|r| *r.native_ref());
+        let native_voting_key_pair = voting_key_pair.map(|r| r.native_ref().clone());
+        let native_reward_address = reward_address.map(|r| r.native_ref().clone());
 
         recipient.update_validator(
             native_signing_key,

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -316,19 +316,19 @@ impl Transaction {
     }
 
     /// The transaction's data as a byte array.
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = data)]
     pub fn recipient_data(&self) -> Vec<u8> {
         self.inner.recipient_data.clone()
     }
 
     /// Set the transaction's data
-    #[wasm_bindgen(setter)]
+    #[wasm_bindgen(setter, js_name = data)]
     pub fn set_recipient_data(&mut self, data: Vec<u8>) {
         self.inner.recipient_data = data;
     }
 
     /// The transaction's sender data as a byte array.
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = senderData)]
     pub fn sender_data(&self) -> Vec<u8> {
         self.inner.sender_data.clone()
     }
@@ -346,7 +346,7 @@ impl Transaction {
     }
 
     /// The transaction's byte size.
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = serializedSize)]
     pub fn serialized_size(&self) -> usize {
         self.inner.serialized_size()
     }


### PR DESCRIPTION
## What's in this pull request?

Fix signing of `InStaking` transactions with the web-client's WASM API.

#### This fixes #1879.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
