### PR TITLE
Handle error correctly when staking contract is missing

### DIFF
--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -1065,7 +1065,9 @@ impl ConsensusInterface for ConsensusDispatcher {
     ) -> RPCResult<Blake2bHash, (), Self::Error> {
         // If the node is in the position of having a full state, it can check upfront if this transaction makes sense
         if let BlockchainReadProxy::Full(blockchain) = self.consensus.blockchain.read() {
-            let staking_contract = blockchain.get_staking_contract();
+            let staking_contract = blockchain
+                .get_staking_contract_if_complete(None)
+                .ok_or(Error::NoConsensus)?;
             let data_store = blockchain.get_staking_contract_store();
             let db_txn = blockchain.read_transaction();
             let validator =
@@ -1129,7 +1131,9 @@ impl ConsensusInterface for ConsensusDispatcher {
     ) -> RPCResult<Blake2bHash, (), Self::Error> {
         // If the node is in the position of having a full state, it can check upfront if this transaction makes sense
         if let BlockchainReadProxy::Full(blockchain) = self.consensus.blockchain.read() {
-            let staking_contract = blockchain.get_staking_contract();
+            let staking_contract = blockchain
+                .get_staking_contract_if_complete(None)
+                .ok_or(Error::NoConsensus)?;
             let data_store = blockchain.get_staking_contract_store();
             let db_txn = blockchain.read_transaction();
             let validator =


### PR DESCRIPTION
## What's in this pull request?
This PR doesn't fix why the `staking_contract` cannot be loaded when processing a RPC request, but rather handles the error case properly.

Why in this case the `staking_contract` can't be loaded is probably related to an issue with the accounts tree what would also explain the reason for the warnings about `Could not get account for address`.

#### This fixes #2081 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
