### PR TITLE
Improve hand-parsing of clientDataJSON

### DIFF
--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -21,10 +21,11 @@ base64 = "0.22"
 bitflags = { version = "2.4", features = ["serde"] }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
+serde_json = "1.0"
 strum_macros = "0.26"
 thiserror = "1.0"
 tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"], optional = true }
-url = "2.4"
+url = { version = "2.4", features = ["serde"] }
 wasm-bindgen = { version = "0.2", optional = true }
 
 nimiq-bls = { workspace = true, features = ["serde-derive"] }

--- a/primitives/transaction/tests/basic_account_verify.rs
+++ b/primitives/transaction/tests/basic_account_verify.rs
@@ -1,10 +1,6 @@
 use nimiq_keys::{Address, ES256PublicKey, ES256Signature, PublicKey, Signature};
 use nimiq_primitives::{account::AccountType, networks::NetworkId, transaction::TransactionError};
-use nimiq_transaction::{
-    account::AccountTransactionVerification, SignatureProof, Transaction, WebauthnClientDataFlags,
-    WebauthnExtraFields,
-};
-use nimiq_utils::merkle::Blake2bMerklePath;
+use nimiq_transaction::{account::AccountTransactionVerification, SignatureProof, Transaction};
 
 #[test]
 fn it_does_not_allow_creation() {
@@ -51,74 +47,48 @@ fn it_does_not_allow_signalling() {
 
 #[test]
 fn it_can_verify_webauthn_signature_proofs() {
-    let signature_proof = SignatureProof {
-        public_key: PublicKey::ES256(
-            ES256PublicKey::from_bytes(&[
-                2, 145, 87, 130, 102, 84, 114, 146, 139, 254, 114, 194, 134, 155, 187, 214, 188,
-                12, 35, 147, 121, 213, 161, 80, 234, 94, 43, 25, 178, 5, 213, 54, 89,
-            ])
+    let signature_proof = SignatureProof::try_from_webauthn(
+        PublicKey::ES256(
+            ES256PublicKey::from_bytes(
+                &hex::decode("02915782665472928bfe72c2869bbbd6bc0c239379d5a150ea5e2b19b205d53659").unwrap(),
+            )
             .unwrap(),
         ),
-        merkle_path: Blake2bMerklePath::default(),
-        signature: Signature::ES256(
-            ES256Signature::from_bytes(&[
-                7, 185, 23, 233, 88, 246, 250, 252, 173, 116, 122, 201, 94, 32, 221, 241, 172, 99,
-                252, 93, 153, 191, 69, 22, 233, 2, 233, 69, 145, 100, 16, 132, 1, 94, 247, 237, 70,
-                3, 74, 241, 133, 18, 116, 58, 13, 203, 199, 167, 134, 170, 226, 113, 16, 184, 203,
-                209, 204, 232, 27, 6, 43, 216, 12, 110,
-            ])
+        None,
+        Signature::ES256(
+            ES256Signature::from_bytes(
+                &hex::decode("07b917e958f6fafcad747ac95e20ddf1ac63fc5d99bf4516e902e94591641084015ef7ed46034af18512743a0dcbc7a786aae27110b8cbd1cce81b062bd80c6e").unwrap(),
+            )
             .unwrap(),
         ),
-        webauthn_fields: Some(WebauthnExtraFields {
-            host: "localhost:3000".to_string(),
-            authenticator_data_suffix: vec![1, 101, 1, 154, 108],
-            client_data_flags: WebauthnClientDataFlags::default(),
-            client_data_extra_fields: "".to_string(),
-        }),
-    };
+            &hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630165019a6c").unwrap(),
+            br#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
+    ).unwrap();
 
-    let tx_content = [
-        0, 0, 154, 96, 106, 136, 176, 143, 11, 229, 208, 208, 107, 52, 170, 88, 232, 81, 173, 106,
-        175, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        152, 150, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0,
-    ];
+    let tx_content = hex::decode("00009a606a88b08f0be5d0d06b34aa58e851ad6aaf0a000000000000000000000000000000000000000000000000000000989680000000000000000000000000050000").unwrap();
     assert!(signature_proof.verify(&tx_content));
 }
 
 #[test]
 fn it_can_verify_android_chrome_webauthn_signature_proofs() {
-    let signature_proof = SignatureProof {
-        public_key: PublicKey::ES256(
-            ES256PublicKey::from_bytes(&[
-                3, 39, 225, 247, 153, 91, 222, 93, 248, 162, 43, 217, 194, 120, 51, 181, 50, 215,
-                156, 35, 80, 230, 31, 201, 168, 86, 33, 209, 67, 142, 171, 235, 124,
-            ])
+    let signature_proof = SignatureProof::try_from_webauthn(
+        PublicKey::ES256(
+            ES256PublicKey::from_bytes(
+                &hex::decode("0327e1f7995bde5df8a22bd9c27833b532d79c2350e61fc9a85621d1438eabeb7c").unwrap(),
+            )
             .unwrap(),
         ),
-        merkle_path: Blake2bMerklePath::default(),
-        signature: Signature::ES256(
-            ES256Signature::from_bytes(&[
-                164, 254, 110, 78, 41, 144, 51, 93, 46, 76, 238, 175, 99, 238, 20, 158, 45, 194,
-                224, 112, 59, 194, 111, 99, 35, 244, 190, 187, 69, 76, 123, 80, 95, 95, 175, 79,
-                197, 164, 126, 168, 155, 237, 249, 211, 119, 134, 206, 126, 83, 85, 177, 121, 189,
-                241, 62, 151, 113, 206, 66, 111, 19, 134, 122, 157,
-            ])
+        None,
+        Signature::ES256(
+            ES256Signature::from_bytes(
+                &hex::decode("a4fe6e4e2990335d2e4ceeaf63ee149e2dc2e0703bc26f6323f4bebb454c7b505f5faf4fc5a47ea89bedf9d37786ce7e5355b179bdf13e9771ce426f13867a9d").unwrap(),
+            )
             .unwrap(),
         ),
-        webauthn_fields: Some(WebauthnExtraFields {
-            host: "webauthn.pos.nimiqwatch.com".to_string(),
-            authenticator_data_suffix: vec![5, 0, 0, 0, 16],
-            client_data_flags: WebauthnClientDataFlags::NO_CROSSORIGIN_FIELD
-                | WebauthnClientDataFlags::ESCAPED_ORIGIN_SLASHES,
-            client_data_extra_fields: r#""androidPackageName":"com.android.chrome""#.to_string(),
-        }),
-    };
+        &hex::decode("7a03a16dfe0c4358b79eebe4f25cba56ec7aa7c8331f46a96988006db440e6900500000010").unwrap(),
+        br#"{"type":"webauthn.get","challenge":"jOG3lhPd8ENEsalR2DSrsLkFO--JT87NHl__MWTVC8c","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#,
+    ).unwrap();
 
-    let tx_content = [
-        0, 0, 95, 36, 214, 238, 163, 240, 41, 157, 80, 220, 206, 207, 183, 163, 79, 139, 213, 213,
-        22, 128, 0, 137, 12, 63, 238, 88, 169, 194, 122, 224, 244, 181, 251, 158, 74, 114, 238, 18,
-        204, 254, 207, 0, 0, 0, 0, 0, 0, 152, 150, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 167, 216, 6,
-        0, 0,
-    ];
+    let tx_content = hex::decode("00005f24d6eea3f0299d50dccecfb7a34f8bd5d5168000890c3fee58a9c27ae0f4b5fb9e4a72ee12ccfecf00000000000098968000000000000000000000a7d8060000").unwrap();
     assert!(signature_proof.verify(&tx_content));
 }

--- a/primitives/transaction/tests/basic_account_verify.rs
+++ b/primitives/transaction/tests/basic_account_verify.rs
@@ -62,7 +62,7 @@ fn it_can_verify_webauthn_signature_proofs() {
             .unwrap(),
         ),
             &hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630165019a6c").unwrap(),
-            br#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
+            r#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
     ).unwrap();
 
     let tx_content = hex::decode("00009a606a88b08f0be5d0d06b34aa58e851ad6aaf0a000000000000000000000000000000000000000000000000000000989680000000000000000000000000050000").unwrap();
@@ -86,7 +86,7 @@ fn it_can_verify_android_chrome_webauthn_signature_proofs() {
             .unwrap(),
         ),
         &hex::decode("7a03a16dfe0c4358b79eebe4f25cba56ec7aa7c8331f46a96988006db440e6900500000010").unwrap(),
-        br#"{"type":"webauthn.get","challenge":"jOG3lhPd8ENEsalR2DSrsLkFO--JT87NHl__MWTVC8c","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#,
+        r#"{"type":"webauthn.get","challenge":"jOG3lhPd8ENEsalR2DSrsLkFO--JT87NHl__MWTVC8c","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#,
     ).unwrap();
 
     let tx_content = hex::decode("00005f24d6eea3f0299d50dccecfb7a34f8bd5d5168000890c3fee58a9c27ae0f4b5fb9e4a72ee12ccfecf00000000000098968000000000000000000000a7d8060000").unwrap();

--- a/primitives/transaction/tests/serialization.rs
+++ b/primitives/transaction/tests/serialization.rs
@@ -98,7 +98,7 @@ fn it_can_serialize_and_deserialize_signature_proofs() {
             .unwrap(),
         ),
         &hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630165019a6c").unwrap(),
-        br#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
+        r#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
     ).unwrap();
 
     let serialized = Serialize::serialize_to_vec(&proof.clone());

--- a/primitives/transaction/tests/serialization.rs
+++ b/primitives/transaction/tests/serialization.rs
@@ -5,7 +5,6 @@ use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
 use nimiq_test_log::test;
 use nimiq_transaction::*;
-use nimiq_utils::merkle::Blake2bMerklePath;
 
 const EXTENDED_TRANSACTION: &str = "014a88aaad038f9b8248865c4b9249efc554960e160000ad25610feb43d75307763d3f010822a757027429000000000746a52880000000000000000000000136c32a00e2010e4712ea5b1703873529dd195b2b8f014c295ab352a12e3332d8f30cfc2db9680480c77af04feb0d89bdb5d5d9432d4ca17866abf3b4d6c1a05fa0fbdaed056181eaff68db063c759a0964bceb5f262f7335ed97c5471e773429926c106eae50881b998c516581e6d93933bb92feb2edcdbdb1b118fc000f8f1df8715538840b79e74721c631efe0f9977ccd88773b022a07b3935f2e8546e20ed7f7e1a0c77da7a7e1737bf0625170610846792ea16bc0f6d8cf9ded8a9da1d467f4191a3a97d5fc17d08d699dfa486787f70eb09e2cdbd5b63fd1a8357e1cd24cd37aa2f3408400";
 const BASIC_TRANSACTION: &str = "00000222666efadc937148a6d61589ce6d4aeecca97fda4c32348d294eab582f14a0754d1260f15bea0e8fb07ab18f45301483599e34000000000000c350000000000000008a00019640023fecb82d3aef4be76853d5c5b263754b7d495d9838f6ae5df60cf3addd3512a82988db0056059c7a52ae15285983ef0db8229ae446c004559147686d28f0a30a";
@@ -86,31 +85,21 @@ fn it_can_serialize_basic_transaction() {
 
 #[test]
 fn it_can_serialize_and_deserialize_signature_proofs() {
-    let proof = SignatureProof {
-        public_key: PublicKey::ES256(
-            ES256PublicKey::from_bytes(&[
-                2, 145, 87, 130, 102, 84, 114, 146, 139, 254, 114, 194, 134, 155, 187, 214, 188,
-                12, 35, 147, 121, 213, 161, 80, 234, 94, 43, 25, 178, 5, 213, 54, 89,
-            ])
+    let proof = SignatureProof::try_from_webauthn(
+        PublicKey::ES256(
+            ES256PublicKey::from_bytes(
+                &hex::decode("02915782665472928bfe72c2869bbbd6bc0c239379d5a150ea5e2b19b205d53659").unwrap()
+            )
             .unwrap(),
         ),
-        merkle_path: Blake2bMerklePath::default(),
-        signature: Signature::ES256(
-            ES256Signature::from_bytes(&[
-                7, 185, 23, 233, 88, 246, 250, 252, 173, 116, 122, 201, 94, 32, 221, 241, 172, 99,
-                252, 93, 153, 191, 69, 22, 233, 2, 233, 69, 145, 100, 16, 132, 1, 94, 247, 237, 70,
-                3, 74, 241, 133, 18, 116, 58, 13, 203, 199, 167, 134, 170, 226, 113, 16, 184, 203,
-                209, 204, 232, 27, 6, 43, 216, 12, 110,
-            ])
+        None,
+        Signature::ES256(
+            ES256Signature::from_bytes(&hex::decode("07b917e958f6fafcad747ac95e20ddf1ac63fc5d99bf4516e902e94591641084015ef7ed46034af18512743a0dcbc7a786aae27110b8cbd1cce81b062bd80c6e").unwrap())
             .unwrap(),
         ),
-        webauthn_fields: Some(WebauthnExtraFields {
-            host: "localhost:3000".to_string(),
-            authenticator_data_suffix: vec![1, 101, 1, 154, 108],
-            client_data_flags: WebauthnClientDataFlags::default(),
-            client_data_extra_fields: "".to_string(),
-        }),
-    };
+        &hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630165019a6c").unwrap(),
+        br#"{"type":"webauthn.get","challenge":"4rk3LpNhR-jlyPRHP-xgniidFviD-pbL1hSyh5Nole8","origin":"http://localhost:3000","crossOrigin":false}"#,
+    ).unwrap();
 
     let serialized = Serialize::serialize_to_vec(&proof.clone());
 

--- a/web-client/src/primitives/signature_proof.rs
+++ b/web-client/src/primitives/signature_proof.rs
@@ -64,7 +64,7 @@ impl SignatureProof {
         public_key: &PublicKeyUnion,
         signature: &SignatureUnion,
         authenticator_data: &[u8],
-        client_data_json: &[u8],
+        client_data_json: &str,
     ) -> Result<SignatureProof, JsError> {
         let public_key = SignatureProof::unpack_public_key(public_key)?;
         let signature = SignatureProof::unpack_signature(signature)?;
@@ -265,7 +265,7 @@ mod tests {
             "49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630100000007",
         )
         .unwrap();
-        let client_data_json = br#"{"type":"webauthn.get","challenge":"u7CRZnGHrWoR9ix5llhl2VopsexuW36FKszgHBx4FfM","origin":"http://localhost:5173","crossOrigin":false}"#;
+        let client_data_json = r#"{"type":"webauthn.get","challenge":"u7CRZnGHrWoR9ix5llhl2VopsexuW36FKszgHBx4FfM","origin":"http://localhost:5173","crossOrigin":false}"#;
         let proof = SignatureProof::webauthn_single_sig(
             &JsValue::from(public_key).into(),
             &JsValue::from(signature).into(),
@@ -295,7 +295,7 @@ mod tests {
             "7a03a16dfe0c4358b79eebe4f25cba56ec7aa7c8331f46a96988006db440e690050000003c",
         )
         .unwrap();
-        let client_data_json = br#"{"type":"webauthn.get","challenge":"OCAjaXEXs-P4zqEk-61MhWPOq9a8VpDL2qf3ZwnAI9I","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#;
+        let client_data_json = r#"{"type":"webauthn.get","challenge":"OCAjaXEXs-P4zqEk-61MhWPOq9a8VpDL2qf3ZwnAI9I","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#;
         let proof = SignatureProof::webauthn_single_sig(
             &JsValue::from(public_key).into(),
             &JsValue::from(signature).into(),

--- a/web-client/src/primitives/signature_proof.rs
+++ b/web-client/src/primitives/signature_proof.rs
@@ -252,38 +252,24 @@ mod tests {
     /// Tests a signature generated with Desktop Chrome, which follows the Webauthn standard.
     #[wasm_bindgen_test]
     fn it_can_create_a_standard_webauthn_signature_proof() {
-        let public_key = ES256PublicKey::new(&[
-            2, 175, 112, 174, 46, 130, 50, 235, 92, 162, 248, 164, 196, 122, 113, 217, 205, 110,
-            166, 47, 85, 36, 103, 240, 211, 197, 100, 40, 190, 71, 214, 56, 8,
-        ])
+        let public_key = ES256PublicKey::new(
+            &hex::decode("02af70ae2e8232eb5ca2f8a4c47a71d9cd6ea62f552467f0d3c56428be47d63808")
+                .unwrap(),
+        )
         .map_err(JsValue::from)
         .unwrap();
-        let signature = ES256Signature::from_asn1(&[
-            48, 69, 2, 33, 0, 201, 203, 227, 93, 193, 31, 158, 177, 202, 78, 166, 237, 11, 99, 247,
-            73, 47, 96, 40, 118, 68, 173, 222, 27, 31, 131, 60, 181, 219, 147, 176, 63, 2, 32, 102,
-            75, 139, 198, 83, 231, 220, 191, 196, 173, 208, 211, 140, 101, 175, 98, 79, 23, 135,
-            16, 43, 90, 100, 21, 92, 13, 37, 33, 169, 36, 253, 73,
-        ])
+        let signature = ES256Signature::from_asn1(&hex::decode("3045022100c9cbe35dc11f9eb1ca4ea6ed0b63f7492f60287644adde1b1f833cb5db93b03f0220664b8bc653e7dcbfc4add0d38c65af624f1787102b5a64155c0d2521a924fd49").unwrap())
         .map_err(JsValue::from)
         .unwrap();
-        let authenticator_data = &[
-            73, 150, 13, 229, 136, 14, 140, 104, 116, 52, 23, 15, 100, 118, 96, 91, 143, 228, 174,
-            185, 162, 134, 50, 199, 153, 92, 243, 186, 131, 29, 151, 99, 1, 0, 0, 0, 7,
-        ];
-        let client_data_json = &[
-            123, 34, 116, 121, 112, 101, 34, 58, 34, 119, 101, 98, 97, 117, 116, 104, 110, 46, 103,
-            101, 116, 34, 44, 34, 99, 104, 97, 108, 108, 101, 110, 103, 101, 34, 58, 34, 117, 55,
-            67, 82, 90, 110, 71, 72, 114, 87, 111, 82, 57, 105, 120, 53, 108, 108, 104, 108, 50,
-            86, 111, 112, 115, 101, 120, 117, 87, 51, 54, 70, 75, 115, 122, 103, 72, 66, 120, 52,
-            70, 102, 77, 34, 44, 34, 111, 114, 105, 103, 105, 110, 34, 58, 34, 104, 116, 116, 112,
-            58, 47, 47, 108, 111, 99, 97, 108, 104, 111, 115, 116, 58, 53, 49, 55, 51, 34, 44, 34,
-            99, 114, 111, 115, 115, 79, 114, 105, 103, 105, 110, 34, 58, 102, 97, 108, 115, 101,
-            125,
-        ];
+        let authenticator_data = hex::decode(
+            "49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630100000007",
+        )
+        .unwrap();
+        let client_data_json = br#"{"type":"webauthn.get","challenge":"u7CRZnGHrWoR9ix5llhl2VopsexuW36FKszgHBx4FfM","origin":"http://localhost:5173","crossOrigin":false}"#;
         let proof = SignatureProof::webauthn_single_sig(
             &JsValue::from(public_key).into(),
             &JsValue::from(signature).into(),
-            authenticator_data,
+            &authenticator_data,
             client_data_json,
         );
         assert!(proof.is_ok());
@@ -296,39 +282,24 @@ mod tests {
     /// and has escaped forward slashes in the origin. It also has extra fields in the client data JSON.
     #[wasm_bindgen_test]
     fn it_can_create_a_nonstandard_webauthn_signature_proof() {
-        let public_key = ES256PublicKey::new(&[
-            3, 39, 225, 247, 153, 91, 222, 93, 248, 162, 43, 217, 194, 120, 51, 181, 50, 215, 156,
-            35, 80, 230, 31, 201, 168, 86, 33, 209, 67, 142, 171, 235, 124,
-        ])
+        let public_key = ES256PublicKey::new(
+            &hex::decode("0327e1f7995bde5df8a22bd9c27833b532d79c2350e61fc9a85621d1438eabeb7c")
+                .unwrap(),
+        )
         .map_err(JsValue::from)
         .unwrap();
-        let signature = ES256Signature::from_asn1(&[
-            48, 68, 2, 32, 113, 93, 20, 133, 221, 14, 184, 248, 122, 252, 45, 231, 122, 117, 249,
-            13, 81, 25, 193, 158, 66, 9, 4, 25, 189, 42, 84, 211, 52, 255, 185, 16, 2, 32, 75, 245,
-            24, 65, 236, 120, 114, 212, 34, 104, 105, 109, 80, 116, 252, 38, 53, 172, 76, 237, 183,
-            46, 144, 179, 241, 138, 5, 61, 235, 172, 178, 252,
-        ])
+        let signature = ES256Signature::from_asn1(&hex::decode("30440220715d1485dd0eb8f87afc2de77a75f90d5119c19e42090419bd2a54d334ffb91002204bf51841ec7872d42268696d5074fc2635ac4cedb72e90b3f18a053debacb2fc").unwrap())
         .map_err(JsValue::from)
         .unwrap();
-        let authenticator_data = &[
-            122, 3, 161, 109, 254, 12, 67, 88, 183, 158, 235, 228, 242, 92, 186, 86, 236, 122, 167,
-            200, 51, 31, 70, 169, 105, 136, 0, 109, 180, 64, 230, 144, 5, 0, 0, 0, 60,
-        ];
-        let client_data_json = &[
-            123, 34, 116, 121, 112, 101, 34, 58, 34, 119, 101, 98, 97, 117, 116, 104, 110, 46, 103,
-            101, 116, 34, 44, 34, 99, 104, 97, 108, 108, 101, 110, 103, 101, 34, 58, 34, 79, 67,
-            65, 106, 97, 88, 69, 88, 115, 45, 80, 52, 122, 113, 69, 107, 45, 54, 49, 77, 104, 87,
-            80, 79, 113, 57, 97, 56, 86, 112, 68, 76, 50, 113, 102, 51, 90, 119, 110, 65, 73, 57,
-            73, 34, 44, 34, 111, 114, 105, 103, 105, 110, 34, 58, 34, 104, 116, 116, 112, 115, 58,
-            92, 47, 92, 47, 119, 101, 98, 97, 117, 116, 104, 110, 46, 112, 111, 115, 46, 110, 105,
-            109, 105, 113, 119, 97, 116, 99, 104, 46, 99, 111, 109, 34, 44, 34, 97, 110, 100, 114,
-            111, 105, 100, 80, 97, 99, 107, 97, 103, 101, 78, 97, 109, 101, 34, 58, 34, 99, 111,
-            109, 46, 97, 110, 100, 114, 111, 105, 100, 46, 99, 104, 114, 111, 109, 101, 34, 125,
-        ];
+        let authenticator_data = hex::decode(
+            "7a03a16dfe0c4358b79eebe4f25cba56ec7aa7c8331f46a96988006db440e690050000003c",
+        )
+        .unwrap();
+        let client_data_json = br#"{"type":"webauthn.get","challenge":"OCAjaXEXs-P4zqEk-61MhWPOq9a8VpDL2qf3ZwnAI9I","origin":"https:\/\/webauthn.pos.nimiqwatch.com","androidPackageName":"com.android.chrome"}"#;
         let proof = SignatureProof::webauthn_single_sig(
             &JsValue::from(public_key).into(),
             &JsValue::from(signature).into(),
-            authenticator_data,
+            &authenticator_data,
             client_data_json,
         );
         assert!(proof.is_ok());


### PR DESCRIPTION
Try to be very precise while doing so. This allows us to work around Android Chrome's standard-violating behavior: https://issues.chromium.org/issues/40191627.

Alternative to #2262 and #2227.