### PR TITLE
Catch invalid genesis block error panic

### DIFF
--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -21,7 +21,7 @@ pub enum BlockchainEvent {
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BlockchainError {
-    #[error("Invalid genesis block stored. Are you on the right network?")]
+    #[error("Invalid genesis block stored. Verify you are on the correct network or reset your consensus database.")]
     InvalidGenesisBlock,
     #[error("Failed to load the main chain. Reset your consensus database.")]
     FailedLoadingMainChain,


### PR DESCRIPTION
## What's in this pull request?
Catch invalid genesis block error upon startup and exit with proper error message instead of a panic. The feature request for a new config setting is skipped as continuing from a newly generated genesis is very unlikely once the real mainnet and testnet are out.
#### This fixes #1853.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
