### PR TITLE
Equivocation proofs inclusion to history store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target
 .nimiq_*
 proving_keys
 .zkp*/verifying_keys/*
+.zkp_testing
 proofs
 !.zkp*/verifying_keys/merger_wrapper.bin
 temp-logs

--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -136,6 +136,10 @@ impl BlockProducer {
             timestamp,
             executed_txns.clone(),
             inherents,
+            equivocation_proofs
+                .iter()
+                .map(|proof| proof.locator())
+                .collect(),
         );
 
         // Store the historic transactions into the history tree and calculate the history root.
@@ -307,6 +311,7 @@ impl BlockProducer {
             timestamp,
             vec![],
             inherents,
+            vec![],
         );
 
         // Store the historic transactions into the history tree and calculate the history root.

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -68,6 +68,7 @@ impl Blockchain {
                         macro_block.header.timestamp,
                         vec![],
                         inherents,
+                        vec![],
                     );
                     total_tx_size = self
                         .history_store
@@ -148,6 +149,10 @@ impl Blockchain {
                         micro_block.header.timestamp,
                         body.transactions.clone(),
                         inherents,
+                        body.equivocation_proofs
+                            .iter()
+                            .map(|proof| proof.locator())
+                            .collect(),
                     );
                     total_tx_size = self
                         .history_store

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -230,7 +230,14 @@ impl Blockchain {
 
         // Remove the transactions from the History tree. For this you only need to calculate the
         // number of transactions that you want to remove.
-        let num_txs = HistoricTransaction::count(body.transactions.len(), &inherents);
+        let num_txs = HistoricTransaction::count(
+            body.transactions.len(),
+            &inherents,
+            body.equivocation_proofs
+                .iter()
+                .map(|proof| proof.locator())
+                .collect(),
+        );
         let (_, total_size) = self
             .history_store
             .remove_partial_history(txn.raw(), block.epoch_number(), num_txs)

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -214,7 +214,7 @@ impl Blockchain {
                         value: ev.value,
                     })
                 }
-                HistoricTransactionData::Equivocation(_event) => {}
+                HistoricTransactionData::Equivocation(_) => {}
                 HistoricTransactionData::Penalize(pen) => {
                     block_inherents
                         .last_mut()

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -214,7 +214,7 @@ impl Blockchain {
                         value: ev.value,
                     })
                 }
-                HistoricTransactionData::Equivocation(_) => {}
+                HistoricTransactionData::Equivocation(_event) => {}
                 HistoricTransactionData::Penalize(pen) => {
                     block_inherents
                         .last_mut()

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -23,6 +23,10 @@ use nimiq_test_utils::{
     test_rng::test_rng,
     zkp_test_data::{get_base_seed, simulate_merger_wrapper, ZKP_TEST_KEYS_PATH},
 };
+use nimiq_transaction::{
+    historic_transaction::{EquivocationEvent, HistoricTransactionData, JailEvent},
+    EquivocationLocator, ForkLocator,
+};
 use nimiq_utils::key_rng::SecureGenerate;
 use nimiq_vrf::VrfSeed;
 use nimiq_zkp::ZKP_VERIFYING_DATA;
@@ -603,4 +607,110 @@ fn can_push_zkps() {
             Some(KeyNibbles::ROOT..)
         );
     }
