### PR TITLE
Improve trienode serialization performance by vendoring postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3566,7 +3566,6 @@ dependencies = [
  "parking_lot 0.12.2",
  "rand",
  "serde",
- "serde-big-array",
  "thiserror",
  "tracing",
 ]
@@ -3856,7 +3855,6 @@ dependencies = [
  "rand",
  "rand_core",
  "serde",
- "serde-big-array",
  "sha2",
  "thiserror",
  "zeroize",
@@ -3966,7 +3964,6 @@ dependencies = [
  "hex",
  "nimiq-serde",
  "serde",
- "serde-big-array",
  "subtle",
 ]
 
@@ -4101,7 +4098,6 @@ dependencies = [
  "prometheus-client",
  "rand",
  "serde",
- "serde-big-array",
  "sha2",
  "thiserror",
  "tokio",
@@ -4207,6 +4203,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "regex",
  "serde",
+ "serde_bytes",
  "serde_repr",
  "strum_macros",
  "thiserror",
@@ -4323,7 +4320,6 @@ dependencies = [
  "hex",
  "postcard",
  "serde",
- "serde-big-array",
  "serde_derive",
 ]
 
@@ -6143,15 +6139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde-wasm-bindgen"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6171,6 +6158,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,15 +514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "attohttpc"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,12 +1071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -2000,15 +1991,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "portable-atomic",
  "serde",
- "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -5371,13 +5360,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "postcard"
-version = "1.0.8"
+name = "portable-atomic"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "postcard"
+version = "1.0.9"
+source = "git+https://github.com/nimiq/postcard-bytes#2467abeaac0a419822c6ebe5df56324fd92e8b44"
 dependencies = [
  "cobs",
- "embedded-io",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
  "heapless",
  "serde",
 ]
@@ -6458,9 +6453,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -20,7 +20,6 @@ log = { workspace = true }
 parking_lot = { version = "0.12.2", optional = true }
 rand = "0.8"
 serde = { version = "1.0", optional = true }
-serde-big-array = { version = "0.5", optional = true }
 thiserror = "1.0"
 
 ark-std = "0.4"
@@ -44,4 +43,4 @@ nimiq-test-utils = { workspace = true }
 cache = ["lazy"]
 default = ["lazy", "serde-derive"]
 lazy = ["parking_lot"]
-serde-derive = ["nimiq-serde", "serde", "serde-big-array"]
+serde-derive = ["nimiq-serde", "serde"]

--- a/hash/benches/hash_serialize.rs
+++ b/hash/benches/hash_serialize.rs
@@ -1,0 +1,23 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use nimiq_hash::Blake2bHash;
+use postcard;
+
+fn serialize_hash(c: &mut Criterion) {
+    let hash = Blake2bHash::default();
+    let mut buf = [0; 32];
+    let mut group = c.benchmark_group("serialize_hash");
+    group.bench_function("serde", |b| {
+        b.iter(|| {
+            let _ = black_box(postcard::to_slice(black_box(&hash), &mut buf).unwrap());
+        })
+    });
+    group.bench_function("plain", |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(&hash).serialize(&mut buf.as_mut_slice()).unwrap());
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(hash, serialize_hash);
+criterion_main!(hash);

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -35,7 +35,6 @@ p256 = "0.13"
 rand = "0.8"
 rand_core = "0.6.4"
 serde = { version = "1.0", optional = true }
-serde-big-array = { version = "0.5", optional = true }
 sha2 = "0.10"
 thiserror = "1.0"
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
@@ -52,4 +51,4 @@ nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }
 
 [features]
-serde-derive = ["nimiq-serde", "serde", "serde-big-array", "p256/serde"]
+serde-derive = ["nimiq-serde", "serde", "p256/serde"]

--- a/keys/src/es256_public_key.rs
+++ b/keys/src/es256_public_key.rs
@@ -108,7 +108,7 @@ mod serde_derive {
             if serializer.is_human_readable() {
                 serializer.serialize_str(&self.to_hex())
             } else {
-                serde_big_array::BigArray::serialize(self.as_bytes(), serializer)
+                nimiq_serde::FixedSizeByteArray::from(*self.as_bytes()).serialize(serializer)
             }
         }
     }
@@ -123,7 +123,7 @@ mod serde_derive {
                 data.parse().map_err(Error::custom)
             } else {
                 let buf: [u8; ES256PublicKey::SIZE] =
-                    serde_big_array::BigArray::deserialize(deserializer)?;
+                    nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
                 ES256PublicKey::from_bytes(&buf).map_err(|_| D::Error::custom("Invalid public key"))
             }
         }

