### PR TITLE
Add block_separation_time to RPC

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -323,6 +323,7 @@ pub struct PolicyConstants {
     pub blocks_per_epoch: u32,
     pub validator_deposit: u64,
     pub total_supply: u64,
+    pub block_separation_time: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -28,6 +28,7 @@ impl PolicyInterface for PolicyDispatcher {
             blocks_per_epoch: Policy::blocks_per_epoch(),
             validator_deposit: Policy::VALIDATOR_DEPOSIT,
             total_supply: Policy::TOTAL_SUPPLY,
+            block_separation_time: Policy::BLOCK_SEPARATION_TIME,
         }
         .into())
     }


### PR DESCRIPTION
## What's in this pull request?

Adding block_separation_time to the RPC Policy Constants.
Need for Validator Trust Score, that way there's no need to hardcode any value

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
