### PR TITLE
lib: Add a network configuration option for desired number of peers

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -297,7 +297,10 @@ impl ClientInner {
             false,
             required_services,
             tls_config,
-            config.consensus.min_peers,
+            config
+                .network
+                .desired_peer_count
+                .unwrap_or(config.consensus.min_peers),
             config.network.autonat_allow_non_global_ips,
             config.network.only_secure_ws_connections,
             config.network.allow_loopback_addresses,

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -119,6 +119,11 @@ pub struct NetworkConfig {
     #[builder(default)]
     pub tls: Option<TlsConfig>,
 
+    /// Optional desired number of peers for the network to connect to.
+    /// The network will always try to maintain this number of connections.
+    #[builder(default)]
+    pub desired_peer_count: Option<usize>,
+
     /// Optional setting to allow network autonat to use non global IPs
     #[builder(default)]
     pub autonat_allow_non_global_ips: bool,
@@ -771,6 +776,8 @@ impl ClientConfigBuilder {
                 .unwrap_or_default(),
 
             seeds: config_file.network.seed_nodes.clone(),
+
+            desired_peer_count: config_file.network.desired_peer_count,
 
             tls: config_file.network.tls.as_ref().map(|s| s.clone().into()),
             autonat_allow_non_global_ips: config_file.network.autonat_allow_non_global_ips,

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -138,6 +138,8 @@ pub struct NetworkSettings {
     pub tls: Option<TlsSettings>,
     pub instant_inbound: Option<bool>,
     #[serde(default)]
+    pub desired_peer_count: Option<usize>,
+    #[serde(default)]
     pub autonat_allow_non_global_ips: bool,
     #[serde(default)]
     pub allow_loopback_addresses: bool,


### PR DESCRIPTION
Add a network configuration option for the desired number of peers and fallback to `consensus.min_peers` if no option was provided. This solution replaces the usage of the consensus `min_peers` value always for the network desired number of peers.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
