### PR TITLE
Fix feature compilation for several subcrates

### DIFF
--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -44,7 +44,7 @@ nimiq-hash = { workspace = true }
 nimiq-hash_derive = { workspace = true }
 nimiq-macros = { workspace = true }
 nimiq-serde = { workspace = true, optional = true }
-nimiq-utils = { workspace = true, features = ["key-rng"] }
+nimiq-utils = { workspace = true, features = ["key-rng", "merkle"] }
 
 [dev-dependencies]
 nimiq-test-log = { workspace = true }

--- a/keys/src/multisig/address.rs
+++ b/keys/src/multisig/address.rs
@@ -19,6 +19,7 @@ pub fn combine_public_keys(public_keys: Vec<PublicKey>, num_signers: usize) -> V
 /// Given a list of possible public keys, generates an address for which each of the public keys is a possible signer.
 /// Our multisig scheme only allows n-of-n signatures. To achieve a k-of-n signature, we generate all possible combinations
 /// for k-of-k signatures and compute the joint address using this method (see `combine_public_keys`).
+#[cfg(feature = "serde-derive")]
 pub fn compute_address(combined_public_keys: &[PublicKey]) -> Address {
     // Calculate address.
     let merkle_root = compute_root_from_content::<Blake2bHasher, _>(combined_public_keys);

--- a/keys/src/multisig/mod.rs
+++ b/keys/src/multisig/mod.rs
@@ -67,8 +67,11 @@ pub struct CommitmentsData {
     /// All public keys (including our own, need to be sorted).
     pub all_public_keys: Vec<PublicKey>,
     /// b = H(aggregate_public_key || (R_1, ..., R_v) || m)
-    #[serde(serialize_with = "serialize_scalar")]
-    #[serde(deserialize_with = "deserialize_scalar")]
+    #[cfg_attr(feature = "serde-derive", serde(serialize_with = "serialize_scalar"))]
+    #[cfg_attr(
+        feature = "serde-derive",
+        serde(deserialize_with = "deserialize_scalar")
+    )]
     pub b: Scalar,
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -68,7 +68,7 @@ nimiq-serde = { workspace = true }
 nimiq-utils = { workspace = true, features = ["time", "key-store"] }
 nimiq-validator = { workspace = true, optional = true, features = ["trusted_push"] }
 nimiq-validator-network = { workspace = true, optional = true }
-nimiq-wallet = { workspace = true, optional = true }
+nimiq-wallet = { workspace = true, optional = true, features = ["store"] }
 nimiq-zkp = { workspace = true }
 nimiq-zkp-circuits = { workspace = true }
 nimiq-zkp-component = { workspace = true }

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -63,5 +63,5 @@ nimiq-utils = { workspace = true, features = ["otp"] }
 nimiq-validator = { workspace = true }
 nimiq-validator-network = { workspace = true }
 nimiq-vrf = { workspace = true, features = ["serde-derive"] }
-nimiq-wallet = { workspace = true }
+nimiq-wallet = { workspace = true, features = ["store"] }
 nimiq-zkp-component = { workspace = true }


### PR DESCRIPTION
Fix feature compilation for these subcrates:
- `keys`: It was missing some `serde-derive` feature gating and was missing the `merkle` feature for the `nimiq-utils` dependency.
- `lib`: It was missing the wallet `store` feature.
- `rpc-server`: It was missing the wallet `store` feature.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
