### PR TITLE
Update validity window flag on gaining consensus

### DIFF
--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -790,8 +790,7 @@ where
         while let Poll::Ready(Some(event)) = self.consensus_event_rx.poll_next_unpin(cx) {
             match event {
                 Ok(ConsensusEvent::Established) => {
-                    self.init();
-                    self.init_mempool();
+                    self.update_can_enforce_validity_window();
                 }
                 Ok(ConsensusEvent::Lost) => {
                     self.pause_validator();


### PR DESCRIPTION
This adds a missing update to the validity window flag when reaching consensus.

This fixes #1905 



- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