+}
+
+#[test]
+fn it_pushes_and_reverts_equivocation_proof_block() {
+    // Produce a fork in producer 1.
+
+    let config = BlockConfig::default();
+    let temp_producer1 = TemporaryBlockProducer::new();
+    let temp_producer2 = TemporaryBlockProducer::new();
+
+    // Adds the same initial block to both producers.
+    assert_eq!(
+        temp_producer2.push(temp_producer1.next_block(vec![], false)),
+        Ok(PushResult::Extended)
+    );
+
+    let header_1a = temp_producer1
+        .next_block(vec![], false)
+        .unwrap_micro()
+        .header;
+
+    let block_2a = {
+        let blockchain = &temp_producer2.blockchain.read();
+        next_micro_block(&temp_producer1.producer.signing_key, blockchain, &config)
+    };
+    let header_2a = block_2a.header.clone();
+
+    assert_eq!(
+        &temp_producer1.push(Block::Micro(block_2a)),
+        &Ok(PushResult::Forked)
+    );
+
+    // Get initial history store.
+    let blockchain = temp_producer1.blockchain.read();
+    let hist_tx_pre = blockchain.history_store.get_epoch_transactions(1, None);
+    drop(blockchain);
+
+    // Add a block with the equivocation proof for the fork.
+    let block_3 = {
+        let blockchain = &temp_producer1.blockchain.read();
+
+        let signing_key = temp_producer1.producer.signing_key.clone();
+        let header1_hash: Blake2bHash = header_1a.hash();
+        let header2_hash: Blake2bHash = header_2a.hash();
+        let justification1 = signing_key.sign(header1_hash.as_bytes());
+        let justification2 = signing_key.sign(header2_hash.as_bytes());
+        let config = BlockConfig {
+            equivocation_proofs: vec![ForkProof::new(
+                validator_address(),
+                header_1a,
+                justification1,
+                header_2a.clone(),
+                justification2,
+            )
+            .into()],
+            test_macro: false,
+            test_election: false,
+            ..Default::default()
+        };
+        next_micro_block(&temp_producer1.producer.signing_key, blockchain, &config)
+    };
+    let header_3 = block_3.header.clone();
+
+    assert_eq!(
+        &temp_producer1.push(Block::Micro(block_3)),
+        &Ok(PushResult::Extended)
+    );
+
+    // Get the new history store after the block push.
+    let blockchain = temp_producer1.blockchain.write();
+    let mut txn = blockchain.write_transaction();
+    let hist_tx_after = blockchain
+        .history_store
+        .get_epoch_transactions(1, Some(&txn));
+
+    // Assert that the jail inherent and equivocation proof are present in history store.
+    assert_eq!(hist_tx_after.len(), 2);
+    assert_eq!(hist_tx_after[0].block_number, header_3.block_number);
+    assert_eq!(hist_tx_after[1].block_number, header_3.block_number);
+    assert_eq!(
+        hist_tx_after[0].data,
+        HistoricTransactionData::Jail(JailEvent {
+            validator_address: validator_address(),
+            slots: 0..512,
+            offense_event_block: header_2a.block_number,
+            new_epoch_slot_range: None
+        })
+    );
+    assert_eq!(
+        hist_tx_after[1].data,
+        HistoricTransactionData::Equivocation(EquivocationEvent {
+            locator: EquivocationLocator::Fork(ForkLocator {
+                validator_address: validator_address(),
+                block_number: header_2a.block_number
+            })
+        })
+    );
+
+    // Revert block and assert that history store is reverted as well.
+    blockchain.revert_blocks(1, &mut txn).unwrap();
+
+    let hist_tx_revert = blockchain
+        .history_store
+        .get_epoch_transactions(1, Some(&txn));
+
+    assert_eq!(hist_tx_pre, hist_tx_revert);
 }

--- a/pow-migration/src/history/mod.rs
+++ b/pow-migration/src/history/mod.rs
@@ -183,7 +183,8 @@ pub async fn get_history_root(
                 block_height,
                 block.timestamp.into(),
                 transactions,
-                [].to_vec(),
+                vec![],
+                vec![],
             ),
         );
         txn.commit();

--- a/primitives/transaction/src/historic_transaction.rs
+++ b/primitives/transaction/src/historic_transaction.rs
@@ -56,6 +56,7 @@ impl HistoricTransaction {
         block_time: u64,
         transactions: Vec<ExecutedTransaction>,
         inherents: Vec<Inherent>,
+        equivocation_locator: Vec<EquivocationLocator>,
     ) -> Vec<HistoricTransaction> {
         let mut hist_txs = vec![];
 
@@ -113,6 +114,15 @@ impl HistoricTransaction {
                 Inherent::FinalizeBatch => {}
                 Inherent::FinalizeEpoch => {}
             }
+        }
+
+        for locator in equivocation_locator {
+            hist_txs.push(HistoricTransaction {
+                network_id,
+                block_number,
+                block_time,
+                data: HistoricTransactionData::Equivocation(EquivocationEvent { locator }),
+            });
         }
 
         hist_txs

--- a/primitives/transaction/src/historic_transaction.rs
+++ b/primitives/transaction/src/historic_transaction.rs
@@ -128,7 +128,11 @@ impl HistoricTransaction {
         hist_txs
     }
 
-    pub fn count(num_transactions: usize, inherents: &[Inherent]) -> usize {
+    pub fn count(
+        num_transactions: usize,
+        inherents: &[Inherent],
+        equivocation_locator: Vec<EquivocationLocator>,
+    ) -> usize {
         num_transactions
             + inherents
                 .iter()
@@ -140,6 +144,7 @@ impl HistoricTransaction {
                     Inherent::FinalizeEpoch => None,
                 })
                 .count()
+            + equivocation_locator.len()
     }
 
     /// Checks if the historic transaction is an inherent.

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -122,6 +122,11 @@ pub fn next_micro_block(
         timestamp,
         executed_txns.clone(),
         inherents,
+        config
+            .equivocation_proofs
+            .iter()
+            .map(|proof| proof.locator())
+            .collect(),
     );
 
     let mut txn = blockchain.write_transaction();
@@ -215,6 +220,7 @@ pub fn next_skip_block(
         timestamp,
         vec![],
         inherents,
+        vec![],
     );
 
     let mut txn = blockchain.write_transaction();
@@ -357,6 +363,7 @@ pub fn next_macro_block_proposal(
         timestamp,
         vec![],
         inherents,
+        vec![],
     );
 
     let mut txn = blockchain.write_transaction();


### PR DESCRIPTION
## What's in this pull request?
Makes us store equivocation proofs in the history store when we push a micro block. It adds a test for this specific scenario as well.

This PR also adds tests pushing and removing different inherents and equivocation proofs to the history store test.

#### This fixes #1978.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
