### PR TITLE
Fix comment in history chunk proof

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -782,6 +782,9 @@ impl HistoryStore {
     /// Returns the `chunk_index`th chunk of size `chunk_size` for a given epoch.
     /// The return value consists of a vector of all the historic transactions in that chunk
     /// and a proof for these in the MMR.
+    /// The `verifier_block_number` is the block the chunk proof should be verified against.
+    /// That means that no leaf beyond this block is returned and that the proof should be
+    /// verified with the history root from this block.
     pub fn prove_chunk(
         &self,
         epoch_number: u32,
@@ -810,8 +813,9 @@ impl HistoryStore {
         let leaf_count = self.length_at(verifier_block_number, Some(txn)) as usize;
         let number_of_nodes = leaf_number_to_index(leaf_count);
 
-        // Calculate chunk boundaries
+        // Calculate chunk boundaries.
         let start = cmp::min(chunk_size * chunk_index, leaf_count);
+        // Do not go beyond the verifier's block.
         let end = cmp::min(start + chunk_size, leaf_count);
 
         // TODO: Setting `assume_previous` to false allows the proofs to be verified independently.


### PR DESCRIPTION
## What's in this pull request?
The `prove_chunk` method was poorly documented, especially the `verifier_block_number` argument.
When discussing with @viquezclaudio, we discovered that it is used to calculate the boundaries of the chunk proof.

If the block is set to a point before the chunk starts, the proof will always be empty.
The block is supposed to mark the end of the sync and the root the chunks will be verified against.

This PR mainly updates the comments to reflect this.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
