### PR TITLE
pow-migration: Switch back to upstream `nimiq_rpc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2424,18 +2424,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
+checksum = "16fcc9dd231e72d22993f1643d5f7f0db785737dbe3c3d7ca222916ab4280795"
 dependencies = [
  "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-types",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
+checksum = "b974d8f6139efbe8425f32cb33302aba6d5e049556b5bfc067874e7a0da54a2e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2452,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.20.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2393386c97ce214851a9677568c5a38223ae4eada833617cb16d8464d1128f1b"
+checksum = "19dc795a277cff37f27173b3ca790d042afcc0372c34a7ca068d2e76de2cb6d1"
 dependencies = [
  "async-trait",
  "hyper",
@@ -2472,16 +2474,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
+checksum = "b13dac43c1a9fc2648b37f306b0a5b0e29b2a6e1c36a33b95c1948da2494e9c5"
 dependencies = [
  "anyhow",
  "beef",
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -4073,7 +4074,6 @@ dependencies = [
  "hex",
  "humantime",
  "indicatif",
- "jsonrpsee",
  "nimiq-blockchain",
  "nimiq-bls",
  "nimiq-database",
@@ -4807,13 +4807,13 @@ dependencies = [
 
 [[package]]
 name = "nimiq_rpc"
-version = "0.1.3"
-source = "git+https://github.com/jsdanielh/rust-client.git#88fe31028df2afd356708ce86d5370f8011b1946"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0757b8e74892e86407afba6601ebcd647832feb4f2360d2ffcf9e28866665d"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
  "jsonrpsee",
- "jsonrpsee-http-client",
  "serde",
  "serde_json",
  "url",

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -25,7 +25,6 @@ convert_case = "0.6"
 hex = "0.4"
 humantime = "2.1"
 indicatif = "0.17"
-jsonrpsee = { version = "0.20", features = ["client-core"] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 nimiq-blockchain = { workspace = true }
 nimiq-bls = { workspace = true }
@@ -52,7 +51,7 @@ nimiq-primitives = { workspace = true, features = ["policy"]}
 nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true }
 nimiq-vrf = { workspace = true }
-nimiq_rpc = { git = "https://github.com/jsdanielh/rust-client.git" }
+nimiq_rpc = "0.3"
 percentage = "0.1"
 rand = "0.8"
 serde = "1.0"

--- a/pow-migration/src/genesis/types.rs
+++ b/pow-migration/src/genesis/types.rs
@@ -8,7 +8,7 @@ use crate::state::types::GenesisValidator;
 pub enum Error {
     /// RPC error
     #[error("RPC error: {0}")]
-    Rpc(#[from] jsonrpsee::core::Error),
+    Rpc(#[from] nimiq_rpc::jsonrpsee::core::ClientError),
     /// Unknown PoW block
     #[error("Unknown PoW block")]
     UnknownBlock,

--- a/pow-migration/src/history/mod.rs
+++ b/pow-migration/src/history/mod.rs
@@ -15,7 +15,7 @@ use nimiq_primitives::{
 };
 use nimiq_rpc::{
     primitives::{
-        TransactionDetails as PoWTransaction, TransactionSequence as PoWTransactionSequence,
+        TransactionDetails2 as PoWTransaction, TransactionSequence as PoWTransactionSequence,
     },
     Client,
 };
@@ -29,7 +29,7 @@ use thiserror::Error;
 pub enum Error {
     /// RPC error
     #[error("RPC error: {0}")]
-    Rpc(#[from] jsonrpsee::core::Error),
+    Rpc(#[from] nimiq_rpc::jsonrpsee::core::ClientError),
     /// Unknown PoW block
     #[error("Unknown PoW block")]
     UnknownBlock,
@@ -159,7 +159,7 @@ pub async fn get_history_root(
                 }
                 for hash in hashes {
                     log::trace!(hash, "Processing transaction");
-                    let pow_transaction = client.get_transaction_by_hash(&hash).await?;
+                    let pow_transaction = client.get_transaction_by_hash_2(&hash).await?;
                     let pos_transaction = from_pow_transaction(&pow_transaction)?;
                     network_id = pos_transaction.network_id;
 

--- a/pow-migration/src/monitor/types.rs
+++ b/pow-migration/src/monitor/types.rs
@@ -16,5 +16,5 @@ pub enum ValidatorsReadiness {
 pub enum Error {
     /// RPC error
     #[error("RPC error: {0}")]
-    Rpc(#[from] jsonrpsee::core::Error),
+    Rpc(#[from] nimiq_rpc::jsonrpsee::core::ClientError),
 }

--- a/pow-migration/src/state/types.rs
+++ b/pow-migration/src/state/types.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum Error {
     /// RPC error
     #[error("RPC error: {0}")]
-    Rpc(#[from] jsonrpsee::core::Error),
+    Rpc(#[from] nimiq_rpc::jsonrpsee::core::ClientError),
     /// Address parsing error
     #[error("Failed to parse Nimiq address: {0}")]
     Address(#[from] AddressParseError),


### PR DESCRIPTION
- Switch back to upstream `nimiq_rpc` now that the upstream repository supports the required RPC methods.
- Update `jsonrpsee` dependency from version 0.20.3 to 0.22.1.
- Remove `jsonrpsee` as a direct dependency from the `pow-migration` subcrate.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
