### PR TITLE
Fix a couple of clippy warnings

### DIFF
--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -85,7 +85,7 @@ impl Blockchain {
     /// It does _not_ deal with the faulty blocks.
     pub(super) fn rebranch_to(
         &self,
-        target_chain: &mut Vec<(Blake2bHash, ChainInfo, Option<TrieDiff>)>,
+        target_chain: &mut [(Blake2bHash, ChainInfo, Option<TrieDiff>)],
         ancestor: &mut (Blake2bHash, ChainInfo, Option<TrieDiff>),
         write_txn: &mut WriteTransactionProxy,
     ) -> Result<

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -106,7 +106,6 @@ pub fn initialize_logging(
     let file = match &settings.file {
         Some(filename) => {
             let file = fs::OpenOptions::new()
-                .write(true)
                 .create(true)
                 .append(true)
                 .open(filename)


### PR DESCRIPTION
Fix a couple of clippy warnings in the `blockchain` and `lib` subcrates detected on the recent `rust` stable upgrade to 1.76.0.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
