### PR TITLE
Web-client: allow deserializing transactions from an Uint8Array

### DIFF
--- a/web-client/example/module.js
+++ b/web-client/example/module.js
@@ -86,7 +86,7 @@ init().then(async () => {
             transaction.sign(keyPair);
         }
 
-        return client.sendTransaction(transaction.toHex());
+        return client.sendTransaction(transaction);
     }
 
     /**
@@ -113,7 +113,7 @@ init().then(async () => {
         );
         transaction.sign(keyPair);
 
-        return client.sendTransaction(transaction.toHex());
+        return client.sendTransaction(transaction);
     }
 
     /**
@@ -139,7 +139,7 @@ init().then(async () => {
         );
         transaction.sign(keyPair);
 
-        return client.sendTransaction(transaction.toHex());
+        return client.sendTransaction(transaction);
     }
 
     /**
@@ -164,6 +164,6 @@ init().then(async () => {
         );
         transaction.sign(keyPair);
 
-        return client.sendTransaction(transaction.toHex());
+        return client.sendTransaction(transaction);
     }
 });

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -386,6 +386,10 @@ impl Transaction {
             Ok(Transaction::from_native(
                 nimiq_transaction::Transaction::deserialize_from_vec(&hex::decode(string)?)?,
             ))
+        } else if let Ok(bytes) = serde_wasm_bindgen::from_value::<Vec<u8>>(js_value.to_owned()) {
+            Ok(Transaction::from_native(
+                nimiq_transaction::Transaction::deserialize_from_vec(&bytes)?,
+            ))
         } else {
             Err(JsError::new("Failed to parse transaction."))
         }
@@ -1144,13 +1148,13 @@ extern "C" {
 #[cfg(feature = "primitives")]
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "Transaction | PlainTransaction | string")]
+    #[wasm_bindgen(typescript_type = "Transaction | PlainTransaction | string | Uint8Array")]
     pub type TransactionAnyType;
 }
 
 #[cfg(not(feature = "primitives"))]
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "PlainTransaction | string")]
+    #[wasm_bindgen(typescript_type = "PlainTransaction | string | Uint8Array")]
     pub type TransactionAnyType;
 }


### PR DESCRIPTION
- Allow deserializing transactions from an Uint8Array
- Make use of native Transaction object instance transfer handlers in example (closes #2008).

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
