### PR TITLE
Improve DHT publishing

### DIFF
--- a/consensus/src/consensus/remote_event_dispatcher.rs
+++ b/consensus/src/consensus/remote_event_dispatcher.rs
@@ -337,7 +337,7 @@ impl<N: Network> Future for RemoteEventDispatcher<N> {
                     // Remove the peer from internal data structures.
                     self.state.write().remove_peer(&peer_id);
                 }
-                Ok(NetworkEvent::PeerJoined(_peer_id, _)) => {}
+                Ok(_) => {}
                 Err(_) => return Poll::Pending,
             }
         }

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -39,6 +39,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                         self.add_peer(peer_id);
                     }
                 }
+                Ok(_) => {}
                 Err(_) => return Poll::Ready(None),
             }
         }

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -42,6 +42,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                         self.add_peer(peer_id);
                     }
                 }
+                Ok(_) => {}
                 Err(_) => return Poll::Ready(None),
             }
         }

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -63,7 +63,7 @@ use crate::{
 pub type Consensus = AbstractConsensus<Network>;
 pub type ConsensusProxy = AbstractConsensusProxy<Network>;
 #[cfg(feature = "validator")]
-pub type Validator = AbstractValidator<Network, ValidatorNetworkImpl<Network>>;
+pub type Validator = AbstractValidator<ValidatorNetworkImpl<Network>>;
 #[cfg(feature = "validator")]
 pub type ValidatorProxy = AbstractValidatorProxy;
 

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -18,6 +18,7 @@ use crate::{
 pub enum NetworkEvent<P> {
     PeerJoined(P, PeerInfo),
     PeerLeft(P),
+    DhtBootstrapped,
 }
 
 pub type SubscribeEvents<PeerId> =

--- a/network-libp2p/tests/helper.rs
+++ b/network-libp2p/tests/helper.rs
@@ -1,0 +1,29 @@
+use futures::{Stream, StreamExt};
+use nimiq_network_interface::network::{NetworkEvent, SubscribeEvents};
+use nimiq_network_libp2p::PeerId;
+
+pub fn assert_peer_joined(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
+    if let NetworkEvent::PeerJoined(peer_id, _) = event {
+        assert_eq!(peer_id, wanted_peer_id);
+    } else {
+        panic!("Event is not a NetworkEvent::PeerJoined: {:?}", event);
+    }
+}
+
+pub fn assert_peer_left(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
+    if let NetworkEvent::PeerLeft(peer_id) = event {
+        assert_eq!(peer_id, wanted_peer_id);
+    } else {
+        panic!("Event is not a NetworkEvent::PeerLeft: {:?}", event);
+    }
+}
+
+pub async fn get_next_peer_event(events: &mut SubscribeEvents<PeerId>) -> NetworkEvent<PeerId> {
+    while let Ok(event) = events.next().await.unwrap() {
+        match event {
+            NetworkEvent::DhtBootstrapped => {}
+            _ => return event,
+        }
+    }
+    panic!("No more events");
+}

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -29,6 +29,9 @@ use tokio::time::Duration;
 #[cfg(feature = "tokio-time")]
 use tokio::time::Instant;
 
+mod helper;
+use self::helper::*;
+
 /// The max number of TestRequests per peer (used for regular tests only).
 const MAX_REQUEST_RESPONSE_TEST_REQUEST: u32 = 1000;
 /// The max number of TestRequests per peer. This is used exclusively for rate limiting testing.
@@ -167,11 +170,11 @@ impl TestNetwork {
 
         log::debug!("Waiting for join events");
 
-        let event1 = events1.next().await.unwrap().unwrap();
+        let event1 = get_next_peer_event(&mut events1).await;
         log::trace!(event = ?event1, "Event 1");
         assert_peer_joined(&event1, &net2.get_local_peer_id());
 
-        let event2 = events2.next().await.unwrap().unwrap();
+        let event2 = get_next_peer_event(&mut events2).await;
         log::trace!(event = ?event2, "Event 2");
         assert_peer_joined(&event2, &net1.get_local_peer_id());
 
@@ -253,19 +256,19 @@ impl TestNetwork {
 
         log::debug!("Waiting for join events");
 
-        let event1 = events1.next().await.unwrap().unwrap();
+        let event1 = get_next_peer_event(&mut events1).await;
         log::trace!(event = ?event1, "Event 1");
         assert_peer_joined(&event1, &net2.get_local_peer_id());
 
-        let event2 = events2.next().await.unwrap().unwrap();
+        let event2 = get_next_peer_event(&mut events2).await;
         log::trace!(event = ?event2, "Event 2");
         assert_peer_joined(&event2, &net1.get_local_peer_id());
 
-        let event3 = events3.next().await.unwrap().unwrap();
+        let event3 = get_next_peer_event(&mut events3).await;
         log::trace!(event = ?event3, "Event 3");
         assert_peer_joined(&event3, &net1.get_local_peer_id());
 
-        let event4 = events4.next().await.unwrap().unwrap();
+        let event4 = get_next_peer_event(&mut events4).await;
         log::trace!(event = ?event4, "Event 4");
         assert_peer_joined(&event4, &net1.get_local_peer_id());
 
@@ -308,23 +311,6 @@ fn network_config(address: Multiaddr) -> Config {
         memory_transport: true,
         required_services: Services::all(),
         tls: None,
-    }
-}
-
-fn assert_peer_joined(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
-    if let NetworkEvent::PeerJoined(peer_id, _) = event {
-        assert_eq!(peer_id, wanted_peer_id);
-    } else {
-        panic!("Event is not a NetworkEvent::PeerJoined: {:?}", event);
-    }
-}
-
-#[cfg(feature = "tokio-time")]
-fn assert_peer_left(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
-    if let NetworkEvent::PeerLeft(peer_id) = event {
-        assert_eq!(peer_id, wanted_peer_id);
-    } else {
-        panic!("Event is not a NetworkEvent::PeerJoined: {:?}", event);
     }
 }
 
@@ -531,11 +517,11 @@ async fn disconnect_successfully(net1: &Arc<Network>, net2: &Arc<Network>) {
 
     log::debug!("Waiting for disconnect events");
 
-    let event1 = events1.next().await.unwrap().unwrap();
+    let event1 = get_next_peer_event(&mut events1).await;
     log::trace!(event = ?event1, "Event 1");
     assert_peer_left(&event1, &net2.get_local_peer_id());
 
-    let event2 = events2.next().await.unwrap().unwrap();
+    let event2 = get_next_peer_event(&mut events2).await;
     log::trace!(event = ?event2, "Event 2");
     assert_peer_left(&event2, &net1.get_local_peer_id());
 }
@@ -552,11 +538,11 @@ async fn reconnect_successfully(net1: &Arc<Network>, addr1: Multiaddr, net2: &Ar
 
     log::debug!("Waiting for join events");
 
-    let event1 = events1.next().await.unwrap().unwrap();
+    let event1 = get_next_peer_event(&mut events1).await;
     log::trace!(event = ?event1, "Event 1");
     assert_peer_joined(&event1, &net2.get_local_peer_id());
 
-    let event2 = events2.next().await.unwrap().unwrap();
+    let event2 = get_next_peer_event(&mut events2).await;
     log::trace!(event = ?event2, "Event 2");
     assert_peer_joined(&event2, &net1.get_local_peer_id());
 }

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -32,7 +32,7 @@ pub async fn build_validator<N: TestNetwork + NetworkInterface>(
     genesis_info: GenesisInfo,
     hub: &mut Option<MockHub>,
     is_prover_active: bool,
-) -> (Validator<N, ValidatorNetworkImpl<N>>, Consensus<N>)
+) -> (Validator<ValidatorNetworkImpl<N>>, Consensus<N>)
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,
@@ -42,7 +42,7 @@ where
     let consensus = node.consensus.expect("Could not create consensus");
     let validator_network = Arc::new(ValidatorNetworkImpl::new(Arc::clone(&consensus.network)));
     (
-        Validator::<N, ValidatorNetworkImpl<N>>::new(
+        Validator::<ValidatorNetworkImpl<N>>::new(
             node.environment,
             &consensus,
             node.blockchain,
@@ -63,7 +63,7 @@ pub async fn build_validators<N: TestNetwork + NetworkInterface>(
     peer_ids: &[u64],
     hub: &mut Option<MockHub>,
     is_prover_active: bool,
-) -> Vec<Validator<N, ValidatorNetworkImpl<N>>>
+) -> Vec<Validator<ValidatorNetworkImpl<N>>>
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,
@@ -145,10 +145,10 @@ where
 }
 
 pub fn validator_for_slot<N: TestNetwork + NetworkInterface>(
-    validators: &[Validator<N, ValidatorNetworkImpl<N>>],
+    validators: &[Validator<ValidatorNetworkImpl<N>>],
     block_number: u32,
     offset: u32,
-) -> &Validator<N, ValidatorNetworkImpl<N>>
+) -> &Validator<ValidatorNetworkImpl<N>>
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,
@@ -170,10 +170,10 @@ where
 }
 
 pub fn pop_validator_for_slot<N: TestNetwork + NetworkInterface>(
-    validators: &mut Vec<Validator<N, ValidatorNetworkImpl<N>>>,
+    validators: &mut Vec<Validator<ValidatorNetworkImpl<N>>>,
     block_number: u32,
     offset: u32,
-) -> Validator<N, ValidatorNetworkImpl<N>>
+) -> Validator<ValidatorNetworkImpl<N>>
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::{stream::BoxStream, Stream};
 use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
