### PR TITLE
Fix historic transaction hash collisions

### DIFF
--- a/hash/hash_derive/src/lib.rs
+++ b/hash/hash_derive/src/lib.rs
@@ -12,10 +12,11 @@ pub fn derive_serialize(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 
 fn impl_serialize_content(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
+    let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
     let gen = quote! {
-        impl ::nimiq_hash::SerializeContent for #name where #name: ::nimiq_hash::nimiq_serde::Serialize {
-            #[allow(unused_mut,unused_variables)]
+        impl #impl_generics ::nimiq_hash::SerializeContent for #name #ty_generics where #name #ty_generics: ::nimiq_hash::nimiq_serde::Serialize {
+            #[allow(unused_mut, unused_variables)]
             fn serialize_content<W: ::std::io::Write, H>(&self, writer: &mut W) -> ::std::io::Result<()> {
                 ::nimiq_hash::nimiq_serde::Serialize::serialize_to_writer(self, writer)?;
                 Ok(())

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -28,6 +28,7 @@ pub enum AccountType {
     Vesting = 1,
     HTLC = 2,
     Staking = 3,
+    // HistoricTransaction = 0xff,
 }
 
 #[derive(Debug, Error)]

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -455,6 +455,9 @@ impl Transaction {
 
 impl SerializeContent for Transaction {
     fn serialize_content<W: Write, H>(&self, writer: &mut W) -> io::Result<()> {
+        // This implementation must be kept in sync with
+        // `HistoricTransaction::tx_hash`.
+
         // Serialize data as in PoW (2 bytes for the length and then the data
         // which in PoS is the recipient data) for backwards compatibility
         writer.write_all(&(self.recipient_data.len() as u16).to_be_bytes())?;


### PR DESCRIPTION
Include block number and network ID in the hash. Also make sure that they can't clash with normal transactions.

Fixes #1935.