### PR TITLE
Finalize the first batch

### DIFF
--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -141,11 +141,6 @@ impl Blockchain {
     /// Creates the inherents to finalize a batch. The inherents are for reward distribution and
     /// updating the StakingContract.
     pub fn finalize_previous_batch(&self, macro_block: &MacroBlock) -> Vec<Inherent> {
-        // Special case for first batch: Batch 0 is finalized by definition.
-        if Policy::batch_at(macro_block.block_number()) - 1 == 0 {
-            return vec![];
-        }
-
         // To get the inherents we either fetch the reward transactions from the macro body;
         // or we create the transactions when there is no macro body.
         let mut inherents: Vec<Inherent> = if let Some(body) = macro_block.body.as_ref() {


### PR DESCRIPTION
The only thing the first batch must not do it create any reward transactions, as those are delayed by one batch. The `create_reward_transactions` already takes care of that special case so `finalize_previous_batch` does not need to make the distinction. Importantly `Inherent::FinalizeBatch` ends up in the returned Vec. 

Fixes #1944 