### PR TITLE
Move Proposal verification. Make sure predecessor exists.

### DIFF
--- a/network-libp2p/tests/helper.rs
+++ b/network-libp2p/tests/helper.rs
@@ -1,4 +1,4 @@
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use nimiq_network_interface::network::{NetworkEvent, SubscribeEvents};
 use nimiq_network_libp2p::PeerId;
 

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -6,13 +6,9 @@ use libp2p::{
     identity::Keypair,
     multiaddr::{multiaddr, Multiaddr},
     swarm::KeepAlive,
-    PeerId,
 };
 use nimiq_network_interface::{
-    network::{
-        CloseReason, MsgAcceptance, Network as NetworkInterface, NetworkEvent, SubscribeEvents,
-        Topic,
-    },
+    network::{CloseReason, MsgAcceptance, Network as NetworkInterface, NetworkEvent, Topic},
     peer_info::Services,
 };
 use nimiq_network_libp2p::{

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -10,7 +10,7 @@ use libp2p::{
 #[cfg(feature = "tokio-time")]
 use nimiq_network_interface::network::CloseReason;
 use nimiq_network_interface::{
-    network::{Network as NetworkInterface, NetworkEvent},
+    network::Network as NetworkInterface,
     peer_info::Services,
     request::{
         InboundRequestError, OutboundRequestError, Request, RequestCommon, RequestError,
@@ -19,7 +19,7 @@ use nimiq_network_interface::{
 };
 use nimiq_network_libp2p::{
     discovery::{behaviour::DiscoveryConfig, peer_contacts::PeerContact},
-    Config, Network, PeerId,
+    Config, Network,
 };
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
 use nimiq_test_log::test;

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -10,10 +10,6 @@ use crate::utils::Step;
 pub enum ProposalError {
     /// Invalid proposals may be used to punish the proposer.
     InvalidProposal,
-    /// Proposals with invalid signatures must be ignored, but the peer who broadcasted it may be banned.
-    InvalidSignature,
-    /// Collectively used for all problems not accounted for by InvalidProposal and InvalidSignature.
-    Other,
 }
 
 #[derive(Clone, Debug)]
@@ -123,7 +119,6 @@ pub trait Protocol: Clone + Send + Sync + Unpin + Sized + 'static {
         &self,
         proposal: &SignedProposalMessage<Self::Proposal, Self::ProposalSignature>,
         precalculated_inherent: Option<Self::Inherent>,
-        signature_only: bool,
     ) -> Result<Self::Inherent, ProposalError>;
 
     /// Broadcasts a signed proposal given as `proposal`.

--- a/tendermint/tests/common/mod.rs
+++ b/tendermint/tests/common/mod.rs
@@ -166,18 +166,15 @@ impl Protocol for Validator {
         &self,
         proposal: &SignedProposalMessage<Self::Proposal, Self::ProposalSignature>,
         precalculated_inherent: Option<Self::Inherent>,
-        signature_only: bool,
     ) -> Result<Self::Inherent, ProposalError> {
         if proposal.signature {
-            if signature_only {
-                Ok(precalculated_inherent.expect("Must not call verify_proposal(_, None, true)"))
-            } else if let Some(inherent) = precalculated_inherent {
+            if let Some(inherent) = precalculated_inherent {
                 Ok(inherent)
             } else {
                 Ok(TestInherent(proposal.message.proposal.0))
             }
         } else {
-            Err(ProposalError::InvalidSignature)
+            Err(ProposalError::InvalidProposal)
         }
     }
 

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
-    network::{MsgAcceptance, Network, PubsubId, SubscribeEvents, Topic},
+    network::{CloseReason, MsgAcceptance, Network, PubsubId, SubscribeEvents, Topic},
     request::{Message, Request, RequestCommon},
 };
 
@@ -68,6 +68,13 @@ pub trait ValidatorNetwork: Send + Sync {
         public_key: &CompressedPublicKey,
         secret_key: &SecretKey,
     ) -> Result<(), Self::Error>;
+
+    /// Closes the connection to the peer with `peer_id` with the given `close_reason`.
+    async fn disconnect_peer(
+        &self,
+        peer_id: <Self::NetworkType as Network>::PeerId,
+        close_reason: CloseReason,
+    );
 
     /// Signals that a Gossipsup'd message with `id` was verified successfully and can be relayed.
     fn validate_message<TTopic>(&self, id: Self::PubsubId, acceptance: MsgAcceptance)

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -5,7 +5,7 @@ use futures::{stream::BoxStream, StreamExt, TryFutureExt};
 use log::warn;
 use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
 use nimiq_network_interface::{
-    network::{MsgAcceptance, Network, SubscribeEvents, Topic},
+    network::{CloseReason, MsgAcceptance, Network, SubscribeEvents, Topic},
     request::{Message, Request, RequestCommon},
 };
 use nimiq_serde::{Deserialize, Serialize};
@@ -289,6 +289,10 @@ where
             .await?;
 
         Ok(())
+    }
+
+    async fn disconnect_peer(&self, peer_id: N::PeerId, close_reason: CloseReason) {
+        self.network.disconnect_peer(peer_id, close_reason).await
     }
 
     fn validate_message<TTopic>(&self, id: Self::PubsubId, acceptance: MsgAcceptance)

--- a/validator/src/aggregation/tendermint/proposal.rs
+++ b/validator/src/aggregation/tendermint/proposal.rs
@@ -44,7 +44,7 @@ impl<Id> Proposal<Blake2sHash, Blake2sHash> for Header<Id> {
 /// Tendermint itself does expect a different kind of structure, which will also include
 /// Message identifier for GossipSub. That identifier is used to signal the validity of
 /// the message to the network. See [nimiq_tendermint::SignedProposalMessage]
-#[derive(std::fmt::Debug, Deserialize, Serialize)]
+#[derive(Clone, std::fmt::Debug, Deserialize, Serialize)]
 pub struct SignedProposal {
     pub(crate) proposal: MacroHeader,
     pub(crate) round: u32,

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -5,5 +5,6 @@ pub mod aggregation;
 mod jail;
 mod r#macro;
 mod micro;
+mod proposal_buffer;
 pub mod tendermint;
 pub mod validator;

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -1,0 +1,118 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll, Waker},
+};
+
+use futures::Stream;
+use linked_hash_map::LinkedHashMap;
+use nimiq_keys::Signature as SchnorrSignature;
+use nimiq_macros::store_waker;
+use nimiq_network_interface::network::{Network, PubsubId, Topic};
+use nimiq_tendermint::SignedProposalMessage;
+use nimiq_validator_network::ValidatorNetwork;
+use parking_lot::RwLock;
+
+use super::{aggregation::tendermint::proposal::Header, r#macro::ProposalTopic};
+
+type ProposalAndPubsubId<TValidatorNetwork> = (
+    <ProposalTopic<TValidatorNetwork> as Topic>::Item,
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId,
+);
+
+pub(crate) struct ProposalBuffer<TValidatorNetwork: ValidatorNetwork + 'static>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    buffer: LinkedHashMap<
+        <TValidatorNetwork::NetworkType as Network>::PeerId,
+        ProposalAndPubsubId<TValidatorNetwork>,
+    >,
+    waker: Option<Waker>,
+}
+
+impl<TValidatorNetwork: ValidatorNetwork + 'static> ProposalBuffer<TValidatorNetwork>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    // Ignoring clippy warning: this return type is on purpose
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new() -> (
+        ProposalSender<TValidatorNetwork>,
+        ProposalReceiver<TValidatorNetwork>,
+    ) {
+        let buffer = Self {
+            buffer: LinkedHashMap::new(),
+            waker: None,
+        };
+        let shared = Arc::new(RwLock::new(buffer));
+        let sender = ProposalSender {
+            shared: Arc::clone(&shared),
+        };
+        let receiver = ProposalReceiver { shared };
+        (sender, receiver)
+    }
+}
+
+pub(crate) struct ProposalSender<TValidatorNetwork: ValidatorNetwork + 'static>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    shared: Arc<RwLock<ProposalBuffer<TValidatorNetwork>>>,
+}
+
+impl<TValidatorNetwork: ValidatorNetwork + 'static> ProposalSender<TValidatorNetwork>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    pub fn send(&self, proposal: ProposalAndPubsubId<TValidatorNetwork>) {
+        let source = proposal.1.propagation_source();
+        let mut shared = self.shared.write();
+        shared.buffer.insert(source, proposal);
+        if let Some(waker) = shared.waker.take() {
+            waker.wake()
+        }
+    }
+}
+
+pub(crate) struct ProposalReceiver<TValidatorNetwork: ValidatorNetwork + 'static>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    shared: Arc<RwLock<ProposalBuffer<TValidatorNetwork>>>,
+}
+
+impl<TValidatorNetwork: ValidatorNetwork + 'static> Stream for ProposalReceiver<TValidatorNetwork>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    type Item = SignedProposalMessage<
+        Header<<TValidatorNetwork as ValidatorNetwork>::PubsubId>,
+        (SchnorrSignature, u16),
+    >;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut shared = self.shared.write();
+        if shared.buffer.is_empty() {
+            store_waker!(shared, waker, cx);
+            Poll::Pending
+        } else {
+            let value = shared.buffer.pop_front().map(|entry| {
+                let (msg, id) = entry.1;
+                msg.into_tendermint_signed_message(Some(id))
+            });
+            Poll::Ready(value)
+        }
+    }
+}
+
+impl<TValidatorNetwork: ValidatorNetwork + 'static> Clone for ProposalReceiver<TValidatorNetwork>
+where
+    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+{
+    fn clone(&self) -> Self {
+        Self {
+            shared: Arc::clone(&self.shared),
+        }
+    }
+}

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -4,73 +4,220 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-use futures::Stream;
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, Stream, StreamExt};
 use linked_hash_map::LinkedHashMap;
