### PR TITLE
bls: Fix `serde-derive` feature compilation

### DIFF
--- a/bls/src/lib.rs
+++ b/bls/src/lib.rs
@@ -16,4 +16,5 @@ pub type SigHash = Blake2sHash;
 pub mod cache;
 
 // Implements the tagged-signing traits
+#[cfg(feature = "serde-derive")]
 mod tagged_signing;

--- a/bls/src/tagged_signing.rs
+++ b/bls/src/tagged_signing.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "serde-derive")]
 use nimiq_serde::Deserialize;
 use nimiq_utils::tagged_signing::{TaggedKeyPair, TaggedPublicKey};
 
@@ -12,7 +11,6 @@ impl TaggedKeyPair for KeyPair {
     }
 }
 
-#[cfg(feature = "serde-derive")]
 impl TaggedPublicKey for PublicKey {
     fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
         let signature = match CompressedSignature::deserialize_from_vec(sig) {


### PR DESCRIPTION
Fix feature compilation when the `serde-derive` feature is not active in the `bls` subcrate.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
