### PR TITLE
Increase max chunk requests

### DIFF
--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -34,7 +34,7 @@ use super::{
 use crate::sync::live::diff_queue::{DiffQueue, QueuedDiff};
 
 /// The max number of chunk requests per peer.
-pub const MAX_REQUEST_RESPONSE_CHUNKS: u32 = 100;
+pub const MAX_REQUEST_RESPONSE_CHUNKS: u32 = 5000;
 
 /// The request of a trie chunk.
 /// The request specifies a limit on the number of nodes in the chunk.


### PR DESCRIPTION
Increase the maximum number of trie chunk requests. This is needed for cases where we have a high number of txns per epoch


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
