### PR TITLE
zkp-circuits: Fix a couple of clippy warnings

### DIFF
--- a/zkp-circuits/src/gadgets/compressed_vk.rs
+++ b/zkp-circuits/src/gadgets/compressed_vk.rs
@@ -59,7 +59,7 @@ impl CompressedInput<VerifyingKey<MNT6_753>, BasePrimeField<MNT6_753>>
             let alpha_g1 = CompressedAffineVar::with_y_bit(
                 ark_relations::ns!(cs, "alpha_g1"),
                 || Ok(alpha_g1),
-                bits_var.get(0).ok_or(SynthesisError::AssignmentMissing)?,
+                bits_var.first().ok_or(SynthesisError::AssignmentMissing)?,
             )?;
             let beta_g2 = CompressedAffineVar::with_y_bit(
                 ark_relations::ns!(cs, "beta_g2"),
@@ -133,7 +133,7 @@ impl CompressedInput<VerifyingKey<MNT4_753>, BasePrimeField<MNT4_753>>
             let alpha_g1 = CompressedAffineVar::with_y_bit(
                 ark_relations::ns!(cs, "alpha_g1"),
                 || Ok(alpha_g1),
-                bits_var.get(0).ok_or(SynthesisError::AssignmentMissing)?,
+                bits_var.first().ok_or(SynthesisError::AssignmentMissing)?,
             )?;
             let beta_g2 = CompressedAffineVar::with_y_bit(
                 ark_relations::ns!(cs, "beta_g2"),


### PR DESCRIPTION
Fix a couple of clippy warnings in the `zkp-circuits` subcrate related to using `get` to access the first element.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
