### PR TITLE
Fix Nodejs support for web-client

### DIFF
--- a/web-client/dist/nodejs/worker.js
+++ b/web-client/dist/nodejs/worker.js
@@ -9,6 +9,24 @@ const { Client } = require('./worker-wasm/index.js');
 
 // Provide a global WebSocket implementation, which is expected by the WASM code built for browsers.
 global.WebSocket = w3cwebsocket;
+// Workaround for Node.js as it currently lacks support for Web Workers by pretending there is
+// a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
+global.WorkerGlobalScope = global;
+
+// Clean up performance measurements created by tracing.
+// TODO: find a solution to disable creating these measurements.
+setInterval(() => {
+    global.performance.clearMarks();
+    global.performance.clearMeasures();
+    global.performance.clearResourceTimings();
+}, 300 * 1000);
+
+// Prevent NodeJS exiting on an uncaught exception that we currently expect,
+// until it is fixed in upstream libp2p websocket-websys transport.
+process.on('uncaughtException', error => {
+    if (error.message.includes('closure invoked recursively')) return;
+    throw error;
+});
 
 // Defined both here and in main thread exports.js
 Comlink.transferHandlers.set('function', {


### PR DESCRIPTION
This PR is a workaround of the upstream libp2p that broke the support for NodeJS: #2301.

## What's in this pull request?

- it sets the `global.WorkerGlobalScope` as a reference to itself which libp2p requires.
- it cleans up performance measurements periodically emitted by the logs that currently cause the memory to grow indefinitely.
- It catches the exception of a failing websocket connetion without exiting the worker thread.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
