### PR TITLE
network-libp2p: Fix `request-response` test compilation

### DIFF
--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -86,11 +86,12 @@ libp2p = { version = "0.53.2", default-features = false, features = [
 
 [dev-dependencies]
 # In dev/testing we require more tokio features
-tokio = { version = "1.35", features = ["macros", "rt", "rt-multi-thread", "test-util", "tracing"] }
+tokio = { version = "1.35", features = ["macros", "rt", "rt-multi-thread", "test-util", "time", "tracing"] }
 
 nimiq-test-log = { workspace = true }
 
 [features]
+default = ["tokio-time"]
 metrics = ["prometheus-client"]
 tokio-time = ["tokio/time"]
 tokio-websocket = ["libp2p/dns", "libp2p/tcp", "libp2p/tokio", "libp2p/websocket"]

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -191,7 +191,6 @@ impl TestNetwork {
         let addr4 = multiaddr![Memory(rng.gen::<u64>())];
 
         let net1 = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr1.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);
@@ -201,7 +200,6 @@ impl TestNetwork {
         net1.listen_on(vec![addr1.clone()]).await;
 
         let net2 = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr2.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);
@@ -211,7 +209,6 @@ impl TestNetwork {
         net2.listen_on(vec![addr2.clone()]).await;
 
         let net3 = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr3.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);
@@ -221,7 +218,6 @@ impl TestNetwork {
         net3.listen_on(vec![addr3.clone()]).await;
 
         let net4 = Network::new(
-            Arc::new(OffsetTime::new()),
             network_config(addr4.clone()),
             Box::new(|fut| {
                 tokio::spawn(fut);


### PR DESCRIPTION
Fix `request-response` test compilation and add the `tokio-time` feature to the `default` features such that these tests are always compiled (and executed).

This fixes #2095.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
