### PR TITLE
Revert "Don't include the signatures in historic transactions"

### DIFF
--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -16,7 +16,9 @@ use nimiq_test_utils::{
     },
     node::TESTING_BLS_CACHE_MAX_CAPACITY,
 };
-use nimiq_transaction::{historic_transaction::HistoricTransactionData, ExecutedTransaction};
+use nimiq_transaction::{
+    historic_transaction::HistoricTransactionData, ExecutedTransaction, TransactionFormat,
+};
 use nimiq_utils::time::OffsetTime;
 use nimiq_zkp_component::ZKPComponent;
 use parking_lot::{Mutex, RwLock};
@@ -106,10 +108,12 @@ async fn test_request_transactions_by_address() {
     assert_eq!(
         txs.iter()
             .filter(|tx| {
-                matches!(
-                    tx.data,
-                    HistoricTransactionData::Basic(ExecutedTransaction::Ok(_)),
-                )
+                if let HistoricTransactionData::Basic(ExecutedTransaction::Ok(transaction)) =
+                    &tx.data
+                {
+                    return transaction.format() == TransactionFormat::Basic;
+                }
+                false
             })
             .count() as u32,
         // There should be one basic transaction in each micro block of the first batch

--- a/primitives/transaction/src/historic_transaction.rs
+++ b/primitives/transaction/src/historic_transaction.rs
@@ -59,17 +59,13 @@ impl HistoricTransaction {
     ) -> Vec<HistoricTransaction> {
         let mut hist_txs = vec![];
 
-        for mut transaction in transactions {
-            match transaction {
-                ExecutedTransaction::Ok(ref mut tx) => tx.proof = Vec::new(),
-                ExecutedTransaction::Err(ref mut tx) => tx.proof = Vec::new(),
-            }
+        for transaction in transactions {
             hist_txs.push(HistoricTransaction {
                 network_id,
                 block_number,
                 block_time,
                 data: HistoricTransactionData::Basic(transaction),
-            });
+            })
         }
 
         for inherent in inherents {
@@ -227,6 +223,8 @@ impl FromDatabaseValue for HistoricTransaction {
 
 /// An enum specifying the type of transaction and containing the necessary data to represent that
 /// transaction.
+// TODO: The transactions include a lot of unnecessary information (ex: the signature). Don't
+//       include all of it here.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializeContent)]
 pub enum HistoricTransactionData {
     /// A basic transaction. It simply contains the transaction as contained in the block.


### PR DESCRIPTION
This reverts commit 043044706555e25a0f98caaf08af68c51af63e25.

We need the proofs at least for HTLC transactions. Thanks to @sisou for noticing this.