### PR TITLE
primitives: Check that the validity window is less than an epoch

### DIFF
--- a/lib/src/extras/signal_handling.rs
+++ b/lib/src/extras/signal_handling.rs
@@ -6,7 +6,7 @@ pub fn initialize_signal_handler() {
 
     if let Ok(mut signals) = signals {
         tokio::spawn(async move {
-            for _ in signals.forever() {
+            if signals.forever().next().is_some() {
                 log::warn!("Received Ctrl+C. Closing client");
                 // Add some delay for the log message to propagate into loki
                 sleep(Duration::from_millis(200)).await;

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -144,18 +144,18 @@ impl Policy {
     #[inline]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TRANSACTION_VALIDITY_WINDOW))]
     pub fn transaction_validity_window() -> u32 {
-        GLOBAL_POLICY
-            .get_or_init(Self::default)
-            .transaction_validity_window
+        let policy = GLOBAL_POLICY.get_or_init(Self::default);
+        assert!(policy.batches_per_epoch as u32 >= policy.transaction_validity_window);
+        policy.transaction_validity_window
     }
 
     /// Number of blocks a transaction is valid with Albatross consensus.
     #[inline]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TRANSACTION_VALIDITY_WINDOW_BLOCKS))]
     pub fn transaction_validity_window_blocks() -> u32 {
-        GLOBAL_POLICY
-            .get_or_init(Self::default)
-            .transaction_validity_window
+        let policy = GLOBAL_POLICY.get_or_init(Self::default);
+        assert!(policy.batches_per_epoch as u32 >= policy.transaction_validity_window);
+        policy.transaction_validity_window
             * GLOBAL_POLICY.get_or_init(Self::default).blocks_per_batch
     }
 

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -903,17 +903,14 @@ impl Client {
                             // Subscribe to all addresses at the new peer
                             let owned_consensus = consensus.clone();
                             let owned_subscribed_addresses = Rc::clone(&subscribed_addresses);
+                            let addresses = owned_subscribed_addresses
+                                .borrow()
+                                .keys()
+                                .cloned()
+                                .collect();
                             spawn_local(async move {
                                 let _ = owned_consensus
-                                    .subscribe_to_addresses(
-                                        owned_subscribed_addresses
-                                            .borrow()
-                                            .keys()
-                                            .cloned()
-                                            .collect(),
-                                        1,
-                                        Some(peer_id),
-                                    )
+                                    .subscribe_to_addresses(addresses, 1, Some(peer_id))
                                     .await;
                                 log::debug!(
                                     peer_id=%peer_id,


### PR DESCRIPTION
- Check that the validity window is less than an epoch. Both the `batches_per_epoch` and `transaction_validity_window` are expressed in batches so we just assert if we find out that the latter is greater.
- Fix clippy warnings.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
