### PR TITLE
History store also stores transaction results

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -5,6 +5,7 @@ use nimiq_database::{
     traits::{ReadTransaction, WriteTransaction},
     TransactionProxy as DBTransaction, WriteTransactionProxy,
 };
+use nimiq_hash::Hash;
 use nimiq_primitives::policy::Policy;
 
 use crate::{blockchain_state::BlockchainState, BlockProducer, Blockchain};
@@ -102,8 +103,9 @@ impl Blockchain {
     fn verify_transactions(&self, block: &Block) -> Result<(), BlockError> {
         if let Some(transactions) = block.transactions() {
             for transaction in transactions {
+                let transaction = transaction.get_raw_transaction();
                 if !self.tx_verification_cache.is_known(&transaction.hash()) {
-                    transaction.get_raw_transaction().verify(self.network_id)?;
+                    transaction.verify(self.network_id)?;
                 }
             }
         }

--- a/blockchain/tests/history_store.rs
+++ b/blockchain/tests/history_store.rs
@@ -418,3 +418,60 @@ fn it_pushes_macro_block_with_rewards() {
         i += 1;
     }
 }
+
+#[test]
+fn it_can_find_txns() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, _temp_producer2) = setup_blockchain_with_history();
+
+    // Get initial history store.
+    let hist_tx_pre = get_hist_tx(&temp_producer1);
+
+    // Adds block with transactions.
+    let key_pair = key_pair_with_funds();
+    let mut txns = generate_transactions(
+        &key_pair,
+        temp_producer1.blockchain.read().block_number(),
+        NetworkId::UnitAlbatross,
+        3,
+        0,
+    );
+    txns.sort_unstable();
+
+    add_block_assert_history_store(&temp_producer1, vec![], txns.clone(), false);
+
+    // Find the transactions in the history store.
+    let blockchain = temp_producer1.blockchain.read();
+    let head = blockchain.head();
+    for txn in txns.iter() {
+        assert_eq!(
+            blockchain
+                .history_store
+                .get_hist_tx_by_hash(&txn.hash(), None)
+                .pop()
+                .unwrap(),
+            HistoricTransaction {
+                network_id: NetworkId::UnitAlbatross,
+                block_number: head.block_number(),
+                block_time: head.timestamp(),
+                data: HistoricTransactionData::Basic(ExecutedTransaction::Ok(txn.clone()))
+            }
+        );
+    }
+    drop(blockchain);
+
+    // Revert block and assert that history store is reverted as well.
+    revert_block(&temp_producer1, &hist_tx_pre);
+
+    // Cannot find the transactions in the history store.
+    let blockchain = temp_producer1.blockchain.read();
+    for txn in txns {
+        assert_eq!(
+            blockchain
+                .history_store
+                .get_hist_tx_by_hash(&txn.hash(), None)
+                .pop(),
+            None
+        );
+    }
+}

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -264,7 +264,7 @@ impl<N: Network> ConsensusProxy<N> {
 
             for (hash, block_number) in &receipts {
                 // If the transaction was already verified, then we don't need to verify it again
-                if verified_transactions.contains_key(hash) {
+                if verified_transactions.contains_key(&hash.clone().into()) {
                     continue;
                 }
 
@@ -288,7 +288,7 @@ impl<N: Network> ConsensusProxy<N> {
                             .or_insert(vec![])
                             .push(hash.clone());
                     } else {
-                        // Third Case: Transanctions from the current batch
+                        // Third Case: Transactions from the current batch
                         hashes_by_block
                             .entry(Some(current_head.block_number()))
                             .or_insert(vec![])

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -564,7 +564,7 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTransactionReceip
         let blockchain = blockchain.read();
 
         // Get the transaction hashes for this address.
-        let tx_hashes = blockchain.history_store.get_tx_hashes_by_address(
+        let raw_tx_hashes = blockchain.history_store.get_tx_hashes_by_address(
             &self.address,
             self.max.unwrap_or(500).min(500),
             None,
@@ -572,14 +572,14 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTransactionReceip
 
         let mut receipts = vec![];
 
-        for hash in tx_hashes {
+        for hash in raw_tx_hashes {
             // Get all the historic transactions that correspond to this hash.
             receipts.extend(
                 blockchain
                     .history_store
                     .get_hist_tx_by_hash(&hash, None)
                     .iter()
-                    .map(|hist_tx| (hist_tx.tx_hash(), hist_tx.block_number)),
+                    .map(|hist_tx| (hist_tx.tx_hash().into(), hist_tx.block_number)),
             );
         }
 


### PR DESCRIPTION
## What's in this pull request?
Introduces the executed transaction hash that includes both the transaction result (Ok or Err) and the transaction itself.
Changes history store to indexes to go from raw transaction to executed transaction hash and address to raw transaction hash.

#### This fixes #1979.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
