### PR TITLE
Store the whole clientDataJSON, but compressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -2412,6 +2413,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -4420,6 +4430,7 @@ dependencies = [
  "tsify",
  "url",
  "wasm-bindgen",
+ "zstd",
 ]
 
 [[package]]
@@ -7665,4 +7676,32 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"], optional = true }
 url = { version = "2.4", features = ["serde"] }
 wasm-bindgen = { version = "0.2", optional = true }
+zstd = { version = "0.13.0", features = ["experimental"] }
 
 nimiq-bls = { workspace = true, features = ["serde-derive"] }
 nimiq-database-value = { workspace = true }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -21,10 +21,11 @@ base64 = "0.21"
 bitflags = { version = "2.4", features = ["serde"] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
+serde_json = "1.0"
 strum_macros = "0.26"
 thiserror = "1.0"
 tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"], optional = true }
-url = "2.4"
+url = { version = "2.4", features = ["serde"] }
 wasm-bindgen = { version = "0.2", optional = true }
 
 nimiq-bls = { workspace = true, features = ["serde-derive"] }

--- a/primitives/transaction/src/signature_proof.rs
+++ b/primitives/transaction/src/signature_proof.rs
@@ -7,6 +7,7 @@ use nimiq_keys::{Address, Ed25519PublicKey, Ed25519Signature, PublicKey, Signatu
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_utils::merkle::Blake2bMerklePath;
 use url::Url;
+use zstd::bulk::{Compressor, Decompressor};
 
 #[derive(Clone, Debug)]
 pub struct SignatureProof {
@@ -17,13 +18,16 @@ pub struct SignatureProof {
 }
 
 fn compress(prediction: &[u8], data: &[u8]) -> Vec<u8> {
-    let _ = prediction;
-    Vec::from(data)
+    let mut compressor =
+        Compressor::with_dictionary(zstd::DEFAULT_COMPRESSION_LEVEL, prediction).unwrap();
+    compressor.include_magicbytes(false).unwrap();
+    compressor.compress(data).unwrap()
 }
 
 fn decompress(prediction: &[u8], compressed: &[u8]) -> Result<Vec<u8>, io::Error> {
-    let _ = prediction;
-    Ok(Vec::from(compressed))
+    let mut decompressor = Decompressor::with_dictionary(prediction).unwrap();
+    decompressor.include_magicbytes(false).unwrap();
+    decompressor.decompress(compressed, 4096)
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/primitives/transaction/tests/basic_account_verify.rs
+++ b/primitives/transaction/tests/basic_account_verify.rs
@@ -1,10 +1,8 @@
 use nimiq_keys::{Address, ES256PublicKey, ES256Signature, PublicKey, Signature};
 use nimiq_primitives::{account::AccountType, networks::NetworkId, transaction::TransactionError};
 use nimiq_transaction::{
-    account::AccountTransactionVerification, SignatureProof, Transaction, WebauthnClientDataFlags,
-    WebauthnExtraFields,
+    account::AccountTransactionVerification, SignatureProof, Transaction,
 };
-use nimiq_utils::merkle::Blake2bMerklePath;
 
 #[test]
 fn it_does_not_allow_creation() {
@@ -51,74 +49,46 @@ fn it_does_not_allow_signalling() {
 
 #[test]
 fn it_can_verify_webauthn_signature_proofs() {
-    let signature_proof = SignatureProof {
-        public_key: PublicKey::ES256(
-            ES256PublicKey::from_bytes(&[
-                2, 145, 87, 130, 102, 84, 114, 146, 139, 254, 114, 194, 134, 155, 187, 214, 188,
-                12, 35, 147, 121, 213, 161, 80, 234, 94, 43, 25, 178, 5, 213, 54, 89,
-            ])
+    let signature_proof = SignatureProof::try_from_webauthn(
+        PublicKey::ES256(
+            ES256PublicKey::from_bytes(
+                &hex::decode("02915782665472928bfe72c2869bbbd6bc0c239379d5a150ea5e2b19b205d53659").unwrap(),
+            )
             .unwrap(),
         ),
-        merkle_path: Blake2bMerklePath::default(),
-        signature: Signature::ES256(
-            ES256Signature::from_bytes(&[
-                7, 185, 23, 233, 88, 246, 250, 252, 173, 116, 122, 201, 94, 32, 221, 241, 172, 99,
-                252, 93, 153, 191, 69, 22, 233, 2, 233, 69, 145, 100, 16, 132, 1, 94, 247, 237, 70,
-                3, 74, 241, 133, 18, 116, 58, 13, 203, 199, 167, 134, 170, 226, 113, 16, 184, 203,
-                209, 204, 232, 27, 6, 43, 216, 12, 110,
-            ])
+        Signature::ES256(
+            ES256Signature::from_bytes(
+                &hex::decode("07b917e958f6fafcad747ac95e20ddf1ac63fc5d99bf4516e902e94591641084015ef7ed46034af18512743a0dcbc7a786aae27110b8cbd1cce81b062bd80c6e").unwrap(),
+            )
             .unwrap(),
         ),
-        webauthn_fields: Some(WebauthnExtraFields {
-            host: "localhost:3000".to_string(),
-            authenticator_data_suffix: vec![1, 101, 1, 154, 108],
-            client_data_flags: WebauthnClientDataFlags::default(),
-            client_data_extra_fields: "".to_string(),
-        }),
-    };
+            &hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630165019a6c").unwrap(),
+            br#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
+    ).unwrap();
 
-    let tx_content = [
-        0, 0, 154, 96, 106, 136, 176, 143, 11, 229, 208, 208, 107, 52, 170, 88, 232, 81, 173, 106,
-        175, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        152, 150, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0,
-    ];
+    let tx_content = hex::decode("00009a606a88b08f0be5d0d06b34aa58e851ad6aaf0a000000000000000000000000000000000000000000000000000000989680000000000000000000000000050000").unwrap();
     assert!(signature_proof.verify(&tx_content));
 }
 
 #[test]
 fn it_can_verify_android_chrome_webauthn_signature_proofs() {
-    let signature_proof = SignatureProof {
-        public_key: PublicKey::ES256(
-            ES256PublicKey::from_bytes(&[
-                3, 39, 225, 247, 153, 91, 222, 93, 248, 162, 43, 217, 194, 120, 51, 181, 50, 215,
-                156, 35, 80, 230, 31, 201, 168, 86, 33, 209, 67, 142, 171, 235, 124,
-            ])
+    let signature_proof = SignatureProof::try_from_webauthn(
+        PublicKey::ES256(
+            ES256PublicKey::from_bytes(
+                &hex::decode("0327e1f7995bde5df8a22bd9c27833b532d79c2350e61fc9a85621d1438eabeb7c").unwrap(),
+            )
             .unwrap(),
         ),
-        merkle_path: Blake2bMerklePath::default(),
-        signature: Signature::ES256(
-            ES256Signature::from_bytes(&[
-                164, 254, 110, 78, 41, 144, 51, 93, 46, 76, 238, 175, 99, 238, 20, 158, 45, 194,
-                224, 112, 59, 194, 111, 99, 35, 244, 190, 187, 69, 76, 123, 80, 95, 95, 175, 79,
-                197, 164, 126, 168, 155, 237, 249, 211, 119, 134, 206, 126, 83, 85, 177, 121, 189,
-                241, 62, 151, 113, 206, 66, 111, 19, 134, 122, 157,
-            ])
+        Signature::ES256(
+            ES256Signature::from_bytes(
+                &hex::decode("a4fe6e4e2990335d2e4ceeaf63ee149e2dc2e0703bc26f6323f4bebb454c7b505f5faf4fc5a47ea89bedf9d37786ce7e5355b179bdf13e9771ce426f13867a9d").unwrap(),
+            )
             .unwrap(),
         ),
-        webauthn_fields: Some(WebauthnExtraFields {
-            host: "webauthn.pos.nimiqwatch.com".to_string(),
-            authenticator_data_suffix: vec![5, 0, 0, 0, 16],
-            client_data_flags: WebauthnClientDataFlags::NO_CROSSORIGIN_FIELD
-                | WebauthnClientDataFlags::ESCAPED_ORIGIN_SLASHES,
-            client_data_extra_fields: r#""androidPackageName":"com.android.chrome""#.to_string(),
-        }),
-    };
+        &hex::decode("7a03a16dfe0c4358b79eebe4f25cba56ec7aa7c8331f46a96988006db440e6900500000010").unwrap(),
+        br#"{"type":"webauthn.get","challenge":"jOG3lhPd8ENEsalR2DSrsLkFO--JT87NHl__MWTVC8c","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#,
+    ).unwrap();
 
-    let tx_content = [
-        0, 0, 95, 36, 214, 238, 163, 240, 41, 157, 80, 220, 206, 207, 183, 163, 79, 139, 213, 213,
-        22, 128, 0, 137, 12, 63, 238, 88, 169, 194, 122, 224, 244, 181, 251, 158, 74, 114, 238, 18,
-        204, 254, 207, 0, 0, 0, 0, 0, 0, 152, 150, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 167, 216, 6,
-        0, 0,
-    ];
+    let tx_content = hex::decode("00005f24d6eea3f0299d50dccecfb7a34f8bd5d5168000890c3fee58a9c27ae0f4b5fb9e4a72ee12ccfecf00000000000098968000000000000000000000a7d8060000").unwrap();
     assert!(signature_proof.verify(&tx_content));
 }

--- a/primitives/transaction/tests/basic_account_verify.rs
+++ b/primitives/transaction/tests/basic_account_verify.rs
@@ -1,8 +1,6 @@
 use nimiq_keys::{Address, ES256PublicKey, ES256Signature, PublicKey, Signature};
 use nimiq_primitives::{account::AccountType, networks::NetworkId, transaction::TransactionError};
-use nimiq_transaction::{
-    account::AccountTransactionVerification, SignatureProof, Transaction,
-};
+use nimiq_transaction::{account::AccountTransactionVerification, SignatureProof, Transaction};
 
 #[test]
 fn it_does_not_allow_creation() {

--- a/primitives/transaction/tests/serialization.rs
+++ b/primitives/transaction/tests/serialization.rs
@@ -5,7 +5,6 @@ use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
 use nimiq_test_log::test;
 use nimiq_transaction::*;
-use nimiq_utils::merkle::Blake2bMerklePath;
 
 const EXTENDED_TRANSACTION: &str = "014a88aaad038f9b8248865c4b9249efc554960e160000ad25610feb43d75307763d3f010822a757027429000000000746a52880000000000000000000000136c32a00e2010e4712ea5b1703873529dd195b2b8f014c295ab352a12e3332d8f30cfc2db9680480c77af04feb0d89bdb5d5d9432d4ca17866abf3b4d6c1a05fa0fbdaed056181eaff68db063c759a0964bceb5f262f7335ed97c5471e773429926c106eae50881b998c516581e6d93933bb92feb2edcdbdb1b118fc000f8f1df8715538840b79e74721c631efe0f9977ccd88773b022a07b3935f2e8546e20ed7f7e1a0c77da7a7e1737bf0625170610846792ea16bc0f6d8cf9ded8a9da1d467f4191a3a97d5fc17d08d699dfa486787f70eb09e2cdbd5b63fd1a8357e1cd24cd37aa2f3408400";
 const BASIC_TRANSACTION: &str = "00000222666efadc937148a6d61589ce6d4aeecca97fda4c32348d294eab582f14a0754d1260f15bea0e8fb07ab18f45301483599e34000000000000c350000000000000008a00019640023fecb82d3aef4be76853d5c5b263754b7d495d9838f6ae5df60cf3addd3512a82988db0056059c7a52ae15285983ef0db8229ae446c004559147686d28f0a30a";
@@ -86,31 +85,20 @@ fn it_can_serialize_basic_transaction() {
 
 #[test]
 fn it_can_serialize_and_deserialize_signature_proofs() {
-    let proof = SignatureProof {
-        public_key: PublicKey::ES256(
-            ES256PublicKey::from_bytes(&[
-                2, 145, 87, 130, 102, 84, 114, 146, 139, 254, 114, 194, 134, 155, 187, 214, 188,
-                12, 35, 147, 121, 213, 161, 80, 234, 94, 43, 25, 178, 5, 213, 54, 89,
-            ])
+    let proof = SignatureProof::try_from_webauthn(
+        PublicKey::ES256(
+            ES256PublicKey::from_bytes(
+                &hex::decode("02915782665472928bfe72c2869bbbd6bc0c239379d5a150ea5e2b19b205d53659").unwrap()
+            )
             .unwrap(),
         ),
-        merkle_path: Blake2bMerklePath::default(),
-        signature: Signature::ES256(
-            ES256Signature::from_bytes(&[
-                7, 185, 23, 233, 88, 246, 250, 252, 173, 116, 122, 201, 94, 32, 221, 241, 172, 99,
-                252, 93, 153, 191, 69, 22, 233, 2, 233, 69, 145, 100, 16, 132, 1, 94, 247, 237, 70,
-                3, 74, 241, 133, 18, 116, 58, 13, 203, 199, 167, 134, 170, 226, 113, 16, 184, 203,
-                209, 204, 232, 27, 6, 43, 216, 12, 110,
-            ])
+        Signature::ES256(
+            ES256Signature::from_bytes(&hex::decode("07b917e958f6fafcad747ac95e20ddf1ac63fc5d99bf4516e902e94591641084015ef7ed46034af18512743a0dcbc7a786aae27110b8cbd1cce81b062bd80c6e").unwrap())
             .unwrap(),
         ),
-        webauthn_fields: Some(WebauthnExtraFields {
-            host: "localhost:3000".to_string(),
-            authenticator_data_suffix: vec![1, 101, 1, 154, 108],
-            client_data_flags: WebauthnClientDataFlags::default(),
-            client_data_extra_fields: "".to_string(),
-        }),
-    };
+        &hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630165019a6c").unwrap(),
+        br#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
+    ).unwrap();
 
     let serialized = Serialize::serialize_to_vec(&proof.clone());
 


### PR DESCRIPTION
This makes reconstruction trivial. Previously, reconstruction of the original JSON was a delicate process, even more so since Android Chrome's behavior violates the standard: https://issues.chromium.org/issues/40191627.

Compressing is done based on expected data, this allows to save a lot of space for the redundant challenge information and the general JSON structure.

This is an alternative to #2227, also fixing https://github.com/nimiq/core-rs-albatross/pull/1867#discussion_r1470116959.