### PR TITLE
Remove associated type `PubsubId` from `ValidatorNetwork`

### DIFF
--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -12,7 +12,7 @@ use nimiq_serde::{Deserialize, Serialize};
 use parking_lot::RwLock;
 use time::OffsetDateTime;
 
-use super::{MessageStream, NetworkError, ValidatorNetwork};
+use super::{MessageStream, NetworkError, PubsubId, ValidatorNetwork};
 use crate::validator_record::ValidatorRecord;
 
 /// Validator Network state
@@ -169,7 +169,6 @@ where
 {
     type Error = NetworkError<N::Error>;
     type NetworkType = N;
-    type PubsubId = N::PubsubId;
 
     fn set_validator_id(&self, validator_id: Option<u16>) {
         self.state.write().own_validator_id = validator_id;
@@ -288,7 +287,7 @@ where
 
     async fn subscribe<'a, TTopic>(
         &self,
-    ) -> Result<BoxStream<'a, (TTopic::Item, Self::PubsubId)>, Self::Error>
+    ) -> Result<BoxStream<'a, (TTopic::Item, PubsubId<Self>)>, Self::Error>
     where
         TTopic: Topic + Sync,
     {
@@ -320,7 +319,7 @@ where
         self.network.disconnect_peer(peer_id, close_reason).await
     }
 
-    fn validate_message<TTopic>(&self, id: Self::PubsubId, acceptance: MsgAcceptance)
+    fn validate_message<TTopic>(&self, id: PubsubId<Self>, acceptance: MsgAcceptance)
     where
         TTopic: Topic + Sync,
     {

--- a/validator/src/aggregation/tendermint/state.rs
+++ b/validator/src/aggregation/tendermint/state.rs
@@ -6,7 +6,7 @@ use nimiq_hash::Blake2sHash;
 use nimiq_keys::Signature as SchnorrSignature;
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_tendermint::{State as TendermintState, Step};
-use nimiq_validator_network::ValidatorNetwork;
+use nimiq_validator_network::{PubsubId, ValidatorNetwork};
 
 use super::{
     contribution::TendermintContribution,
@@ -49,7 +49,7 @@ impl MacroState {
     ) -> Self
     where
         TValidatorNetwork: ValidatorNetwork + 'static,
-        <TValidatorNetwork as ValidatorNetwork>::PubsubId: Unpin,
+        PubsubId<TValidatorNetwork>: Unpin,
     {
         let mut known_proposals = BTreeMap::default();
         for (proposal_hash, Header(proposal, _)) in state.known_proposals.into_iter() {
@@ -80,7 +80,7 @@ impl MacroState {
     ) -> Option<TendermintState<TendermintProtocol<TValidatorNetwork>>>
     where
         TValidatorNetwork: ValidatorNetwork + 'static,
-        <TValidatorNetwork as ValidatorNetwork>::PubsubId: Unpin,
+        PubsubId<TValidatorNetwork>: Unpin,
     {
         if self.block_number != reference_height {
             return None;
@@ -90,7 +90,7 @@ impl MacroState {
         for (proposal_hash, proposal) in self.known_proposals.iter() {
             known_proposals.insert(
                 proposal_hash.clone(),
-                Header::<<TValidatorNetwork as ValidatorNetwork>::PubsubId>(proposal.clone(), None),
+                Header::<PubsubId<TValidatorNetwork>>(proposal.clone(), None),
             );
         }
         let mut inherents = BTreeMap::default();
@@ -147,11 +147,11 @@ struct State<TValidatorNetwork: ValidatorNetwork + 'static>(
     pub TendermintState<TendermintProtocol<TValidatorNetwork>>,
 )
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin;
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin;
 
 impl<TValidatorNetwork: ValidatorNetwork + 'static> Clone for State<TValidatorNetwork>
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin,
 {
     fn clone(&self) -> Self {
         Self(self.0, self.1.clone())

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -24,7 +24,7 @@ use nimiq_tendermint::{
     TaggedAggregationMessage,
 };
 use nimiq_validator_network::{
-    single_response_requester::SingleResponseRequester, ValidatorNetwork,
+    single_response_requester::SingleResponseRequester, PubsubId, ValidatorNetwork,
 };
 use parking_lot::RwLock;
 
@@ -131,7 +131,7 @@ impl<TValidatorNetwork: ValidatorNetwork> Clone for TendermintProtocol<TValidato
 
 impl<TValidatorNetwork: ValidatorNetwork + 'static> TendermintProtocol<TValidatorNetwork>
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin,
 {
     pub fn new(
         blockchain: Arc<RwLock<Blockchain>>,
@@ -156,10 +156,10 @@ where
 impl<TValidatorNetwork: ValidatorNetwork + 'static> Protocol
     for TendermintProtocol<TValidatorNetwork>
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin,
 {
     type Decision = MacroBlock;
-    type Proposal = Header<<TValidatorNetwork as ValidatorNetwork>::PubsubId>;
+    type Proposal = Header<PubsubId<TValidatorNetwork>>;
     type ProposalHash = Blake2sHash;
     type Inherent = Body;
     type InherentHash = Blake2sHash;

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -29,7 +29,7 @@ use nimiq_network_interface::{
 };
 use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_transaction_builder::TransactionBuilder;
-use nimiq_validator_network::ValidatorNetwork;
+use nimiq_validator_network::{PubsubId, ValidatorNetwork};
 use parking_lot::RwLock;
 #[cfg(feature = "metrics")]
 use tokio_metrics::TaskMonitor;
@@ -85,7 +85,7 @@ impl Clone for ValidatorProxy {
 
 pub struct Validator<TValidatorNetwork: ValidatorNetwork + 'static>
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin,
 {
     pub consensus: ConsensusProxy<TValidatorNetwork::NetworkType>,
     pub blockchain: Arc<RwLock<Blockchain>>,
@@ -126,7 +126,7 @@ where
 
 impl<TValidatorNetwork: ValidatorNetwork> Validator<TValidatorNetwork>
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin,
 {
     const MACRO_STATE_DB_NAME: &'static str = "ValidatorState";
     const MACRO_STATE_KEY: &'static str = "validatorState";
@@ -814,7 +814,7 @@ where
 
 impl<TValidatorNetwork: ValidatorNetwork> Future for Validator<TValidatorNetwork>
 where
-    <TValidatorNetwork as ValidatorNetwork>::PubsubId: std::fmt::Debug + Unpin,
+    PubsubId<TValidatorNetwork>: std::fmt::Debug + Unpin,
 {
     type Output = ();
 


### PR DESCRIPTION
Instead a type alias is added.

The reason is that before this the types of `TValidatorNetwork::PubsubId` and `TvalidatorNetwork::NetworkType::PubsubId` are not guaranteed to be the same. There would be other ways of enforcing this with additional traits but the alias seemed the easiest solution.
