### PR TITLE
Remove unused constant `MAX_REQUEST_RESPONSE_LEVEL_UPDATE_MESSAGE`

### DIFF
--- a/handel/src/update.rs
+++ b/handel/src/update.rs
@@ -4,8 +4,6 @@ use nimiq_serde::fixint;
 use serde::{Deserialize, Serialize};
 
 use crate::contribution::AggregatableContribution;
-/// The max number of LevelUpdateMessages requests per peer.
-pub const MAX_REQUEST_RESPONSE_LEVEL_UPDATE_MESSAGE: u32 = 1000;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "C: AggregatableContribution")]
 pub struct LevelUpdate<C: AggregatableContribution> {


### PR DESCRIPTION
Its use went away in 076af2cca817807c1d7b8c7196fd4a683b8307dc.