+use nimiq_block::Block;
+use nimiq_blockchain::Blockchain;
+use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_keys::Signature as SchnorrSignature;
 use nimiq_macros::store_waker;
-use nimiq_network_interface::network::{Network, PubsubId, Topic};
+use nimiq_network_interface::network::{CloseReason, MsgAcceptance, Network, PubsubId, Topic};
+use nimiq_serde::Serialize;
 use nimiq_tendermint::SignedProposalMessage;
 use nimiq_validator_network::ValidatorNetwork;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 
-use super::{aggregation::tendermint::proposal::Header, r#macro::ProposalTopic};
+use super::{
+    aggregation::tendermint::proposal::{Header, SignedProposal},
+    r#macro::ProposalTopic,
+};
 
 type ProposalAndPubsubId<TValidatorNetwork> = (
     <ProposalTopic<TValidatorNetwork> as Topic>::Item,
     <TValidatorNetwork as ValidatorNetwork>::PubsubId,
 );
 
+/// The buffer holding all proposals, which have been received, but were not yet needed. Any peer can at most have
+/// one proposal in this buffer.
+///
+/// Any proposal in this buffer must have a valid signature, given the signer index within the message.
+/// On taking these messages out of the buffer (see [ProposalReceiver]) it must be maintained that
+///     1. The predecessor exists
+///     2. The proposer of the proposal calculated with the predecessor vrf seed was indeed supposed
+///         to be who was stated in the original message.
+///
+/// Any message that fails any of the above should be dropped, however depending on why it failed, additional
+/// action may be advised. If the signature was incorrect for the assumed signer, the peer who relayed the
+/// message relayed invalid data and should be banned. If the assumed proposer does not match the actual proposer,
+/// the assumed proposer may be punished (as he produced faulty data, proven by the signature and the predecessor vrf).
+/// If the predecessor is unavailable (even after requesting it from the peer who originated the proposal or relayed
+/// the proposal) they both could be banned as they failed to produce proper data upon being asked to do so.
 pub(crate) struct ProposalBuffer<TValidatorNetwork: ValidatorNetwork + 'static>
 where
     <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
 {
+    /// A LinkedHashMap containing a proposal per peer_id.
+    /// A single proposal could thus be in the buffer multiple times, but a single peer cannot have
+    /// more than once proposal waiting.
     buffer: LinkedHashMap<
         <TValidatorNetwork::NetworkType as Network>::PeerId,
         ProposalAndPubsubId<TValidatorNetwork>,
     >,
-    waker: Option<Waker>,
+
+    /// A FuturesUnordered collection of incomplete tasks to disconnect from a peer.
+    unresolved_futures: FuturesUnordered<BoxFuture<'static, ()>>,
+
+    /// A waker in case a proposal gets entered into a buffer while some code is
+    /// already waiting to get one out of it.
+    proposal_waker: Option<Waker>,
+
+    /// An additional waker in case a disconnect future is added while some code is
+    /// waiting to get a proposal.
+    ///
+    /// The additional waker makes sense, as otherwise the waker would have to be stored for both
+    /// the proposal buffer being empty or the unresolved futures being empty. Ideally the
+    /// unresolved futures would most of the time be empty as other nodes send validly signed proposals.
+    /// With only one waker that would lead to every poll storing the waker, because the futures are empty,
+    /// while every addition of a proposal will trigger wake unnecessarily.
+    /// The proposals operations in the [ProposalReceiver] are not cheap, as they do read the predecessor.
+    disconnect_waker: Option<Waker>,
 }
 
 impl<TValidatorNetwork: ValidatorNetwork + 'static> ProposalBuffer<TValidatorNetwork>
 where
     <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
 {
+    /// Creates a new ProposalBuffer, returning the [ProposalSender] and [ProposalReceiver] that share the buffer.
+    /// Blockchain and Network are necessary to do basic verification and punishments.
     // Ignoring clippy warning: this return type is on purpose
     #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> (
+    pub fn new(
+        blockchain: Arc<RwLock<Blockchain>>,
+        network: Arc<TValidatorNetwork>,
+    ) -> (
         ProposalSender<TValidatorNetwork>,
         ProposalReceiver<TValidatorNetwork>,
     ) {
+        // Create the shared buffer
         let buffer = Self {
             buffer: LinkedHashMap::new(),
-            waker: None,
+            unresolved_futures: FuturesUnordered::new(),
+            proposal_waker: None,
+            disconnect_waker: None,
         };
-        let shared = Arc::new(RwLock::new(buffer));
+
+        //  Create the shared buffer.
+        let shared = Arc::new(Mutex::new(buffer));
+
+        // Create both the sender and the receiver using the same shared buffer.
         let sender = ProposalSender {
             shared: Arc::clone(&shared),
+            blockchain: Arc::clone(&blockchain),
+            network: Arc::clone(&network),
         };
-        let receiver = ProposalReceiver { shared };
+        let receiver = ProposalReceiver {
+            shared,
+            blockchain,
+            network,
+        };
+
         (sender, receiver)
     }
 }
 
+/// Structure to send a proposal into the proposal Buffer. Signature verification happens immediately given the signers
+/// identity in the message.
+/// Checking for a known predecessor and it having been signed by the correct proposer, happens on the receiver
+/// side as chances are higher to already have received the blocks predecessor later in the process.
 pub(crate) struct ProposalSender<TValidatorNetwork: ValidatorNetwork + 'static>
 where
     <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
 {
-    shared: Arc<RwLock<ProposalBuffer<TValidatorNetwork>>>,
+    /// The buffer holding all buffered proposals shared with the [ProposalReceiver]
+    shared: Arc<Mutex<ProposalBuffer<TValidatorNetwork>>>,
+
+    /// Reference to the blockchain structure. It is necessary to retrieve the validators.
+    /// Just storing the validators themselves here is impractical for they may change with a
+    /// skip block.
+    blockchain: Arc<RwLock<Blockchain>>,
+
+    /// Reference to the network structure. Necessary to validate message for gossipsup as well as
+    /// banning peers if necessary.
+    network: Arc<TValidatorNetwork>,
 }
 
 impl<TValidatorNetwork: ValidatorNetwork + 'static> ProposalSender<TValidatorNetwork>
 where
     <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
 {
+    /// Sends the proposal and PubsubId into the buffer.
+    ///
+    /// This function may lead to the proposal not actually being admitted into the buffer as the signature may not verify.
+    /// in that case appropriate action is taken within the function as well, as there is no return value.
     pub fn send(&self, proposal: ProposalAndPubsubId<TValidatorNetwork>) {
+        // Before progressing any further the signature must be verified against the stated proposer of the message.
+        // Whether or not that proposer is the correct proposer will be checked when polling the proposal out of the buffer.
+
+        // Fetch current validators and get the validator whose id was presented in the proposal message.
+        let validators = self.blockchain.read().current_validators().unwrap();
+        let stated_proposer = validators.get_validator_by_slot_band(proposal.0.signer);
+
+        // Calculate the hash which had been signed.
+        let data = SignedProposal::hash(
+            &proposal.0.proposal,
+            proposal.0.round,
+            proposal.0.valid_round,
+        )
+        .serialize_to_vec();
+
+        // Get the propagation source, as it is going to be required either way the verification goes,
+        // either for storing the proposal in the buffer, or to ban the relaying peer.
         let source = proposal.1.propagation_source();
-        let mut shared = self.shared.write();
-        shared.buffer.insert(source, proposal);
-        if let Some(waker) = shared.waker.take() {
-            waker.wake()
+
+        // Verify the stated signer did in fact sign this proposal.
+        if stated_proposer
+            .signing_key
+            .verify(&proposal.0.signature, &data)
+        {
+            // Acquire the lock on the shared buffer.
+            let mut shared = self.shared.lock();
+
+            // Put the proposal into the buffer, potentially evicting an already existing proposal.
+            if let Some((old_proposal, old_pubsub)) = shared.buffer.insert(source, proposal.clone())
+            {
+                // If a previous proposal existed, print a debug message to log
+                log::debug!(?source, ?old_proposal, ?proposal, "Proposal was replaced",);
+                // Indicate to not propagate the proposal.
+                // This may not be ideal, but the message got evicted before its validity could be checked fully.
+                self.network
+                    .validate_message::<ProposalTopic<TValidatorNetwork>>(
+                        old_pubsub,
+                        MsgAcceptance::Ignore,
+                    );
+            }
+
+            // A new proposal was admitted into the buffer. Potential waiting tasks can be woken.
+            if let Some(waker) = shared.proposal_waker.take() {
+                waker.wake()
+            }
+        } else {
+            // The signature verification did not succeed.
+
+            // Signal the network, that this specific message is not to be propagated by this node.
+            // The message is also not only not interesting, but it is faulty.
+            self.network
+                .validate_message::<ProposalTopic<TValidatorNetwork>>(
+                    proposal.1,
+                    MsgAcceptance::Reject,
+                );
+
+            // Punish the propagation source of the proposal for propagating invalid proposal messages, i.e ban the peer.
+            let nw = Arc::clone(&self.network);
+            let future = async move {
+                nw.disconnect_peer(source, CloseReason::MaliciousPeer).await;
+            }
+            .boxed();
+
+            // Acquire the lock on the shared buffer.
+            let mut shared = self.shared.lock();
+            // Add the disconnect future to the FuturesUnordered collection.
+            shared.unresolved_futures.push(future);
+
+            // Wake, as a new future was added and needs to be polled.
+            // A new proposal was admitted into the buffer. Potential waiting tasks can be woken.
+            if let Some(waker) = shared.disconnect_waker.take() {
+                waker.wake()
+            }
         }
     }
 }
@@ -79,7 +226,16 @@ pub(crate) struct ProposalReceiver<TValidatorNetwork: ValidatorNetwork + 'static
 where
     <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
 {
-    shared: Arc<RwLock<ProposalBuffer<TValidatorNetwork>>>,
+    /// The buffer holding all buffered proposals shared with the [ProposalSender]
+    shared: Arc<Mutex<ProposalBuffer<TValidatorNetwork>>>,
+
+    /// Reference to the blockchain structure. It is necessary to retrieve the proposals predecessor
+    /// as well as the validators.
+    blockchain: Arc<RwLock<Blockchain>>,
+
+    /// Reference to the network structure. Necessary to validate message for gossipsup as well as
+    /// banning peers if necessary.
+    network: Arc<TValidatorNetwork>,
 }
 
 impl<TValidatorNetwork: ValidatorNetwork + 'static> Stream for ProposalReceiver<TValidatorNetwork>
@@ -92,16 +248,135 @@ where
     >;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut shared = self.shared.write();
-        if shared.buffer.is_empty() {
-            store_waker!(shared, waker, cx);
-            Poll::Pending
+        // Acquire the shared buffer lock.
+        let mut shared = self.shared.lock();
+
+        // Collect futures which need pushing into the futures unordered of the shared buffer.
+        // Since the `entries` call down a couple of lines will take a mutable borrow of shared they
+        // must be pushed after that loop returned.
+        let mut futures = vec![];
+
+        let proposal_and_pubsubid = shared.buffer.entries().find_map(|entry| {
+            let (signed_proposal, _pubsub_id) = entry.get();
+
+            // Get a read lock of the blockchain.
+            let blockchain = self.blockchain.read();
+
+            // Try and retrieve the predecessor of the proposal.
+            match blockchain.get_block(&signed_proposal.proposal.parent_hash, false, None) {
+                Ok(Block::Micro(block)) => {
+                    // Proposal predecessor is known.
+                    // Proceed to make sure the signer, whose signature was already verified,
+                    // is in fact also the one who was supposed to produce this proposal.
+
+                    // Get the active validators.
+                    let validators = blockchain.current_validators().unwrap();
+
+                    // Get the validator who signed the proposal and whose signature was already verified.
+                    let assumed_validator =
+                        validators.get_validator_by_slot_band(signed_proposal.signer);
+
+                    // Calculate the validator who was supposed to produce the block.
+                    let actual_validator = blockchain
+                        .get_proposer_at(
+                            signed_proposal.proposal.block_number,
+                            signed_proposal.round,
+                            block.header.seed.entropy(),
+                            None,
+                        )
+                        .expect("Must be able to calculate block producer.")
+                        .validator;
+
+                    // Compare the expected and the actual validator
+                    if *assumed_validator == actual_validator {
+                        // Validators match. The signature was already verified. Proposal is good to go.
+                        // DO NOT validate message the proposal, as there is much more to the validity than the signature.
+                        Some(entry.remove())
+                    } else {
+                        // Assumed validator is not the proposer. Punish the validator (TODO).
+                        // Proposal is removed as it is not a valid proposal.
+                        log::debug!("Found MacroHeader Proposal where validators do not match.");
+                        let (_proposal, id) = entry.remove();
+
+                        // The peer relaying this proposal relayed a faulty proposal, disconnect him.
+                        let source = id.propagation_source();
+                        let nw = Arc::clone(&self.network);
+                        let future = async move {
+                            nw.disconnect_peer(source, CloseReason::MaliciousPeer).await;
+                        }
+                        .boxed();
+
+                        // Push the future to the futures unordered
+                        futures.push(future);
+
+                        // Don't propagate the proposal
+                        self.network
+                            .validate_message::<ProposalTopic<TValidatorNetwork>>(
+                                id,
+                                MsgAcceptance::Reject,
+                            );
+
+                        None
+                    }
+                }
+                Ok(Block::Macro(_)) => {
+                    // the proposal points to a macro block which in the presence of micro blocks is impossible.
+                    // The originator created a bogus block. Punish the validator(TODO)
+                    log::debug!("Found MacroHeader Proposal with a non MicroBlock predecessor.");
+                    let (_proposal, id) = entry.remove();
+
+                    // The peer relaying this proposal relayed a faulty proposal, disconnect him.
+                    let source = id.propagation_source();
+                    let nw = Arc::clone(&self.network);
+                    let future = async move {
+                        nw.disconnect_peer(source, CloseReason::MaliciousPeer).await;
+                    }
+                    .boxed();
+
+                    // Push the future to the futures unordered
+                    futures.push(future);
+
+                    // Don't propagate the proposal
+                    self.network
+                        .validate_message::<ProposalTopic<TValidatorNetwork>>(
+                            id,
+                            MsgAcceptance::Reject,
+                        );
+                    None
+                }
+                Err(_) => {
+                    // Block is not known. Request it. (TODO)
+                    // Do not remove the block, maybe next time the predecessor is there.
+                    None
+                }
+            }
+        });
+
+        // Push newly accumulated futures.
+        for future in futures {
+            shared.unresolved_futures.push(future);
+        }
+
+        // Poll the unresolved disconnect futures now that the new futures have been added.
+        while let Poll::Ready(Some(())) = shared.unresolved_futures.poll_next_unpin(cx) {
+            // nothing to for any of the completed futures
+        }
+
+        if let Some((proposal, pubsubid)) = proposal_and_pubsubid {
+            Poll::Ready(Some(
+                proposal.into_tendermint_signed_message(Some(pubsubid)),
+            ))
         } else {
-            let value = shared.buffer.pop_front().map(|entry| {
-                let (msg, id) = entry.1;
-                msg.into_tendermint_signed_message(Some(id))
-            });
-            Poll::Ready(value)
+            // Before returning, check if any of the collections are empty, if so, store a waker.
+            if shared.buffer.is_empty() {
+                store_waker!(shared, proposal_waker, cx);
+            }
+            if shared.unresolved_futures.is_empty() {
+                store_waker!(shared, disconnect_waker, cx);
+            }
+
+            // There is nothing to return, so return Pending
+            Poll::Pending
         }
     }
 }
@@ -113,6 +388,8 @@ where
     fn clone(&self) -> Self {
         Self {
             shared: Arc::clone(&self.shared),
+            blockchain: Arc::clone(&self.blockchain),
+            network: Arc::clone(&self.network),
         }
     }
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -174,8 +174,8 @@ where
         };
         let macro_state = Arc::new(RwLock::new(macro_state));
 
