### PR TITLE
Drop outdated proposals earlier

### DIFF
--- a/hash/src/blake2s.rs
+++ b/hash/src/blake2s.rs
@@ -92,7 +92,7 @@ impl Blake2sWithParameterBlock {
         let res = b.finalize();
         assert_eq!(res.len(), 32);
         let mut ret = [0; 32];
-        ret.copy_from_slice(&res.as_bytes());
+        ret.copy_from_slice(res.as_bytes());
         ret
     }
 }


### PR DESCRIPTION
Instead of delivering proposals to Tendermint to drop them later outdated proposals can be dropped immediately in the proposal buffer and this PR adds that functionality.