-    network::{MsgAcceptance, Network, PubsubId, Topic},
+    network::{MsgAcceptance, Network, PubsubId, SubscribeEvents, Topic},
     request::{Message, Request, RequestCommon},
 };
 
@@ -61,6 +61,9 @@ pub trait ValidatorNetwork: Send + Sync {
     async fn subscribe<'a, TTopic: Topic + Sync>(
         &self,
     ) -> Result<BoxStream<'a, (TTopic::Item, Self::PubsubId)>, Self::Error>;
+
+    /// Subscribes to network events
+    fn subscribe_events(&self) -> SubscribeEvents<<Self::NetworkType as Network>::PeerId>;
 
     /// Registers a cache for the specified message type.
     /// Incoming messages of this type should be held in a FIFO queue of total size `buffer_size`,

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt, TryFutureExt};
 use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
-    network::{MsgAcceptance, Network, NetworkEvent, Topic},
+    network::{MsgAcceptance, Network, NetworkEvent, SubscribeEvents, Topic},
     request::{Message, Request, RequestCommon},
 };
 use nimiq_serde::{Deserialize, Serialize};
@@ -274,6 +274,10 @@ where
         TTopic: Topic + Sync,
     {
         Ok(self.network.subscribe::<TTopic>().await?)
+    }
+
+    fn subscribe_events(&self) -> SubscribeEvents<<Self::NetworkType as Network>::PeerId> {
+        self.network.subscribe_events()
     }
 
     fn cache<M: Message>(&self, _buffer_size: usize, _lifetime: Duration) {

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -934,8 +934,8 @@ impl Client {
                     Some(Ok(NetworkEvent::PeerLeft(peer_id))) => {
                         Some((peer_id.to_string(), "left", None))
                     }
-                    Some(Err(_error)) => {
-                        None // Ignore stream errors
+                    Some(_) => {
+                        None // Ignore stream errors and other events
                     }
                     None => {
                         break;


### PR DESCRIPTION
Previously, the own DHT entry was published on every new epoch. That means
- It might try to publish before the DHT finished setting up
- It republishes the DHT although we configured the library to automatically do that every 60 seconds.

This PR adds an event to the Network that is fired when DHT is done bootstrapping. The validator listens for this event and publishes the own record upon receiving it.
