### PR TITLE
network-libp2p: Fix connection limits

### DIFF
--- a/network-libp2p/src/connection_pool/handler.rs
+++ b/network-libp2p/src/connection_pool/handler.rs
@@ -32,13 +32,9 @@ pub enum ConnectionPoolHandlerError {
     #[error("Peer is banned")]
     BannedPeer,
 
-    /// Maximum connections per IPv4 subnet has been reached
-    #[error("Maximum connections per IPV4 subnet has been reached")]
-    MaxIpv4SubnetConnectionsReached,
-
-    /// Maximum connections per IPv6 subnet has been reached
-    #[error("Maximum connections per IPv6 subnet has been reached")]
-    MaxIpv6SubnetConnectionsReached,
+    /// Maximum connections per subnet has been reached
+    #[error("Maximum connections per subnet has been reached")]
+    MaxSubnetConnectionsReached,
 
     /// Maximum peer connections has been reached
     #[error("Maximum peer connections has been reached")]


### PR DESCRIPTION
Fix network connection limits detection in the connection pool within the `network-libp2p` crate.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
