### PR TITLE
Validity Window in terms of batches

### DIFF
--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -212,7 +212,7 @@ impl Blockchain {
     ) -> bool {
         let max_block_number = self
             .block_number()
-            .saturating_sub(Policy::transaction_validity_window());
+            .saturating_sub(Policy::transaction_validity_window_blocks());
         self.tx_in_validity_window(tx_hash, max_block_number, txn_opt)
     }
 
@@ -264,7 +264,7 @@ impl Blockchain {
             // and not occur in the history store at all. Using the election block of the epoch will guarantee
             // to return the length at the most recent existing block in this epoch.
             let first_validity_window_block =
-                self.block_number() + 1 - Policy::transaction_validity_window();
+                self.block_number() + 1 - Policy::transaction_validity_window_blocks();
             let election_block = Policy::election_block_after(first_validity_window_block - 1);
 
             // Check whether we do have a history tree for the epoch of the first validity window block.

--- a/blockchain/tests/blockchain.rs
+++ b/blockchain/tests/blockchain.rs
@@ -24,7 +24,7 @@ async fn can_enforce_validity_window() {
     );
 
     // Produce validity window - 1 blocks
-    for _ in 0..Policy::transaction_validity_window() - 1 {
+    for _ in 0..Policy::transaction_validity_window_blocks() - 1 {
         let _block = producer1.next_block(vec![], false);
     }
     assert!(
@@ -72,7 +72,7 @@ async fn can_enforce_validity_window() {
     );
 
     // Produce validity window - 1 blocks
-    for _ in 0..Policy::transaction_validity_window() - 1 {
+    for _ in 0..Policy::transaction_validity_window_blocks() - 1 {
         let block = producer1.next_block(vec![], false);
         assert!(Blockchain::push_with_chunks(
             producer2.blockchain.upgradable_read(),

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1264,7 +1264,7 @@ async fn mempool_update_aged_transaction() {
     let producer = BlockProducer::new(signing_key(), voting_key());
 
     let macro_blocks_to_be_produced =
-        Policy::transaction_validity_window() / Policy::blocks_per_batch();
+        Policy::transaction_validity_window_blocks() / Policy::blocks_per_batch();
 
     // Now we produce blocks past the transaction validity window
     produce_macro_blocks_with_txns(

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -30,8 +30,7 @@ pub struct Policy {
     /// Maximum size of accounts trie chunks.
     #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub state_chunks_max_size: u32,
-    /// Number of blocks a transaction is valid with Albatross consensus.
-    /// This should be a multiple of `blocks_per_batch`.
+    /// Number of batches a transaction is valid with Albatross consensus.
     #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub transaction_validity_window: u32,
     /// Genesis block number
@@ -141,14 +140,23 @@ impl Policy {
 
 #[cfg_attr(feature = "ts-types", wasm_bindgen)]
 impl Policy {
-    /// Number of blocks a transaction is valid with Albatross consensus.
-    /// This should be a multiple of `blocks_per_batch`.
+    /// Number of batches a transaction is valid with Albatross consensus.
     #[inline]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TRANSACTION_VALIDITY_WINDOW))]
     pub fn transaction_validity_window() -> u32 {
         GLOBAL_POLICY
             .get_or_init(Self::default)
             .transaction_validity_window
+    }
+
+    /// Number of blocks a transaction is valid with Albatross consensus.
+    #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TRANSACTION_VALIDITY_WINDOW_BLOCKS))]
+    pub fn transaction_validity_window_blocks() -> u32 {
+        GLOBAL_POLICY
+            .get_or_init(Self::default)
+            .transaction_validity_window
+            * GLOBAL_POLICY.get_or_init(Self::default).blocks_per_batch
     }
 
     /// How many batches constitute an epoch
@@ -664,7 +672,7 @@ impl Default for Policy {
             tendermint_timeout_init: 1000,
             tendermint_timeout_delta: 1000,
             state_chunks_max_size: 200, // #Nodes/accounts 200, TODO: Simulate with different sizes
-            transaction_validity_window: 7200,
+            transaction_validity_window: 120,
             genesis_block_number: 0,
         }
     }
@@ -676,7 +684,7 @@ pub const TEST_POLICY: Policy = Policy {
     tendermint_timeout_init: 1000,
     tendermint_timeout_delta: 1000,
     state_chunks_max_size: 2,
-    transaction_validity_window: 64,
+    transaction_validity_window: 2,
     genesis_block_number: 0,
 };
 

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -413,7 +413,7 @@ impl Transaction {
     }
 
     pub fn is_valid_at(&self, block_height: u32) -> bool {
-        let window = Policy::transaction_validity_window();
+        let window = Policy::transaction_validity_window_blocks();
         block_height
             >= self
                 .validity_start_height


### PR DESCRIPTION
- Change the Policy::TransactionValidityWindow constant to batches instead of blocks
- Introduce a new transaction_validity_window_blocks() function to obtain the transaction validity window in terms of blocks

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
