### PR TITLE
Fix set active stake and revert update staker

### DIFF
--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -514,11 +514,11 @@ impl StakingContract {
         let mut staker = store.expect_staker(staker_address)?;
 
         // Fail if staker does not have sufficient funds.
-        let total_balance = staker.total_balance();
-        if total_balance < new_active_balance {
+        let non_retired_balance = staker.none_retired_balance();
+        if non_retired_balance < new_active_balance {
             return Err(AccountError::InsufficientFunds {
                 needed: new_active_balance,
-                balance: total_balance,
+                balance: non_retired_balance,
             });
         }
 
@@ -527,7 +527,7 @@ impl StakingContract {
         // Store old values for receipt.
         let old_inactive_from = staker.inactive_from;
         let old_active_balance = staker.active_balance;
-        let new_inactive_balance = total_balance - new_active_balance;
+        let new_inactive_balance = non_retired_balance - new_active_balance;
 
         // Update the staker's balances.
         staker.active_balance = new_active_balance;
@@ -580,14 +580,14 @@ impl StakingContract {
         let mut staker = store.expect_staker(staker_address)?;
 
         // Keep the old values.
-        let total_balance = staker.total_balance();
+        let non_retired_balance = staker.none_retired_balance();
         let old_inactive_from = staker.inactive_from;
         let old_inactive_balance = staker.inactive_balance;
 
         // Restore the previous inactive since and balances.
         staker.inactive_from = receipt.old_inactive_from;
         staker.active_balance = receipt.old_active_balance;
-        staker.inactive_balance = total_balance - staker.active_balance;
+        staker.inactive_balance = non_retired_balance - staker.active_balance;
 
         // If we are delegating to a validator, we update the active stake of the validator.
         // This function never changes the staker's delegation, so the validator counter should not be updated.

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -95,7 +95,7 @@ impl Staker {
     }
 
     /// Returns the current non-retired balance of the staker.
-    pub fn none_retired_balance(&self) -> Coin {
+    pub fn non_retired_balance(&self) -> Coin {
         self.active_balance + self.inactive_balance
     }
 
@@ -484,9 +484,9 @@ impl StakingContract {
         }
 
         // Restore the previous balances and values.
-        let total_balance = staker.total_balance();
+        let non_retired_balance = staker.non_retired_balance();
         staker.active_balance = receipt.active_balance;
-        staker.inactive_balance = total_balance - staker.active_balance;
+        staker.inactive_balance = non_retired_balance - staker.active_balance;
         staker.inactive_from = receipt.inactive_from;
 
         // Update the staker entry.
@@ -514,7 +514,7 @@ impl StakingContract {
         let mut staker = store.expect_staker(staker_address)?;
 
         // Fail if staker does not have sufficient funds.
-        let non_retired_balance = staker.none_retired_balance();
+        let non_retired_balance = staker.non_retired_balance();
         if non_retired_balance < new_active_balance {
             return Err(AccountError::InsufficientFunds {
                 needed: new_active_balance,
@@ -580,7 +580,7 @@ impl StakingContract {
         let mut staker = store.expect_staker(staker_address)?;
 
         // Keep the old values.
-        let non_retired_balance = staker.none_retired_balance();
+        let non_retired_balance = staker.non_retired_balance();
         let old_inactive_from = staker.inactive_from;
         let old_inactive_balance = staker.inactive_balance;
 

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -406,19 +406,6 @@ struct StakerSetup {
 }
 
 impl StakerSetup {
-    fn setup_staker_with_inactive_balance(
-        validator_state: ValidatorState,
-        active_stake: u64,
-        inactive_stake: u64,
-    ) -> Self {
-        Self::setup_staker_with_inactive_retired_balance(
-            validator_state,
-            active_stake,
-            inactive_stake,
-            0,
-        )
-    }
-
     fn setup_staker_with_inactive_retired_balance(
         validator_state: ValidatorState,
         active_stake: u64,

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -536,10 +536,11 @@ fn can_set_inactive_balance() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let mut staker_setup = StakerSetup::setup_staker_with_inactive_balance(
+    let mut staker_setup = StakerSetup::setup_staker_with_inactive_retired_balance(
         ValidatorState::Active,
         50_000_000,
         50_000_000,
+        10_000_000,
     );
     let data_store = staker_setup
         .accounts

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -964,10 +964,11 @@ fn retire_stake_does_not_violate_jail_or_inactive_releases() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let mut staker_setup = StakerSetup::setup_staker_with_inactive_balance(
+    let mut staker_setup = StakerSetup::setup_staker_with_inactive_retired_balance(
         ValidatorState::Active,
         0,
         Policy::MINIMUM_STAKE,
+        10_000_000,
     );
     let data_store = staker_setup
         .accounts
@@ -996,10 +997,11 @@ fn retire_stake_does_not_violate_jail_or_inactive_releases() {
     // Cannot retire before jail.
 
     // Setup jailed validator
-    let mut staker_setup = StakerSetup::setup_staker_with_inactive_balance(
+    let mut staker_setup = StakerSetup::setup_staker_with_inactive_retired_balance(
         ValidatorState::Jailed,
         0,
         Policy::MINIMUM_STAKE,
+        20_000_000,
     );
     let data_store = staker_setup
         .accounts
@@ -1199,8 +1201,12 @@ fn update_staker_works() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let (mut staker_setup, validator_address2, tx) =
-        prepare_second_validator_for_redelegation(ValidatorState::Active, 0, 150_000_000, 0);
+    let (mut staker_setup, validator_address2, tx) = prepare_second_validator_for_redelegation(
+        ValidatorState::Active,
+        0,
+        150_000_000,
+        100_000_000,
+    );
 
     let data_store = staker_setup
         .accounts
@@ -1263,6 +1269,10 @@ fn update_staker_works() {
         Coin::from_u64_unchecked(150_000_000)
     );
     assert_eq!(staker.active_balance, Coin::ZERO);
+    assert_eq!(
+        staker.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
     assert_eq!(staker.delegation, Some(validator_address2.clone()));
 
     let old_validator = staker_setup
@@ -1381,6 +1391,10 @@ fn update_staker_works() {
         staker.inactive_balance,
         Coin::from_u64_unchecked(150_000_000)
     );
+    assert_eq!(
+        staker.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
     assert_eq!(staker.active_balance, Coin::ZERO);
     assert_eq!(staker.delegation, None);
 
@@ -1432,6 +1446,23 @@ fn update_staker_works() {
         }]
     );
 
+    let staker = staker_setup
+        .staking_contract
+        .get_staker(&data_store.read(&db_txn), &staker_address)
+        .expect("Staker should exist");
+
+    assert_eq!(staker.address, staker_address);
+    assert_eq!(
+        staker.inactive_balance,
+        Coin::from_u64_unchecked(150_000_000)
+    );
+    assert_eq!(staker.active_balance, Coin::ZERO);
+    assert_eq!(
+        staker.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
+    assert_eq!(staker.delegation, Some(validator_address2.clone()));
+
     let validator = staker_setup
         .staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address2)
@@ -1482,8 +1513,12 @@ fn update_staker_with_stake_reactivation_works() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let mut staker_setup =
-        StakerSetup::setup_staker_with_inactive_balance(ValidatorState::Active, 0, 150_000_000);
+    let mut staker_setup = StakerSetup::setup_staker_with_inactive_retired_balance(
+        ValidatorState::Active,
+        0,
+        150_000_000,
+        100_000_000,
+    );
     let data_store = staker_setup
         .accounts
         .data_store(&Policy::STAKING_CONTRACT_ADDRESS);
@@ -1571,6 +1606,10 @@ fn update_staker_with_stake_reactivation_works() {
     assert_eq!(staker_after.address, staker_address);
     assert_eq!(staker_after.inactive_balance, Coin::ZERO);
     assert_eq!(
+        staker_after.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
+    assert_eq!(
         staker_after.active_balance,
         Coin::from_u64_unchecked(150_000_000)
     );
@@ -1638,6 +1677,26 @@ fn update_staker_with_stake_reactivation_works() {
         }]
     );
 
+    let staker_reverted = staker_setup
+        .staking_contract
+        .get_staker(&data_store.read(&db_txn), &staker_address)
+        .expect("Staker should exist");
+    assert_eq!(
+        staker_reverted.inactive_from,
+        Some(staker_setup.effective_block_state.number)
+    );
+    assert_eq!(staker_reverted.address, staker_address);
+    assert_eq!(
+        staker_reverted.inactive_balance,
+        Coin::from_u64_unchecked(150_000_000)
+    );
+    assert_eq!(
+        staker_reverted.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
+    assert_eq!(staker_reverted.active_balance, Coin::ZERO);
+    assert_eq!(staker_reverted.delegation, Some(validator_address1.clone()));
+
     let validator2 = staker_setup
         .staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address2)
@@ -1682,8 +1741,12 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let mut staker_setup =
-        StakerSetup::setup_staker_with_inactive_balance(ValidatorState::Active, 0, 150_000_000);
+    let mut staker_setup = StakerSetup::setup_staker_with_inactive_retired_balance(
+        ValidatorState::Active,
+        0,
+        150_000_000,
+        100_000_000,
+    );
     let data_store = staker_setup
         .accounts
         .data_store(&Policy::STAKING_CONTRACT_ADDRESS);
@@ -1744,6 +1807,10 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
     );
 
     assert_eq!(staker_after.address, staker_address);
+    assert_eq!(
+        staker_after.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
     assert_eq!(staker_after.inactive_balance, Coin::ZERO);
     assert_eq!(
         staker_after.active_balance,
@@ -1813,169 +1880,26 @@ fn update_staker_remove_delegation_with_stake_reactivation_works() {
             .get(&validator_address1),
         Some(&Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT))
     );
-}
 
-#[test]
-fn update_staker_with_no_delegation_no_reactivation() {
-    // -----------------------------------
-    // Test setup:
-    // -----------------------------------
-    // Create a validator with no staker
-    let mut validator_setup = ValidatorSetup::new(None);
-    let data_store = validator_setup
-        .accounts
-        .data_store(&Policy::STAKING_CONTRACT_ADDRESS);
-    let mut db_txn = validator_setup.env.write_transaction();
-    let mut db_txn: WriteTransactionProxy = (&mut db_txn).into();
-    let validator_address1 = validator_setup.validator_address;
-
-    // Create a staker with no delegation
-    let staker_keypair = ed25519_key_pair(STAKER_PRIVATE_KEY);
-    let staker_address = staker_address();
-    let block_state = BlockState::new(2, 2);
-
-    let tx = make_signed_incoming_transaction(
-        IncomingStakingTransactionData::CreateStaker {
-            delegation: None,
-            proof: SignatureProof::default(),
-        },
-        150_000_000,
-        &staker_keypair,
-    );
-
-    let receipt = validator_setup
-        .staking_contract
-        .commit_incoming_transaction(
-            &tx,
-            &block_state,
-            data_store.write(&mut db_txn),
-            &mut TransactionLog::empty(),
-        )
-        .expect("Failed to commit transaction");
-
-    assert_eq!(receipt, None);
-
-    // -----------------------------------
-    // Test execution:
-    // -----------------------------------
-    // Works when changing to no validator.
-    let block_state = BlockState::new(3, 3);
-    let tx = make_signed_incoming_transaction(
-        IncomingStakingTransactionData::UpdateStaker {
-            new_delegation: Some(validator_address1.clone()),
-            reactivate_all_stake: false,
-            proof: SignatureProof::default(),
-        },
-        0,
-        &staker_keypair,
-    );
-
-    let mut tx_logger = TransactionLog::empty();
-    let receipt = validator_setup
-        .staking_contract
-        .commit_incoming_transaction(
-            &tx,
-            &block_state,
-            data_store.write(&mut db_txn),
-            &mut tx_logger,
-        )
-        .expect("Failed to commit transaction");
-
-    let expected_receipt = StakerReceipt {
-        delegation: None,
-        active_balance: Coin::from_u64_unchecked(150_000_000),
-        inactive_from: None,
-    };
-    assert_eq!(receipt, Some(expected_receipt.into()));
-
-    let staker_after = validator_setup
+    let staker_reverted = staker_setup
         .staking_contract
         .get_staker(&data_store.read(&db_txn), &staker_address)
         .expect("Staker should exist");
-
     assert_eq!(
-        tx_logger.logs,
-        vec![Log::UpdateStaker {
-            staker_address: staker_address.clone(),
-            old_validator_address: None,
-            new_validator_address: Some(validator_address1.clone()),
-            active_balance: staker_after.active_balance,
-            inactive_from: staker_after.inactive_from,
-        }]
+        staker_reverted.inactive_from,
+        Some(staker_setup.effective_block_state.number)
     );
-
-    assert_eq!(staker_after.address, staker_address);
-    assert_eq!(staker_after.inactive_balance, Coin::ZERO);
+    assert_eq!(staker_reverted.address, staker_address);
     assert_eq!(
-        staker_after.active_balance,
+        staker_reverted.inactive_balance,
         Coin::from_u64_unchecked(150_000_000)
     );
-    assert_eq!(staker_after.delegation, Some(validator_address1.clone()));
-    assert!(staker_after.inactive_from.is_none());
-
-    let validator1 = validator_setup
-        .staking_contract
-        .get_validator(&data_store.read(&db_txn), &validator_address1)
-        .expect("Validator should exist");
-
     assert_eq!(
-        validator1.total_stake,
-        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT + 150_000_000)
+        staker_reverted.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
     );
-    assert_eq!(validator1.num_stakers, 1);
-
-    assert_eq!(
-        validator_setup
-            .staking_contract
-            .active_validators
-            .get(&validator_address1),
-        Some(&Coin::from_u64_unchecked(
-            Policy::VALIDATOR_DEPOSIT + 150_000_000
-        ))
-    );
-
-    // Revert the transaction.
-    let mut tx_logger = TransactionLog::empty();
-    validator_setup
-        .staking_contract
-        .revert_incoming_transaction(
-            &tx,
-            &block_state,
-            receipt,
-            data_store.write(&mut db_txn),
-            &mut tx_logger,
-        )
-        .expect("Failed to revert transaction");
-
-    assert_eq!(
-        tx_logger.logs,
-        vec![Log::UpdateStaker {
-            staker_address: staker_address.clone(),
-            old_validator_address: None,
-            new_validator_address: Some(validator_address1.clone()),
-            active_balance: staker_after.active_balance,
-            inactive_from: staker_after.inactive_from,
-        }]
-    );
-
-    let validator1 = validator_setup
-        .staking_contract
-        .get_validator(&data_store.read(&db_txn), &validator_address1)
-        .expect("Validator should exist");
-
-    assert_eq!(
-        validator1.total_stake,
-        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT)
-    );
-    assert_eq!(validator1.num_stakers, 0);
-
-    assert_eq!(
-        validator_setup
-            .staking_contract
-            .active_validators
-            .get(&validator_address1),
-        Some(&Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT))
-    );
+    assert_eq!(staker_reverted.active_balance, Coin::ZERO);
+    assert_eq!(staker_reverted.delegation, Some(validator_address1.clone()));
 }
 
 #[test]
@@ -1983,8 +1907,12 @@ fn update_staker_same_validator() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let mut staker_setup =
-        StakerSetup::setup_staker_with_inactive_balance(ValidatorState::Active, 0, 150_000_000);
+    let mut staker_setup = StakerSetup::setup_staker_with_inactive_retired_balance(
+        ValidatorState::Active,
+        0,
+        150_000_000,
+        100_000_000,
+    );
     let data_store = staker_setup
         .accounts
         .data_store(&Policy::STAKING_CONTRACT_ADDRESS);
@@ -2062,6 +1990,10 @@ fn update_staker_same_validator() {
         Coin::from_u64_unchecked(150_000_000)
     );
     assert_eq!(staker.active_balance, Coin::ZERO);
+    assert_eq!(
+        staker.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
     assert_eq!(staker.delegation, Some(validator_address.clone()));
 
     // Validator should have the same counter as before.
@@ -2134,6 +2066,26 @@ fn update_staker_same_validator() {
             .get(&validator_address),
         Some(&Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT))
     );
+
+    let staker_reverted = staker_setup
+        .staking_contract
+        .get_staker(&data_store.read(&db_txn), &staker_address)
+        .expect("Staker should exist");
+    assert_eq!(
+        staker_reverted.inactive_from,
+        Some(staker_setup.effective_block_state.number)
+    );
+    assert_eq!(staker_reverted.address, staker_address);
+    assert_eq!(
+        staker_reverted.inactive_balance,
+        Coin::from_u64_unchecked(150_000_000)
+    );
+    assert_eq!(
+        staker_reverted.retired_balance,
+        Coin::from_u64_unchecked(100_000_000)
+    );
+    assert_eq!(staker_reverted.active_balance, Coin::ZERO);
+    assert_eq!(staker_reverted.delegation, Some(validator_address.clone()));
 }
 
 #[test]
@@ -2580,14 +2532,195 @@ fn can_remove_stake_with_no_delegation() {
     assert_eq!(staker.retired_balance, Coin::ZERO);
 }
 
+#[test]
+fn can_delegate_if_no_delegation_prior_delegation() {
+    // -----------------------------------
+    // Test setup:
+    // -----------------------------------
+    // Create a validator with no staker
+    let mut validator_setup = ValidatorSetup::new(None);
+    let data_store = validator_setup
+        .accounts
+        .data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+    let mut db_txn = validator_setup.env.write_transaction();
+    let mut db_txn: WriteTransactionProxy = (&mut db_txn).into();
+    let validator_address = validator_setup.validator_address;
+
+    // Create a staker with no delegation
+    let staker_keypair = ed25519_key_pair(STAKER_PRIVATE_KEY);
+    let staker_address = staker_address();
+    let block_state = BlockState::new(2, 2);
+
+    let tx = make_signed_incoming_transaction(
+        IncomingStakingTransactionData::CreateStaker {
+            delegation: None,
+            proof: SignatureProof::default(),
+        },
+        150_000_000,
+        &staker_keypair,
+    );
+
+    let receipt = validator_setup
+        .staking_contract
+        .commit_incoming_transaction(
+            &tx,
+            &block_state,
+            data_store.write(&mut db_txn),
+            &mut TransactionLog::empty(),
+        )
+        .expect("Failed to commit transaction");
+
+    assert_eq!(receipt, None);
+
+    // -----------------------------------
+    // Test execution:
+    // -----------------------------------
+    // Works when changing to a validator, despite active stake, because there is no prior delegation.
+    let block_state = BlockState::new(3, 3);
+    let tx = make_signed_incoming_transaction(
+        IncomingStakingTransactionData::UpdateStaker {
+            new_delegation: Some(validator_address.clone()),
+            reactivate_all_stake: false,
+            proof: SignatureProof::default(),
+        },
+        0,
+        &staker_keypair,
+    );
+
+    let mut tx_logger = TransactionLog::empty();
+    let receipt = validator_setup
+        .staking_contract
+        .commit_incoming_transaction(
+            &tx,
+            &block_state,
+            data_store.write(&mut db_txn),
+            &mut tx_logger,
+        )
+        .expect("Failed to commit transaction");
+
+    let expected_receipt = StakerReceipt {
+        delegation: None,
+        active_balance: Coin::from_u64_unchecked(150_000_000),
+        inactive_from: None,
+    };
+    assert_eq!(receipt, Some(expected_receipt.into()));
+
+    let staker_after = validator_setup
+        .staking_contract
+        .get_staker(&data_store.read(&db_txn), &staker_address)
+        .expect("Staker should exist");
+
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::UpdateStaker {
+            staker_address: staker_address.clone(),
+            old_validator_address: None,
+            new_validator_address: Some(validator_address.clone()),
+            active_balance: staker_after.active_balance,
+            inactive_from: staker_after.inactive_from,
+        }]
+    );
+
+    assert_eq!(staker_after.address, staker_address);
+    assert_eq!(staker_after.inactive_balance, Coin::ZERO);
+    assert_eq!(
+        staker_after.active_balance,
+        Coin::from_u64_unchecked(150_000_000)
+    );
+    assert_eq!(staker_after.delegation, Some(validator_address.clone()));
+    assert!(staker_after.inactive_from.is_none());
+
+    let validator1 = validator_setup
+        .staking_contract
+        .get_validator(&data_store.read(&db_txn), &validator_address)
+        .expect("Validator should exist");
+
+    assert_eq!(
+        validator1.total_stake,
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT + 150_000_000)
+    );
+    assert_eq!(validator1.num_stakers, 1);
+
+    assert_eq!(
+        validator_setup
+            .staking_contract
+            .active_validators
+            .get(&validator_address),
+        Some(&Coin::from_u64_unchecked(
+            Policy::VALIDATOR_DEPOSIT + 150_000_000
+        ))
+    );
+
+    // Revert the transaction.
+    let mut tx_logger = TransactionLog::empty();
+    validator_setup
+        .staking_contract
+        .revert_incoming_transaction(
+            &tx,
+            &block_state,
+            receipt,
+            data_store.write(&mut db_txn),
+            &mut tx_logger,
+        )
+        .expect("Failed to revert transaction");
+
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::UpdateStaker {
+            staker_address: staker_address.clone(),
+            old_validator_address: None,
+            new_validator_address: Some(validator_address.clone()),
+            active_balance: staker_after.active_balance,
+            inactive_from: staker_after.inactive_from,
+        }]
+    );
+
+    let validator = validator_setup
+        .staking_contract
+        .get_validator(&data_store.read(&db_txn), &validator_address)
+        .expect("Validator should exist");
+
+    assert_eq!(
+        validator.total_stake,
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT)
+    );
+    assert_eq!(validator.num_stakers, 0);
+
+    assert_eq!(
+        validator_setup
+            .staking_contract
+            .active_validators
+            .get(&validator_address),
+        Some(&Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT))
+    );
+
+    let staker_reverted = validator_setup
+        .staking_contract
+        .get_staker(&data_store.read(&db_txn), &staker_address)
+        .expect("Staker should exist");
+    assert!(staker_reverted.inactive_from.is_none());
+    assert_eq!(staker_reverted.address, staker_address);
+    assert_eq!(staker_reverted.inactive_balance, Coin::ZERO);
+
+    assert_eq!(
+        staker_reverted.active_balance,
+        Coin::from_u64_unchecked(150_000_000)
+    );
+    assert_eq!(staker_reverted.delegation, None);
+}
+
 /// Staker cannot re delegate while jailed although inactive funds are already released.
 #[test]
 fn can_only_redelegate_after_jail() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let (mut staker_setup, _validator_address2, tx) =
-        prepare_second_validator_for_redelegation(ValidatorState::Jailed, 0, 50_000_000, 0);
+    let (mut staker_setup, _validator_address2, tx) = prepare_second_validator_for_redelegation(
+        ValidatorState::Jailed,
+        0,
+        50_000_000,
+        10_000_000,
+    );
 
     let data_store = staker_setup
         .accounts
@@ -2627,8 +2760,12 @@ fn can_only_redelegate_after_release() {
     // -----------------------------------
     // Test setup:
     // -----------------------------------
-    let (mut staker_setup, _validator_address2, tx) =
-        prepare_second_validator_for_redelegation(ValidatorState::Active, 0, 50_000_000, 0);
+    let (mut staker_setup, _validator_address2, tx) = prepare_second_validator_for_redelegation(
+        ValidatorState::Active,
+        0,
+        50_000_000,
+        10_000_000,
+    );
 
     let data_store = staker_setup
         .accounts
@@ -2672,7 +2809,7 @@ fn cannot_redelegate_while_having_active_stake() {
         ValidatorState::Active,
         50_000_000,
         50_000_000,
-        0,
+        10_000_000,
     );
 
     let data_store = staker_setup


### PR DESCRIPTION
## What's in this pull request?
The set active stake was rebalancing between the total balance instead of the non-retired balance. This added the retired balance to the inactive stake increasing the total staker funds.
It also fixes the same issue on the revert update staker.
This also fixes the tests to take these scenarios into account.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
