### PR TITLE
Fix initial blockchain state flag

### DIFF
--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -163,12 +163,11 @@ where
         let blockchain_rg = blockchain.read();
         let blockchain_event_rx = blockchain_rg.notifier_as_stream();
         let fork_event_rx = BroadcastStream::new(blockchain_rg.fork_notifier.subscribe());
-        let can_enforce_validity_window = blockchain_rg.can_enforce_validity_window();
         drop(blockchain_rg);
 
         let blockchain_state = BlockchainState {
             equivocation_proofs: EquivocationProofPool::new(),
-            can_enforce_validity_window,
+            can_enforce_validity_window: false,
         };
 
         let database = env.open_table(Self::MACRO_STATE_DB_NAME.to_string());


### PR DESCRIPTION
This fixes an initialization flag that was causing the `update_can_enforce_validity_window` to not call the validator and mempool init function.
This issue was introduced by #1906  and  should be considered part of a fix for #1905 



## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
