### PR TITLE
ci: Change MultipleValidatorsDown test topology

### DIFF
--- a/.github/devnet_topologies/eight_validators.toml
+++ b/.github/devnet_topologies/eight_validators.toml
@@ -26,6 +26,10 @@ sync_mode = "history"
 restartable = true
 sync_mode = "history"
 
+[[validator]]
+restartable = true
+sync_mode = "history"
+
 [[seed]]
 restartable = false
 sync_mode = "history"

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -24,7 +24,7 @@ jobs:
         - test: FourValidatorsReconnect
           devnet_args: -t .github/devnet_topologies/four_validators.toml -R
         - test: MultipleValidatorsDown
-          devnet_args: -t .github/devnet_topologies/seven_validators.toml -k 2 -R
+          devnet_args: -t .github/devnet_topologies/eight_validators.toml -k 2 -R
         - test: FourValidatorsReconnectRmDatabase
           devnet_args: -t .github/devnet_topologies/four_validators.toml -d -R
         - test: FourValidatorsReconnectSpammer

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -23,7 +23,7 @@ jobs:
         - test: FourValidatorsReconnect
           devnet_args: -t .github/devnet_topologies/four_validators.toml
         - test: MultipleValidatorsDown
-          devnet_args: -t .github/devnet_topologies/seven_validators.toml -k 2 -ut 100
+          devnet_args: -t .github/devnet_topologies/eight_validators.toml -k 2 -ut 100
         - test: FourValidatorsReconnectRmDatabase
           devnet_args: -t .github/devnet_topologies/four_validators.toml -d -ut 100
         - test: FourValidatorsReconnectSpammer


### PR DESCRIPTION
Add an extra validator to the `MultipleValidatorsDown` test such that validators can always produce skip blocks (with 2f+1) while there are two validators down.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