--- a/keys/src/es256_signature.rs
+++ b/keys/src/es256_signature.rs
@@ -90,7 +90,7 @@ mod serde_derive {
             if serializer.is_human_readable() {
                 serializer.serialize_str(&self.to_hex())
             } else {
-                serde_big_array::BigArray::serialize(&self.to_bytes(), serializer)
+                nimiq_serde::FixedSizeByteArray::from(self.to_bytes()).serialize(serializer)
             }
         }
     }
@@ -105,7 +105,7 @@ mod serde_derive {
                 data.parse().map_err(Error::custom)
             } else {
                 let buf: [u8; ES256Signature::SIZE] =
-                    serde_big_array::BigArray::deserialize(deserializer)?;
+                    nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
                 Self::from_bytes(&buf).map_err(|_| D::Error::custom("Invalid signature"))
             }
         }

--- a/keys/src/multisig/commitment.rs
+++ b/keys/src/multisig/commitment.rs
@@ -167,7 +167,7 @@ mod serde_derive {
         where
             S: Serializer,
         {
-            serde_big_array::BigArray::serialize(&self.to_bytes(), serializer)
+            nimiq_serde::FixedSizeByteArray::from(self.to_bytes()).serialize(serializer)
         }
     }
 
@@ -176,7 +176,8 @@ mod serde_derive {
         where
             D: Deserializer<'de>,
         {
-            let buf: [u8; Commitment::SIZE] = serde_big_array::BigArray::deserialize(deserializer)?;
+            let buf: [u8; Commitment::SIZE] =
+                nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
             Self::from_bytes(buf).ok_or_else(|| D::Error::custom("Invalid commitment"))
         }
     }
@@ -186,7 +187,7 @@ mod serde_derive {
         where
             S: Serializer,
         {
-            serde_big_array::BigArray::serialize(&self.0.to_bytes(), serializer)
+            nimiq_serde::FixedSizeByteArray::from(self.0.to_bytes()).serialize(serializer)
         }
     }
 
@@ -195,7 +196,8 @@ mod serde_derive {
         where
             D: Deserializer<'de>,
         {
-            let buf: [u8; Nonce::SIZE] = serde_big_array::BigArray::deserialize(deserializer)?;
+            let buf: [u8; Nonce::SIZE] =
+                nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
             Ok(Self::from(&buf))
         }
     }

--- a/keys/src/multisig/mod.rs
+++ b/keys/src/multisig/mod.rs
@@ -35,7 +35,9 @@ fn deserialize_scalar<'de, D>(deserializer: D) -> Result<Scalar, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let buf: [u8; commitment::Nonce::SIZE] = serde_big_array::BigArray::deserialize(deserializer)?;
+    use serde::Deserialize as _;
+    let buf: [u8; commitment::Nonce::SIZE] =
+        nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
     Ok(Scalar::from_bytes_mod_order(buf))
 }
 
@@ -44,7 +46,8 @@ fn serialize_scalar<S>(value: &Scalar, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serde_big_array::BigArray::serialize(&value.to_bytes(), serializer)
+    use serde::Serialize as _;
+    nimiq_serde::FixedSizeByteArray::from(value.to_bytes()).serialize(serializer)
 }
 
 /// This struct contains the data related to the commitments step of MuSig2.

--- a/keys/src/signature.rs
+++ b/keys/src/signature.rs
@@ -93,7 +93,7 @@ mod serde_derive {
             if serializer.is_human_readable() {
                 serializer.serialize_str(&self.to_hex())
             } else {
-                serde_big_array::BigArray::serialize(&self.to_bytes(), serializer)
+                nimiq_serde::FixedSizeByteArray::from(self.to_bytes()).serialize(serializer)
             }
         }
     }
@@ -108,7 +108,7 @@ mod serde_derive {
                 data.parse().map_err(Error::custom)
             } else {
                 let buf: [u8; Ed25519Signature::SIZE] =
-                    serde_big_array::BigArray::deserialize(deserializer)?;
+                    nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
                 Self::from_bytes(&buf).map_err(|_| D::Error::custom("Invalid signature"))
             }
         }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [dependencies]
 hex = "0.4"
 serde = "1.0"
-serde-big-array = "0.5"
 subtle = "2.5"
 
 nimiq-serde = { workspace = true }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -5,9 +5,6 @@ pub extern crate hex;
 pub extern crate serde;
 
 #[doc(hidden)]
-pub extern crate serde_big_array;
-
-#[doc(hidden)]
 pub extern crate subtle;
 
 #[doc(hidden)]
