### PR TITLE
web-client: Add basic Merkle Tree and multisig APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,6 +4611,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-transaction",
  "nimiq-transaction-builder",
+ "nimiq-utils",
  "nimiq-zkp-component",
  "parking_lot 0.12.1",
  "serde",

--- a/primitives/transaction/src/signature_proof.rs
+++ b/primitives/transaction/src/signature_proof.rs
@@ -41,6 +41,7 @@ impl SignatureProof {
 
     pub fn try_from_webauthn(
         public_key: PublicKey,
+        merkle_path: Option<Blake2bMerklePath>,
         signature: Signature,
         authenticator_data: &[u8],
         client_data_json: &[u8],
@@ -116,7 +117,7 @@ impl SignatureProof {
 
         Ok(SignatureProof {
             public_key,
-            merkle_path: Blake2bMerklePath::empty(),
+            merkle_path: merkle_path.unwrap_or_default(),
             signature,
             webauthn_fields: Some(WebauthnExtraFields {
                 host,

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -49,6 +49,7 @@ nimiq-primitives = { workspace = true, features = ["coin", "networks", "ts-types
 nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true, features = ["ts-types"] }
 nimiq-transaction-builder = { workspace = true }
+nimiq-utils = { workspace = true, features = ["merkle"] }
 
 [dependencies.nimiq]
 package = "nimiq-lib"

--- a/web-client/src/primitives/merkle_tree.rs
+++ b/web-client/src/primitives/merkle_tree.rs
@@ -1,0 +1,42 @@
+use js_sys::Uint8Array;
+use nimiq_serde::Serialize;
+use nimiq_utils::merkle::compute_root_from_content;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// The Merkle tree is a data structure that allows for efficient verification of the membership of an element in a set.
+#[wasm_bindgen]
+pub struct MerkleTree;
+
+#[wasm_bindgen]
+impl MerkleTree {
+    /// Computes the root of a Merkle tree from a list of Uint8Arrays.
+    #[wasm_bindgen(js_name = computeRoot)]
+    pub fn compute_root(values: Vec<Uint8Array>) -> Vec<u8> {
+        let mut values: Vec<_> = values.iter().map(|u| u.to_vec()).collect();
+        values.sort_unstable();
+
+        let root = compute_root_from_content::<nimiq_hash::Blake2bHasher, Vec<u8>>(&values);
+        root.serialize_to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_sys::Uint8Array;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use crate::primitives::merkle_tree::MerkleTree;
+
+    #[wasm_bindgen_test]
+    pub fn it_computes_the_same_root_for_any_array_order() {
+        let value1 = Uint8Array::new_with_length(8);
+        value1.copy_from(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        let value2 = Uint8Array::new_with_length(8);
+        value2.copy_from(&[9, 10, 11, 12, 13, 14, 15, 16]);
+
+        let root_ordered = MerkleTree::compute_root(vec![value1.clone(), value2.clone()]);
+        let root_unordered = MerkleTree::compute_root(vec![value2.clone(), value1.clone()]);
+
+        assert_eq!(root_ordered, root_unordered);
+    }
+}

--- a/web-client/src/primitives/mod.rs
+++ b/web-client/src/primitives/mod.rs
@@ -5,6 +5,7 @@ pub mod es256_public_key;
 pub mod es256_signature;
 pub mod hash;
 pub mod key_pair;
+pub mod merkle_tree;
 pub mod private_key;
 pub mod public_key;
 pub mod signature;


### PR DESCRIPTION
## What's in this pull request?

Adds `MerkleTree` and `MerklePath` APIs to the web-client WASM library.

This is useful for basic 1-of-x "multi"sigs.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
