### PR TITLE
[RPC] Refactor Inherent Enum Serialization in types.rs

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -576,8 +576,9 @@ impl Transaction {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "type")]
 pub enum Inherent {
+    #[serde(rename_all = "camelCase")]
     Reward {
         block_number: u32,
         block_time: u64,
@@ -586,12 +587,14 @@ pub enum Inherent {
         value: Coin,
         hash: Blake2bHash,
     },
+    #[serde(rename_all = "camelCase")]
     Penalize {
         block_number: u32,
         block_time: u64,
         validator_address: Address,
         offense_event_block: u32,
     },
+    #[serde(rename_all = "camelCase")]
     Jail {
         block_number: u32,
         block_time: u64,


### PR DESCRIPTION
## What's in this pull request?

> [!WARNING]  
> This PR breaks existing RPC clients that use the `Inherent' object.

This pull request introduces updates to the Inherent enum in `rpc-interface/src/types.rs`, changing the serialisation attributes to follow the same standard as other `enums` in the RPC interface.


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
