### PR TITLE
network-libp2p: Cleanup, fix and remove ToDos from the discovery behaviour

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -308,8 +308,7 @@ impl ClientInner {
             "Advertised addresses",
         );
 
-        let network =
-            Arc::new(Network::new(Arc::clone(&time), network_config, executor.clone()).await);
+        let network = Arc::new(Network::new(network_config, executor.clone()).await);
 
         // Start buffering network events as early as possible
         let network_events = network.subscribe_events();

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -7,7 +7,6 @@ use libp2p::{
     swarm::NetworkBehaviour,
     Multiaddr, PeerId, StreamProtocol,
 };
-use nimiq_utils::time::OffsetTime;
 use parking_lot::RwLock;
 
 use crate::{
@@ -43,7 +42,6 @@ pub struct Behaviour {
 impl Behaviour {
     pub fn new(
         config: Config,
-        clock: Arc<OffsetTime>,
         contacts: Arc<RwLock<PeerContactBook>>,
         peer_score_params: gossipsub::PeerScoreParams,
     ) -> Self {
@@ -62,7 +60,6 @@ impl Behaviour {
             config.discovery.clone(),
             config.keypair.clone(),
             Arc::clone(&contacts),
-            clock,
         );
 
         // Gossipsub behaviour

--- a/network-libp2p/src/discovery/protocol.rs
+++ b/network-libp2p/src/discovery/protocol.rs
@@ -51,9 +51,6 @@ pub enum DiscoveryMessage {
 
         /// Service flags for which the sender needs peer contacts.
         services: Services,
-
-        /// User agent string of the sender.
-        user_agent: String,
     },
 
     HandshakeAck {

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -22,7 +22,6 @@ use nimiq_network_libp2p::discovery::{
     peer_contacts::{PeerContact, PeerContactBook, SignedPeerContact},
 };
 use nimiq_test_log::test;
-use nimiq_utils::time::OffsetTime;
 use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
 
@@ -71,13 +70,8 @@ impl TestNode {
 
         let peer_contact_book = Arc::new(RwLock::new(PeerContactBook::new(peer_contact)));
 
-        let clock = Arc::new(OffsetTime::new());
-        let behaviour = discovery::Behaviour::new(
-            config,
-            keypair.clone(),
-            Arc::clone(&peer_contact_book),
-            clock,
-        );
+        let behaviour =
+            discovery::Behaviour::new(config, keypair.clone(), Arc::clone(&peer_contact_book));
 
         let mut swarm = SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use futures::{Stream, StreamExt};
 use libp2p::{
@@ -15,7 +15,6 @@ use nimiq_network_libp2p::{
     Config, Network,
 };
 use nimiq_test_log::test;
-use nimiq_utils::time::OffsetTime;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
@@ -78,9 +77,7 @@ impl TestNetwork {
         let address = multiaddr![Memory(self.next_address)];
         self.next_address += 1;
 
-        let clock = Arc::new(OffsetTime::new());
         let net = Network::new(
-            clock,
             network_config(address.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);
@@ -115,7 +112,6 @@ async fn create_connected_networks() -> (Network, Network) {
     let addr2 = multiaddr![Memory(rng.gen::<u64>())];
 
     let net1 = Network::new(
-        Arc::new(OffsetTime::new()),
         network_config(addr1.clone()),
         Box::new(|fut| {
             tokio::spawn(fut);
@@ -125,7 +121,6 @@ async fn create_connected_networks() -> (Network, Network) {
     net1.listen_on(vec![addr1.clone()]).await;
 
     let net2 = Network::new(
-        Arc::new(OffsetTime::new()),
         network_config(addr2.clone()),
         Box::new(|fut| {
             tokio::spawn(fut);
@@ -163,7 +158,6 @@ async fn create_double_connected_networks() -> (Network, Network) {
     let addr2 = multiaddr![Memory(rng.gen::<u64>())];
 
     let net1 = Network::new(
-        Arc::new(OffsetTime::new()),
         network_config(addr1.clone()),
         Box::new(|fut| {
             tokio::spawn(fut);
@@ -173,7 +167,6 @@ async fn create_double_connected_networks() -> (Network, Network) {
     net1.listen_on(vec![addr1.clone()]).await;
 
     let net2 = Network::new(
-        Arc::new(OffsetTime::new()),
         network_config(addr2.clone()),
         Box::new(|fut| {
             tokio::spawn(fut);
@@ -219,7 +212,6 @@ async fn create_network_with_n_peers(n_peers: usize) -> Vec<Network> {
         addresses.push(addr.clone());
 
         let network = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -22,7 +22,6 @@ use nimiq_network_libp2p::{
 };
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
 use nimiq_test_log::test;
-use nimiq_utils::time::OffsetTime;
 use rand::{thread_rng, Rng};
 use tokio::time::Duration;
 #[cfg(feature = "tokio-time")]
@@ -138,7 +137,6 @@ impl TestNetwork {
         let addr2 = multiaddr![Memory(rng.gen::<u64>())];
 
         let net1 = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr1.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);
@@ -148,7 +146,6 @@ impl TestNetwork {
         net1.listen_on(vec![addr1.clone()]).await;
 
         let net2 = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr2.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -8,7 +8,6 @@ use nimiq_network_libp2p::{
     Network,
 };
 use nimiq_network_mock::{MockHub, MockNetwork};
-use nimiq_utils::time::OffsetTime;
 
 #[async_trait]
 pub trait TestNetwork<N = Self>
@@ -54,7 +53,6 @@ impl TestNetwork for Network {
         genesis_hash: Blake2bHash,
         _hub: &mut Option<MockHub>,
     ) -> Arc<Network> {
-        let clock = Arc::new(OffsetTime::new());
         let peer_key = Keypair::generate_ed25519();
         let peer_address = multiaddr![Memory(peer_id)];
         let mut peer_contact = PeerContact::new(
@@ -75,7 +73,6 @@ impl TestNetwork for Network {
         );
         let network = Arc::new(
             Network::new(
-                clock,
                 config,
                 Box::new(|fut| {
                     tokio::spawn(fut);


### PR DESCRIPTION
Cleanup, fix and remove ToDos from the discovery behaviour:
- Fix the update the `own_peer_contact`.
- Make sure that the `own_peer_contact` never gets to the `peer_contacts`.
- Only update peer contacts if the timestamp is greater than ours and do not allow future timestamps.
- Remove the unused clock argument from the behaviour and the network.
- Make sure that the key of the peer contact matches the `PeerId` of the connection.
- Remove the unused `user_agent` from the `DiscoveryMessage` message in the discovery protocol.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
