### PR TITLE
Fix inherents not being applied in history sync

### DIFF
--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -95,8 +95,6 @@ pub enum PushError {
     BlockchainError(#[from] BlockchainError),
     #[error("Push with incomplete accounts and without trie diff")]
     MissingAccountsTrieDiff,
-    #[error("Invalid macro block historic transaction")]
-    InvalidHistoricTransaction,
     #[error("Proof for equivocation already included")]
     EquivocationAlreadyIncluded(EquivocationLocator),
     #[error("Accounts trie is incomplete and thus cannot be verified.")]

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -179,11 +179,9 @@ impl Blockchain {
                         value: ev.value,
                     })
                 }
-                HistoricTransactionData::Equivocation(_)
-                | HistoricTransactionData::Penalize(_)
-                | HistoricTransactionData::Jail(_) => {
-                    return Err(PushError::InvalidHistoricTransaction)
-                }
+                HistoricTransactionData::Equivocation(_) => {}
+                HistoricTransactionData::Penalize(_) => {}
+                HistoricTransactionData::Jail(_) => {}
             }
         }
 


### PR DESCRIPTION
I made the wrong assumption that the inherents getting applied in `Blockchain::extend_history_sync` are only inherents from macro blocks.

Since that's not the case, equivocation, penalize and jail inherents can also appear and are not an error condition.