### PR TITLE
RPC schema generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,6 +4398,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "convert_case 0.6.0",
  "hex",
  "nimiq-bls",
  "nimiq-hash",
@@ -4400,7 +4407,12 @@ dependencies = [
  "nimiq-serde",
  "nimiq-transaction",
  "nimiq-utils",
+ "quote",
  "rand",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn 2.0.58",
  "thiserror",
  "tracing",
 ]
@@ -5902,6 +5914,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.26.0",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6046,6 +6082,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6895,7 +6942,7 @@ source = "git+https://github.com/sisou/tsify?branch=sisou/comments#e36e55bcf3c9a
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.28.0",
  "syn 2.0.58",
 ]
 

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -14,7 +14,7 @@ use nimiq_blockchain_proxy::BlockchainReadProxy;
 use nimiq_bls::CompressedPublicKey;
 use nimiq_collections::BitSet;
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
-use nimiq_keys::{Address, Ed25519PublicKey};
+use nimiq_keys::{Address, Ed25519PublicKey, Ed25519Signature, PrivateKey};
 use nimiq_primitives::{
     coin::Coin, networks::NetworkId, policy::Policy, slots_allocation::Validators,
 };
@@ -683,6 +683,28 @@ pub struct Account {
 
     #[serde(flatten)]
     pub account_additional_fields: AccountAdditionalFields,
+}
+
+/// A Ed25519 signature containing the actual signature and the corresponding public key.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReturnSignature {
+    /// The public key of the keypair that signed the signature.
+    pub public_key: Ed25519PublicKey,
+    /// The output of the signing process. The signature can be used to verify the authenticity and integrity of the message using the corresponding public key.
+    pub signature: Ed25519Signature,
+}
+
+/// A wallet account.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReturnAccount {
+    /// The address of the wallet account.
+    pub address: Address,
+    /// The public key of the account keypair.
+    pub public_key: Ed25519PublicKey,
+    /// The private key of the account keypair.
+    pub private_key: PrivateKey,
 }
 
 #[serde_as]

--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -1,22 +1,7 @@
 use async_trait::async_trait;
-use nimiq_keys::{Address, Ed25519PublicKey, Ed25519Signature, PrivateKey};
+use nimiq_keys::{Address, Ed25519PublicKey, Ed25519Signature};
 
-use crate::types::RPCResult;
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReturnSignature {
-    pub public_key: Ed25519PublicKey,
-    pub signature: Ed25519Signature,
-}
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReturnAccount {
-    pub address: Address,
-    pub public_key: Ed25519PublicKey,
-    pub private_key: PrivateKey,
-}
+use crate::types::{RPCResult, ReturnAccount, ReturnSignature};
 
 #[nimiq_jsonrpc_derive::proxy(name = "WalletProxy", rename_all = "camelCase")]
 #[async_trait]

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use nimiq_database::traits::WriteTransaction;
 use nimiq_keys::{Address, Ed25519PublicKey, Ed25519Signature, KeyPair, PrivateKey};
 use nimiq_rpc_interface::{
-    types::RPCResult,
-    wallet::{ReturnAccount, ReturnSignature, WalletInterface},
+    types::{RPCResult, ReturnAccount, ReturnSignature},
+    wallet::WalletInterface,
 };
 use nimiq_serde::Deserialize;
 use nimiq_utils::otp::Locked;

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -25,12 +25,22 @@ path = "src/address/main.rs"
 name = "nimiq-signtx"
 path = "src/signtx/main.rs"
 
+[[bin]]
+name = "nimiq-rpc-schema"
+path = "src/rpc-schema/main.rs"
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["cargo"] }
+convert_case = "0.6"
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
+quote = "1.0"
 rand = "0.8"
+schemars = "0.8"
+serde = "1.0"
+serde_json = "1.0"
+syn = { version = "2.0", features = ["full"] }
 thiserror = "1.0"
 
 nimiq-bls = { workspace = true }

