### PR TITLE
network-libp2p: Filter valid addresses and fix discovery protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,6 @@ dependencies = [
  "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
- "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
@@ -2645,29 +2644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-identify"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20499a945d2f0221fdc6269b3848892c0f370d2ee3e19c7f65a29d8f860f6126"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "lru",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "smallvec",
- "thiserror",
- "tracing",
- "void",
-]
-
-[[package]]
 name = "libp2p-identity"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,7 +2723,6 @@ dependencies = [
  "instant",
  "libp2p-core",
  "libp2p-gossipsub",
- "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
@@ -3044,15 +3019,6 @@ checksum = "f56d36f573486ba7f462b62cbae597fef7d5d93665e7047956b457531b8a1ced"
 dependencies = [
  "prost 0.11.8",
  "prost-types 0.11.8",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
-dependencies = [
- "hashbrown 0.14.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ dependencies = [
  "rand",
  "serde",
  "serde-big-array",
+ "sha2",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -219,16 +219,14 @@ impl ClientInner {
         }
 
         // Generate my peer contact from identity keypair, our own addresses
-        // (which could be the advertised addresses from the configuration file
-        // if they were passed or the listen addresses if not) and my provided services
+        // (from the configured advertised addresses) and my provided services
         // Filter out unspecified IP addresses since those are not addresses suitable
         // for the contact book (for others to contact ourself).
         let mut peer_contact_addresses = config
             .network
             .advertised_addresses
-            .as_ref()
-            .unwrap_or(&config.network.listen_addresses)
-            .clone();
+            .clone()
+            .unwrap_or_default();
         peer_contact_addresses.retain(|address| {
             let mut protocols = address.iter();
             match protocols.next() {
@@ -299,6 +297,8 @@ impl ClientInner {
             required_services,
             tls_config,
             config.network.autonat_allow_non_global_ips,
+            config.network.only_secure_ws_connections,
+            config.network.allow_loopback_addresses,
         );
 
         log::debug!(

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -122,6 +122,14 @@ pub struct NetworkConfig {
     /// Optional setting to allow network autonat to use non global IPs
     #[builder(default)]
     pub autonat_allow_non_global_ips: bool,
+
+    /// Optional bool to only accept secure websocket connections
+    #[builder(default)]
+    pub only_secure_ws_connections: bool,
+
+    /// Optional bool to allow connections to loopback addresses
+    #[builder(default)]
+    pub allow_loopback_addresses: bool,
 }
 
 /// Configuration for setting TLS for secure WebSocket
@@ -689,13 +697,11 @@ impl ClientConfigBuilder {
     }
 
     /// Sets the network ID to the Albatross DevNet
-    ///
     pub fn dev(&mut self) -> &mut Self {
         self.network_id(NetworkId::DevAlbatross)
     }
 
     /// Sets the network ID to the Albatross TestNet
-    ///
     pub fn test(&mut self) -> &mut Self {
         self.network_id(NetworkId::TestAlbatross)
     }
@@ -768,6 +774,8 @@ impl ClientConfigBuilder {
 
             tls: config_file.network.tls.as_ref().map(|s| s.clone().into()),
             autonat_allow_non_global_ips: config_file.network.autonat_allow_non_global_ips,
+            only_secure_ws_connections: false,
+            allow_loopback_addresses: config_file.network.allow_loopback_addresses,
         });
 
         // Configure consensus

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -139,6 +139,8 @@ pub struct NetworkSettings {
     pub instant_inbound: Option<bool>,
     #[serde(default)]
     pub autonat_allow_non_global_ips: bool,
+    #[serde(default)]
+    pub allow_loopback_addresses: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -59,7 +59,6 @@ nimiq-validator-network = { workspace = true }
 libp2p = { version = "0.53.2", default-features = false, features = [
     "autonat",
     "gossipsub",
-    "identify",
     "kad",
     "macros",
     "noise",
@@ -74,7 +73,6 @@ libp2p = { version = "0.53.2", default-features = false, features = [
 libp2p = { version = "0.53.2", default-features = false, features = [
     "autonat",
     "gossipsub",
-    "identify",
     "kad",
     "macros",
     "noise",

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -35,6 +35,7 @@ prometheus-client = { version = "0.22.0", optional = true}
 rand = "0.8"
 serde = "1.0"
 serde-big-array = "0.5"
+sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1.35", features = ["macros", "rt", "tracing"] }
 tokio-stream = "0.1"

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -31,6 +31,8 @@ pub struct Config {
     pub required_services: Services,
     pub tls: Option<TlsConfig>,
     pub autonat_allow_non_global_ips: bool,
+    pub only_secure_ws_connections: bool,
+    pub allow_loopback_addresses: bool,
 }
 
 impl Config {
@@ -43,6 +45,8 @@ impl Config {
         required_services: Services,
         tls_settings: Option<TlsConfig>,
         autonat_allow_non_global_ips: bool,
+        only_secure_ws_connections: bool,
+        allow_loopback_addresses: bool,
     ) -> Self {
         // Hardcoding the minimum number of peers in mesh network before adding more
         // TODO: Maybe change this to a mesh limits configuration argument of this function
@@ -58,7 +62,7 @@ impl Config {
                 let mut s = DefaultHasher::new();
                 message.topic.hash(&mut s);
                 message.data.hash(&mut s);
-                gossipsub::MessageId::from(s.finish().to_string())
+                gossipsub::MessageId::from(s.finish().to_be_bytes())
             })
             .build()
             .expect("Invalid Gossipsub config");
@@ -76,13 +80,19 @@ impl Config {
             keypair,
             peer_contact,
             seeds,
-            discovery: discovery::Config::new(genesis_hash, required_services),
+            discovery: discovery::Config::new(
+                genesis_hash,
+                required_services,
+                only_secure_ws_connections,
+            ),
             kademlia,
             gossipsub,
             memory_transport,
             required_services,
             tls: tls_settings,
             autonat_allow_non_global_ips,
+            only_secure_ws_connections,
+            allow_loopback_addresses,
         }
     }
 }

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -810,8 +810,7 @@ impl NetworkBehaviour for Behaviour {
         Ok(self
             .contacts
             .read()
-            .get(&peer_id)
-            .map(|e| e.contact().addresses.clone())
+            .get_addresses(&peer_id)
             .unwrap_or_default())
     }
 

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -521,12 +521,14 @@ impl ConnectionHandler for Handler {
                                     peer_contact_book.insert_filtered(
                                         peer_contact.clone(),
                                         self.config.required_services,
+                                        self.config.only_secure_ws_connections,
                                     );
 
                                     // Insert the peer's contacts (filtered) into my contact book
                                     peer_contact_book.insert_all_filtered(
                                         peer_contacts,
                                         self.config.required_services,
+                                        self.config.only_secure_ws_connections,
                                     );
 
                                     drop(peer_contact_book);
@@ -622,6 +624,7 @@ impl ConnectionHandler for Handler {
                                     self.peer_contact_book.write().insert_all_filtered(
                                         peer_contacts,
                                         self.config.required_services,
+                                        self.config.only_secure_ws_connections,
                                     );
 
                                     return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use futures::StreamExt;
+use futures::{stream::FlatMap, StreamExt};
 use libp2p::{
     core::{
         multiaddr::{multiaddr, Multiaddr},
@@ -58,6 +58,7 @@ impl TestNode {
             min_recv_update_interval: Duration::from_secs(1),
             house_keeping_interval: Duration::from_secs(1),
             keep_alive: true,
+            only_secure_ws_connections: false,
         };
 
         let peer_contact = PeerContact {
@@ -68,7 +69,12 @@ impl TestNode {
         }
         .sign(&keypair);
 
-        let peer_contact_book = Arc::new(RwLock::new(PeerContactBook::new(peer_contact)));
+        let peer_contact_book = Arc::new(RwLock::new(PeerContactBook::new(
+            peer_contact,
+            false,
+            true,
+            true,
+        )));
 
         let behaviour =
             discovery::Behaviour::new(config, keypair.clone(), Arc::clone(&peer_contact_book));
@@ -235,7 +241,12 @@ pub async fn test_dialing_peer_from_contacts() {
 
 #[test]
 fn test_housekeeping() {
-    let mut peer_contact_book = PeerContactBook::new(random_peer_contact(1, Services::FULL_BLOCKS));
+    let mut peer_contact_book = PeerContactBook::new(
+        random_peer_contact(1, Services::FULL_BLOCKS),
+        false,
+        true,
+        true,
+    );
 
     let fresh_contact = random_peer_contact(1, Services::FULL_BLOCKS);
 

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -457,7 +457,7 @@ async fn ban_peer() {
         .await;
     log::debug!("Closed peer");
 
-    let event2 = events2.next().await.unwrap().unwrap();
+    let event2 = helper::get_next_peer_event(&mut events2).await;
     helper::assert_peer_left(&event2, &net1_peer_id);
     log::trace!(event = ?event2, "Event 2");
 

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -50,6 +50,7 @@ fn network_config(address: Multiaddr) -> Config {
             min_send_update_interval: Duration::from_secs(30),
             house_keeping_interval: Duration::from_secs(60),
             keep_alive: false,
+            only_secure_ws_connections: false,
         },
         kademlia: Default::default(),
         gossipsub,
@@ -57,6 +58,8 @@ fn network_config(address: Multiaddr) -> Config {
         required_services: Services::all(),
         tls: None,
         autonat_allow_non_global_ips: true,
+        only_secure_ws_connections: false,
+        allow_loopback_addresses: true,
     }
 }
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -296,6 +296,7 @@ fn network_config(address: Multiaddr) -> Config {
             min_send_update_interval: Duration::from_secs(30),
             house_keeping_interval: Duration::from_secs(60),
             keep_alive: true,
+            only_secure_ws_connections: false,
         },
         kademlia: Default::default(),
         gossipsub,
@@ -303,6 +304,8 @@ fn network_config(address: Multiaddr) -> Config {
         required_services: Services::all(),
         tls: None,
         autonat_allow_non_global_ips: true,
+        only_secure_ws_connections: false,
+        allow_loopback_addresses: true,
     }
 }
 

--- a/scripts/devnet/templates/node_conf.toml.j2
+++ b/scripts/devnet/templates/node_conf.toml.j2
@@ -3,6 +3,7 @@ peer_key_file = "{{ state_path }}/peer_key.dat"
 listen_addresses = [
     "/ip4/{{ listen_ip }}/tcp/{{ port }}/ws",
 ]
+allow_loopback_addresses = true
 
 {% if seed_addresses is defined %}
 seed_nodes = [

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -71,6 +71,8 @@ impl TestNetwork for Network {
             Services::all(),
             None,
             true,
+            false,
+            true,
         );
         let network = Arc::new(
             Network::new(

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -158,6 +158,7 @@ impl Client {
             .collect::<Vec<Seed>>();
 
         config.network.seeds = seed_nodes;
+        config.network.only_secure_ws_connections = true;
         config.network_id = web_config.network_id;
 
         log::info!(?config, "Final configuration");


### PR DESCRIPTION
- Add several changes to filter valid addresses:
  - Remove the `identify` behaviour since it was returning peer addresses that sometimes are not valid such as secure websocket and IPs multiaddresses.
  - Let know the discovery behaviour about new listen addresses to mimic the `identify` behaviour and be able to discover more of our own addresses.
  - Add some filtering in the `PeerContactBook` such that the `discovery` and the `connection_pool` behaviours only return valid addresses (in `handle_pending_outbound_connection`).
  - Add a configuration knob in the network to allow only secure websocket connections and another one for allowing loopback addresses.
  - Only add an address for a peer in the DHT behaviour if it passes the validity filters such that it doesn't return invalid addresses when the swarm dials a peer.
  This fixes #2052.
- Fix the discovery protocol to always periodically send our own `PeerContact` (along with some of our contacts) which is updated frequently to avoid being aged.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
