### PR TITLE
network-libp2p: Add configuration option for the DHT quorum

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fs, sync::Arc};
+use std::{fs, num::NonZeroU8, sync::Arc};
 
 use nimiq_block::Block;
 #[cfg(feature = "full-consensus")]
@@ -304,6 +304,10 @@ impl ClientInner {
             config.network.autonat_allow_non_global_ips,
             config.network.only_secure_ws_connections,
             config.network.allow_loopback_addresses,
+            config
+                .network
+                .dht_quorum
+                .unwrap_or(NonZeroU8::new(1).unwrap()),
         );
 
         log::debug!(

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -4,6 +4,7 @@ use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::{
     fmt::Debug,
+    num::NonZeroU8,
     path::{Path, PathBuf},
     string::ToString,
 };
@@ -135,6 +136,10 @@ pub struct NetworkConfig {
     /// Optional bool to allow connections to loopback addresses
     #[builder(default)]
     pub allow_loopback_addresses: bool,
+
+    /// Optional quorum value for the network DHT
+    #[builder(default)]
+    pub dht_quorum: Option<NonZeroU8>,
 }
 
 /// Configuration for setting TLS for secure WebSocket
@@ -783,6 +788,7 @@ impl ClientConfigBuilder {
             autonat_allow_non_global_ips: config_file.network.autonat_allow_non_global_ips,
             only_secure_ws_connections: false,
             allow_loopback_addresses: config_file.network.allow_loopback_addresses,
+            dht_quorum: config_file.network.dht_quorum,
         });
 
         // Configure consensus

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, fmt::Debug, fs::read_to_string, path::Path, str::FromStr};
+use std::{
+    collections::HashMap, fmt::Debug, fs::read_to_string, num::NonZeroU8, path::Path, str::FromStr,
+};
 
 use log::level_filters::LevelFilter;
 #[cfg(feature = "nimiq-mempool")]
@@ -143,6 +145,8 @@ pub struct NetworkSettings {
     pub autonat_allow_non_global_ips: bool,
     #[serde(default)]
     pub allow_loopback_addresses: bool,
+    #[serde(default)]
+    pub dht_quorum: Option<NonZeroU8>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroU8, time::Duration};
 
 use libp2p::{gossipsub, identity::Keypair, kad, Multiaddr};
 use nimiq_hash::Blake2bHash;
@@ -31,6 +31,7 @@ pub struct Config {
     pub autonat_allow_non_global_ips: bool,
     pub only_secure_ws_connections: bool,
     pub allow_loopback_addresses: bool,
+    pub dht_quorum: NonZeroU8,
 }
 
 impl Config {
@@ -46,6 +47,7 @@ impl Config {
         autonat_allow_non_global_ips: bool,
         only_secure_ws_connections: bool,
         allow_loopback_addresses: bool,
+        dht_quorum: NonZeroU8,
     ) -> Self {
         // Hardcoding the minimum number of peers in mesh network before adding more
         // TODO: Maybe change this to a mesh limits configuration argument of this function
@@ -94,6 +96,7 @@ impl Config {
             autonat_allow_non_global_ips,
             only_secure_ws_connections,
             allow_loopback_addresses,
+            dht_quorum,
         }
     }
 }

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroU8, time::Duration};
 
 use futures::{Stream, StreamExt};
 use libp2p::{
@@ -66,6 +66,7 @@ fn network_config(address: Multiaddr) -> Config {
         autonat_allow_non_global_ips: true,
         only_secure_ws_connections: false,
         allow_loopback_addresses: true,
+        dht_quorum: NonZeroU8::new(1).unwrap(),
     }
 }
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZeroU8, sync::Arc};
 
 use futures::{future::join_all, StreamExt};
 use libp2p::{
@@ -286,6 +286,7 @@ fn network_config(address: Multiaddr) -> Config {
         autonat_allow_non_global_ips: true,
         only_secure_ws_connections: false,
         allow_loopback_addresses: true,
+        dht_quorum: NonZeroU8::new(1).unwrap(),
     }
 }
 

--- a/scripts/devnet/templates/node_conf.toml.j2
+++ b/scripts/devnet/templates/node_conf.toml.j2
@@ -4,6 +4,7 @@ listen_addresses = [
     "/ip4/{{ listen_ip }}/tcp/{{ port }}/ws",
 ]
 allow_loopback_addresses = true
+dht_quorum = 1
 
 {% if seed_addresses is defined %}
 seed_nodes = [

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZeroU8, sync::Arc};
 
 use async_trait::async_trait;
 use nimiq_hash::Blake2bHash;
@@ -74,6 +74,7 @@ impl TestNetwork for Network {
             true,
             false,
             true,
+            NonZeroU8::new(1).unwrap(),
         );
         let network = Arc::new(
             Network::new(


### PR DESCRIPTION
Add a configuration option in `network-libp2p` and thus in the `lib` subcrates to be able to configure the DHT quorum value. In the configuration file this setting is optional and the default is to use a quorum value of 1.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
