### PR TITLE
rpc: Rename `get_is_…` to `is_…`

### DIFF
--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -193,7 +193,7 @@ impl HandleSubcommand for PolicyCommand {
             PolicyCommand::IsElectionBlockAt { block_number } => {
                 println!(
                     "{:#?}",
-                    client.policy.get_is_election_block_at(block_number).await?
+                    client.policy.is_election_block_at(block_number).await?
                 );
             }
             PolicyCommand::MacroBlockAfter { block_number } => {
@@ -217,13 +217,13 @@ impl HandleSubcommand for PolicyCommand {
             PolicyCommand::IsMacroBlockAt { block_number } => {
                 println!(
                     "{:#?}",
-                    client.policy.get_is_macro_block_at(block_number).await?
+                    client.policy.is_macro_block_at(block_number).await?
                 );
             }
             PolicyCommand::IsMicroBlockAt { block_number } => {
                 println!(
                     "{:#?}",
-                    client.policy.get_is_micro_block_at(block_number).await?
+                    client.policy.is_micro_block_at(block_number).await?
                 );
             }
             PolicyCommand::FirstBlockOf { epoch } => {

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -32,10 +32,8 @@ pub trait PolicyInterface {
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_is_election_block_at(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error>;
+    async fn is_election_block_at(&mut self, block_number: u32)
+        -> RPCResult<bool, (), Self::Error>;
 
     async fn get_macro_block_after(&mut self, block_number: u32)
         -> RPCResult<u32, (), Self::Error>;
@@ -47,15 +45,9 @@ pub trait PolicyInterface {
 
     async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
-    async fn get_is_macro_block_at(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error>;
+    async fn is_macro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
-    async fn get_is_micro_block_at(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error>;
+    async fn is_micro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
     async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -86,7 +86,7 @@ impl PolicyInterface for PolicyDispatcher {
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
-    async fn get_is_election_block_at(
+    async fn is_election_block_at(
         &mut self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error> {
@@ -121,18 +121,12 @@ impl PolicyInterface for PolicyDispatcher {
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
-    async fn get_is_macro_block_at(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error> {
+    async fn is_macro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_macro_block_at(block_number).into())
     }
 
     /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
-    async fn get_is_micro_block_at(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error> {
+    async fn is_micro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_micro_block_at(block_number).into())
     }
 


### PR DESCRIPTION
This unifies the naming convention in the RPC functions.