### PR TITLE
Handle special case when adopting a new macro head

### DIFF
--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -66,6 +66,8 @@ pub struct ValidityChunkRequest {
     pub validity_start: u32,
     /// Flag to indicate if there is an election block within the validity window
     pub election_in_window: bool,
+    /// Number of items in the previous requested chunk (for cases where we adopt a new macro head)
+    pub last_chunk_items: Option<usize>,
 }
 
 /// This struct is used to track all the macro requests sent to a particular peer


### PR DESCRIPTION
When we adopt a new macro head, while we are doing the validity sync, we need to re-request the chunk, because it could potentially include more items with the new adopted macro head.



#### This fixes #2293 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
