### PR TITLE
Add RPC methods for querying validator status

### DIFF
--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -18,4 +18,8 @@ pub trait ValidatorInterface {
         &mut self,
         automatic_reactivate: bool,
     ) -> RPCResult<(), (), Self::Error>;
+
+    async fn is_validator_elected(&mut self) -> RPCResult<bool, (), Self::Error>;
+
+    async fn is_validator_synced(&mut self) -> RPCResult<bool, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -57,4 +57,15 @@ impl ValidatorInterface for ValidatorDispatcher {
         log::debug!("Automatic reactivation set to {}.", automatic_reactivate);
         Ok(().into())
     }
+
+    async fn is_validator_elected(&mut self) -> RPCResult<bool, (), Self::Error> {
+        let is_elected = self.validator.slot_band.read().is_some();
+        Ok(is_elected.into())
+    }
+
+    async fn is_validator_synced(&mut self) -> RPCResult<bool, (), Self::Error> {
+        let state = self.validator.consensus_state.read();
+        let is_synced = state.consensus_established && state.validity_window_synced;
+        Ok(is_synced.into())
+    }
 }


### PR DESCRIPTION
## What's in this pull request?

Add RPC methods `getIsValidatorElected() => bool` and `getIsValidatorSynced() => bool` to enable querying this information for running validators. Otherwise, this information is only available by parsing logs.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
