### PR TITLE
network-libp2p: Shorten the DHT query timeout

### DIFF
--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -70,6 +70,7 @@ impl Config {
         kademlia.set_kbucket_inserts(kad::BucketInserts::OnConnected);
         kademlia.set_record_ttl(Some(Duration::from_secs(5 * 60)));
         kademlia.set_publication_interval(Some(Duration::from_secs(60)));
+        kademlia.set_query_timeout(Duration::from_secs(10));
 
         // Since we have a record TTL of 5 minutes, record replication is not needed right now
         kademlia.set_replication_interval(None);

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -951,6 +951,7 @@ impl Network {
                                         } else {
                                             warn!(query_id = ?id, ?step, query_error=?error, "GetRecord query result error for unknown query ID");
                                         }
+                                        state.dht_get_results.remove(&id);
                                     }
                                     QueryResult::PutRecord(result) => {
                                         // dht_put resolved


### PR DESCRIPTION
Shorten the DHT query timeout and make sure that the partial DHT results are removed on an error.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
