### PR TITLE
Add spammer profile CI test

### DIFF
--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -21,6 +21,7 @@ jobs:
         - LowBlockProducerTimeout
         - FiveValidatorsWithSpammer
         - FiveValidatorsWithSpammerFullNodes
+        - FiveValidatorsWithSpammerProfile
 
         include:
         - test: FourValidatorsReconnect
@@ -45,6 +46,8 @@ jobs:
           devnet_args: -t .github/devnet_topologies/five_validators_spammer.toml -R -k 0
         - test: FiveValidatorsWithSpammerFullNodes
           devnet_args: -t .github/devnet_topologies/five_validators_spammer_full_nodes.toml -R -k 0
+        - test: FiveValidatorsWithSpammerProfile
+          devnet_args: -t .github/devnet_topologies/five_validators_spammer.toml -R -k 0 -sp spammer/src/spammer_profile.toml
 
     runs-on: ubuntu-22.04
 

--- a/scripts/devnet/control_settings.py
+++ b/scripts/devnet/control_settings.py
@@ -90,8 +90,8 @@ class RestartSettings:
 
     def get_allow_stall(self):
         """
-        Gets the flag that indicates whether the chain is allowed to stall while
-        nodes are down.
+        Gets the flag that indicates whether the chain is allowed
+        to stall while nodes are down.
 
         :return: The allow stall flag.
         :rtype: bool

--- a/scripts/devnet/devnet.py
+++ b/scripts/devnet/devnet.py
@@ -51,7 +51,7 @@ def parse_args():
     parser.add_argument('-o', "--output", metavar='DIR', type=str,
                         help="Output directory", default="/tmp/nimiq-devnet")
     parser.add_argument('-sp', "--spammer-profile", type=str,
-                        help="Spammer generation profile to be used", default=None)
+                        help="Spammer generation profile", default=None)
     parser.add_argument('-R', '--release', action='store_true', help="Compiles"
                         " and runs the code in release mode")
     parser.add_argument('-m', "--metrics", action="store_true",
@@ -150,7 +150,8 @@ def main():
 
     topology_settings = TopologySettings(
         nimiq_dir, logs_dir, conf_dir, state_dir, args.release,
-        args.namespace, args.env, args.spammer_profile, loki_settings=loki_settings, )
+        args.namespace, args.env, args.spammer_profile,
+        loki_settings=loki_settings)
 
     # Now create topology object and run it
     topology = Topology(topology_settings)

--- a/scripts/devnet/devnet.py
+++ b/scripts/devnet/devnet.py
@@ -50,6 +50,8 @@ def parse_args():
                         help="Input TOML topology file")
     parser.add_argument('-o', "--output", metavar='DIR', type=str,
                         help="Output directory", default="/tmp/nimiq-devnet")
+    parser.add_argument('-sp', "--spammer-profile", type=str,
+                        help="Spammer generation profile to be used", default=None)
     parser.add_argument('-R', '--release', action='store_true', help="Compiles"
                         " and runs the code in release mode")
     parser.add_argument('-m', "--metrics", action="store_true",
@@ -148,7 +150,7 @@ def main():
 
     topology_settings = TopologySettings(
         nimiq_dir, logs_dir, conf_dir, state_dir, args.release,
-        args.namespace, args.env, loki_settings=loki_settings)
+        args.namespace, args.env, args.spammer_profile, loki_settings=loki_settings, )
 
     # Now create topology object and run it
     topology = Topology(topology_settings)

--- a/scripts/devnet/spammer.py
+++ b/scripts/devnet/spammer.py
@@ -37,7 +37,7 @@ class Spammer(Node):
         if topology_settings.spammer_profile is None:
             nimiq_exec_extra_args=['-t', str(tpb)]
         else:
-            nimiq_exec_extra_args=['-t', str(tpb), '--profile', topology_settings.spammer_profile]
+            nimiq_exec_extra_args=['--profile', topology_settings.spammer_profile]
 
         super(Spammer, self).__init__(NodeType.SPAMMER,
                                       name, "nimiq-spammer", listen_port,

--- a/scripts/devnet/spammer.py
+++ b/scripts/devnet/spammer.py
@@ -33,11 +33,17 @@ class Spammer(Node):
                  metrics: Optional[dict] = None,
                  container_image: Optional[str] = None):
         self.address = "NQ40 GCAA U3UX 8BKD GUN0 PG3T 17HA 4X5H TXVE"
+
+        if topology_settings.spammer_profile is None:
+            nimiq_exec_extra_args=['-t', str(tpb)]
+        else:
+            nimiq_exec_extra_args=['-t', str(tpb), '--profile', topology_settings.spammer_profile]
+
         super(Spammer, self).__init__(NodeType.SPAMMER,
                                       name, "nimiq-spammer", listen_port,
                                       topology_settings, sync_mode,
                                       rpc, metrics, container_image,
-                                      nimiq_exec_extra_args=['-t', str(tpb)])
+                                      nimiq_exec_extra_args)
 
     def get_address(self):
         """

