### PR TITLE
network-libp2p: Add the autonat behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,19 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "asynchronous-codec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
@@ -2483,6 +2496,7 @@ dependencies = [
  "getrandom",
  "instant",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
@@ -2518,6 +2532,27 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95151726170e41b591735bf95c42b888fe4aa14f65216a9fbf0edcc04510586"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec 0.6.2",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
+ "rand",
+ "tracing",
 ]
 
 [[package]]
@@ -2583,7 +2618,7 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d665144a616dadebdc5fff186b1233488cdcd8bfb1223218ff084b6d052c94f7"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "base64 0.21.5",
  "byteorder",
  "bytes",
@@ -2599,7 +2634,7 @@ dependencies = [
  "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.3.1",
  "rand",
  "regex",
  "serde",
@@ -2615,7 +2650,7 @@ version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20499a945d2f0221fdc6269b3848892c0f370d2ee3e19c7f65a29d8f860f6126"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "either",
  "futures",
  "futures-bounded",
@@ -2625,7 +2660,7 @@ dependencies = [
  "libp2p-swarm",
  "lru",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.3.1",
  "smallvec",
  "thiserror",
  "tracing",
@@ -2658,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc5767727d062c4eac74dd812c998f0e488008e82cce9c33b463d38423f9ad2"
 dependencies = [
  "arrayvec 0.7.4",
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "either",
  "fnv",
@@ -2670,7 +2705,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.3.1",
  "rand",
  "serde",
  "sha2",
@@ -2727,7 +2762,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecd0545ce077f6ea5434bcb76e8d0fe942693b4380aaad0d34a358c2bd05793"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "curve25519-dalek",
  "futures",
@@ -5323,11 +5358,24 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
+dependencies = [
+ "asynchronous-codec 0.6.2",
+ "bytes",
+ "quick-protobuf",
+ "thiserror",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf",
  "thiserror",
@@ -6829,6 +6877,10 @@ name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+dependencies = [
+ "asynchronous-codec 0.6.2",
+ "bytes",
+]
 
 [[package]]
 name = "unsigned-varint"

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -298,6 +298,7 @@ impl ClientInner {
             false,
             required_services,
             tls_config,
+            config.network.autonat_allow_non_global_ips,
         );
 
         log::debug!(

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -118,6 +118,10 @@ pub struct NetworkConfig {
     /// Optional TLS configuration for secure WebSocket
     #[builder(default)]
     pub tls: Option<TlsConfig>,
+
+    /// Optional setting to allow network autonat to use non global IPs
+    #[builder(default)]
+    pub autonat_allow_non_global_ips: bool,
 }
 
 /// Configuration for setting TLS for secure WebSocket
@@ -763,6 +767,7 @@ impl ClientConfigBuilder {
             seeds: config_file.network.seed_nodes.clone(),
 
             tls: config_file.network.tls.as_ref().map(|s| s.clone().into()),
+            autonat_allow_non_global_ips: config_file.network.autonat_allow_non_global_ips,
         });
 
         // Configure consensus

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -10,8 +10,6 @@
 #
 ##############################################################################
 
-
-
 ##############################################################################
 #
 # Network specific configuration
@@ -21,11 +19,11 @@
 [network]
 
 listen_addresses = [
-        "/ip4/0.0.0.0/tcp/8443/ws",
+  "/ip4/0.0.0.0/tcp/8443/ws",
 ]
 
 seed_nodes = [
-        { address = "/dns4/seed1.pos.nimiq-testnet.com/tcp/8443/wss" }
+  { address = "/dns4/seed1.pos.nimiq-testnet.com/tcp/8443/wss" },
 ]
 
 # Optionally specify address(es) that will be advertised to peers instead of the ones in `listen_addresses`
@@ -33,7 +31,9 @@ seed_nodes = [
 # This can be used to advertise the public URL and port that peers should connect to, while
 # `listen_addresses` contains the loopback IP and port that this nodes listens on, which may
 # not be publicly reachable.
+# For validators it is strongly recommended to list a public reachable IPv4 IP.
 #advertised_addresses = [
+#        "/ip4/my.ip/tcp/8444/ws",
 #        "/dns4/my.public.domain.com/tcp/8443/wss",
 #]
 
@@ -44,7 +44,11 @@ seed_nodes = [
 # Default: Generated from version, operating system and processor architecture
 #user_agent = "core-rs/0.1.0 (native; linux x86_64)"
 
-
+# Optionally specify if the network should allow the autonat feature to use non global IPs
+# Recommended setting is to keep it in false.
+#
+# Default: false
+#autonat_allow_non_global_ips = false
 
 ##############################################################################
 #
@@ -58,8 +62,6 @@ seed_nodes = [
 #[network.tls]
 #private_key = "./my_private_key.pem"
 #certificates = "./my_certificate.pem"
-
-
 
 ##############################################################################
 #
@@ -127,7 +129,7 @@ sync_mode = "full"
 
 # Bind the RPC server to specified IP
 # Default: 127.0.0.1
-bind="127.0.0.1"
+bind = "127.0.0.1"
 
 # TCP-Port to use to create a listening socket for the JSON-RPC server.
 # Possible values: any valid port number
@@ -144,7 +146,6 @@ methods = []
 username = "super"
 # Default: none
 password = "secret"
-
 
 ##############################################################################
 #
@@ -170,7 +171,6 @@ username = "super"
 
 # Default: none
 password = "secret"
-
 
 ##############################################################################
 #
@@ -201,7 +201,6 @@ level = "debug"
 # Default: None
 #tokio_console_bind_address = "127.0.0.1:6669"
 
-
 # Loki target
 # [log.loki]
 
@@ -216,7 +215,6 @@ level = "debug"
 
 # Extra fields added to each log message (e.g. to distinguish runs)
 # extra_fields = { run = "e2f8e044-0067-4902-914f-261b7f500ba7" }
-
 
 ##############################################################################
 #

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -137,6 +137,8 @@ pub struct NetworkSettings {
 
     pub tls: Option<TlsSettings>,
     pub instant_inbound: Option<bool>,
+    #[serde(default)]
+    pub autonat_allow_non_global_ips: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -14,11 +14,15 @@ use crate::{
     request::{Message, Request, RequestError},
 };
 
+/// Network events that the network will report when subscribing
 #[derive(Clone, Debug)]
 pub enum NetworkEvent<P> {
+    /// A connection to a new peer has been started
     PeerJoined(P, PeerInfo),
+    /// A peer disconnected
     PeerLeft(P),
-    DhtBootstrapped,
+    /// DHT is ready (bootstrapped and in server mode) to publish records
+    DhtReady,
 }
 
 pub type SubscribeEvents<PeerId> =

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -57,6 +57,7 @@ nimiq-validator-network = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 libp2p = { version = "0.53.2", default-features = false, features = [
+    "autonat",
     "gossipsub",
     "identify",
     "kad",
@@ -71,6 +72,7 @@ libp2p = { version = "0.53.2", default-features = false, features = [
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 libp2p = { version = "0.53.2", default-features = false, features = [
+    "autonat",
     "gossipsub",
     "identify",
     "kad",

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -101,7 +101,11 @@ impl Behaviour {
         );
 
         // Autonat behaviour
-        let autonat = autonat::Behaviour::new(peer_id, autonat::Config::default());
+        let mut autonat_config = autonat::Config::default();
+        if config.autonat_allow_non_global_ips {
+            autonat_config.only_global_ips = false;
+        }
+        let autonat = autonat::Behaviour::new(peer_id, autonat_config);
 
         // Connection limits behaviour
         let limits = connection_limits::ConnectionLimits::default()

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub memory_transport: bool,
     pub required_services: Services,
     pub tls: Option<TlsConfig>,
+    pub autonat_allow_non_global_ips: bool,
 }
 
 impl Config {
@@ -41,6 +42,7 @@ impl Config {
         memory_transport: bool,
         required_services: Services,
         tls_settings: Option<TlsConfig>,
+        autonat_allow_non_global_ips: bool,
     ) -> Self {
         // Hardcoding the minimum number of peers in mesh network before adding more
         // TODO: Maybe change this to a mesh limits configuration argument of this function
@@ -80,6 +82,7 @@ impl Config {
             memory_transport,
             required_services,
             tls: tls_settings,
+            autonat_allow_non_global_ips,
         }
     }
 }

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -119,12 +119,18 @@ impl Behaviour {
         let house_keeping_timer = Interval::new(config.house_keeping_interval);
         peer_contact_book.write().update_own_contact(&keypair);
 
+        // Report our own known addresses as candidates to the swarm
+        let mut events = VecDeque::new();
+        for address in peer_contact_book.read().get_own_contact().addresses() {
+            events.push_back(ToSwarm::NewExternalAddrCandidate(address.clone()));
+        }
+
         Self {
             config,
             keypair,
             connected_peers: HashSet::new(),
             peer_contact_book,
-            events: VecDeque::new(),
+            events,
             house_keeping_timer,
         }
     }

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -450,9 +450,13 @@ impl Network {
         rate_limits_pending_deletion: Arc<Mutex<PendingDeletion>>,
         mut update_scores: Interval,
         contacts: Arc<RwLock<PeerContactBook>>,
+        force_dht_server_mode: bool,
         #[cfg(feature = "metrics")] metrics: Arc<NetworkMetrics>,
     ) {
-        let mut task_state = TaskState::default();
+        let mut task_state = TaskState {
+            dht_server_mode: force_dht_server_mode,
+            ..Default::default()
+        };
 
         let peer_id = Swarm::local_peer_id(&swarm);
         let task_span = trace_span!("swarm task", peer_id=?peer_id);
@@ -521,8 +525,10 @@ impl Network {
         force_dht_server_mode: bool,
         #[cfg(feature = "metrics")] metrics: Arc<NetworkMetrics>,
     ) {
-        let mut task_state = TaskState::default();
-        task_state.dht_server_mode = force_dht_server_mode;
+        let mut task_state = TaskState {
+            dht_server_mode: force_dht_server_mode,
+            ..Default::default()
+        };
 
         let peer_id = Swarm::local_peer_id(&swarm);
         let task_span = trace_span!("swarm task", peer_id=?peer_id);

--- a/network-libp2p/tests/helper/mod.rs
+++ b/network-libp2p/tests/helper/mod.rs
@@ -22,7 +22,7 @@ pub fn assert_peer_left(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
 pub async fn get_next_peer_event(events: &mut SubscribeEvents<PeerId>) -> NetworkEvent<PeerId> {
     while let Ok(event) = events.next().await.unwrap() {
         match event {
-            NetworkEvent::DhtBootstrapped => {}
+            NetworkEvent::DhtReady => {}
             _ => return event,
         }
     }

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -249,7 +249,7 @@ async fn create_network_with_n_peers(n_peers: usize) -> Vec<Network> {
                 Ok(NetworkEvent::PeerJoined(peer_id, _)) => {
                     log::info!(%local_peer_id, %peer_id, "Received peer joined event");
                 }
-                Ok(NetworkEvent::DhtBootstrapped) => {}
+                Ok(NetworkEvent::DhtReady) => {}
                 _ => log::error!(?event, "Unexpected NetworkEvent"),
             };
         });

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -56,6 +56,7 @@ fn network_config(address: Multiaddr) -> Config {
         memory_transport: true,
         required_services: Services::all(),
         tls: None,
+        autonat_allow_non_global_ips: true,
     }
 }
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -302,6 +302,7 @@ fn network_config(address: Multiaddr) -> Config {
         memory_transport: true,
         required_services: Services::all(),
         tls: None,
+        autonat_allow_non_global_ips: true,
     }
 }
 

--- a/scripts/devnet/templates/node_conf.toml.j2
+++ b/scripts/devnet/templates/node_conf.toml.j2
@@ -12,6 +12,8 @@ seed_nodes = [
 ]
 
 {% endif %}
+autonat_allow_non_global_ips = true
+
 [consensus]
 network = "dev-albatross"
 sync_mode = "{{ sync_mode }}"

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -70,6 +70,7 @@ impl TestNetwork for Network {
             true,
             Services::all(),
             None,
+            true,
         );
         let network = Arc::new(
             Network::new(

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -880,7 +880,7 @@ where
         // Check if DHT is bootstrapped and we can publish our record
         while let Poll::Ready(Some(result)) = self.network_event_rx.poll_next_unpin(cx) {
             match result {
-                Ok(NetworkEvent::DhtBootstrapped) => {
+                Ok(NetworkEvent::DhtReady) => {
                     self.publish_dht();
                 }
                 Ok(_) => {}


### PR DESCRIPTION
- Add the `autonat` behaviour to detect when a peer is behind a private `NAT`. If in the other hand a peer has a public rachable IP, then the behaviour will fire the `ExternalAddrConfirmed` event and will put the `kad` behaviour (DHT) into server mode.
  This removes the previous setting where the DHT was being set always in server mode regardless of the node reachability except for the memory transport where Autonat doesn't work (only works with IPs).
- Add a configuration file option to allow `Autonat` to use non global IPs. This is useful in our `devnet` testing scenarios since it
  regularly consists of nodes with non global IPs (like loopback addresses, etc).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
