### PR TITLE
Adding retire balance field on rpc and webclient staker types

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -791,6 +791,7 @@ pub struct Staker {
     pub delegation: Option<Address>,
     pub inactive_balance: Coin,
     pub inactive_from: Option<u32>,
+    pub retired_balance: Coin,
 }
 
 impl Staker {
@@ -801,6 +802,7 @@ impl Staker {
             delegation: staker.delegation.clone(),
             inactive_balance: staker.inactive_balance,
             inactive_from: staker.inactive_from,
+            retired_balance: staker.retired_balance,
         }
     }
 }

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -143,16 +143,21 @@ pub struct PlainStaker {
     /// (or if there was no prior delegation). For inactive balance to be released, the maximum of
     /// the inactive and the validator's jailed periods must have passed.
     inactive_balance: u64,
-    /// The block number from which the staker's `inactive_balance` becomes inactive.
-    /// Stake can only effectively become inactive on the next election block. Thus, this may contain a
+    /// The block number at which the inactive balance was last inactivated.
+    /// If the stake is currently delegated to a jailed validator, the maximum of its jail release
+    /// and the inactive release is taken. Re-delegation requires the whole balance of the staker to be inactive.
+    /// The stake can only effectively become inactive on the next election block. Thus, this may contain a
     /// future block height.
-    /// Re-delegation requires the whole balance of the staker to be inactive and released, as well as
-    /// its delegated validator to not currently be jailed.
     inactive_from: Option<u32>,
-    /// The block number from which the staker's `inactive_balance` gets released, e.g. for unstaking.
+    /// The block number from which the staker's `inactive_balance` gets released, e.g. for retirement.
     /// Re-delegation requires the whole balance of the staker to be inactive and released, as well as
     /// its delegated validator to not currently be jailed.
     inactive_release: Option<u32>,
+    /// The staker's retired balance. Retired balance can only be withdrawn, thus retiring is irreversible.
+    /// Only released inactive balance can be retired, so the maximum of the inactive and the validator's jailed
+    /// periods must have passed.
+    /// Once retired, the funds are immediately available to be withdrawn (removed).
+    retired_balance: u64,
 }
 
 impl PlainStaker {
@@ -168,6 +173,7 @@ impl PlainStaker {
             inactive_release: staker
                 .inactive_from
                 .map(Policy::block_after_reporting_window),
+            retired_balance: staker.retired_balance.into(),
         }
     }
 }


### PR DESCRIPTION
## What's in this pull request?
In PR #2114 we added the retire balance however the rpc and web client staker structs were not reflecting this change.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
