### PR TITLE
Use a lightweight JSON-parser for parsing Webauthn clientData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,6 +4412,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-test-utils",
  "nimiq-utils",
+ "rust_json",
  "serde",
  "serde_json",
  "strum_macros",
@@ -5752,6 +5753,12 @@ dependencies = [
  "blake2b_simd",
  "constant_time_eq 0.3.0",
 ]
+
+[[package]]
+name = "rust_json"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540c69f089252cacc268b7f273cfcd4ddeeae2d961936e43baa1311ab1c17388"
 
 [[package]]
 name = "rustc-demangle"

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 base64 = "0.21"
 bitflags = { version = "2.4", features = ["serde"] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
+rust_json = "0.1"
 serde = "1.0"
 strum_macros = "0.26"
 thiserror = "1.0"

--- a/web-client/src/primitives/signature_proof.rs
+++ b/web-client/src/primitives/signature_proof.rs
@@ -108,6 +108,26 @@ impl SignatureProof {
     pub fn serialize(&self) -> Vec<u8> {
         self.inner.serialize_to_vec()
     }
+
+    #[cfg(test)]
+    pub fn webauthn_fields_flags(&self) -> u8 {
+        self.inner
+            .webauthn_fields
+            .as_ref()
+            .unwrap()
+            .client_data_flags
+            .bits()
+    }
+
+    #[cfg(test)]
+    pub fn webauthn_extra_fields(&self) -> String {
+        self.inner
+            .webauthn_fields
+            .as_ref()
+            .unwrap()
+            .client_data_extra_fields
+            .clone()
+    }
 }
 
 impl From<nimiq_transaction::SignatureProof> for SignatureProof {
@@ -184,6 +204,10 @@ mod tests {
         // if proof.is_err() {
         //     console_log!("{:?}", proof.map_err(JsValue::from).err().unwrap());
         // }
+        let proof = proof.map_err(JsValue::from).unwrap();
+        assert_eq!(proof.serialize()[0], 0b0001_0001);
+        assert_eq!(proof.webauthn_fields_flags(), 0b0000_0000);
+        assert_eq!(proof.webauthn_extra_fields().is_empty(), true);
     }
 
     /// Tests a signature generated with Android Chrome, which has no crossOrigin field in the client data JSON
@@ -229,5 +253,9 @@ mod tests {
         // if proof.is_err() {
         //     console_log!("{:?}", proof.map_err(JsValue::from).err().unwrap());
         // }
+        let proof = proof.map_err(JsValue::from).unwrap();
+        assert_eq!(proof.serialize()[0], 0b0001_0001);
+        assert_eq!(proof.webauthn_fields_flags(), 0b0000_0011);
+        assert_eq!(proof.webauthn_extra_fields().is_empty(), false);
     }
 }


### PR DESCRIPTION
Also handle errors correctly, fixing all FIXMEs.

## What's in this pull request?

Instead of hand-parsing external clientDataJSON for Webauthn signatures, this PR introduces a small library to parse it.

This also fixes a few FIXMEs left in the section from the comment. These FIXMEs could also be fixed without the parser.

Unfortunately, even though the JSON-parser crate should only be 6.4kb according to crates.io, this PR increases the main-thread "primitives" WASM file by 33.5kb, which is 3.7% of the previous 904.9kb. No idea why.

#### This fixes https://github.com/nimiq/core-rs-albatross/pull/1867#discussion_r1470116959.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