-        let network1 = Arc::clone(&network);
-        let (proposal_sender, proposal_receiver) = ProposalBuffer::new();
+        let (proposal_sender, proposal_receiver) =
+            ProposalBuffer::new(Arc::clone(&blockchain), Arc::clone(&network));
 
         let mempool = Arc::new(Mempool::new(Arc::clone(&blockchain), mempool_config));
         let mempool_state = MempoolState::Inactive;
@@ -185,8 +185,8 @@ where
         let mut this = Self {
             consensus: consensus.proxy(),
             blockchain,
-            network,
-            network_event_rx: network1.subscribe_events(),
+            network: Arc::clone(&network),
+            network_event_rx: network.subscribe_events(),
 
             database,
             env,
@@ -223,7 +223,7 @@ where
         this.init();
 
         tokio::spawn(async move {
-            network1
+            network
                 .subscribe::<ProposalTopic<TValidatorNetwork>>()
                 .await
                 .expect("Failed to subscribe to proposal topic")

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -6,12 +6,11 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
     time::Duration,
 };
 
-use futures::stream::{BoxStream, Stream, StreamExt};
-use linked_hash_map::LinkedHashMap;
+use futures::stream::{BoxStream, StreamExt};
 use nimiq_block::{Block, BlockHeaderTopic, BlockTopic, BlockType, EquivocationProof};
 use nimiq_blockchain::{BlockProducer, Blockchain};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, ForkEvent, PushResult};
@@ -22,15 +21,13 @@ use nimiq_database::{
     DatabaseProxy, TableProxy,
 };
 use nimiq_hash::{Blake2bHash, Hash};
-use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, Signature as SchnorrSignature};
-use nimiq_macros::store_waker;
+use nimiq_keys::{Address, KeyPair as SchnorrKeyPair};
 use nimiq_mempool::{config::MempoolConfig, mempool::Mempool};
 use nimiq_network_interface::{
-    network::{MsgAcceptance, Network, NetworkEvent, PubsubId, SubscribeEvents, Topic},
+    network::{MsgAcceptance, Network, NetworkEvent, SubscribeEvents},
     request::request_handler,
 };
 use nimiq_primitives::{coin::Coin, policy::Policy};
