### PR TITLE
Fix Jail handling in extended transactions

### DIFF
--- a/primitives/transaction/src/extended_transaction.rs
+++ b/primitives/transaction/src/extended_transaction.rs
@@ -64,7 +64,7 @@ impl ExtendedTransaction {
 
         for inherent in inherents {
             match inherent {
-                Inherent::Penalize { .. } | Inherent::Reward { .. } => {
+                Inherent::Penalize { .. } | Inherent::Reward { .. } | Inherent::Jail { .. } => {
                     ext_txs.push(ExtendedTransaction {
                         network_id,
                         block_number,
@@ -72,7 +72,8 @@ impl ExtendedTransaction {
                         data: ExtTxData::Inherent(inherent),
                     })
                 }
-                _ => {}
+                // These special types of inherents do not generate extended transactions
+                Inherent::FinalizeBatch | Inherent::FinalizeEpoch => {}
             }
         }
 


### PR DESCRIPTION
The Jail inherent was not being handled when converting to extended transactions. 

...
#### This fixes #1897 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