--- a/tools/src/rpc-schema/main.rs
+++ b/tools/src/rpc-schema/main.rs
@@ -1,0 +1,113 @@
+mod openrpc;
+mod parser;
+
+use std::{env, fs};
+
+use anyhow::Error;
+use clap::{crate_authors, crate_description, crate_version, Arg, Command};
+use syn::parse_file;
+use thiserror::Error;
+
+use crate::openrpc::OpenRpcBuilder;
+
+fn main() -> Result<(), Error> {
+    let matches = Command::new("RPC schema generator")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .arg(
+            Arg::new("openrpc_version")
+                .short('o')
+                .long("openrpc-version")
+                .value_name("OPENRPC_VERSION")
+                .help("Specify the OpenRPC version of the document. Usually you want to match this with your release version number."),
+        )
+        .arg(
+            Arg::new("openrpc_title")
+                .short('t')
+                .long("openrpc-title")
+                .value_name("OPENRPC_TITLE")
+                .default_value("Nimiq JSON-RPC Specification")
+                .help("Specify the OpenRPC title of the document."),
+        )
+        .arg(
+            Arg::new("source")
+            .short('s')
+            .long("source")
+            .value_name("SOURCE")
+            .default_value("rpc-interface/src")
+            .help("The folder that contains the source of the RPC interface traits and structs.")
+        )
+        .get_matches();
+
+    let mut builder = OpenRpcBuilder::builder()
+        .version(
+            matches
+                .get_one::<String>("openrpc_version")
+                .ok_or(AppError::OpenRpcArgumentMissing("version".to_string()))?
+                .to_string(),
+        )
+        .title(
+            matches
+                .get_one::<String>("openrpc_title")
+                .ok_or(AppError::OpenRpcArgumentMissing("title".to_string()))?
+                .to_string(),
+        );
+
+    match fs::read_dir(
+        matches
+            .get_one::<String>("source")
+            .ok_or(AppError::SourceCode)?,
+    ) {
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    if let Ok(contents) = fs::read_to_string(&path) {
+                        match parse_file(&contents) {
+                            Ok(ast) => {
+                                let structs = parser::extract_structs_from_ast(&ast);
+                                let fns = parser::extract_fns_from_ast(&ast);
+                                for index in 0..structs.len() {
+                                    builder = builder.with_schema(structs.get(index).unwrap());
+                                }
+                                for index in 0..fns.len() {
+                                    builder = builder.with_method(
+                                        fns.get(index).unwrap(),
+                                        path.file_name()
+                                            .unwrap()
+                                            .to_string_lossy()
+                                            .replace(".rs", ""),
+                                    );
+                                }
+                            }
+                            Err(err) => {
+                                return Err(AppError::ParsingError(err).into());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err(err) => return Err(AppError::LoadDirectoryError(err).into()),
+    }
+
+    print!(
+        "{}",
+        serde_json::to_string_pretty(&builder.build()).expect("Failed to serialize OpenRPC spec")
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+enum AppError {
+    #[error("Unable to load specified directory: {0}")]
+    LoadDirectoryError(#[from] std::io::Error),
+    #[error("Failed to parse Rust source file: {0}")]
+    ParsingError(#[from] syn::Error),
+    #[error("OpenRPC {0} argument is missing")]
+    OpenRpcArgumentMissing(String),
+    #[error("The source argument is missing")]
+    SourceCode,
+}

--- a/tools/src/rpc-schema/openrpc/document.rs
+++ b/tools/src/rpc-schema/openrpc/document.rs
@@ -1,0 +1,633 @@
+use std::collections::BTreeMap;
+
+use nimiq_serde::{Deserialize, Serialize};
+use schemars::{gen::SchemaSettings, schema::RootSchema, JsonSchema};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Openrpc {
+    #[serde(rename = "1.2.6")]
+    V26,
+    #[serde(rename = "1.2.5")]
+    V25,
+    #[serde(rename = "1.2.4")]
+    V24,
+    #[serde(rename = "1.2.3")]
+    V23,
+    #[serde(rename = "1.2.2")]
+    V22,
+    #[serde(rename = "1.2.1")]
+    V21,
+    #[serde(rename = "1.2.0")]
+    V20,
+    #[serde(rename = "1.1.12")]
+    V112,
+    #[serde(rename = "1.1.11")]
+    V111,
+    #[serde(rename = "1.1.10")]
+    V110,
+    #[serde(rename = "1.1.9")]
+    V19,
+    #[serde(rename = "1.1.8")]
+    V18,
+    #[serde(rename = "1.1.7")]
+    V17,
+    #[serde(rename = "1.1.6")]
+    V16,
+    #[serde(rename = "1.1.5")]
+    V15,
+    #[serde(rename = "1.1.4")]
+    V14,
+    #[serde(rename = "1.1.3")]
+    V13,
+    #[serde(rename = "1.1.2")]
+    V12,
+    #[serde(rename = "1.1.1")]
+    V11,
+    #[serde(rename = "1.1.0")]
+    V10,
+    #[serde(rename = "1.0.0")]
+    V00,
+    #[serde(rename = "1.0.0-rc1")]
+    V00Rc1,
+    #[serde(rename = "1.0.0-rc0")]
+    V00Rc0,
+}
+
+pub type InfoObjectProperties = String;
+pub type InfoObjectDescription = String;
+pub type InfoObjectTermsOfService = String;
+pub type InfoObjectVersion = String;
+pub type ContactObjectName = String;
+pub type ContactObjectEmail = String;
+pub type ContactObjectUrl = String;
+pub type SpecificationExtension = serde_json::Value;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ContactObject {
+    pub name: Option<ContactObjectName>,
+    pub email: Option<ContactObjectEmail>,
+    pub url: Option<ContactObjectUrl>,
+}
+
+pub type LicenseObjectName = String;
+pub type LicenseObjectUrl = String;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LicenseObject {
+    pub name: Option<LicenseObjectName>,
+    pub url: Option<LicenseObjectUrl>,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub struct InfoObject {
+    pub title: InfoObjectProperties,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<InfoObjectDescription>,
+    #[serde(rename = "termsOfService")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terms_of_service: Option<InfoObjectTermsOfService>,
+    pub version: InfoObjectVersion,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<ContactObject>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<LicenseObject>,
+}
+
+pub type ExternalDocumentationObjectDescription = String;
+pub type ExternalDocumentationObjectUrl = String;
+
+/// ExternalDocumentationObject
+///
+/// information about external documentation
+///
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ExternalDocumentationObject {
+    pub description: Option<ExternalDocumentationObjectDescription>,
+    pub url: ExternalDocumentationObjectUrl,
+}
+
+pub type ServerObjectUrl = String;
+pub type ServerObjectName = String;
+pub type ServerObjectDescription = String;
+pub type ServerObjectSummary = String;
+pub type ServerObjectVariableDefault = String;
+pub type ServerObjectVariableDescription = String;
+pub type ServerObjectVariableEnumItem = String;
+pub type ServerObjectVariableEnum = Vec<ServerObjectVariableEnumItem>;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ServerObjectVariable {
+    pub default: ServerObjectVariableDefault,
+    pub description: Option<ServerObjectVariableDescription>,
+    #[serde(rename = "enum")]
+    pub variable_enum: Option<ServerObjectVariableEnum>,
+}
+
+pub type ServerObjectVariables = BTreeMap<String, Option<serde_json::Value>>;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ServerObject {
+    pub url: ServerObjectUrl,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<ServerObjectName>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<ServerObjectDescription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ServerObjectSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<ServerObjectVariables>,
+}
+
+pub type Servers = Vec<ServerObject>;
+/// MethodObjectName
+///
+/// The cannonical name for the method. The name MUST be unique within the methods array.
+///
+pub type MethodObjectName = String;
+/// MethodObjectDescription
+///
+/// A verbose explanation of the method behavior. GitHub Flavored Markdown syntax MAY be used for rich text representation.
+///
+pub type MethodObjectDescription = String;
+/// MethodObjectSummary
+///
+/// A short summary of what the method does.
+///
+pub type MethodObjectSummary = String;
+pub type TagObjectName = String;
+pub type TagObjectDescription = String;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TagObject {
+    pub name: TagObjectName,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<TagObjectDescription>,
+    #[serde(rename = "externalDocs")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<ExternalDocumentationObject>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ReferenceObject {
+    #[serde(rename = "$ref")]
+    pub reference: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum TagOrReference {
+    TagObject(TagObject),
+    ReferenceObject(ReferenceObject),
+}
+
+pub type MethodObjectTags = Vec<TagOrReference>;
+
+/// MethodObjectParamStructure
+///
+/// Format the server expects the params. Defaults to 'either'.
+///
+/// # Default
+///
+/// either
+///
+#[derive(Serialize, Deserialize, Clone)]
+pub enum MethodObjectParamStructure {
+    #[serde(rename = "by-position")]
+    ByPosition,
+    #[serde(rename = "by-name")]
+    ByName,
+    #[serde(rename = "either")]
+    Either,
+}
+
+pub type ContentDescriptorObjectName = String;
+pub type ContentDescriptorObjectDescription = String;
+pub type ContentDescriptorObjectSummary = String;
+pub type Id = String;
+pub type Schema = String;
+pub type Comment = String;
+pub type Title = String;
+pub type Description = String;
+type AlwaysTrue = serde_json::Value;
+pub type ReadOnly = bool;
+pub type Examples = Vec<AlwaysTrue>;
+pub type MultipleOf = f64;
+pub type Maximum = f64;
+pub type ExclusiveMaximum = f64;
+pub type Minimum = f64;
+pub type ExclusiveMinimum = f64;
+pub type NonNegativeInteger = i64;
+pub type NonNegativeIntegerDefaultZero = i64;
+pub type Pattern = String;
+pub type SchemaArray = Vec<JSONSchema>;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum Items {
+    JSONSchema(JSONSchema),
+    SchemaArray(SchemaArray),
+}
+
+pub type UniqueItems = bool;
+pub type StringDoaGddGA = String;
+/// StringArray
+///
+/// # Default
+///
+/// []
+///
+pub type StringArray = Vec<StringDoaGddGA>;
+/// Definitions
+///
+/// # Default
+///
+/// {}
+///
+pub type Definitions = BTreeMap<String, Option<serde_json::Value>>;
+/// Properties
+///
+/// # Default
+///
+/// {}
+///
+pub type Properties = BTreeMap<String, Option<serde_json::Value>>;
+/// PatternProperties
+///
+/// # Default
+///
+/// {}
+///
+pub type PatternProperties = BTreeMap<String, Option<serde_json::Value>>;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum DependenciesSet {
+    JSONSchema(JSONSchema),
+    StringArray(StringArray),
+}
+
+pub type Dependencies = BTreeMap<String, Option<serde_json::Value>>;
+pub type Enum = Vec<AlwaysTrue>;
+pub type SimpleTypes = serde_json::Value;
+pub type ArrayOfSimpleTypes = Vec<SimpleTypes>;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum Type {
+    SimpleTypes(SimpleTypes),
+    ArrayOfSimpleTypes(ArrayOfSimpleTypes),
+}
+
+pub type Format = String;
+pub type ContentMediaType = String;
+pub type ContentEncoding = String;
+
+/// JSONSchemaBoolean
+///
+/// Always valid if true. Never valid if false. Is constant.
+///
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum JSONSchema {
+    JsonSchemaObject(RootSchema),
+    JSONSchemaBoolean(bool),
+}
+
+pub type ContentDescriptorObjectRequired = bool;
+pub type ContentDescriptorObjectDeprecated = bool;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ContentDescriptorObject {
+    pub name: ContentDescriptorObjectName,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<ContentDescriptorObjectDescription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ContentDescriptorObjectSummary>,
+    pub schema: JSONSchema,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<ContentDescriptorObjectRequired>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<ContentDescriptorObjectDeprecated>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ContentDescriptorOrReference {
+    ContentDescriptorObject(ContentDescriptorObject),
+    ReferenceObject(ReferenceObject),
+}
+
+pub type MethodObjectParams = Vec<ContentDescriptorOrReference>;
+
+/// ErrorObjectCode
+///
+/// A Number that indicates the error type that occurred. This MUST be an integer. The error codes from and including -32768 to -32000 are reserved for pre-defined errors. These pre-defined errors SHOULD be assumed to be returned from any JSON-RPC api.
+///
+pub type ErrorObjectCode = i64;
+/// ErrorObjectMessage
+///
+/// A String providing a short description of the error. The message SHOULD be limited to a concise single sentence.
+///
+pub type ErrorObjectMessage = String;
+/// ErrorObjectData
+///
+/// A Primitive or Structured value that contains additional information about the error. This may be omitted. The value of this member is defined by the Server (e.g. detailed error information, nested errors etc.).
+///
+pub type ErrorObjectData = serde_json::Value;
+
+/// ErrorObject
+///
+/// Defines an application level error.
+///
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ErrorObject {
+    pub code: ErrorObjectCode,
+    pub message: ErrorObjectMessage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<ErrorObjectData>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ErrorOrReference {
+    ErrorObject(ErrorObject),
+    ReferenceObject(ReferenceObject),
+}
+
+/// MethodObjectErrors
+///
+/// Defines an application level error.
+///
+pub type MethodObjectErrors = Vec<ErrorOrReference>;
+pub type LinkObjectName = String;
+pub type LinkObjectSummary = String;
+pub type LinkObjectMethod = String;
+pub type LinkObjectDescription = String;
+pub type LinkObjectParams = serde_json::Value;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LinkObjectServer {
+    pub url: ServerObjectUrl,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<ServerObjectName>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<ServerObjectDescription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ServerObjectSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<ServerObjectVariables>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LinkObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<LinkObjectName>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<LinkObjectSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<LinkObjectMethod>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<LinkObjectDescription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<LinkObjectParams>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<LinkObjectServer>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum LinkOrReference {
+    LinkObject(LinkObject),
+    ReferenceObject(ReferenceObject),
+}
+
+pub type MethodObjectLinks = Vec<LinkOrReference>;
+pub type ExamplePairingObjectName = String;
+pub type ExamplePairingObjectDescription = String;
+pub type ExampleObjectSummary = String;
+pub type ExampleObjectValue = serde_json::Value;
+pub type ExampleObjectDescription = String;
+pub type ExampleObjectName = String;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ExampleObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ExampleObjectSummary>,
+    pub value: ExampleObjectValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<ExampleObjectDescription>,
+    pub name: ExampleObjectName,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ExampleOrReference {
+    ExampleObject(ExampleObject),
+    ReferenceObject(ReferenceObject),
+}
+
+pub type ExamplePairingObjectParams = Vec<ExampleOrReference>;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ExamplePairingObjectResult {
+    ExampleObject(ExampleObject),
+    ReferenceObject(ReferenceObject),
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ExamplePairingObject {
+    pub name: ExamplePairingObjectName,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<ExamplePairingObjectDescription>,
+    pub params: ExamplePairingObjectParams,
+    pub result: ExamplePairingObjectResult,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ExamplePairingOrReference {
+    ExampleObject(ExampleObject),
+    ReferenceObject(ReferenceObject),
+}
+
+pub type MethodObjectExamples = Vec<ExamplePairingOrReference>;
+pub type MethodObjectDeprecated = bool;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MethodObject {
+    pub name: MethodObjectName,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<MethodObjectDescription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<MethodObjectSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub servers: Option<Servers>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<MethodObjectTags>,
+    #[serde(rename = "paramStructure")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param_structure: Option<MethodObjectParamStructure>,
+    pub params: MethodObjectParams,
+    pub result: ContentDescriptorOrReference,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errors: Option<MethodObjectErrors>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<MethodObjectLinks>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub examples: Option<MethodObjectExamples>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<MethodObjectDeprecated>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "externalDocs")]
+    pub external_docs: Option<ExternalDocumentationObject>,
+}
+
+pub type Methods = Vec<MethodObject>;
+pub type SchemaComponents = BTreeMap<String, Option<serde_json::Value>>;
+pub type LinkComponents = BTreeMap<String, Option<serde_json::Value>>;
+pub type ErrorComponents = BTreeMap<String, Option<serde_json::Value>>;
+pub type ExampleComponents = BTreeMap<String, Option<serde_json::Value>>;
+pub type ExamplePairingComponents = BTreeMap<String, Option<serde_json::Value>>;
+pub type ContentDescriptorComponents = BTreeMap<String, Option<serde_json::Value>>;
+pub type TagComponents = BTreeMap<String, Option<serde_json::Value>>;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Components {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schemas: Option<SchemaComponents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<LinkComponents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errors: Option<ErrorComponents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub examples: Option<ExampleComponents>,
+    #[serde(rename = "examplePairings")]
+    pub example_pairings: Option<ExamplePairingComponents>,
+    #[serde(rename = "contentDescriptors")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_descriptors: Option<ContentDescriptorComponents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<TagComponents>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OpenrpcDocument {
+    pub openrpc: Openrpc,
+    pub info: InfoObject,
+    #[serde(rename = "externalDocs")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<ExternalDocumentationObject>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub servers: Option<Servers>,
+    pub methods: Methods,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Components>,
+}
+
+impl Default for OpenrpcDocument {
+    fn default() -> Self {
+        OpenrpcDocument {
+            openrpc: Openrpc::V26,
+            info: InfoObject {
+                title: "".to_string(),
+                description: None,
+                terms_of_service: None,
+                version: "".to_string(),
+                contact: None,
+                license: None,
+            },
+            external_docs: None,
+            servers: None,
+            methods: vec![],
+            components: None,
+        }
+    }
+}
+
+impl OpenrpcDocument {
+    pub fn set_info(mut self, info: InfoObject) -> Self {
+        self.info = info;
+        self
+    }
+    pub fn add_object_method(&mut self, method: MethodObject) {
+        self.methods.push(method)
+    }
+}
+
+impl ContentDescriptorOrReference {
+    pub fn new_content_descriptor<T: ?Sized + JsonSchema>(
+        name: ContactObjectName,
+        description: Option<Description>,
+    ) -> Self {
+        let mut setting = SchemaSettings::draft07();
+        setting.inline_subschemas = true;
+        let schema = schemars::gen::SchemaGenerator::new(setting).into_root_schema_for::<T>();
+        let json_schema = JSONSchema::JsonSchemaObject(schema);
+        ContentDescriptorOrReference::ContentDescriptorObject(ContentDescriptorObject {
+            name,
+            description,
+            summary: None,
+            schema: json_schema,
+            required: None,
+            deprecated: None,
+        })
+    }
+}
+
+impl MethodObject {
+    pub fn new(name: MethodObjectName, description: Option<Description>) -> Self {
+        Self {
+            name,
+            description,
+            summary: None,
+            servers: None,
+            tags: None,
+            param_structure: None,
+            params: vec![],
+            result: ContentDescriptorOrReference::ReferenceObject(ReferenceObject {
+                reference: "".to_string(),
+            }),
+            errors: None,
+            links: None,
+            examples: None,
+            deprecated: None,
+            external_docs: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[derive(JsonSchema)]
+    pub struct MyType([u8; 8]);
+
+    #[derive(JsonSchema)]
+    pub struct MyParam {
+        pub my_int: i32,
+        pub my_bool: bool,
+        pub my_type: Box<MyType>,
+    }
+
+    #[derive(JsonSchema)]
+    pub struct MyRet {
+        pub success: Box<bool>,
+    }
+
+    #[test]
+    fn test_openrpc_document() {
+        let mut document = OpenrpcDocument::default();
+        let mut method = MethodObject::new("method1".to_string(), None);
+        let param = ContentDescriptorOrReference::new_content_descriptor::<MyParam>(
+            "first_param".to_string(),
+            Some("no desc".to_string()),
+        );
+        method.params.push(param);
+        method.result =
+            ContentDescriptorOrReference::new_content_descriptor::<MyRet>("ret".to_string(), None);
+        document.add_object_method(method);
+        let j = serde_json::to_string_pretty(&document).unwrap();
+        println!("{}", j);
+    }
+}

--- a/tools/src/rpc-schema/openrpc/mod.rs
+++ b/tools/src/rpc-schema/openrpc/mod.rs
@@ -1,0 +1,126 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use self::document::{
+    Components, ContactObject, InfoObject, LicenseObject, MethodObject, Openrpc, OpenrpcDocument,
+    TagObject, TagOrReference,
+};
+use crate::parser::{ParsedItemStruct, ParsedTraitItemFn};
+
+#[allow(unused)]
+pub mod document;
+
+/// A builder for constructing an OpenRPC document.
+#[derive(Clone)]
+pub struct OpenRpcBuilder {
+    open_rpc_doc: OpenrpcDocument,
+    structs: Vec<ParsedItemStruct>,
+    methods: Vec<(ParsedTraitItemFn, String)>,
+}
+
+impl OpenRpcBuilder {
+    /// Adds a schema based on a Rust struct to the OpenRPC document.
+    pub fn with_schema(mut self, item_struct: &ParsedItemStruct) -> OpenRpcBuilder {
+        self.structs.push(item_struct.clone());
+        self
+    }
+
+    /// Adds a method based on a Rust trait method to the OpenRPC document.
+    pub fn with_method(mut self, item_fn: &ParsedTraitItemFn, module: String) -> OpenRpcBuilder {
+        self.methods.push((item_fn.clone(), module));
+        self
+    }
+
+    /// Sets the title of the OpenRPC document.
+    pub fn title(mut self, title: String) -> OpenRpcBuilder {
+        self.open_rpc_doc.info.title = title;
+        self
+    }
+
+    /// Sets the version of the OpenRPC document.
+    pub fn version(mut self, version: String) -> OpenRpcBuilder {
+        self.open_rpc_doc.info.version = version;
+        self
+    }
+
+    /// Creates a new instance of OpenRpcBuilder with default settings and returns it.
+    pub fn builder() -> OpenRpcBuilder {
+        OpenRpcBuilder{ open_rpc_doc: OpenrpcDocument {
+            openrpc: Openrpc::V26,
+            info: InfoObject {
+                description: Some("Through the use of JSON-RPC, Nimiq nodes expose a set of standardized methods and endpoints that allow external applications and tools to interact, stream and control the behavior of the nodes. This includes functionalities such as retrieving information about the blockchain state, submitting transactions, managing accounts, and configuring node settings.".to_string()),
+                contact: Some(ContactObject { name: Some(env!("CARGO_PKG_AUTHORS").to_string()), email: Some("".to_string()), url: Some(env!("CARGO_PKG_HOMEPAGE").to_string()) }),
+                license: Some(LicenseObject{ name: Some(env!("CARGO_PKG_LICENSE").to_string()), url: Some("".to_string()) }),
+                ..Default::default()
+            },
+            components: Some(Components {
+                schemas: Some(BTreeMap::new()),
+                links: None,
+                errors: None,
+                examples: None,
+                example_pairings: Some(BTreeMap::new()),
+                content_descriptors: None,
+                tags: None,
+            }),
+            ..Default::default()
+        }, structs: vec![], methods: vec![]}
+    }
+
+    /// Builds the final OpenRPC document and returns constructed OpenrpcDocument.
+    pub fn build(self) -> OpenrpcDocument {
+        let mut doc = OpenrpcDocument {
+            openrpc: self.open_rpc_doc.openrpc,
+            info: self.open_rpc_doc.info,
+            servers: self.open_rpc_doc.servers,
+            methods: self.open_rpc_doc.methods,
+            components: self.open_rpc_doc.components,
+            external_docs: self.open_rpc_doc.external_docs,
+        };
+
+        let schemas = doc
+            .components
+            .as_mut()
+            .expect("Components not initialized.")
+            .schemas
+            .as_mut()
+            .expect("Component schema not initialized.");
+
+        self.structs.iter().for_each(|s| {
+            let mut schema = Map::new();
+            schema.insert("title".into(), Value::String(s.title()));
+            schema.insert("description".into(), Value::String(s.description()));
+            schema.insert("required".into(), Value::Array(s.required_fields()));
+            schema.insert("properties".into(), s.properties(&self.structs));
+            schemas.insert(s.title(), Some(Value::Object(schema)));
+        });
+
+        self.methods.iter().for_each(|m| {
+            let mut method = MethodObject::new(m.0.title(), Some(m.0.description()));
+            method.params = m.0.params(&self.structs);
+            method.result = m.0.return_type(&self.structs);
+            method.tags = Some(Vec::with_capacity(2));
+
+            if let Some(ref mut tags) = method.tags {
+                tags.push(TagOrReference::TagObject(TagObject {
+                    name: m.1.clone(),
+                    description: None,
+                    external_docs: None,
+                }));
+
+                if method.name.contains("subscribe") {
+                    tags.push(TagOrReference::TagObject(TagObject {
+                        name: "stream".to_string(),
+                        description: None,
+                        external_docs: None,
+                    }));
+                }
+            }
+
+            doc.methods.push(method);
+        });
+        doc.methods.sort_by_key(|m| m.name.clone());
+
+        doc
+    }
+}

--- a/tools/src/rpc-schema/parser.rs
+++ b/tools/src/rpc-schema/parser.rs
@@ -1,0 +1,477 @@
+use convert_case::{Case, Casing};
+use quote::ToTokens;
+use schemars::schema::{
+    ArrayValidation, InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec,
+};
+use serde_json::{Map, Value};
+use syn::{
+    Field, File, GenericArgument, Ident, ItemStruct, Pat, PatIdent, Path, PathArguments,
+    PathSegment, ReturnType, TraitItem, TraitItemFn, Type,
+};
+
+use crate::openrpc::document::{ContentDescriptorObject, ContentDescriptorOrReference, JSONSchema};
+
+/// Represents a parsed Rust struct.
+#[derive(Clone)]
+pub struct ParsedItemStruct(ItemStruct);
+/// Represents a parsed Rust trait method.
+#[derive(Clone)]
+pub struct ParsedTraitItemFn(TraitItemFn);
+
+impl ParsedItemStruct {
+    /// Retrieves the name of a Rust struct.
+    #[inline]
+    pub fn title(&self) -> String {
+        self.0.ident.to_string()
+    }
+
+    /// Retrieves the description of a Rust struct based on the Rustdoc.
+    #[inline]
+    pub fn description(&self) -> String {
+        "".into()
+    }
+
+    /// Generates the properties for the Rust struct in the form of a JSON Object.
+    pub fn properties(&self, structs: &[ParsedItemStruct]) -> Value {
+        let props: Map<String, Value> = self
+            .0
+            .fields
+            .iter()
+            .filter_map(|field| {
+                let path = match &field.ty {
+                    Type::Path(p) => p,
+                    Type::Array(_) => {
+                        return None;
+                    }
+                    _ => unreachable!(),
+                };
+                let inner_type = Self::unwrap_type(path.path.clone(), true);
+
+                let mut prop_fields = Map::new();
+                let field_ident = field
+                    .ident
+                    .to_token_stream()
+                    .to_string()
+                    .to_case(Case::Camel);
+
+                prop_fields.insert("title".into(), Value::String(field_ident.clone()));
+                let schema_ref = structs.iter().find(|s| inner_type.1 == s.title());
+                prop_fields.append(&mut Self::param_to_json_type(field, schema_ref));
+
+                Some((field_ident, Value::Object(prop_fields)))
+            })
+            .collect();
+
+        Value::Object(props)
+    }
+
+    /// Converts a Rust struct property to JSON type.
+    fn param_to_json_type(
+        param: &Field,
+        schema_ref: Option<&ParsedItemStruct>,
+    ) -> Map<String, Value> {
+        let mut map = Map::new();
+        match &param.ty {
+            Type::Path(type_path) => {
+                let mut path = type_path.path.clone();
+                let mut ident = path
+                    .segments
+                    .first()
+                    .expect("Function paramater should have a segment")
+                    .ident
+                    .clone();
+
+                if ident == "Option" {
+                    (path, ident) = Self::unwrap_type(type_path.path.clone(), false);
+                }
+
+                if ident == "Vec" {
+                    let mut items_map = Map::new();
+                    if let Some(reference) = schema_ref {
+                        items_map.insert(
+                            "$ref".into(),
+                            Value::String(format!("#/components/schemas/{}", reference.title())),
+                        );
+                    } else {
+                        items_map.insert("type".into(), Self::map_type(&path));
+                    }
+
+                    map.insert("type".to_string(), Value::String("array".into()));
+                    map.insert("items".to_string(), Value::Object(items_map));
+                } else if let Some(reference) = schema_ref {
+                    map.insert(
+                        "$ref".into(),
+                        Value::String(format!("#/components/schemas/{}", reference.title())),
+                    );
+                } else {
+                    map.insert("type".into(), Self::map_type(&path));
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        map
+    }
+
+    /// Maps a Rust type to a JSON type.
+    fn map_type(path: &Path) -> Value {
+        let (_, inner_ident) = Self::unwrap_type(path.clone(), true);
+        match inner_ident.to_string().as_str() {
+            "Address"
+            | "Blake2bHash"
+            | "Blake2sHash"
+            | "CompressedPublicKey"
+            | "Ed25519PublicKey"
+            | "NetworkId"
+            | "PrivateKey"
+            | "Ed25519Signature"
+            | "String"
+            | "VrfSeed" => Value::String("string".into()),
+            "u8" | "u16" | "u32" | "u64" | "usize" | "Coin" => Value::String("number".into()),
+            "bool" => Value::String("boolean".into()),
+            "AccountAdditionalFields"
+            | "BitSet"
+            | "S"
+            | "T"
+            | "BlockAdditionalFields"
+            | "MultiSignature" => Value::String("object".into()),
+            _ => panic!("{}", inner_ident),
+        }
+    }
+
+    /// Creates a list of Rust struct properties that are mandatory.
+    /// This is determined by checking if the type is wrapped in an `Option<T>`.
+    pub fn required_fields(&self) -> Vec<Value> {
+        self.0
+            .fields
+            .iter()
+            .filter_map(|field| {
+                if field.ty.to_token_stream().to_string().contains("Option") {
+                    return None;
+                }
+
+                Some(Value::String(
+                    field
+                        .ident
+                        .to_token_stream()
+                        .to_string()
+                        .to_case(Case::Camel),
+                ))
+            })
+            .collect()
+    }
+
+    /// Check if we are dealing with a wrapped type here, e.g. `Vec<u8>`, `Option<String>` and flatten those to its child type.
+    /// `Vec<u8>` becomes `u8`, `Option<String>` becomes `String` and `Option<Vec<String>>` becomes `Vec<String>`.
+    /// Calling this function with `recursive` is true, it will keep unwrapping until it no further can. `Option<Vec<String>>` would become `String`.
+    fn unwrap_type(path: Path, recursive: bool) -> (Path, Ident) {
+        let ident = path.segments.first().unwrap().ident.clone();
+
+        match ident.to_string().as_str() {
+            "Vec" | "Option" => {
+                if let PathArguments::AngleBracketed(outer_type) =
+                    path.segments.first().unwrap().arguments.clone()
+                {
+                    if let GenericArgument::Type(Type::Path(inner_type)) =
+                        outer_type.args.first().unwrap()
+                    {
+                        if recursive {
+                            return Self::unwrap_type(inner_type.path.clone(), true);
+                        }
+
+                        (
+                            inner_type.path.clone(),
+                            inner_type.path.segments.first().unwrap().ident.clone(),
+                        )
+                    } else {
+                        (path, ident)
+                    }
+                } else {
+                    (path, ident)
+                }
+            }
+            _ => (path, ident),
+        }
+    }
+}
+
+impl ParsedTraitItemFn {
+    /// Retrieves the name of a Rust trait method.
+    #[inline]
+    pub fn title(&self) -> String {
+        self.0.sig.ident.to_string().to_case(Case::Camel)
+    }
+
+    /// Retrieves the description of a Rust trait method based on the Rustdoc.
+    #[inline]
+    pub fn description(&self) -> String {
+        self.0
+            .attrs
+            .iter()
+            .fold(String::new(), |acc, attr| {
+                if attr.path().is_ident("doc") {
+                    return acc + &attr.to_token_stream().to_string();
+                }
+                acc
+            })
+            .replace("# [doc = \"", "")
+            .replace("\"]", "")
+            .trim_start()
+            .into()
+    }
+
+    /// Generates a list of parameters that accepted by the Rust trait method.
+    pub fn params(&self, structs: &[ParsedItemStruct]) -> Vec<ContentDescriptorOrReference> {
+        self.0
+            .sig
+            .inputs
+            .iter()
+            .filter_map(|input| match input {
+                syn::FnArg::Typed(typed) => {
+                    let segment = match *typed.ty.clone() {
+                        Type::Path(p) => p.path.segments.first().unwrap().clone(),
+                        _ => unreachable!(),
+                    };
+
+                    let (inner_segment, inner_type) = Self::unwrap_type(&segment);
+                    let schema_ref = structs.iter().find(|s| inner_type == s.title());
+
+                    Some(ContentDescriptorOrReference::ContentDescriptorObject(
+                        ContentDescriptorObject {
+                            name: Self::param_ident(&typed.pat)
+                                .ident
+                                .to_string()
+                                .to_case(Case::Camel),
+                            description: None,
+                            summary: None,
+                            schema: JSONSchema::JsonSchemaObject(RootSchema {
+                                schema: Self::return_type_schema(&inner_segment, schema_ref),
+                                ..Default::default()
+                            }),
+                            required: Some(Self::param_required(&typed.ty)),
+                            deprecated: None,
+                        },
+                    ))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Extract the identity of a parameter.
+    fn param_ident(pat: &Pat) -> PatIdent {
+        match pat {
+            syn::Pat::Ident(ident) => ident.clone(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Determines whether a Rust trait method parameter is required.
+    fn param_required(_ty: &Type) -> bool {
+        // At the moment, all params are required even if the type is wrapped in an Option.
+        // if ty.to_token_stream().to_string().contains("Option") {
+        //     return false;
+        // }
+        true
+    }
+
+    /// Generates a content descriptor containing the base information about the return type
+    /// of the Rust trait method.
+    pub fn return_type(&self, structs: &[ParsedItemStruct]) -> ContentDescriptorOrReference {
+        let ty = match &self.0.sig.output {
+            ReturnType::Type(_, ty) => match ty.as_ref() {
+                Type::Path(path) => path,
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
+        };
+
+        let arg = match &ty
+            .path
+            .segments
+            .first()
+            .expect("Type must have at least one segment.")
+            .arguments
+        {
+            PathArguments::AngleBracketed(arg) => arg
+                .args
+                .first()
+                .expect("Type must have at least one argument."),
+            _ => unreachable!(),
+        };
+
+        let path = match arg {
+            GenericArgument::Type(return_type) => match return_type {
+                Type::Path(path) => path,
+                Type::Tuple(_) => {
+                    return ContentDescriptorOrReference::ContentDescriptorObject(
+                        ContentDescriptorObject {
+                            name: "null".to_string(),
+                            description: None,
+                            summary: None,
+                            schema: JSONSchema::JsonSchemaObject(RootSchema {
+                                schema: SchemaObject {
+                                    instance_type: Some(SingleOrVec::Single(Box::new(
+                                        InstanceType::Null,
+                                    ))),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            }),
+                            required: None,
+                            deprecated: None,
+                        },
+                    )
+                }
+                _ => {
+                    unreachable!()
+                }
+            },
+            _ => unreachable!(),
+        };
+        let ident = path
+            .path
+            .segments
+            .first()
+            .expect("Path must have an identity.");
+
+        let inner_type = Self::unwrap_type(ident);
+        let schema_ref = structs.iter().find(|s| inner_type.1 == s.title());
+
+        ContentDescriptorOrReference::ContentDescriptorObject(ContentDescriptorObject {
+            name: ident.ident.to_string(),
+            description: None,
+            summary: None,
+            schema: JSONSchema::JsonSchemaObject(RootSchema {
+                schema: Self::return_type_schema(ident, schema_ref),
+                ..Default::default()
+            }),
+            required: None,
+            deprecated: None,
+        })
+    }
+
+    /// Generates the schema object for the return type of the Rust trait method.
+    fn return_type_schema(
+        ident: &PathSegment,
+        schema_ref: Option<&ParsedItemStruct>,
+    ) -> SchemaObject {
+        let mut schema = SchemaObject {
+            ..Default::default()
+        };
+
+        let (is_rust_type, instance_type) = Self::to_instance_type(&ident.ident);
+
+        if is_rust_type {
+            schema.instance_type = Some(SingleOrVec::Single(Box::new(instance_type)));
+        } else {
+            schema.reference = Some(format!("#/components/schemas/{}", ident.ident));
+        }
+
+        if instance_type == InstanceType::Array {
+            let inner_type = Self::unwrap_type(ident);
+            let mut inner_instance_type = Self::to_instance_type(&inner_type.1);
+            let mut inner_schema = SchemaObject {
+                ..Default::default()
+            };
+
+            if schema_ref.is_some() {
+                inner_schema.reference = Some(format!("#/components/schemas/{}", inner_type.1));
+            } else {
+                if inner_instance_type.1 == InstanceType::Array {
+                    inner_instance_type.1 = InstanceType::String;
+                }
+
+                inner_schema.instance_type =
+                    Some(SingleOrVec::Single(Box::new(inner_instance_type.1)))
+            }
+
+            schema.array = Some(Box::new(ArrayValidation {
+                items: Some(SingleOrVec::Single(Box::new(Schema::Object(inner_schema)))),
+                ..Default::default()
+            }));
+        }
+
+        schema
+    }
+
+    /// Converts a Rust type to a JSON Value.
+    fn to_instance_type(ident: &Ident) -> (bool, InstanceType) {
+        match ident.to_string().as_str() {
+            "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "f64"
+            | "usize"
+            | "BoxStream"
+            | "ValidityStartHeight"
+            | "Coin" => (true, InstanceType::Number),
+            "Vec" | "LogType" => (true, InstanceType::Array),
+            "String" | "AnyHash" | "Ed25519Signature" | "Ed25519PublicKey" | "PreImage"
+            | "Blake2bHash" | "Address" => (true, InstanceType::String),
+            "bool" => (true, InstanceType::Boolean),
+            _ => (false, InstanceType::Object),
+        }
+    }
+
+    /// Unwrap a type if it is wrapped. This method turns an `Option<String>` into a String for example.
+    fn unwrap_type(path_segment: &PathSegment) -> (PathSegment, Ident) {
+        let ident = path_segment.ident.clone();
+
+        match ident.to_string().as_str() {
+            "Vec" | "Option" => {
+                if let PathArguments::AngleBracketed(outer_type) = &path_segment.arguments {
+                    if let GenericArgument::Type(Type::Path(inner_type)) =
+                        outer_type.args.first().unwrap()
+                    {
+                        let segment = inner_type.path.segments.first().unwrap();
+                        return (segment.to_owned(), segment.ident.clone());
+                    }
+                    unreachable!()
+                }
+                (path_segment.to_owned(), ident)
+            }
+            _ => (path_segment.to_owned(), ident),
+        }
+    }
+}
+
+impl From<ItemStruct> for ParsedItemStruct {
+    fn from(val: ItemStruct) -> Self {
+        ParsedItemStruct(val)
+    }
+}
+
+impl From<TraitItemFn> for ParsedTraitItemFn {
+    fn from(val: TraitItemFn) -> Self {
+        ParsedTraitItemFn(val)
+    }
+}
+
+/// Filter a syntrax tree and only extract the Rust struct definitions.
+pub fn extract_structs_from_ast(file: &File) -> Vec<ParsedItemStruct> {
+    file.items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Struct(item_struct) => Some(item_struct.clone().into()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Filter a syntrax tree and only extract the Rust methods within a trait definition.
+pub fn extract_fns_from_ast(file: &File) -> Vec<ParsedTraitItemFn> {
+    file.items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Trait(trait_item) => Some(trait_item.items.clone()),
+            _ => None,
+        })
+        .flatten()
+        .filter_map(|trait_item| match trait_item {
+            TraitItem::Fn(trait_item_fn) => Some(trait_item_fn.into()),
+            _ => None,
+        })
+        .collect()
+}


### PR DESCRIPTION
## What's in this pull request?
This pull request introduces a new tool called `nimiq-rpc-schema`. It generates a JSON object written to stdout based on the trait and struct definitions in the `rpc-interface`-crate by parsing the code into an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) and turning it into an [OpenRPC specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/nimiq/core-rs-albatross/stefan/openrpc-gen/tools/src/rpc-schema/schema.json). This schema is meant as the base for generating a consistent API documentation or the generation of RPC clients in various programming languages.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
