### PR TITLE
Update web-client transaction-getter to handle known transactions like the PoW client did

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -140,32 +140,6 @@ impl<N: Network> ConsensusProxy<N> {
         Ok(receipts)
     }
 
-    pub async fn request_transactions_by_address(
-        &self,
-        address: Address,
-        since_block_height: u32,
-        ignored_hashes: Vec<Blake2bHash>,
-        min_peers: usize,
-        max: Option<u16>,
-    ) -> Result<Vec<HistoricTransaction>, RequestError> {
-        let receipts: Vec<_> = self
-            .request_transaction_receipts_by_address(address, min_peers, max)
-            .await?
-            .into_iter()
-            .filter(|(hash, block_number)| {
-                block_number > &since_block_height && !ignored_hashes.contains(hash)
-            })
-            .map(|(hash, block_number)| (hash, Some(block_number)))
-            .collect();
-
-        if receipts.is_empty() {
-            return Ok(vec![]);
-        }
-
-        self.prove_transactions_from_receipts(receipts, min_peers)
-            .await
-    }
-
     pub async fn request_transaction_by_hash_and_block_number(
         &self,
         tx_hash: Blake2bHash,

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -90,8 +90,20 @@ async fn test_request_transactions_by_address() {
 
     // Fetching all the transactions of the epoch.
     let key_pair = KeyPair::from(PrivateKey::from_str(REWARD_KEY).unwrap());
+
+    let receipts = consensus_proxy
+        .request_transaction_receipts_by_address(Address::from(&key_pair.public), 1, None)
+        .await;
+    assert!(receipts.is_ok());
     let res = consensus_proxy
-        .request_transactions_by_address(Address::from(&key_pair.public), 0, vec![], 1, None)
+        .prove_transactions_from_receipts(
+            receipts
+                .unwrap()
+                .into_iter()
+                .map(|r| (r.0, Some(r.1)))
+                .collect(),
+            1,
+        )
         .await;
     assert!(res.is_ok());
 

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -1171,9 +1171,7 @@ impl PlainTransactionDetails {
         let block_number = hist_tx.block_number;
         let block_time = hist_tx.block_time;
 
-        let last_macro_block = Policy::last_macro_block(current_block);
-
-        let state = if last_macro_block >= block_number {
+        let state = if Policy::last_macro_block(current_block) >= block_number {
             TransactionState::Confirmed
         } else {
             TransactionState::Included


### PR DESCRIPTION
The PoW client by @mar-v-in did some [genius handling of known transactions](https://github.com/nimiq/core-js/blob/fad56cdf5a1cb13ca61f867b46048b0e83e85d94/src/main/generic/api/Client.js#L719-L839), which can be optionally passed to the client's `getTransactionsByAddress` method.

It, and now this client too, make sure all known transactions are included in the receipts, unconfirmed known transactions are queried again (and confirmed if they are, returned as expired if they have expired), pending or unsent transactions are re-broadcast, known transactions not in the receipts are also rechecked.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
