### PR TITLE
Internally tag all web-client plain transaction data variants

### DIFF
--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -465,13 +465,14 @@ impl Transaction {
                     // Parse transaction data
                     let data = IncomingStakingTransactionData::parse(&self.inner).unwrap();
                     match data {
-                        IncomingStakingTransactionData::CreateStaker { delegation, .. } => {
-                            PlainTransactionRecipientData::CreateStaker(PlainCreateStakerData {
-                                raw: hex::encode(self.recipient_data()),
-                                delegation: delegation
-                                    .map(|address| address.to_user_friendly_address()),
-                            })
-                        }
+                        IncomingStakingTransactionData::CreateStaker {
+                            delegation,
+                            proof: _proof,
+                        } => PlainTransactionRecipientData::CreateStaker(PlainCreateStakerData {
+                            raw: hex::encode(self.recipient_data()),
+                            delegation: delegation
+                                .map(|address| address.to_user_friendly_address()),
+                        }),
                         IncomingStakingTransactionData::AddStake { staker_address } => {
                             PlainTransactionRecipientData::AddStake(PlainAddStakeData {
                                 raw: hex::encode(self.recipient_data()),
@@ -481,7 +482,7 @@ impl Transaction {
                         IncomingStakingTransactionData::UpdateStaker {
                             new_delegation,
                             reactivate_all_stake,
-                            ..
+                            proof: _proof,
                         } => PlainTransactionRecipientData::UpdateStaker(PlainUpdateStakerData {
                             raw: hex::encode(self.recipient_data()),
                             new_delegation: new_delegation
@@ -494,7 +495,7 @@ impl Transaction {
                             reward_address,
                             signal_data,
                             proof_of_knowledge,
-                            ..
+                            proof: _proof,
                         } => PlainTransactionRecipientData::CreateValidator(
                             PlainCreateValidatorData {
                                 raw: hex::encode(self.recipient_data()),
@@ -511,7 +512,7 @@ impl Transaction {
                             new_reward_address,
                             new_signal_data,
                             new_proof_of_knowledge,
-                            ..
+                            proof: _proof,
                         } => PlainTransactionRecipientData::UpdateValidator(
                             PlainUpdateValidatorData {
                                 raw: hex::encode(self.recipient_data()),
@@ -530,7 +531,7 @@ impl Transaction {
                         ),
                         IncomingStakingTransactionData::DeactivateValidator {
                             validator_address,
-                            ..
+                            proof: _proof,
                         } => {
                             PlainTransactionRecipientData::DeactivateValidator(PlainValidatorData {
                                 raw: hex::encode(self.recipient_data()),
@@ -539,21 +540,21 @@ impl Transaction {
                         }
                         IncomingStakingTransactionData::ReactivateValidator {
                             validator_address,
-                            ..
+                            proof: _proof,
                         } => {
                             PlainTransactionRecipientData::ReactivateValidator(PlainValidatorData {
                                 raw: hex::encode(self.recipient_data()),
                                 validator: validator_address.to_user_friendly_address(),
                             })
                         }
-                        IncomingStakingTransactionData::RetireValidator { .. } => {
+                        IncomingStakingTransactionData::RetireValidator { proof: _proof } => {
                             PlainTransactionRecipientData::RetireValidator(PlainRawData {
                                 raw: hex::encode(self.recipient_data()),
                             })
                         }
                         IncomingStakingTransactionData::SetInactiveStake {
                             new_inactive_balance,
-                            ..
+                            proof: _proof,
                         } => PlainTransactionRecipientData::SetInactiveStake(
                             PlainSetInactiveStakeData {
                                 raw: hex::encode(self.recipient_data()),


### PR DESCRIPTION
## What's in this pull request?

This PR adds a `type` field to all plain transaction data and proof variants in the web-client, to let users easily distinguish between data types. This will be especially helpful in our Keyguard to distinguish between staking transaction types, without having to hard-code the variant ID in the Keyguard. Experience showed that these IDs sometimes shifted, requiring manual updates. With this change, the update would be included in the client update.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
