### PR TITLE
Set default desired peer count to 12

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -297,10 +297,7 @@ impl ClientInner {
             false,
             required_services,
             tls_config,
-            config
-                .network
-                .desired_peer_count
-                .unwrap_or(config.consensus.min_peers),
+            config.network.desired_peer_count,
             config.network.autonat_allow_non_global_ips,
             config.network.only_secure_ws_connections,
             config.network.allow_loopback_addresses,

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -122,8 +122,8 @@ pub struct NetworkConfig {
 
     /// Optional desired number of peers for the network to connect to.
     /// The network will always try to maintain this number of connections.
-    #[builder(default)]
-    pub desired_peer_count: Option<usize>,
+    #[builder(default = "12")]
+    pub desired_peer_count: usize,
 
     /// Optional setting to allow network autonat to use non global IPs
     #[builder(default)]

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -50,6 +50,12 @@ seed_nodes = [
 # Default: false
 #autonat_allow_non_global_ips = false
 
+# Optionally specify the desired number of peer connections the network should try to maintain
+# Recommended setting is to keep it in the default value (12).
+#
+# Default: 12
+#desired_peer_count = 12
+
 ##############################################################################
 #
 # TLS network configuration:

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -139,14 +139,20 @@ pub struct NetworkSettings {
 
     pub tls: Option<TlsSettings>,
     pub instant_inbound: Option<bool>,
-    #[serde(default)]
-    pub desired_peer_count: Option<usize>,
+    #[serde(default = "NetworkSettings::default_desired_peer_count")]
+    pub desired_peer_count: usize,
     #[serde(default)]
     pub autonat_allow_non_global_ips: bool,
     #[serde(default)]
     pub allow_loopback_addresses: bool,
     #[serde(default)]
     pub dht_quorum: Option<NonZeroU8>,
+}
+
+impl NetworkSettings {
+    pub fn default_desired_peer_count() -> usize {
+        12
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/scripts/devnet/templates/node_conf.toml.j2
+++ b/scripts/devnet/templates/node_conf.toml.j2
@@ -15,6 +15,7 @@ seed_nodes = [
 
 {% endif %}
 autonat_allow_non_global_ips = true
+desired_peer_count = {{ min_peers }}
 
 [consensus]
 network = "dev-albatross"


### PR DESCRIPTION
## What's in this pull request?

Set the default value for the network desired number of peers to 12.
In the devnet scenarios the value is set to `min_peers` to keep previous behavior for testing to avoid several dial attempts when a node is taken down.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
