### PR TITLE
ci: Change MultipleValidatorsDown test topology

### DIFF
--- a/.github/devnet_topologies/five_validators.toml
+++ b/.github/devnet_topologies/five_validators.toml
@@ -1,0 +1,23 @@
+[[validator]]
+restartable = true
+sync_mode = "history"
+
+[[validator]]
+restartable = true
+sync_mode = "history"
+
+[[validator]]
+restartable = true
+sync_mode = "history"
+
+[[validator]]
+restartable = true
+sync_mode = "history"
+
+[[validator]]
+restartable = true
+sync_mode = "history"
+
+[[seed]]
+restartable = false
+sync_mode = "history"

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -24,7 +24,7 @@ jobs:
         - test: FourValidatorsReconnect
           devnet_args: -t .github/devnet_topologies/four_validators.toml -R
         - test: MultipleValidatorsDown
-          devnet_args: -t .github/devnet_topologies/four_validators.toml -k 2 -R
+          devnet_args: -t .github/devnet_topologies/five_validators.toml -k 2 -R
         - test: FourValidatorsReconnectRmDatabase
           devnet_args: -t .github/devnet_topologies/four_validators.toml -d -R
         - test: FourValidatorsReconnectSpammer

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -23,7 +23,7 @@ jobs:
         - test: FourValidatorsReconnect
           devnet_args: -t .github/devnet_topologies/four_validators.toml
         - test: MultipleValidatorsDown
-          devnet_args: -t .github/devnet_topologies/four_validators.toml -k 2 -ut 100
+          devnet_args: -t .github/devnet_topologies/five_validators.toml -k 2 -ut 100
         - test: FourValidatorsReconnectRmDatabase
           devnet_args: -t .github/devnet_topologies/four_validators.toml -d -ut 100
         - test: FourValidatorsReconnectSpammer


### PR DESCRIPTION
Add an extra validator to the `MultipleValidatorsDown` test such that validators don't lose consensus when 2 of them are taken down.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
