### PR TITLE
Fix interlink hop calculation for block inclusion proofs

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -337,6 +337,12 @@ impl<N: Network> ConsensusProxy<N> {
                                     .verify(block.history_root().clone())
                                     .map_or(false, |result| result);
 
+                                if !verification_result {
+                                    // If the proof didn't verify, we continue with another peer
+                                    log::warn!(peer=%peer_id, "The transaction history proof from this peer did not verify");
+                                    continue;
+                                }
+
                                 // Verify that the transaction proof fits to the chain
                                 if block.block_number() <= election_head.block_number() {
                                     let block_hash = block.hash();
@@ -401,7 +407,7 @@ impl<N: Network> ConsensusProxy<N> {
                                     }
                                 } else {
                                     // The proof didn't verify so we continue with another peer
-                                    log::warn!(peer=%peer_id, "The transaction proof from this peer did not verify");
+                                    log::warn!(peer=%peer_id, "The transaction block proof from this peer did not verify");
                                 }
                             } else {
                                 // If we receive a proof but we do not receive a block, we disconnect from the peer

--- a/primitives/block/src/block_proof.rs
+++ b/primitives/block/src/block_proof.rs
@@ -17,8 +17,8 @@ impl BlockInclusionProof {
     // Computes the interlink hops needed to proof `wanted_election_number` when starting from `latest_election_number`
     pub fn get_interlink_hops(target: u32, latest_election_number: u32) -> Vec<u32> {
         // For simplicity, refer to election blocks by the number of their epoch
-        let target_number = target / Policy::blocks_per_epoch();
-        let latest_number = latest_election_number / Policy::blocks_per_epoch();
+        let target_number = Policy::epoch_at(target);
+        let latest_number = Policy::epoch_at(latest_election_number);
 
         // Compute the hops
         let mut hops = vec![];
@@ -48,7 +48,7 @@ impl BlockInclusionProof {
 
         // Convert hops back from epoch to block numbers
         hops.into_iter()
-            .map(|i| i * Policy::blocks_per_epoch())
+            .map(|i| Policy::election_block_of(i).expect("Invalid epoch number"))
             .collect()
     }
 


### PR DESCRIPTION
## What's in this pull request?

Block inclusion proofs for past epochs were failing, because the response contained no blocks. The reason is that the calculation for which blocks must be included (hops) was not updated to non-zero genesis block numbers and still used the naive blocknumber-divided-by-blocks-per-epoch approach.

A second commit adds an early "return" (actually a `continue`) for the case when the `HistoryTreeProof` already fails to verify. If it does, the `verification_result` cannot become `true` anymore, so in order to prevent the fetching of block inclusion proofs (both for accidental and purposefully invalid proofs) in this case and to reduce time spent in the loop, we can already skip to the next loop iteration, as it would anyway at the end of the loop body where the `verification_result` is checked.

#### This fixes #2059.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
