### PR TITLE
network-libp2p: Allow the network to recover itself

### DIFF
--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -917,6 +917,10 @@ impl Network {
                         match event.result {
                             Err(error) => {
                                 log::debug!(%error, ?event.peer, "Ping failed with peer");
+                                swarm
+                                    .behaviour_mut()
+                                    .pool
+                                    .close_connection(event.peer, CloseReason::RemoteClosed);
                             }
                             Ok(duration) => {
                                 log::trace!(?event.peer, ?duration, "Successful ping from peer");

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -738,14 +738,14 @@ impl Client {
                     let network = network.clone();
                     spawn_local(async move {
                         let network = network.clone();
-                        network.restart_connecting().await;
+                        network.start_connecting().await;
                     });
                 } else if state == &JsString::from_str("visible").unwrap() {
                     log::debug!("Content became visible: restarting network");
                     let network = network.clone();
                     spawn_local(async move {
                         let network = network.clone();
-                        network.restart_connecting().await;
+                        network.start_connecting().await;
                     });
                 }
             }


### PR DESCRIPTION
- Allow the network to recover itself
  - Allow the network to recover itself by resetting the peers and addresses marked as down when no connections nor dial attempts are being made.
  - Remove the restart functionality since now it is essentially the same as the `start_connecting` functionality.
  - Properly handle transport errors and mark the failed addresses as such in the connection pool behaviour.
  - Fix `TODO` in the connection pool related to not incrementing the dial attempt failures if the peer is already marked as down.
  - This fixes #1337.
- Re-introduce closing peer connections on ping failures. This was inadvertently removed in the latest `libp2p` upgrade since this is no longer performed by the `ping` behaviour.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