--- a/scripts/devnet/spammer.py
+++ b/scripts/devnet/spammer.py
@@ -34,10 +34,11 @@ class Spammer(Node):
                  container_image: Optional[str] = None):
         self.address = "NQ40 GCAA U3UX 8BKD GUN0 PG3T 17HA 4X5H TXVE"
 
-        if topology_settings.spammer_profile is None:
-            nimiq_exec_extra_args=['-t', str(tpb)]
+        if topology_settings.get_spammer_profile() is None:
+            nimiq_exec_extra_args = ['-t', str(tpb)]
         else:
-            nimiq_exec_extra_args=['--profile', topology_settings.spammer_profile]
+            nimiq_exec_extra_args = ['--profile',
+                                     topology_settings.spammer_profile]
 
         super(Spammer, self).__init__(NodeType.SPAMMER,
                                       name, "nimiq-spammer", listen_port,

--- a/scripts/devnet/topology.py
+++ b/scripts/devnet/topology.py
@@ -340,7 +340,8 @@ class Topology:
                 self.__generate_docker_k8s_dir(validators, seeds, spammers,
                                                regular_nodes)
 
-    def __run_monitor_for(self, mon_time: int, exp_down_nodes: list = [], allow_stall: bool = False):
+    def __run_monitor_for(self, mon_time: int, exp_down_nodes: list = [],
+                          allow_stall: bool = False):
         """
         Runs and monitor all nodes for a period of time
 

--- a/scripts/devnet/topology_settings.py
+++ b/scripts/devnet/topology_settings.py
@@ -102,6 +102,8 @@ class TopologySettings:
     :type namespace: str
     :param env: Type of environment this topology will be run in.
     :type env: Environment
+    :param spammer_profile: Spammer profile to be used (if any)
+    :type spammer_profile: str
     :param loki_settings: Optional Loki settings.
     :type loki_settings: Optional[LokiSettings]
     """
@@ -109,6 +111,7 @@ class TopologySettings:
     def __init__(
             self, nimiq_dir: str, logs_dir: str, conf_dir: str, state_dir: str,
             release: bool, namespace: str, env: Environment,
+            spammer_profile: str,
             loki_settings: Optional[LokiSettings] = None):
         self.nimiq_dir = nimiq_dir
         self.logs_dir = logs_dir
@@ -118,6 +121,7 @@ class TopologySettings:
         self.namespace = namespace
         self.loki_settings = loki_settings
         self.env = env
+        self.spammer_profile = spammer_profile
 
     def get_nimiq_dir(self):
         """

--- a/scripts/devnet/topology_settings.py
+++ b/scripts/devnet/topology_settings.py
@@ -239,6 +239,15 @@ class TopologySettings:
         """
         return self.env
 
+    def get_spammer_profile(self):
+        """
+        Gets the spammer profile (if any)
+
+        :return: The path to the spammer profile
+        :rtype: str
+        """
+        return self.spammer_profile
+
     def is_env_containerized(self):
         """
         Returns whether the environment is containerized (docker-compose or

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -469,7 +469,7 @@ fn generate_basic_transactions(
                 continue;
             }
 
-            //We need to make sure the txns are mined and included in the blockchain first.
+            // We need to make sure the txns are included in the blockchain first.
             if current_block_number - account.block_number < Policy::blocks_per_batch() {
                 continue;
             }


### PR DESCRIPTION
Add a test that uses a spammer profile to use more interesting transactions profiles
Some minor adjustments to the spammer.


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