-use nimiq_tendermint::SignedProposalMessage;
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_validator_network::ValidatorNetwork;
 use parking_lot::RwLock;
@@ -39,12 +36,10 @@ use tokio_metrics::TaskMonitor;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::{
-    aggregation::tendermint::{
-        proposal::{Header, RequestProposal},
-        state::MacroState,
-    },
+    aggregation::tendermint::{proposal::RequestProposal, state::MacroState},
     jail::EquivocationProofPool,
     micro::{ProduceMicroBlock, ProduceMicroBlockEvent},
+    proposal_buffer::{ProposalBuffer, ProposalReceiver},
     r#macro::{MappedReturn, ProduceMacroBlock, ProposalTopic},
 };
 
@@ -918,107 +913,5 @@ where
         }
 
         Poll::Pending
-    }
-}
-
-type ProposalAndPubsubId<TValidatorNetwork> = (
-    <ProposalTopic<TValidatorNetwork> as Topic>::Item,
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId,
-);
-
-struct ProposalBuffer<TValidatorNetwork: ValidatorNetwork + 'static>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    buffer: LinkedHashMap<
-        <TValidatorNetwork::NetworkType as Network>::PeerId,
-        ProposalAndPubsubId<TValidatorNetwork>,
-    >,
-    waker: Option<Waker>,
-}
-
-impl<TValidatorNetwork: ValidatorNetwork + 'static> ProposalBuffer<TValidatorNetwork>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    // Ignoring clippy warning: this return type is on purpose
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> (
-        ProposalSender<TValidatorNetwork>,
-        ProposalReceiver<TValidatorNetwork>,
-    ) {
-        let buffer = Self {
-            buffer: LinkedHashMap::new(),
-            waker: None,
-        };
-        let shared = Arc::new(RwLock::new(buffer));
-        let sender = ProposalSender {
-            shared: Arc::clone(&shared),
-        };
-        let receiver = ProposalReceiver { shared };
-        (sender, receiver)
-    }
-}
-
-struct ProposalSender<TValidatorNetwork: ValidatorNetwork + 'static>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    shared: Arc<RwLock<ProposalBuffer<TValidatorNetwork>>>,
-}
-
-impl<TValidatorNetwork: ValidatorNetwork + 'static> ProposalSender<TValidatorNetwork>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    pub fn send(&self, proposal: ProposalAndPubsubId<TValidatorNetwork>) {
-        let source = proposal.1.propagation_source();
-        let mut shared = self.shared.write();
-        shared.buffer.insert(source, proposal);
-        if let Some(waker) = shared.waker.take() {
-            waker.wake()
-        }
-    }
-}
-
-struct ProposalReceiver<TValidatorNetwork: ValidatorNetwork + 'static>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    shared: Arc<RwLock<ProposalBuffer<TValidatorNetwork>>>,
-}
-
-impl<TValidatorNetwork: ValidatorNetwork + 'static> Stream for ProposalReceiver<TValidatorNetwork>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    type Item = SignedProposalMessage<
-        Header<<TValidatorNetwork as ValidatorNetwork>::PubsubId>,
-        (SchnorrSignature, u16),
-    >;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut shared = self.shared.write();
-        if shared.buffer.is_empty() {
-            store_waker!(shared, waker, cx);
-            Poll::Pending
-        } else {
-            let value = shared.buffer.pop_front().map(|entry| {
-                let (msg, id) = entry.1;
-                msg.into_tendermint_signed_message(Some(id))
-            });
-            Poll::Ready(value)
-        }
-    }
-}
-
-impl<TValidatorNetwork: ValidatorNetwork + 'static> Clone for ProposalReceiver<TValidatorNetwork>
-where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
-{
-    fn clone(&self) -> Self {
-        Self {
-            shared: Arc::clone(&self.shared),
-        }
     }
 }

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -138,7 +138,7 @@ async fn it_verifies_inferior_chain_proposals() {
         signature: main_chain_sig,
     };
 
