### PR TITLE
Add state to the validator-network and fix some network issues

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -307,7 +307,7 @@ impl ClientInner {
             config
                 .network
                 .dht_quorum
-                .unwrap_or(NonZeroU8::new(1).unwrap()),
+                .unwrap_or(NonZeroU8::new(3).unwrap()),
         );
 
         log::debug!(

--- a/scripts/devnet/templates/node_conf.toml.j2
+++ b/scripts/devnet/templates/node_conf.toml.j2
@@ -4,7 +4,7 @@ listen_addresses = [
     "/ip4/{{ listen_ip }}/tcp/{{ port }}/ws",
 ]
 allow_loopback_addresses = true
-dht_quorum = 1
+dht_quorum = 3
 
 {% if seed_addresses is defined %}
 seed_nodes = [

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -37,6 +37,7 @@ pub async fn build_validator<N: TestNetwork + NetworkInterface>(
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,
+    N::Error: Sync,
 {
     let node =
         Node::<N>::history_with_genesis_info(peer_id, genesis_info, hub, is_prover_active).await;
@@ -66,7 +67,7 @@ pub async fn build_validators<N: TestNetwork + NetworkInterface>(
     is_prover_active: bool,
 ) -> Vec<Validator<ValidatorNetworkImpl<N>>>
 where
-    N::Error: Send,
+    N::Error: Send + Sync,
     N::PeerId: Deserialize + Serialize,
 {
     let num_validators = peer_ids.len();
@@ -149,6 +150,7 @@ pub fn validator_for_slot<N: TestNetwork + NetworkInterface>(
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,
+    N::Error: Sync,
 {
     let consensus = &validators.first().unwrap().consensus;
 
@@ -174,6 +176,7 @@ pub fn pop_validator_for_slot<N: TestNetwork + NetworkInterface>(
 where
     N::Error: Send,
     N::PeerId: Deserialize + Serialize,
+    N::Error: Sync,
 {
     let consensus = &validators.first().unwrap().consensus;
 

--- a/validator-network/src/error.rs
+++ b/validator-network/src/error.rs
@@ -20,6 +20,11 @@ where
     #[error("Network is offline")]
     Offline,
 
+    /// The peer ID of this validator is still unknown
+    /// It might be eventually resolved.
+    #[error("Unknown validator peer ID: {0}")]
+    UnknownPeerID(u16),
+
     /// The public key for that validator is not known.
     #[error("Unknown validator: {0}")]
     UnknownValidator(u16),


### PR DESCRIPTION
- lib: Go back to use `3` as the default network quorum value
  - Change the client code to use `3` as the default network quorum value.
    Also make the `devnet` scripts use this value for configuring the
    nodes.
- validator-network: Do less validator `PeerId` cache clears    
  - Change the function that clears the validator `PeerId` to receive the request error such that it doesn't clear the cache if     `InboundRequestError::NoReceiver` error was received. This error is an indicative that the requested peer has no receiver for such request which could happen when the peer is no running the specified aggregation and this is not an indicative of the `PeerId` cache entry being wrong. Thus in case of receiving this error, the network won't invalidate the cache entry for this validator.
- network-libp2p: Fix mishandling of `FinishedWithNoAdditionalRecord`
  - Fix the mishandling of `FinishedWithNoAdditionalRecord` since we could get such event even if the `query.finish` isn't called (which the network is calling once `Quorum` records have been received).
    This mishandling was causing some of the queries to hang indefinitely since no error nor result was being sent to the application layer.
    Now the network always pushes the result to the application layer once the `FinishedWithNoAdditionalRecord` is received.
- validator-network: Add some state to the `PeerId` cache
  - Add some state to the validator `PeerId` cache to make less queries as possible to the DHT.
    This also makes the `validator-network` able to quickly return if the DHT query is still in progress allowing upper layers to continue their process without blocking them until the query finishes or errors out.


## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
