### PR TITLE
Simplify `Handle` trait

### DIFF
--- a/consensus/src/consensus/remote_event_dispatcher.rs
+++ b/consensus/src/consensus/remote_event_dispatcher.rs
@@ -32,7 +32,7 @@ pub const MAX_SUBSCRIBED_PEERS: usize = 50;
 /// The max number of addresses that can be subscribed, per peer.
 pub const MAX_SUBSCRIBED_PEERS_ADDRESSES: usize = 250;
 
-impl<N: Network> Handle<N, ResponseSubscribeToAddress, Arc<RwLock<RemoteEventDispatcherState<N>>>>
+impl<N: Network> Handle<N, Arc<RwLock<RemoteEventDispatcherState<N>>>>
     for RequestSubscribeToAddress
 {
     fn handle(

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -21,7 +21,7 @@ use crate::sync::live::{
     state_queue::{Chunk, RequestChunk, ResponseChunk},
 };
 
-impl<N: Network> Handle<N, MacroChain, BlockchainProxy> for RequestMacroChain {
+impl<N: Network> Handle<N, BlockchainProxy> for RequestMacroChain {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &BlockchainProxy) -> MacroChain {
         let blockchain = blockchain.read();
 
@@ -89,7 +89,7 @@ impl<N: Network> Handle<N, MacroChain, BlockchainProxy> for RequestMacroChain {
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, BatchSetInfo, Arc<RwLock<Blockchain>>> for RequestBatchSet {
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestBatchSet {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &Arc<RwLock<Blockchain>>) -> BatchSetInfo {
         let blockchain = blockchain.read();
 
@@ -148,7 +148,7 @@ impl<N: Network> Handle<N, BatchSetInfo, Arc<RwLock<Blockchain>>> for RequestBat
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, HistoryChunk, Arc<RwLock<Blockchain>>> for RequestHistoryChunk {
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestHistoryChunk {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &Arc<RwLock<Blockchain>>) -> HistoryChunk {
         let chunk = blockchain.read().history_store.prove_chunk(
             self.epoch_number,
@@ -161,7 +161,7 @@ impl<N: Network> Handle<N, HistoryChunk, Arc<RwLock<Blockchain>>> for RequestHis
     }
 }
 
-impl<N: Network> Handle<N, Option<Block>, BlockchainProxy> for RequestBlock {
+impl<N: Network> Handle<N, BlockchainProxy> for RequestBlock {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &BlockchainProxy) -> Option<Block> {
         let blockchain = blockchain.read();
         if let Ok(block) = blockchain.get_block(&self.hash, false) {
@@ -190,7 +190,7 @@ impl<N: Network> Handle<N, Option<Block>, BlockchainProxy> for RequestBlock {
     }
 }
 
-impl<N: Network> Handle<N, ResponseBlocks, BlockchainProxy> for RequestMissingBlocks {
+impl<N: Network> Handle<N, BlockchainProxy> for RequestMissingBlocks {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &BlockchainProxy) -> ResponseBlocks {
         let blockchain = blockchain.read();
 
@@ -287,14 +287,14 @@ impl<N: Network> Handle<N, ResponseBlocks, BlockchainProxy> for RequestMissingBl
     }
 }
 
-impl<N: Network> Handle<N, Blake2bHash, BlockchainProxy> for RequestHead {
+impl<N: Network> Handle<N, BlockchainProxy> for RequestHead {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &BlockchainProxy) -> Blake2bHash {
         blockchain.read().head_hash()
     }
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, ResponseChunk, Arc<RwLock<Blockchain>>> for RequestChunk {
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestChunk {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &Arc<RwLock<Blockchain>>) -> ResponseChunk {
         let blockchain_rg = blockchain.read();
 
@@ -318,7 +318,7 @@ impl<N: Network> Handle<N, ResponseChunk, Arc<RwLock<Blockchain>>> for RequestCh
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, ResponseTrieDiff, Arc<RwLock<Blockchain>>> for RequestTrieDiff {
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTrieDiff {
     fn handle(&self, _peer_id: N::PeerId, context: &Arc<RwLock<Blockchain>>) -> ResponseTrieDiff {
         // TODO return the requested range only
         let blockchain = context.read();
@@ -546,9 +546,7 @@ fn prove_transaction(
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, ResponseTransactionsProof, Arc<RwLock<Blockchain>>>
-    for RequestTransactionsProof
-{
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTransactionsProof {
     fn handle(
         &self,
         _peer_id: N::PeerId,
@@ -572,9 +570,7 @@ impl<N: Network> Handle<N, ResponseTransactionsProof, Arc<RwLock<Blockchain>>>
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, ResponseTransactionReceiptsByAddress, Arc<RwLock<Blockchain>>>
-    for RequestTransactionReceiptsByAddress
-{
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTransactionReceiptsByAddress {
     fn handle(
         &self,
         _peer_id: N::PeerId,
@@ -607,7 +603,7 @@ impl<N: Network> Handle<N, ResponseTransactionReceiptsByAddress, Arc<RwLock<Bloc
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, ResponseTrieProof, Arc<RwLock<Blockchain>>> for RequestTrieProof {
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTrieProof {
     fn handle(
         &self,
         _peer_id: N::PeerId,
@@ -636,7 +632,7 @@ impl<N: Network> Handle<N, ResponseTrieProof, Arc<RwLock<Blockchain>>> for Reque
 }
 
 #[cfg(feature = "full")]
-impl<N: Network> Handle<N, ResponseBlocksProof, Arc<RwLock<Blockchain>>> for RequestBlocksProof {
+impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestBlocksProof {
     fn handle(
         &self,
         _peer_id: N::PeerId,

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -8,7 +8,7 @@ use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_consensus::{
-    messages::{RequestMissingBlocks, ResponseBlocks},
+    messages::RequestMissingBlocks,
     sync::{
         live::{
             block_queue::BlockQueue,
@@ -639,7 +639,6 @@ async fn can_reset_chain_of_chunks() {
                 .set(|peer_id, request, blockchain| {
                     let mut chunk = <RequestChunk as Handle<
                         MockNetwork,
-                        ResponseChunk,
                         Arc<RwLock<Blockchain>>,
                     >>::handle(request, peer_id, blockchain);
                     // Make chunk invalid.
@@ -729,11 +728,12 @@ async fn can_remove_chunks_related_to_invalid_blocks() {
     mock_node
         .request_missing_block_handler
         .set(|mock_id, request, blockchain_proxy| {
-            let mut response = <RequestMissingBlocks as Handle<
-                MockNetwork,
-                ResponseBlocks,
-                BlockchainProxy,
-            >>::handle(request, mock_id, blockchain_proxy);
+            let mut response =
+                <RequestMissingBlocks as Handle<MockNetwork, BlockchainProxy>>::handle(
+                    request,
+                    mock_id,
+                    blockchain_proxy,
+                );
             match response.blocks {
                 Some(ref mut blocks) => match blocks[0] {
                     Block::Micro(ref mut micro_block) => {
@@ -843,7 +843,6 @@ async fn clears_buffer_after_macro_block() {
         .set(|mock_id, request, blockchain| {
             let mut chunk = <RequestChunk as nimiq_network_interface::request::Handle<
                 MockNetwork,
-                ResponseChunk,
                 Arc<RwLock<Blockchain>>,
             >>::handle(request, mock_id, blockchain);
             match chunk {

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -189,8 +189,8 @@ pub fn peek_type(buffer: &[u8]) -> Result<RequestType, DeserializeError> {
 }
 
 /// This trait defines the behaviour when receiving a message and how to generate the response.
-pub trait Handle<N: Network, Response, T> {
-    fn handle(&self, peer_id: N::PeerId, context: &T) -> Response;
+pub trait Handle<N: Network, T>: Request {
+    fn handle(&self, peer_id: N::PeerId, context: &T) -> <Self as RequestCommon>::Response;
 }
 
 /// This trait defines the behaviour when receiving a message
@@ -200,11 +200,7 @@ pub trait MessageHandle<N: Network, T> {
 
 const MAX_CONCURRENT_HANDLERS: usize = 64;
 
-pub fn request_handler<
-    T: Send + Sync + Clone + 'static,
-    Req: Handle<N, Req::Response, T> + Request,
-    N: Network,
->(
+pub fn request_handler<T: Send + Sync + Clone + 'static, Req: Handle<N, T>, N: Network>(
     network: &Arc<N>,
     stream: BoxStream<'static, (Req, N::RequestId, N::PeerId)>,
     req_environment: &T,

--- a/test-utils/src/mock_node.rs
+++ b/test-utils/src/mock_node.rs
@@ -13,10 +13,7 @@ use nimiq_consensus::{
     sync::live::{diff_queue::RequestTrieDiff, state_queue::RequestChunk},
 };
 use nimiq_database::volatile::VolatileDatabase;
-use nimiq_network_interface::{
-    network::Network as NetworkInterface,
-    request::{Handle, Request},
-};
+use nimiq_network_interface::{network::Network as NetworkInterface, request::Handle};
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::{networks::NetworkId, trie::TrieItem};
 use nimiq_utils::time::OffsetTime;
@@ -24,11 +21,8 @@ use parking_lot::RwLock;
 
 use crate::test_network::TestNetwork;
 
-pub struct MockHandler<
-    N: NetworkInterface + TestNetwork,
-    Req: Request + Handle<N, Req::Response, T>,
-    T: Send + Sync + Unpin,
-> {
+pub struct MockHandler<N: NetworkInterface + TestNetwork, Req: Handle<N, T>, T: Send + Sync + Unpin>
+{
     network: Arc<N>,
     subscription: BoxStream<'static, (Req, N::RequestId, N::PeerId)>,
     paused: bool,
@@ -38,11 +32,8 @@ pub struct MockHandler<
     environment: T,
 }
 
-impl<
-        N: NetworkInterface + TestNetwork,
-        Req: Request + Handle<N, Req::Response, T>,
-        T: Send + Sync + Unpin,
-    > MockHandler<N, Req, T>
+impl<N: NetworkInterface + TestNetwork, Req: Handle<N, T>, T: Send + Sync + Unpin>
+    MockHandler<N, Req, T>
 {
     pub fn new(
         network: Arc<N>,
@@ -76,11 +67,8 @@ impl<
     }
 }
 
-impl<
-        N: NetworkInterface + TestNetwork,
-        Req: Request + Handle<N, Req::Response, T>,
-        T: Send + Sync + Unpin,
-    > Stream for MockHandler<N, Req, T>
+impl<N: NetworkInterface + TestNetwork, Req: Handle<N, T>, T: Send + Sync + Unpin> Stream
+    for MockHandler<N, Req, T>
 {
     type Item = u16;
 

--- a/validator/src/aggregation/tendermint/proposal.rs
+++ b/validator/src/aggregation/tendermint/proposal.rs
@@ -122,9 +122,7 @@ impl RequestCommon for RequestProposal {
     const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_PROPOSAL;
 }
 
-impl<N: Network> Handle<N, Option<SignedProposal>, Arc<RwLock<Option<MacroState>>>>
-    for RequestProposal
-{
+impl<N: Network> Handle<N, Arc<RwLock<Option<MacroState>>>> for RequestProposal {
     fn handle(
         &self,
         _peer_id: N::PeerId,

--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -260,7 +260,7 @@ impl<N: Network> From<&ZKPComponent<N>> for ZKPStateEnvironment {
     }
 }
 
-impl<N: Network> Handle<N, RequestZKPResponse, Arc<ZKPStateEnvironment>> for RequestZKP {
+impl<N: Network> Handle<N, Arc<ZKPStateEnvironment>> for RequestZKP {
     fn handle(&self, _peer_id: N::PeerId, env: &Arc<ZKPStateEnvironment>) -> RequestZKPResponse {
         // First retrieve the ZKP proof and release the lock again.
         let zkp_state = env.zkp_state.read();


### PR DESCRIPTION
The response is no longer an extra type parameter but instead derived from the new `Request` bound.