-    assert!(interface.verify_proposal(&message, None, false).is_ok());
+    assert!(interface.verify_proposal(&message, None).is_ok());
 
     // Make sure the second inferior chain proposal is not acceptable without the micro block
     let inf_chain2 = ProposalMessage {
@@ -151,14 +151,14 @@ async fn it_verifies_inferior_chain_proposals() {
         message: inf_chain2,
         signature: inf_chain2_sig,
     };
-    assert!(interface.verify_proposal(&message, None, false).is_err());
+    assert!(interface.verify_proposal(&message, None).is_err());
 
     // push the micro block and then make sure the proposal is ok
     temp_producer2
         .push(last)
         .expect("Pushing inferior micro block should succeed.");
     let body = interface
-        .verify_proposal(&message, None, false)
+        .verify_proposal(&message, None)
         .expect("Verification must succeed.");
 
     assert_eq!(inf_proposal2.body.expect(""), body.0);
@@ -174,12 +174,12 @@ async fn it_verifies_inferior_chain_proposals() {
         message: inf_chain1.clone(),
         signature: inf_chain1_sig,
     };
-    assert!(interface.verify_proposal(&message, None, false).is_err());
+    assert!(interface.verify_proposal(&message, None).is_err());
 
     temp_producer2
         .push(second_to_last1)
         .expect("Pushing inferior micro block should succeed.");
-    assert!(interface.verify_proposal(&message, None, false).is_err());
+    assert!(interface.verify_proposal(&message, None).is_err());
 
     temp_producer2
         .push(second_to_last2)
@@ -188,7 +188,7 @@ async fn it_verifies_inferior_chain_proposals() {
     // After the last micro block is pushed the proposal should verify
     // The calculated body should match the one given by block production itself.
     let body = interface
-        .verify_proposal(&message, None, false)
+        .verify_proposal(&message, None)
         .expect("Verification must succeed.");
     assert_eq!(inf_proposal1.body.clone().expect(""), body.0);
 }


### PR DESCRIPTION
This PR moves the proposal verification into the `ProposalBuffer`. From the viewpoint of Tendermint this results in all proposals being properly authenticated. Additionally all proposal which enter Tendermint have an existing Microblock predecessor.