@@ -90,7 +87,10 @@ macro_rules! add_serialization_fns_typed_arr {
                         serializer,
                     )
                 } else {
-                    ::nimiq_macros::serde_big_array::BigArray::serialize(&self.0, serializer)
+                    ::nimiq_macros::serde::Serialize::serialize(
+                        &::nimiq_macros::nimiq_serde::FixedSizeByteArray::from(self.0),
+                        serializer,
+                    )
                 }
             }
         }
@@ -116,7 +116,8 @@ macro_rules! add_serialization_fns_typed_arr {
                             )
                         })?
                 } else {
-                    ::nimiq_macros::serde_big_array::BigArray::deserialize(deserializer)?
+                    ::nimiq_macros::nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?
+                        .into_inner()
                 };
                 Ok($name(data))
             }

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -34,7 +34,6 @@ pin-project-lite = "0.2.14"
 prometheus-client = { version = "0.22.2", optional = true}
 rand = "0.8"
 serde = "1.0"
-serde-big-array = "0.5"
 sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["macros", "rt", "tracing"] }

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -37,7 +37,7 @@ impl Serialize for Libp2pKeyPair {
         S: Serializer,
     {
         if let Ok(pk) = self.0.clone().try_into_ed25519() {
-            serde_big_array::BigArray::serialize(&pk.to_bytes(), serializer)
+            nimiq_serde::FixedSizeByteArray::from(pk.to_bytes()).serialize(serializer)
         } else {
             Err(S::Error::custom("Unsupported key type"))
         }
@@ -49,7 +49,8 @@ impl<'de> Deserialize<'de> for Libp2pKeyPair {
     where
         D: Deserializer<'de>,
     {
-        let mut hex_encoded: [u8; 64] = serde_big_array::BigArray::deserialize(deserializer)?;
+        let mut hex_encoded: [u8; 64] =
+            nimiq_serde::FixedSizeByteArray::deserialize(deserializer)?.into_inner();
 
         let keypair = libp2p::identity::ed25519::Keypair::try_from_bytes(&mut hex_encoded)
             .map_err(|_| D::Error::custom("Invalid value"))?;

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -31,6 +31,7 @@ once_cell = "1.19"
 parking_lot = { version = "0.12.2", optional = true }
 regex = { version = "1.10", optional = true }
 serde = { version = "1.0", optional = true }
+serde_bytes = { version = "0.11", optional = true }
 serde_repr = { version = "0.1", optional = true }
 strum_macros = "0.26"
 thiserror = { version = "1.0", optional = true }
@@ -54,7 +55,7 @@ coin = ["hex", "nimiq-serde", "regex", "thiserror"]
 key-nibbles = ["hex", "nimiq-keys", "nimiq-database-value", "nimiq-serde"]
 networks = ["thiserror"]
 policy = ["nimiq-keys", "nimiq-utils", "parking_lot"]
-serde-derive = ["nimiq-serde", "serde", "serde_repr"]
+serde-derive = ["nimiq-serde", "serde", "serde_bytes", "serde_repr"]
 slots = ["nimiq-bls", "nimiq-keys", "nimiq-utils", "policy"]
 tendermint = ["networks", "nimiq-bls", "serde-derive"]
 transaction = ["nimiq-serde", "thiserror"]

--- a/primitives/src/trie/trie_node.rs
+++ b/primitives/src/trie/trie_node.rs
@@ -479,7 +479,10 @@ mod serde_derive {
             let mut state = serializer.serialize_struct("TrieNode", FIELDS.len())?;
             state.serialize_field(FIELDS[0], &flags)?;
             state.serialize_field(FIELDS[1], &self.root_data)?;
-            state.serialize_field(FIELDS[2], &self.value)?;
+            state.serialize_field(
+                FIELDS[2],
+                &self.value.as_ref().map(|v| serde_bytes::Bytes::new(v)),
+            )?;
             state.serialize_field(FIELDS[3], &child_count)?;
             state.serialize_field(FIELDS[4], &self.children)?;
             state.end()

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
-postcard = { version = "1.0", features = ["alloc"] }
+postcard = { git = "https://github.com/nimiq/postcard-bytes", features = ["alloc"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde-big-array = "0.5"

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -18,4 +18,3 @@ hex = "0.4"
 postcard = { git = "https://github.com/nimiq/postcard-bytes", features = ["alloc"] }
 serde = "1.0"
 serde_derive = "1.0"
-serde-big-array = "0.5"


### PR DESCRIPTION
The PR to postcard is unlikely to get merged anytime soon. We could instead vendor postcard and get the performance this way.

Alternative to #2156.