### PR TITLE
Add metrics support for k8s in the devnet script

### DIFF
--- a/scripts/devnet/node.py
+++ b/scripts/devnet/node.py
@@ -404,6 +404,7 @@ class RegularNode(Node):
         genesis_filename = "dev-albatross.toml"
         int_genesis_file = f"{int_genesis_dir}/{genesis_filename}"
         filename = self.topology_settings.get_node_k8s_dir(self.name)
+        enable_metrics = self.get_metrics() is not None
         config_content = self.get_config_files_content(jinja_env, listen_ip,
                                                        seed_addresses)
         # Now read and render the template
@@ -413,7 +414,8 @@ class RegularNode(Node):
                                   internal_genesis_file=int_genesis_file,
                                   internal_genesis_dir=int_genesis_dir,
                                   genesis_filename=genesis_filename,
-                                  config_content=config_content)
+                                  config_content=config_content,
+                                  enable_metrics=enable_metrics)
         with open(filename, mode="w", encoding="utf-8") as file:
             file.write(content)
 
@@ -507,6 +509,7 @@ class Seed(Node):
         genesis_filename = "dev-albatross.toml"
         int_genesis_file = f"{int_genesis_dir}/{genesis_filename}"
         filename = self.topology_settings.get_node_k8s_dir(self.name)
+        enable_metrics = self.get_metrics() is not None
         config_content = self.get_config_files_content(jinja_env, listen_ip)
         # Now read and render the template
         template = jinja_env.get_template("k8s_node_deployment.yml.j2")
@@ -515,7 +518,8 @@ class Seed(Node):
                                   internal_genesis_file=int_genesis_file,
                                   internal_genesis_dir=int_genesis_dir,
                                   genesis_filename=genesis_filename,
-                                  config_content=config_content)
+                                  config_content=config_content,
+                                  enable_metrics=enable_metrics)
         with open(filename, mode="w", encoding="utf-8") as file:
             file.write(content)
 

--- a/scripts/devnet/spammer.py
+++ b/scripts/devnet/spammer.py
@@ -88,6 +88,7 @@ class Spammer(Node):
         genesis_filename = "dev-albatross.toml"
         int_genesis_file = f"{int_genesis_dir}/{genesis_filename}"
         filename = self.topology_settings.get_node_k8s_dir(self.name)
+        enable_metrics = self.get_metrics() is not None
         config_content = self.get_config_files_content(jinja_env, listen_ip,
                                                        seed_addresses)
         # Now read and render the template
@@ -97,7 +98,8 @@ class Spammer(Node):
                                   internal_genesis_file=int_genesis_file,
                                   internal_genesis_dir=int_genesis_dir,
                                   genesis_filename=genesis_filename,
-                                  config_content=config_content)
+                                  config_content=config_content,
+                                  enable_metrics=enable_metrics)
         with open(filename, mode="w", encoding="utf-8") as file:
             file.write(content)
 

--- a/scripts/devnet/templates/k8s_node_deployment.yml.j2
+++ b/scripts/devnet/templates/k8s_node_deployment.yml.j2
@@ -29,12 +29,16 @@ spec:
       labels:
         app: {{ name }}-nimiq-client
         node_type: {{ node_type }}
+        node_name: {{ name }}
     spec:
       containers:
       - name: {{ name }}
         image: ghcr.io/nimiq/core-rs-albatross:latest
         ports:
         - containerPort: 8443
+        {% if enable_metrics %}
+        - containerPort: 9100
+        {% endif %}
         env:
         - name: NIMIQ_OVERRIDE_DEVNET_CONFIG
           value: {{ internal_genesis_file }}

--- a/scripts/devnet/templates/node_conf.toml.j2
+++ b/scripts/devnet/templates/node_conf.toml.j2
@@ -48,7 +48,7 @@ lock_api = "trace"
 
 {% if metrics is defined %}
 [metrics-server]
-bind="127.0.0.1"
+bind="{{ metrics['ip'] }}"
 port = {{ metrics['port'] }}
 
 {% endif %}

--- a/scripts/devnet/topology.py
+++ b/scripts/devnet/topology.py
@@ -114,14 +114,21 @@ class Topology:
                         "Unexpected restartable value for a node: "
                         f"{node['restartable']}")
                 name = f"{key}{count+1}"
+                metrics = None
                 if 'enable_metrics' in node:
-                    if containerized:
-                        metrics_port = 9100
-                    else:
-                        metrics_port = port_bases[node]['metrics'] + count
-                    metrics = {'port': metrics_port}
-                else:
-                    metrics = None
+                    if not isinstance(node['enable_metrics'], bool):
+                        raise Exception(
+                            "Unexpected enable_metrics value for a node: "
+                            f"{node['enable_metrics']}")
+                    if node['enable_metrics']:
+                        if containerized:
+                            metrics_port = 9100
+                            metrics_ip = "0.0.0.0"
+                        else:
+                            metrics_port = port_bases[node]['metrics'] + count
+                            metrics_ip = "127.0.0.1"
+                        metrics = {'ip': metrics_ip, 'port': metrics_port}
+
                 # Create objects depending on type:
                 if containerized:
                     port = 8443

--- a/scripts/devnet/validator.py
+++ b/scripts/devnet/validator.py
@@ -115,6 +115,7 @@ class Validator(Node):
         genesis_filename = "dev-albatross.toml"
         int_genesis_file = f"{int_genesis_dir}/{genesis_filename}"
         filename = self.topology_settings.get_node_k8s_dir(self.name)
+        enable_metrics = self.get_metrics() is not None
         config_content = self.get_config_files_content(jinja_env, listen_ip,
                                                        seed_addresses)
         # Now read and render the template
@@ -124,7 +125,8 @@ class Validator(Node):
                                   internal_genesis_file=int_genesis_file,
                                   internal_genesis_dir=int_genesis_dir,
                                   genesis_filename=genesis_filename,
-                                  config_content=config_content['config'])
+                                  config_content=config_content['config'],
+                                  enable_metrics=enable_metrics)
         with open(filename, mode="w", encoding="utf-8") as file:
             file.write(content)
 


### PR DESCRIPTION
Add metrics support for k8s in the devnet script and improve the handling of metrics settings.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
