### PR TITLE
Revert "BlockQueue: only consider block announcements from synced peers"

### DIFF
--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -16,7 +16,7 @@ use parking_lot::RwLock;
 
 use self::block_request_component::BlockRequestComponent;
 use super::{block_queue::block_request_component::BlockRequestComponentEvent, queue::QueueConfig};
-use crate::sync::peer_list::PeerList;
+use crate::sync::{live::LiveSyncQueue, peer_list::PeerList};
 
 pub mod block_request_component;
 pub mod live_sync;
@@ -601,8 +601,8 @@ impl<N: Network> Stream for BlockQueue<N> {
         loop {
             match self.block_stream.poll_next_unpin(cx) {
                 Poll::Ready(Some((block, peer_id, pubsub_id))) => {
-                    // Only consider announcements from synced peers.
-                    if self.peer_list().read().has_peer(&peer_id) {
+                    // Ignore all block announcements until there is at least one synced peer.
+                    if self.num_peers() > 0 {
                         log::debug!(%block, %peer_id, "Received block via gossipsub");
                         if let Some(block) = self.check_announced_block(block, peer_id, pubsub_id) {
                             return Poll::Ready(Some(block));

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -371,7 +371,7 @@ async fn send_invalid_block() {
         Block::Micro(block)
     };
 
-    let mock_id = MockId::new(mock_node.network.get_local_peer_id());
+    let mock_id = MockId::new(hub.new_address().into());
 
     // Send block2 first
     block_tx


### PR DESCRIPTION
This reverts commit 5e0c54e479b2ca24117e81fd7bad25d95b50be1f. This is an intermediate solution to fix an issue where block announcements are being ignored if the peer has incompatible service flags.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
