### PR TITLE
Upgrade `portable-atomic` dependency to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5277,9 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postcard"


### PR DESCRIPTION
Upgrade `portable-atomic` dependency from 1.4.2 to 1.6.0. This removes early errors when compiling the code for `miri`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
