### PR TITLE
Storing equivocation proofs before inherents to the history store

### DIFF
--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -688,20 +688,20 @@ fn it_pushes_and_reverts_equivocation_proof_block() {
     assert_eq!(hist_tx_after[1].block_number, header_3.block_number);
     assert_eq!(
         hist_tx_after[0].data,
-        HistoricTransactionData::Jail(JailEvent {
-            validator_address: validator_address(),
-            slots: 0..512,
-            offense_event_block: header_2a.block_number,
-            new_epoch_slot_range: None
-        })
-    );
-    assert_eq!(
-        hist_tx_after[1].data,
         HistoricTransactionData::Equivocation(EquivocationEvent {
             locator: EquivocationLocator::Fork(ForkLocator {
                 validator_address: validator_address(),
                 block_number: header_2a.block_number
             })
+        })
+    );
+    assert_eq!(
+        hist_tx_after[1].data,
+        HistoricTransactionData::Jail(JailEvent {
+            validator_address: validator_address(),
+            slots: 0..512,
+            offense_event_block: header_2a.block_number,
+            new_epoch_slot_range: None
         })
     );
 

--- a/primitives/transaction/src/historic_transaction.rs
+++ b/primitives/transaction/src/historic_transaction.rs
@@ -69,6 +69,15 @@ impl HistoricTransaction {
             })
         }
 
+        for locator in equivocation_locator {
+            hist_txs.push(HistoricTransaction {
+                network_id,
+                block_number,
+                block_time,
+                data: HistoricTransactionData::Equivocation(EquivocationEvent { locator }),
+            });
+        }
+
         for inherent in inherents {
             match inherent {
                 Inherent::Reward {
@@ -114,15 +123,6 @@ impl HistoricTransaction {
                 Inherent::FinalizeBatch => {}
                 Inherent::FinalizeEpoch => {}
             }
-        }
-
-        for locator in equivocation_locator {
-            hist_txs.push(HistoricTransaction {
-                network_id,
-                block_number,
-                block_time,
-                data: HistoricTransactionData::Equivocation(EquivocationEvent { locator }),
-            });
         }
 
         hist_txs


### PR DESCRIPTION
## What's in this pull request?
Just a small fix that should have been included in #2033. We decided that it would make more sense to store the equivocation proofs before inherents in the history store.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
