### PR TITLE
Add missing fields to RPC Policy dispatcher

### DIFF
--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -62,6 +62,13 @@ pub trait PolicyInterface {
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error>;
 
+    async fn get_block_after_reporting_window(
+        &mut self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error>;
+
+    async fn get_block_after_jail(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+
     async fn get_supply_at(
         &mut self,
         genesis_supply: u64,

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -321,8 +321,11 @@ pub struct PolicyConstants {
     pub batches_per_epoch: u16,
     pub blocks_per_epoch: u32,
     pub validator_deposit: u64,
+    pub minimum_stake: u64,
     pub total_supply: u64,
     pub block_separation_time: u64,
+    pub jail_epochs: u32,
+    pub genesis_block_number: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rpc-server/src/error.rs
+++ b/rpc-server/src/error.rs
@@ -21,14 +21,8 @@ pub enum Error {
     #[error("Block not found: {0}")]
     BlockNotFoundByHash(Blake2bHash),
 
-    #[error("Block number is not allowed to be 0")]
-    BlockNumberNotZero,
-
-    #[error("Epoch number is not allowed to be 0")]
-    EpochNumberNotZero,
-
-    #[error("Batch number is not allowed to be 0")]
-    BatchNumberNotZero,
+    #[error("Block number cannot be smaller than genesis block")]
+    BlockNumberBeforeGenesis,
 
     #[error("Unexpected macro block: {0}")]
     UnexpectedMacroBlock(u32),


### PR DESCRIPTION
Recently added fields, such as minimum_stake, jail_epochs and related methods were missing. I also added the genesis_block_number and removed two 0-checks that became unnessary.

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
