### PR TITLE
Move Rustdocs from rpc-server to rpc-interface for trait methods

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -13,60 +13,87 @@ use crate::types::{
 pub trait BlockchainInterface {
     type Error;
 
+    /// Returns the block number for the current head.
     async fn get_block_number(&mut self) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the batch number for the current head.
     async fn get_batch_number(&mut self) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the epoch number for the current head.
     async fn get_epoch_number(&mut self) -> RPCResult<u32, (), Self::Error>;
 
+    /// Tries to fetch a block given its hash. It has an option to include the transactions in the
+    /// block, which defaults to false.
     async fn get_block_by_hash(
         &mut self,
         hash: Blake2bHash,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
+    /// Tries to fetch a block given its number. It has an option to include the transactions in the
+    /// block, which defaults to false. Note that this function will only fetch blocks that are part
+    /// of the main chain.
     async fn get_block_by_number(
         &mut self,
         block_number: u32,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
+    /// Returns the block at the head of the main chain. It has an option to include the
+    /// transactions in the block, which defaults to false.
     async fn get_latest_block(
         &mut self,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
+    /// Returns information about the proposer slot at the given block height and offset. The
+    /// offset is optional, it will default to getting the offset for the existing block
+    /// at the given height.
+    /// We only have this information available for the last 2 batches at most.
     async fn get_slot_at(
         &mut self,
         block_number: u32,
         offset_opt: Option<u32>,
     ) -> RPCResult<Slot, BlockchainState, Self::Error>;
 
+    /// Tries to fetch a transaction (including reward transactions) given its hash.
     async fn get_transaction_by_hash(
         &mut self,
         hash: Blake2bHash,
     ) -> RPCResult<ExecutedTransaction, (), Self::Error>;
 
+    /// Returns all the transactions (including reward transactions) for the given block number. Note
+    /// that this only considers blocks in the main chain.
     async fn get_transactions_by_block_number(
         &mut self,
         block_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
+    /// Returns all the inherents (including reward inherents) for the given block number. Note
+    /// that this only considers blocks in the main chain.
     async fn get_inherents_by_block_number(
         &mut self,
         block_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error>;
 
+    /// Returns all the transactions (including reward transactions) for the given batch number. Note
+    /// that this only considers blocks in the main chain.
     async fn get_transactions_by_batch_number(
         &mut self,
         batch_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
+    /// Returns all the inherents (including reward inherents) for the given batch number. Note
+    /// that this only considers blocks in the main chain.  
     async fn get_inherents_by_batch_number(
         &mut self,
         batch_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error>;
 
+    /// Returns the hashes for the latest transactions for a given address. All the transactions
+    /// where the given address is listed as a recipient or as a sender are considered. Reward
+    /// transactions are also returned. It has an option to specify the maximum number of hashes to
+    /// fetch, it defaults to 500.
     // TODO: includes reward txs
     async fn get_transaction_hashes_by_address(
         &mut self,
@@ -74,12 +101,17 @@ pub trait BlockchainInterface {
         max: Option<u16>,
     ) -> RPCResult<Vec<Blake2bHash>, (), Self::Error>;
 
+    /// Returns the latest transactions for a given address. All the transactions
+    /// where the given address is listed as a recipient or as a sender are considered. Reward
+    /// transactions are also returned. It has an option to specify the maximum number of transactions
+    /// to fetch, it defaults to 500.
     async fn get_transactions_by_address(
         &mut self,
         address: Address,
         max: Option<u16>,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
+    /// Tries to fetch the account at the given address.
     async fn get_account_by_address(
         &mut self,
         address: Address,
@@ -90,18 +122,24 @@ pub trait BlockchainInterface {
     /// and thus is extremely computationally expensive.
     async fn get_accounts(&mut self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error>;
 
+    /// Returns a collection of the currently active validator's addresses and balances.
     async fn get_active_validators(
         &mut self,
     ) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;
 
+    /// Returns information about the currently penalized slots. This includes slots that lost rewards
+    /// and that were disabled.
     async fn get_current_penalized_slots(
         &mut self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error>;
 
+    /// Returns information about the penalized slots of the previous batch. This includes slots that
+    /// lost rewards and that were disabled.
     async fn get_previous_penalized_slots(
         &mut self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error>;
 
+    /// Tries to fetch a validator information given its address.
     async fn get_validator_by_address(
         &mut self,
         address: Address,
@@ -120,28 +158,35 @@ pub trait BlockchainInterface {
         address: Address,
     ) -> RPCResult<Vec<Staker>, BlockchainState, Self::Error>;
 
+    /// Tries to fetch a staker information given its address.
     async fn get_staker_by_address(
         &mut self,
         address: Address,
     ) -> RPCResult<Staker, BlockchainState, Self::Error>;
 
+    /// Subscribes to new block events (retrieves the full block).
     #[stream]
     async fn subscribe_for_head_block(
         &mut self,
         include_body: Option<bool>,
     ) -> Result<BoxStream<'static, RPCData<Block, ()>>, Self::Error>;
 
+    /// Subscribes to new block events (only retrieves the block hash).
     #[stream]
     async fn subscribe_for_head_block_hash(
         &mut self,
     ) -> Result<BoxStream<'static, RPCData<Blake2bHash, ()>>, Self::Error>;
 
+    /// Subscribes to pre epoch validators events.
     #[stream]
     async fn subscribe_for_validator_election_by_address(
         &mut self,
         address: Address,
     ) -> Result<BoxStream<'static, RPCData<Validator, BlockchainState>>, Self::Error>;
 
+    /// Subscribes to log events related to a given list of addresses and of any of the log types provided.
+    /// If addresses is empty it does not filter by address. If log_types is empty it won't filter by log types.
+    /// Thus the behavior is to assume all addresses or log_types are to be provided if the corresponding vec is empty.
     #[stream]
     async fn subscribe_for_logs_by_addresses_and_types(
         &mut self,

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -11,20 +11,24 @@ use crate::types::{RPCResult, Transaction, ValidityStartHeight};
 pub trait ConsensusInterface {
     type Error;
 
+    /// Returns a boolean specifying if we have established consensus with the network.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
     async fn is_consensus_established(&mut self) -> RPCResult<bool, (), Self::Error>;
 
+    /// Given a serialized transaction, it will return the corresponding transaction struct.
     async fn get_raw_transaction_info(
         &mut self,
         raw_tx: String,
     ) -> RPCResult<Transaction, (), Self::Error>;
 
+    /// Sends the given serialized transaction to the network.
     async fn send_raw_transaction(
         &mut self,
         raw_tx: String,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized basic transaction.
     async fn create_basic_transaction(
         &mut self,
         wallet: Address,
@@ -34,6 +38,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a basic transaction to the network.
     async fn send_basic_transaction(
         &mut self,
         wallet: Address,
@@ -43,6 +48,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized basic transaction with an arbitrary data field.
     async fn create_basic_transaction_with_data(
         &mut self,
         wallet: Address,
@@ -53,6 +59,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a basic transaction, with an arbitrary data field, to the network.
     async fn send_basic_transaction_with_data(
         &mut self,
         wallet: Address,
@@ -63,6 +70,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized transaction creating a new vesting contract.
     async fn create_new_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -75,6 +83,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a transaction creating a new vesting contract to the network.
     async fn send_new_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -87,6 +96,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized transaction redeeming a vesting contract.
     async fn create_redeem_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -97,6 +107,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a transaction redeeming a vesting contract to the network.
     async fn send_redeem_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -107,6 +118,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized transaction creating a new HTLC contract.
     async fn create_new_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -120,6 +132,7 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a transaction creating a new HTLC contract to the network.
     async fn send_new_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -133,6 +146,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized transaction redeeming a HTLC contract
+    /// using the `RegularTransfer` method.
     async fn create_redeem_regular_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -146,6 +161,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a transaction redeeming a HTLC contract, using the `RegularTransfer` method, to the
+    /// network.
     async fn send_redeem_regular_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -159,6 +176,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized transaction redeeming a HTLC contract using the `TimeoutResolve`
+    /// method.
     async fn create_redeem_timeout_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -169,6 +188,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a transaction redeeming a HTLC contract, using the `TimeoutResolve` method, to the
+    /// network.
     async fn send_redeem_timeout_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -179,6 +200,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized transaction redeeming a HTLC contract using the `EarlyResolve`
+    /// method.
     async fn create_redeem_early_htlc_transaction(
         &mut self,
         contract_address: Address,
@@ -190,6 +213,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a transaction redeeming a HTLC contract, using the `EarlyResolve` method, to the
+    /// network.
     async fn send_redeem_early_htlc_transaction(
         &mut self,
         contract_address: Address,
@@ -201,6 +226,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized signature that can be used to redeem funds from a HTLC contract using
+    /// the `EarlyResolve` method.
     async fn sign_redeem_early_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -211,6 +238,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Returns a serialized `new_staker` transaction. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn create_new_staker_transaction(
         &mut self,
         sender_wallet: Address,
@@ -221,6 +250,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `new_staker` transaction to the network. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn send_new_staker_transaction(
         &mut self,
         sender_wallet: Address,
@@ -231,6 +262,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `stake` transaction. The funds to be staked and the transaction fee will
+    /// be paid from the `sender_wallet`.
     async fn create_stake_transaction(
         &mut self,
         sender_wallet: Address,
@@ -240,6 +273,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `stake` transaction to the network. The funds to be staked and the transaction fee will
+    /// be paid from the `sender_wallet`.
     async fn send_stake_transaction(
         &mut self,
         sender_wallet: Address,
@@ -249,6 +284,9 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `update_staker` transaction. You can pay the transaction fee from a basic
+    /// account (by providing the sender wallet) or from the staker account's balance (by not
+    /// providing a sender wallet).
     async fn create_update_staker_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -259,6 +297,9 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `update_staker` transaction to the network. You can pay the transaction fee from a basic
+    /// account (by providing the sender wallet) or from the staker account's balance (by not
+    /// providing a sender wallet).
     async fn send_update_staker_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -269,6 +310,9 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `set_active_stake` transaction. You can pay the transaction fee from a basic
+    /// account (by providing the sender wallet) or from the staker account's balance (by not
+    /// providing a sender wallet).
     async fn create_set_active_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -278,6 +322,9 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `set_active_stake` transaction to the network. You can pay the transaction fee from a basic
+    /// account (by providing the sender wallet) or from the staker account's balance (by not
+    /// providing a sender wallet).
     async fn send_set_active_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -287,6 +334,9 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `retire_stake` transaction. You can pay the transaction fee from a basic
+    /// account (by providing the sender wallet) or from the staker account's balance (by not
+    /// providing a sender wallet).
     async fn create_retire_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -296,6 +346,9 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `retire_stake` transaction to the network. You can pay the transaction fee from a basic
+    /// account (by providing the sender wallet) or from the staker account's balance (by not
+    /// providing a sender wallet).
     async fn send_retire_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -305,6 +358,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `remove_stake` transaction. The transaction fee will be paid from the funds
+    /// being removed.
     async fn create_remove_stake_transaction(
         &mut self,
         staker_wallet: Address,
@@ -314,6 +369,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `remove_stake` transaction to the network. The transaction fee will be paid from the funds
+    /// being removed.
     async fn send_remove_stake_transaction(
         &mut self,
         staker_wallet: Address,
@@ -323,6 +380,12 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `new_validator` transaction. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee and the validator deposit.
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// have a double Option. So we use the following work-around for the signal data:
+    /// "" = Set the signal data field to None.
+    /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn create_new_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -335,6 +398,12 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `new_validator` transaction to the network. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee and the validator deposit.
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// have a double Option. So we use the following work-around for the signal data:
+    /// "" = Set the signal data field to None.
+    /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn send_new_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -347,6 +416,13 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `update_validator` transaction. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// have a double Option. So we use the following work-around for the signal data:
+    /// null = No change in the signal data field.
+    /// "" = Change the signal data field to None.
+    /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn create_update_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -359,6 +435,13 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `update_validator` transaction to the network. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
+    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
+    /// have a double Option. So we use the following work-around for the signal data:
+    /// null = No change in the signal data field.
+    /// "" = Change the signal data field to None.
+    /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn send_update_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -371,6 +454,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `deactivate_validator` transaction. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn create_deactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -380,6 +465,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `deactivate_validator` transaction to the network. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn send_deactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -389,6 +476,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `reactivate_validator` transaction. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn create_reactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -398,6 +487,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `reactivate_validator` transaction to the network. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn send_reactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -407,6 +498,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `retire_validator` transaction. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn create_retire_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -415,6 +508,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `retire_validator` transaction to the network. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
     async fn send_retire_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -423,6 +518,10 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
+    /// Returns a serialized `delete_validator` transaction. The transaction fee will be paid from the
+    /// validator deposit that is being returned.
+    /// Note in order for this transaction to be accepted fee + value should be equal to the validator deposit, which is not a fixed value:
+    /// Failed delete validator transactions can diminish the validator deposit
     async fn create_delete_validator_transaction(
         &mut self,
         validator_wallet: Address,
@@ -432,6 +531,8 @@ pub trait ConsensusInterface {
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
 
+    /// Sends a `delete_validator` transaction to the network. The transaction fee will be paid from the
+    /// validator deposit that is being returned.
     async fn send_delete_validator_transaction(
         &mut self,
         validator_wallet: Address,

--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -9,29 +9,29 @@ use crate::types::{HashOrTx, MempoolInfo, RPCResult};
 pub trait MempoolInterface {
     type Error;
 
-    /// Pushes a raw transaction into the mempool, it will be assigned a default priority
+    /// Pushes a raw transaction into the mempool, it will be assigned a default priority.
     async fn push_transaction(&mut self, raw_tx: String)
         -> RPCResult<Blake2bHash, (), Self::Error>;
 
-    /// Pushes a raw transaction into the mempool with high priority
+    /// Pushes a raw transaction into the mempool with high priority.
     async fn push_high_priority_transaction(
         &mut self,
         raw_tx: String,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
-    /// Obtains the list of transactions that are currently in the mempool
+    /// Obtains the list of transactions that are currently in the mempool.
     async fn mempool_content(
         &mut self,
         include_transactions: bool,
     ) -> RPCResult<Vec<HashOrTx>, (), Self::Error>;
 
-    /// Obtains the mempool content in fee per byte buckets
+    /// Obtains the mempool content in fee per byte buckets.
     async fn mempool(&mut self) -> RPCResult<MempoolInfo, (), Self::Error>;
 
-    /// Obtains the minimum fee per byte as per mempool configuration
+    /// Obtains the minimum fee per byte as per mempool configuration.
     async fn get_min_fee_per_byte(&mut self) -> RPCResult<f64, (), Self::Error>;
 
-    /// Tries to obtain the given transaction (using its hash) from the mempool
+    /// Tries to obtain the given transaction (using its hash) from the mempool.
     async fn get_transaction_from_mempool(
         &mut self,
         hash: Blake2bHash,

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -7,9 +7,12 @@ use crate::types::RPCResult;
 pub trait NetworkInterface {
     type Error;
 
+    /// Returns the peer ID for our local peer.
     async fn get_peer_id(&mut self) -> RPCResult<String, (), Self::Error>;
 
+    /// Returns the number of peers.
     async fn get_peer_count(&mut self) -> RPCResult<usize, (), Self::Error>;
 
+    /// Returns a list with the IDs of all our peers.
     async fn get_peer_list(&mut self) -> RPCResult<Vec<String>, (), Self::Error>;
 }

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -7,68 +7,102 @@ use crate::types::{PolicyConstants, RPCResult};
 pub trait PolicyInterface {
     type Error;
 
+    /// Returns a bundle of policy constants.
     async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error>;
 
+    /// Returns the epoch number at a given block number (height).
     async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
+    /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
     async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the batch number at a given `block_number` (height).
     async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the batch index at a given block number. The batch index is the number of a block relative
+    /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
     async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the number (height) of the next election macro block after a given block number (height).
     async fn get_election_block_after(
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the number block (height) of the preceding election macro block before a given block number (height).
+    /// If the given block number is an election macro block, it returns the election macro block before it.
     async fn get_election_block_before(
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the block number (height) of the last election macro block at a given block number (height).
+    /// If the given block number is an election macro block, then it returns that block number.
     async fn get_last_election_block(
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
     async fn is_election_block_at(&mut self, block_number: u32)
         -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns the block number (height) of the next macro block after a given block number (height).
     async fn get_macro_block_after(&mut self, block_number: u32)
         -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the block number (height) of the preceding macro block before a given block number (height).
+    /// If the given block number is a macro block, it returns the macro block before it.
     async fn get_macro_block_before(
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns block the number (height) of the last macro block at a given block number (height).
+    /// If the given block number is a macro block, then it returns that block number.
     async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
     async fn is_macro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
     async fn is_micro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns the block number of the first block of the given epoch (which is always a micro block).
     async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the block number of the first block of the given batch (which is always a micro block).
     async fn get_first_block_of_batch(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the block number of the election macro block of the given epoch (which is always the last block).
     async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
+    /// is always the last block).
     async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
+    /// of the epoch.
     async fn get_first_batch_of_epoch(
         &mut self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns the first block after the reporting window of a given block number has ended.
     async fn get_block_after_reporting_window(
         &mut self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the first block after the jail period of a given block number has ended.
     async fn get_block_after_jail(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
+    /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
+    /// calculated using the following formula:
+    /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
+    /// Where e is the exponential function, t is the time in milliseconds since the genesis block and
+    /// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
     async fn get_supply_at(
         &mut self,
         genesis_supply: u64,

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -8,18 +8,24 @@ use crate::types::RPCResult;
 pub trait ValidatorInterface {
     type Error;
 
+    /// Returns our validator address.
     async fn get_address(&mut self) -> RPCResult<Address, (), Self::Error>;
 
+    /// Returns our validator signing key.
     async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error>;
 
+    /// Returns our validator voting key.
     async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error>;
 
+    /// Updates the configuration setting to automatically reactivate our validator.
     async fn set_automatic_reactivation(
         &mut self,
         automatic_reactivate: bool,
     ) -> RPCResult<(), (), Self::Error>;
 
+    /// Returns if our validator is currently elected.
     async fn is_validator_elected(&mut self) -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns if our validator is currently synced.
     async fn is_validator_synced(&mut self) -> RPCResult<bool, (), Self::Error>;
 }

--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -23,25 +23,31 @@ pub struct ReturnAccount {
 pub trait WalletInterface {
     type Error;
 
+    /// Import an account by its private key, in hexadecimal format, and lock it with the passphrase.
     async fn import_raw_key(
         &mut self,
         key_data: String,
         passphrase: Option<String>,
     ) -> RPCResult<Address, (), Self::Error>;
 
+    /// Returns if an account has been imported.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
     async fn is_account_imported(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns the accounts that have been imported.
     async fn list_accounts(&mut self) -> RPCResult<Vec<Address>, (), Self::Error>;
 
+    /// Locks the account to prevent further usage.
     async fn lock_account(&mut self, address: Address) -> RPCResult<(), (), Self::Error>;
 
+    /// Generates a new account and store it.
     async fn create_account(
         &mut self,
         passphrase: Option<String>,
     ) -> RPCResult<ReturnAccount, (), Self::Error>;
 
+    /// Unlocks the account.
     async fn unlock_account(
         &mut self,
         address: Address,
@@ -49,6 +55,7 @@ pub trait WalletInterface {
         duration: Option<u64>,
     ) -> RPCResult<bool, (), Self::Error>;
 
+    /// Returns if the account currently is unlocked.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
     async fn is_account_unlocked(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
@@ -61,6 +68,7 @@ pub trait WalletInterface {
         is_hex: bool,
     ) -> RPCResult<ReturnSignature, (), Self::Error>;
 
+    /// Verifies the signature based on the provided public key and message.
     async fn verify_signature(
         &mut self,
         message: String,

--- a/rpc-interface/src/zkp_component.rs
+++ b/rpc-interface/src/zkp_component.rs
@@ -7,5 +7,6 @@ use crate::types::{RPCResult, ZKPState};
 pub trait ZKPComponentInterface {
     type Error;
 
+    /// Returns the current ZKP state (proof with its related block hash and block number).
     async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -76,23 +76,18 @@ fn get_validator_by_address(
 impl BlockchainInterface for BlockchainDispatcher {
     type Error = Error;
 
-    /// Returns the block number for the current head.
     async fn get_block_number(&mut self) -> RPCResult<u32, (), Self::Error> {
         Ok(self.blockchain.read().block_number().into())
     }
 
-    /// Returns the batch number for the current head.
     async fn get_batch_number(&mut self) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_at(self.blockchain.read().block_number()).into())
     }
 
-    /// Returns the epoch number for the current head.
     async fn get_epoch_number(&mut self) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::epoch_at(self.blockchain.read().block_number()).into())
     }
 
-    /// Tries to fetch a block given its hash. It has an option to include the transactions in the
-    /// block, which defaults to false.
     async fn get_block_by_hash(
         &mut self,
         hash: Blake2bHash,
@@ -101,9 +96,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         get_block_by_hash(&self.blockchain.read(), &hash, include_body)
     }
 
-    /// Tries to fetch a block given its number. It has an option to include the transactions in the
-    /// block, which defaults to false. Note that this function will only fetch blocks that are part
-    /// of the main chain.
     async fn get_block_by_number(
         &mut self,
         block_number: u32,
@@ -123,8 +115,6 @@ impl BlockchainInterface for BlockchainDispatcher {
             .into())
     }
 
-    /// Returns the block at the head of the main chain. It has an option to include the
-    /// transactions in the block, which defaults to false.
     async fn get_latest_block(
         &mut self,
         include_body: Option<bool>,
@@ -139,10 +129,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         )
     }
 
-    /// Returns information about the proposer slot at the given block height and offset. The
-    /// offset is optional, it will default to getting the offset for the existing block
-    /// at the given height.
-    /// We only have this information available for the last 2 batches at most.
     async fn get_slot_at(
         &mut self,
         block_number: u32,
@@ -165,7 +151,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         Ok(RPCData::with_blockchain(slot, &blockchain))
     }
 
-    /// Tries to fetch a transaction (including reward transactions) given its hash.
     async fn get_transaction_by_hash(
         &mut self,
         hash: Blake2bHash,
@@ -205,8 +190,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns all the transactions (including reward transactions) for the given block number. Note
-    /// that this only considers blocks in the main chain.
     async fn get_transactions_by_block_number(
         &mut self,
         block_number: u32,
@@ -242,8 +225,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns all the inherents (including reward inherents) for the given block number. Note
-    /// that this only considers blocks in the main chain.
     async fn get_inherents_by_block_number(
         &mut self,
         block_number: u32,
@@ -269,8 +250,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns all the transactions (including reward transactions) for the given batch number. Note
-    /// that this only considers blocks in the main chain.
     async fn get_transactions_by_batch_number(
         &mut self,
         batch_number: u32,
@@ -314,8 +293,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns all the inherents (including reward inherents) for the given batch number. Note
-    /// that this only considers blocks in the main chain.  
     async fn get_inherents_by_batch_number(
         &mut self,
         batch_number: u32,
@@ -358,10 +335,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns the hashes for the latest transactions for a given address. All the transactions
-    /// where the given address is listed as a recipient or as a sender are considered. Reward
-    /// transactions are also returned. It has an option to specify the maximum number of hashes to
-    /// fetch, it defaults to 500.
     async fn get_transaction_hashes_by_address(
         &mut self,
         address: Address,
@@ -378,10 +351,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns the latest transactions for a given address. All the transactions
-    /// where the given address is listed as a recipient or as a sender are considered. Reward
-    /// transactions are also returned. It has an option to specify the maximum number of transactions
-    /// to fetch, it defaults to 500.
     async fn get_transactions_by_address(
         &mut self,
         address: Address,
@@ -433,7 +402,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Tries to fetch the account at the given address.
     async fn get_account_by_address(
         &mut self,
         address: Address,
@@ -453,9 +421,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Fetches all accounts in the accounts tree.
-    /// IMPORTANT: This operation iterates over all accounts in the accounts tree
-    /// and thus is extremely computationally expensive.
     async fn get_accounts(&mut self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
@@ -475,7 +440,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns a collection of the currently active validator's addresses and balances.
     async fn get_active_validators(
         &mut self,
     ) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error> {
@@ -502,8 +466,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns information about the currently penalized slots. This includes slots that lost rewards
-    /// and that were disabled.
     async fn get_current_penalized_slots(
         &mut self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error> {
@@ -528,8 +490,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Returns information about the penalized slots of the previous batch. This includes slots that
-    /// lost rewards and that were disabled.
     async fn get_previous_penalized_slots(
         &mut self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error> {
@@ -554,7 +514,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Tries to fetch a validator information given its address.
     async fn get_validator_by_address(
         &mut self,
         address: Address,
@@ -562,10 +521,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         get_validator_by_address(&self.blockchain.read(), &address)
     }
 
-    /// Fetches all validators in the staking contract.
-    /// IMPORTANT: This operation iterates over all validators in the staking contract
-    /// and thus is extremely computationally expensive.
-    /// This function requires the read lock acquisition prior to its execution.
     async fn get_validators(&mut self) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
 
@@ -586,10 +541,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Fetches all stakers for a given validator.
-    /// IMPORTANT: This operation iterates over all stakers of the staking contract
-    /// and thus is extremely computationally expensive.
-    /// This function requires the read lock acquisition prior to its execution.
     async fn get_stakers_by_validator_address(
         &mut self,
         address: Address,
@@ -614,7 +565,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Tries to fetch a staker information given its address.
     async fn get_staker_by_address(
         &mut self,
         address: Address,
@@ -639,7 +589,6 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    /// Subscribes to new block events (retrieves the full block).
     #[stream]
     async fn subscribe_for_head_block(
         &mut self,
@@ -664,7 +613,6 @@ impl BlockchainInterface for BlockchainDispatcher {
             .boxed())
     }
 
-    /// Subscribes to new block events (only retrieves the block hash).
     #[stream]
     async fn subscribe_for_head_block_hash(
         &mut self,
@@ -686,7 +634,6 @@ impl BlockchainInterface for BlockchainDispatcher {
             .boxed())
     }
 
-    /// Subscribes to pre epoch validators events.
     #[stream]
     async fn subscribe_for_validator_election_by_address(
         &mut self,
@@ -709,9 +656,6 @@ impl BlockchainInterface for BlockchainDispatcher {
             .boxed())
     }
 
-    /// Subscribes to log events related to a given list of addresses and of any of the log types provided.
-    /// If addresses is empty it does not filter by address. If log_types is empty it won't filter by log types.
-    /// Thus the behavior is to assume all addresses or log_types are to be provided if the corresponding vec is empty.
     #[stream]
     async fn subscribe_for_logs_by_addresses_and_types(
         &mut self,

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -73,12 +73,10 @@ fn transaction_to_hex_string(transaction: &Transaction) -> String {
 impl ConsensusInterface for ConsensusDispatcher {
     type Error = Error;
 
-    /// Returns a boolean specifying if we have established consensus with the network.
     async fn is_consensus_established(&mut self) -> RPCResult<bool, (), Self::Error> {
         Ok(self.consensus.is_established().into())
     }
 
-    /// Given a serialized transaction, it will return the corresponding transaction struct.
     async fn get_raw_transaction_info(
         &mut self,
         raw_tx: String,
@@ -87,7 +85,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(RPCTransaction::from_transaction(transaction).into())
     }
 
-    /// Sends the given serialized transaction to the network.
     async fn send_raw_transaction(
         &mut self,
         raw_tx: String,
@@ -101,7 +98,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         }
     }
 
-    /// Returns a serialized basic transaction.
     async fn create_basic_transaction(
         &mut self,
         wallet: Address,
@@ -122,7 +118,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a basic transaction to the network.
     async fn send_basic_transaction(
         &mut self,
         wallet: Address,
@@ -138,7 +133,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized basic transaction with an arbitrary data field.
     async fn create_basic_transaction_with_data(
         &mut self,
         wallet: Address,
@@ -161,7 +155,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a basic transaction, with an arbitrary data field, to the network.
     async fn send_basic_transaction_with_data(
         &mut self,
         wallet: Address,
@@ -185,7 +178,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized transaction creating a new vesting contract.
     async fn create_new_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -212,7 +204,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a transaction creating a new vesting contract to the network.
     async fn send_new_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -240,7 +231,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized transaction redeeming a vesting contract.
     async fn create_redeem_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -263,7 +253,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a transaction redeeming a vesting contract to the network.
     async fn send_redeem_vesting_transaction(
         &mut self,
         wallet: Address,
@@ -287,7 +276,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized transaction creating a new HTLC contract.
     async fn create_new_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -316,7 +304,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a transaction creating a new HTLC contract to the network.
     async fn send_new_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -346,8 +333,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized transaction redeeming a HTLC contract using the `RegularTransfer`
-    /// method.
     async fn create_redeem_regular_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -376,8 +361,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a transaction redeeming a HTLC contract, using the `RegularTransfer` method, to the
-    /// network.
     async fn send_redeem_regular_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -407,8 +390,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized transaction redeeming a HTLC contract using the `TimeoutResolve`
-    /// method.
     async fn create_redeem_timeout_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -431,8 +412,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a transaction redeeming a HTLC contract, using the `TimeoutResolve` method, to the
-    /// network.
     async fn send_redeem_timeout_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -456,8 +435,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized transaction redeeming a HTLC contract using the `EarlyResolve`
-    /// method.
     async fn create_redeem_early_htlc_transaction(
         &mut self,
         contract_address: Address,
@@ -489,8 +466,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a transaction redeeming a HTLC contract, using the `EarlyResolve` method, to the
-    /// network.
     async fn send_redeem_early_htlc_transaction(
         &mut self,
         contract_address: Address,
@@ -516,8 +491,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized signature that can be used to redeem funds from a HTLC contract using
-    /// the `EarlyResolve` method.
     async fn sign_redeem_early_htlc_transaction(
         &mut self,
         wallet: Address,
@@ -540,8 +513,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(hex::encode(sig.serialize_to_vec()).into())
     }
 
-    /// Returns a serialized `new_staker` transaction. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn create_new_staker_transaction(
         &mut self,
         sender_wallet: Address,
@@ -564,8 +535,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `new_staker` transaction to the network. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn send_new_staker_transaction(
         &mut self,
         sender_wallet: Address,
@@ -589,8 +558,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `stake` transaction. The funds to be staked and the transaction fee will
-    /// be paid from the `sender_wallet`.
     async fn create_stake_transaction(
         &mut self,
         sender_wallet: Address,
@@ -611,8 +578,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `stake` transaction to the network. The funds to be staked and the transaction fee will
-    /// be paid from the `sender_wallet`.
     async fn send_stake_transaction(
         &mut self,
         sender_wallet: Address,
@@ -635,9 +600,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `update_staker` transaction. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn create_update_staker_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -665,9 +627,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `update_staker` transaction to the network. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn send_update_staker_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -691,9 +650,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `set_active_stake` transaction. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn create_set_active_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -719,9 +675,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `set_active_stake` transaction to the network. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn send_set_active_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -743,9 +696,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `retire_stake` transaction. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn create_retire_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -771,9 +721,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `retire_stake` transaction to the network. You can pay the transaction fee from a basic
-    /// account (by providing the sender wallet) or from the staker account's balance (by not
-    /// providing a sender wallet).
     async fn send_retire_stake_transaction(
         &mut self,
         sender_wallet: Option<Address>,
@@ -795,8 +742,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `remove_stake` transaction. The transaction fee will be paid from the funds
-    /// being removed.
     async fn create_remove_stake_transaction(
         &mut self,
         staker_wallet: Address,
@@ -817,8 +762,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `remove_stake` transaction to the network. The transaction fee will be paid from the funds
-    /// being removed.
     async fn send_remove_stake_transaction(
         &mut self,
         staker_wallet: Address,
@@ -840,12 +783,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `new_validator` transaction. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee and the validator deposit.
-    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
-    /// have a double Option. So we use the following work-around for the signal data:
-    /// "" = Set the signal data field to None.
-    /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn create_new_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -897,12 +834,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `new_validator` transaction to the network. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee and the validator deposit.
-    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
-    /// have a double Option. So we use the following work-around for the signal data:
-    /// "" = Set the signal data field to None.
-    /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn send_new_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -930,13 +861,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `update_validator` transaction. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
-    /// Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
-    /// have a double Option. So we use the following work-around for the signal data:
-    /// null = No change in the signal data field.
-    /// "" = Change the signal data field to None.
-    /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn create_update_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1001,13 +925,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `update_validator` transaction to the network. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
-    ///  Since JSON doesn't have a primitive for Option (it just has the null primitive), we can't
-    /// have a double Option. So we use the following work-around for the signal data:
-    ///  null = No change in the signal data field.
-    ///  "" = Change the signal data field to None.
-    ///  "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn send_update_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1035,8 +952,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `deactivate_validator` transaction. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn create_deactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1062,8 +977,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `deactivate_validator` transaction to the network. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn send_deactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1085,8 +998,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `reactivate_validator` transaction. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn create_reactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1111,8 +1022,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `reactivate_validator` transaction to the network. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn send_reactivate_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1158,8 +1067,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `retire_validator` transaction. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn create_retire_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1178,8 +1085,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `retire_validator` transaction to the network. You need to provide the address of a basic
-    /// account (the sender wallet) to pay the transaction fee.
     async fn send_retire_validator_transaction(
         &mut self,
         sender_wallet: Address,
@@ -1221,10 +1126,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         self.send_raw_transaction(raw_tx).await
     }
 
-    /// Returns a serialized `delete_validator` transaction. The transaction fee will be paid from the
-    /// validator deposit that is being returned.
-    /// Note in order for this transaction to be accepted fee + value should be equal to the validator deposit, which is not a fixed value:
-    /// Failed delete validator transactions can diminish the validator deposit
     async fn create_delete_validator_transaction(
         &mut self,
         validator_wallet: Address,
@@ -1245,8 +1146,6 @@ impl ConsensusInterface for ConsensusDispatcher {
         Ok(transaction_to_hex_string(&transaction).into())
     }
 
-    /// Sends a `delete_validator` transaction to the network. The transaction fee will be paid from the
-    /// validator deposit that is being returned.
     async fn send_delete_validator_transaction(
         &mut self,
         validator_wallet: Address,

--- a/rpc-server/src/dispatchers/mempool.rs
+++ b/rpc-server/src/dispatchers/mempool.rs
@@ -28,7 +28,6 @@ impl MempoolDispatcher {
 impl MempoolInterface for MempoolDispatcher {
     type Error = Error;
 
-    /// Pushes the given serialized transaction to the local mempool.
     async fn push_transaction(
         &mut self,
         raw_tx: String,
@@ -43,7 +42,6 @@ impl MempoolInterface for MempoolDispatcher {
         }
     }
 
-    /// Pushes the given serialized transaction to the local mempool with high priority
     async fn push_high_priority_transaction(
         &mut self,
         raw_tx: String,

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -22,17 +22,14 @@ impl NetworkDispatcher {
 impl NetworkInterface for NetworkDispatcher {
     type Error = Error;
 
-    /// Returns the peer ID for our local peer.
     async fn get_peer_id(&mut self) -> RPCResult<String, (), Self::Error> {
         Ok(self.network.local_peer_id().to_string().into())
     }
 
-    /// Returns the number of peers.
     async fn get_peer_count(&mut self) -> RPCResult<usize, (), Self::Error> {
         Ok(self.network.get_peers().len().into())
     }
 
-    /// Returns a list with the IDs of all our peers.
     async fn get_peer_list(&mut self) -> RPCResult<Vec<String>, (), Self::Error> {
         Ok(self
             .network

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -14,7 +14,6 @@ pub struct PolicyDispatcher {}
 impl PolicyInterface for PolicyDispatcher {
     type Error = Error;
 
-    /// Returns a bundle of policy constants
     async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error> {
         Ok(PolicyConstants {
             staking_contract_address: Policy::STAKING_CONTRACT_ADDRESS.to_string(),
@@ -36,29 +35,22 @@ impl PolicyInterface for PolicyDispatcher {
         .into())
     }
 
-    /// Returns the epoch number at a given block number (height).
     async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::epoch_at(block_number).into())
     }
 
-    /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
-    /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
     async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::epoch_index_at(block_number).into())
     }
 
-    /// Returns the batch number at a given `block_number` (height)
     async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_at(block_number).into())
     }
 
-    /// Returns the batch index at a given block number. The batch index is the number of a block relative
-    /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
     async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_index_at(block_number).into())
     }
 
-    /// Returns the number (height) of the next election macro block after a given block number (height).
     async fn get_election_block_after(
         &mut self,
         block_number: u32,
@@ -66,8 +58,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::election_block_after(block_number).into())
     }
 
-    /// Returns the number block (height) of the preceding election macro block before a given block number (height).
-    /// If the given block number is an election macro block, it returns the election macro block before it.
     async fn get_election_block_before(
         &mut self,
         block_number: u32,
@@ -78,8 +68,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::election_block_before(block_number).into())
     }
 
-    /// Returns the block number (height) of the last election macro block at a given block number (height).
-    /// If the given block number is an election macro block, then it returns that block number.
     async fn get_last_election_block(
         &mut self,
         block_number: u32,
@@ -90,7 +78,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::last_election_block(block_number).into())
     }
 
-    /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
     async fn is_election_block_at(
         &mut self,
         block_number: u32,
@@ -98,7 +85,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::is_election_block_at(block_number).into())
     }
 
-    /// Returns the block number (height) of the next macro block after a given block number (height).
     async fn get_macro_block_after(
         &mut self,
         block_number: u32,
@@ -106,8 +92,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::macro_block_after(block_number).into())
     }
 
-    /// Returns the block number (height) of the preceding macro block before a given block number (height).
-    /// If the given block number is a macro block, it returns the macro block before it.
     async fn get_macro_block_before(
         &mut self,
         block_number: u32,
@@ -118,8 +102,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::macro_block_before(block_number).into())
     }
 
-    /// Returns block the number (height) of the last macro block at a given block number (height).
-    /// If the given block number is a macro block, then it returns that block number.
     async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         if block_number < Policy::genesis_block_number() {
             return Err(Error::BlockNumberBeforeGenesis);
@@ -127,17 +109,14 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::last_macro_block(block_number).into())
     }
 
-    /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
     async fn is_macro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_macro_block_at(block_number).into())
     }
 
-    /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
     async fn is_micro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_micro_block_at(block_number).into())
     }
 
-    /// Returns the block number of the first block of the given epoch (which is always a micro block).
     async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::first_block_of(epoch) {
             Some(block_number) => Ok(block_number.into()),
@@ -145,7 +124,6 @@ impl PolicyInterface for PolicyDispatcher {
         }
     }
 
-    /// Returns the block number of the first block of the given batch (which is always a micro block).
     async fn get_first_block_of_batch(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::first_block_of_batch(batch) {
             Some(block_number) => Ok(block_number.into()),
@@ -153,7 +131,6 @@ impl PolicyInterface for PolicyDispatcher {
         }
     }
 
-    /// Returns the block number of the election macro block of the given epoch (which is always the last block).
     async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::election_block_of(epoch) {
             Some(block_number) => Ok(block_number.into()),
@@ -161,8 +138,6 @@ impl PolicyInterface for PolicyDispatcher {
         }
     }
 
-    /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
-    /// is always the last block).
     async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::macro_block_of(batch) {
             Some(block_number) => Ok(block_number.into()),
@@ -170,8 +145,6 @@ impl PolicyInterface for PolicyDispatcher {
         }
     }
 
-    /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
-    /// of the epoch.
     async fn get_first_batch_of_epoch(
         &mut self,
         block_number: u32,
@@ -179,7 +152,6 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::first_batch_of_epoch(block_number).into())
     }
 
-    /// Returns the first block after the reporting window of a given block number has ended.
     async fn get_block_after_reporting_window(
         &mut self,
         block_number: u32,
@@ -187,16 +159,10 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::block_after_reporting_window(block_number).into())
     }
 
-    /// Returns the first block after the jail period of a given block number has ended.
     async fn get_block_after_jail(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::block_after_jail(block_number).into())
     }
 
-    /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
-    /// calculated using the following formula:
-    /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - e^(- Supply_decay * t))
-    /// Where e is the exponential function, t is the time in milliseconds since the genesis block and
-    /// Genesis_supply is the supply at the genesis of the Nimiq 2.0 chain.
     async fn get_supply_at(
         &mut self,
         genesis_supply: u64,

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -23,17 +23,14 @@ impl ValidatorDispatcher {
 impl ValidatorInterface for ValidatorDispatcher {
     type Error = Error;
 
-    /// Returns our validator address.
     async fn get_address(&mut self) -> RPCResult<Address, (), Self::Error> {
         Ok(self.validator.validator_address.read().clone().into())
     }
 
-    /// Returns our validator signing key.
     async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error> {
         Ok(hex::encode(self.validator.signing_key.read().private.serialize_to_vec()).into())
     }
 
-    /// Returns our validator voting key.
     async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error> {
         Ok(hex::encode(
             self.validator
@@ -45,7 +42,6 @@ impl ValidatorInterface for ValidatorDispatcher {
         .into())
     }
 
-    /// Updates the configuration setting to automatically reactivate our validator.
     async fn set_automatic_reactivation(
         &mut self,
         automatic_reactivate: bool,

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -99,10 +99,7 @@ impl WalletInterface for WalletDispatcher {
         .into())
     }
 
-    /// # TODO
-    ///
-    ///  - The duration parameter is ignored.
-    ///
+    // # TODO The duration parameter is ignored.
     async fn unlock_account(
         &mut self,
         address: Address,

--- a/rpc-server/src/dispatchers/zkp_component.rs
+++ b/rpc-server/src/dispatchers/zkp_component.rs
@@ -23,7 +23,6 @@ impl ZKPComponentDispatcher {
 impl ZKPComponentInterface for ZKPComponentDispatcher {
     type Error = Error;
 
-    /// Returns the current ZKP state (proof with its related block hash and block number).
     async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error> {
         Ok(ZKPState::with_zkp_state(&self.zkp_component.get_zkp_state()).into())
     }


### PR DESCRIPTION
## What's in this pull request?
Move all the Rustdocs from the `rpc-server` methods tot he `rpc-interface` trait methods. 


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
