### PR TITLE
Add own abstraction layer over tokio::time::Interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3535,7 +3535,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-transaction",
  "nimiq-vrf",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "thiserror",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
 ]
 
@@ -1861,6 +1861,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4091,6 +4103,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
+ "nimiq-time",
  "nimiq-utils",
  "nimiq-validator-network",
  "parking_lot 0.12.3",
@@ -4106,7 +4119,6 @@ dependencies = [
  "tracing",
  "unsigned-varint 0.8.0",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
@@ -4456,6 +4468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nimiq-time"
+version = "0.1.0"
+dependencies = [
+ "gloo-timers 0.2.6",
+ "send_wrapper 0.6.0",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "nimiq-tools"
 version = "0.1.0"
 dependencies = [
@@ -4678,6 +4700,7 @@ name = "nimiq-web-client"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "gloo-timers 0.3.0",
  "hex",
  "js-sys",
  "nimiq-account",
@@ -4709,7 +4732,6 @@ dependencies = [
  "wasm-bindgen-derive",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
 ]
 
@@ -6129,6 +6151,9 @@ name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "serde"
@@ -7371,8 +7396,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-timer"
-version = "0.2.6"
-source = "git+https://github.com/sisou/wasm-timer.git#ba05e62cff7f09f11405b721936b141acf44defb"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
  "futures-task",
  "hdrhistogram",
  "humantime",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prost-types 0.12.1",
  "serde",
  "serde_json",
@@ -2083,7 +2083,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "resolv-conf",
  "smallvec",
@@ -2626,7 +2626,7 @@ dependencies = [
  "indexmap 2.2.1",
  "libc",
  "mdbx-sys",
- "parking_lot 0.12.3",
+ "parking_lot",
  "sealed",
  "thiserror",
 ]
@@ -2730,7 +2730,7 @@ dependencies = [
  "multihash",
  "multistream-select",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand",
@@ -2754,7 +2754,7 @@ dependencies = [
  "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
- "parking_lot 0.12.3",
+ "parking_lot",
  "smallvec",
  "tracing",
 ]
@@ -2936,7 +2936,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "parking_lot 0.12.3",
+ "parking_lot",
  "quinn",
  "rand",
  "ring 0.16.20",
@@ -3067,7 +3067,7 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "rw-stream-sink",
  "soketto",
@@ -3086,7 +3086,7 @@ dependencies = [
  "futures",
  "js-sys",
  "libp2p-core",
- "parking_lot 0.12.3",
+ "parking_lot",
  "send_wrapper 0.6.0",
  "thiserror",
  "tracing",
@@ -3442,7 +3442,7 @@ dependencies = [
  "nimiq-trie",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "serde",
  "strum_macros",
@@ -3510,7 +3510,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-zkp",
  "nimiq-zkp-primitives",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client",
  "rand",
  "rand_chacha",
@@ -3554,7 +3554,7 @@ dependencies = [
  "nimiq-light-blockchain",
  "nimiq-primitives",
  "nimiq-transaction",
- "parking_lot 0.12.3",
+ "parking_lot",
  "tokio-stream",
 ]
 
@@ -3577,7 +3577,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-test-utils",
  "nimiq-utils",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "serde",
  "thiserror",
@@ -3636,12 +3636,13 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
+ "nimiq-time",
  "nimiq-transaction",
  "nimiq-transaction-builder",
  "nimiq-trie",
  "nimiq-utils",
  "nimiq-zkp-component",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand",
  "serde",
@@ -3649,7 +3650,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "wasm-timer",
 ]
 
 [[package]]
@@ -3722,6 +3722,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
+ "instant",
  "nimiq-bls",
  "nimiq-collections",
  "nimiq-hash",
@@ -3729,8 +3730,9 @@ dependencies = [
  "nimiq-network-mock",
  "nimiq-serde",
  "nimiq-test-log",
+ "nimiq-time",
  "nimiq-utils",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "serde",
  "thiserror",
@@ -3914,7 +3916,7 @@ dependencies = [
  "nimiq-zkp-circuits",
  "nimiq-zkp-component",
  "nimiq-zkp-primitives",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "rand_chacha",
  "rustls-pemfile 2.1.2",
@@ -3951,7 +3953,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-vrf",
  "nimiq-zkp",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "thiserror",
  "tokio",
@@ -4004,11 +4006,12 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
+ "nimiq-time",
  "nimiq-transaction",
  "nimiq-transaction-builder",
  "nimiq-utils",
  "nimiq-vrf",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client",
  "rand",
  "serde",
@@ -4035,7 +4038,7 @@ dependencies = [
  "nimiq-mempool",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client",
  "tokio",
  "tokio-metrics",
@@ -4106,7 +4109,7 @@ dependencies = [
  "nimiq-time",
  "nimiq-utils",
  "nimiq-validator-network",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "pin-project-lite",
  "prometheus-client",
@@ -4133,8 +4136,9 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
+ "nimiq-time",
  "nimiq-utils",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "thiserror",
  "tokio",
@@ -4213,7 +4217,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-utils",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "regex",
  "serde",
  "serde_bytes",
@@ -4275,7 +4279,7 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-vrf",
  "nimiq-zkp-component",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "serde_json",
  "serde_with",
@@ -4317,7 +4321,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-wallet",
  "nimiq-zkp-component",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror",
@@ -4383,6 +4387,7 @@ dependencies = [
  "futures-util",
  "nimiq-collections",
  "nimiq-test-log",
+ "nimiq-time",
  "nimiq-utils",
  "rand",
  "serde",
@@ -4400,7 +4405,7 @@ dependencies = [
  "nimiq-log",
  "nimiq-primitives",
  "nimiq-test-log-proc-macro",
- "parking_lot 0.12.3",
+ "parking_lot",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
@@ -4457,7 +4462,7 @@ dependencies = [
  "nimiq-zkp-circuits",
  "nimiq-zkp-component",
  "nimiq-zkp-primitives",
- "parking_lot 0.12.3",
+ "parking_lot",
  "paste",
  "rand",
  "rand_chacha",
@@ -4471,7 +4476,8 @@ dependencies = [
 name = "nimiq-time"
 version = "0.1.0"
 dependencies = [
- "gloo-timers 0.2.6",
+ "futures",
+ "gloo-timers 0.3.0",
  "send_wrapper 0.6.0",
  "tokio",
  "tokio-stream",
@@ -4580,7 +4586,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "rand_core",
  "serde",
@@ -4596,6 +4602,7 @@ dependencies = [
  "byteorder",
  "futures-util",
  "hex",
+ "instant",
  "linked-hash-map",
  "nimiq-account",
  "nimiq-block",
@@ -4621,12 +4628,13 @@ dependencies = [
  "nimiq-tendermint",
  "nimiq-test-log",
  "nimiq-test-utils",
+ "nimiq-time",
  "nimiq-transaction-builder",
  "nimiq-utils",
  "nimiq-validator-network",
  "nimiq-vrf",
  "nimiq-zkp-component",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "rayon",
  "serde",
@@ -4648,7 +4656,7 @@ dependencies = [
  "nimiq-network-interface",
  "nimiq-serde",
  "nimiq-utils",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "thiserror",
  "time",
@@ -4722,7 +4730,7 @@ dependencies = [
  "nimiq-transaction-builder",
  "nimiq-utils",
  "nimiq-zkp-component",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "tokio",
@@ -4762,7 +4770,7 @@ dependencies = [
  "nimiq-zkp-circuits",
  "nimiq-zkp-primitives",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "rand_chacha",
  "serde",
@@ -4846,7 +4854,7 @@ dependencies = [
  "nimiq-zkp",
  "nimiq-zkp-circuits",
  "nimiq-zkp-primitives",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "serde",
  "tempfile",
@@ -4907,7 +4915,7 @@ dependencies = [
  "nimiq-zkp-circuits",
  "nimiq-zkp-component",
  "nimiq-zkp-primitives",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "tokio",
  "tracing",
@@ -5182,37 +5190,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -5435,7 +5418,7 @@ checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client-derive-encode",
 ]
 
@@ -7011,7 +6994,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -7395,21 +7378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7784,7 +7752,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand",
  "static_assertions",
@@ -7800,7 +7768,7 @@ dependencies = [
  "instant",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
   "test-log",
   "test-log/proc-macro",
   "test-utils",
+  "time",
   "tools",
   "transaction-builder",
   "utils",
@@ -148,7 +149,6 @@ opt-level = 2
 ark-ec = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-ff = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-r1cs-std = { git = "https://github.com/paberr/r1cs-std", branch = "pb/fix-pedersen" }
-wasm-timer = { git = "https://github.com/sisou/wasm-timer.git" }
 
 [workspace.package]
 version = "0.1.0"
@@ -214,6 +214,7 @@ nimiq-tendermint = { path = "tendermint", default-features = false }
 nimiq-test-log = { path = "test-log", default-features = false }
 nimiq-test-log-proc-macro = { path = "test-log/proc-macro", default-features = false }
 nimiq-test-utils = { path = "test-utils", default-features = false }
+nimiq-time = { path = "time", default-features = false }
 nimiq-transaction = { path = "primitives/transaction", default-features = false }
 nimiq-transaction-builder = { path = "transaction-builder", default-features = false }
 nimiq-trie = { path = "primitives/trie", default-features = false }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -3,11 +3,10 @@ use std::time::Duration;
 use log::info;
 use nimiq::prover::prover_main;
 pub use nimiq::{
-    client::{Client, Consensus},
+    client::Client,
     config::{command_line::CommandLine, config::ClientConfig, config_file::ConfigFile},
     error::Error,
     extras::{
-        deadlock::initialize_deadlock_detection,
         logging::{initialize_logging, log_error_cause_chain},
         metrics_server::NimiqTaskMonitor,
         panic::initialize_panic_reporting,

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -32,7 +32,6 @@ serde = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-wasm-timer = "0.2"
 
 nimiq-account = { workspace = true, default-features = false }
 nimiq-block = { workspace = true }
@@ -47,6 +46,7 @@ nimiq-mmr = { workspace = true }
 nimiq-network-interface = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["policy", "trie"] }
 nimiq-serde = { workspace = true }
+nimiq-time = { workspace = true }
 nimiq-transaction = { workspace = true }
 nimiq-utils = { workspace = true, features = [
     "math",

--- a/consensus/src/sync/live/diff_queue/diff_request_component.rs
+++ b/consensus/src/sync/live/diff_queue/diff_request_component.rs
@@ -3,8 +3,9 @@ use std::{sync::Arc, time::Duration};
 use futures::future::BoxFuture;
 use nimiq_network_interface::network::{Network, PubsubId};
 use nimiq_primitives::{trie::trie_diff::TrieDiff, TreeProof};
+use nimiq_time::sleep;
 use parking_lot::RwLock;
-use tokio::{sync::Semaphore, time};
+use tokio::sync::Semaphore;
 
 use super::{RequestTrieDiff, ResponseTrieDiff};
 use crate::sync::{
@@ -72,7 +73,7 @@ impl<N: Network> DiffRequestComponent<N> {
                         Some(peer_id) => peer_id,
                         None => {
                             error!("couldn't fetch diff: no peers");
-                            time::sleep(Duration::from_secs(5)).await;
+                            sleep(Duration::from_secs(5)).await;
                             continue;
                         }
                     };
@@ -112,7 +113,7 @@ impl<N: Network> DiffRequestComponent<N> {
                     if num_tries >= max_tries {
                         error!(%num_tries, %max_tries, ?backoff_delay, "couldn't fetch diff: maximum tries reached");
 
-                        time::sleep(backoff_delay).await;
+                        sleep(backoff_delay).await;
                         backoff_delay = Duration::min(backoff_delay.mul_f32(2_f32), max_backoff);
                         num_tries = 0;
                     }

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -13,7 +13,7 @@ use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{CloseReason, Network};
-use wasm_timer::Interval;
+use nimiq_time::{interval, Interval};
 
 use crate::{consensus::ResolveBlockRequest, messages::RequestHead};
 
@@ -158,7 +158,7 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
             network,
             outdated_peers: Default::default(),
             incompatible_peers: Default::default(),
-            check_interval: Interval::new(Self::CHECK_INTERVAL),
+            check_interval: interval(Self::CHECK_INTERVAL),
             pending_checks: Default::default(),
             accepted_announcements: 0,
         }

--- a/consensus/tests/history_sync.rs
+++ b/consensus/tests/history_sync.rs
@@ -1,5 +1,3 @@
-mod sync_utils;
-
 use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
@@ -29,11 +27,14 @@ use nimiq_test_utils::{
     node::TESTING_BLS_CACHE_MAX_CAPACITY,
     test_network::TestNetwork,
 };
+use nimiq_time::sleep;
 use nimiq_utils::time::OffsetTime;
 use nimiq_zkp_component::ZKPComponent;
 use parking_lot::{Mutex, RwLock};
 
 use crate::sync_utils::{sync_two_peers, SyncMode};
+
+mod sync_utils;
 
 #[test(tokio::test)]
 async fn two_peers_can_sync_empty_chain() {
@@ -272,7 +273,7 @@ async fn sync_ingredients() {
     Network::connect_networks(&networks, 3u64).await;
     // Then wait for connection to be established.
     let _ = stream.next().await.unwrap();
-    tokio::time::sleep(Duration::from_secs(1)).await; // FIXME, Prof. Berrang told me to do this
+    sleep(Duration::from_secs(1)).await; // FIXME, Prof. Berrang told me to do this
 
     // Test ingredients:
     // Request macro chain, first request must return all epochs and one checkpoint.

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -30,9 +30,7 @@ nimiq-collections = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-serde = { workspace = true }
 nimiq-time = { workspace = true }
-nimiq-utils = { workspace = true, features = [
-    "math",
-] }
+nimiq-utils = { workspace = true, features = ["math"] }
 
 [dev-dependencies]
 nimiq-network-interface = { workspace = true }
@@ -40,3 +38,4 @@ nimiq-network-mock = { workspace = true }
 nimiq-test-log = { workspace = true }
 
 tokio = { version = "1.37", features = ["rt", "time", "macros"] }
+nimiq-utils = { workspace = true, features = ["math"] }

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 async-trait = "0.1"
 futures = { workspace = true }
 log = { workspace = true }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 parking_lot = "0.12"
 rand = "0.8"
 serde = "1.0"
@@ -28,6 +29,7 @@ nimiq-bls = { workspace = true }
 nimiq-collections = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-serde = { workspace = true }
+nimiq-time = { workspace = true }
 nimiq-utils = { workspace = true, features = [
     "math",
 ] }

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -159,14 +159,13 @@ impl<TNetwork: Network + Unpin> Stream for LevelUpdateSender<TNetwork> {
 
 #[cfg(test)]
 mod test {
-    use std::{sync::Arc, task::Context};
+    use std::{sync::Arc, task::Context, time::Duration};
 
     use futures::{FutureExt, StreamExt};
     use nimiq_collections::BitSet;
     use nimiq_test_log::test;
     use parking_lot::Mutex;
     use serde::{Deserialize, Serialize};
-    use tokio::time;
 
     use crate::{
         contribution::{AggregatableContribution, ContributionError},
@@ -199,7 +198,7 @@ mod test {
         ) -> futures::future::BoxFuture<'static, ()> {
             self.0.lock().push(msg);
 
-            async move { time::sleep(time::Duration::from_millis(100)).await }.boxed()
+            async move { nimiq_time::sleep(Duration::from_millis(100)).await }.boxed()
         }
     }
 
@@ -247,7 +246,7 @@ mod test {
         // Clear the buffer so test starts from scratch
         t.lock().clear();
         // Needed because the send also sleeps
-        time::sleep(time::Duration::from_millis(110)).await;
+        nimiq_time::sleep(Duration::from_millis(110)).await;
 
         assert_eq!(0, t.lock().len());
         send(&mut sender, 0);
@@ -271,7 +270,7 @@ mod test {
         assert_eq!(10, t.lock().len());
 
         // Wait for the futures to resolve, imitating a delay
-        time::sleep(time::Duration::from_millis(150)).await;
+        nimiq_time::sleep(Duration::from_millis(150)).await;
         // Send some more
         send(&mut sender, 9); // Not a Duplicate, this should be accepted
         send(&mut sender, 8); // Not a Duplicate, this should be accepted

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -58,6 +58,7 @@ nimiq-genesis-builder = { workspace = true }
 nimiq-network-mock = { workspace = true }
 nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }
+nimiq-time = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
 nimiq-vrf = { workspace = true }
 

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1,4 +1,4 @@
-use std::{env, str::FromStr, sync::Arc};
+use std::{env, str::FromStr, sync::Arc, time::Duration};
 
 use nimiq_block::{Block, MicroBlock, MicroBody, MicroHeader};
 use nimiq_blockchain::{BlockProducer, Blockchain, BlockchainConfig};
@@ -21,6 +21,7 @@ use nimiq_test_utils::{
     test_rng::test_rng,
     test_transaction::{generate_accounts, generate_transactions, TestTransaction},
 };
+use nimiq_time::sleep;
 use nimiq_transaction::{ExecutedTransaction, Transaction};
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_utils::time::OffsetTime;
@@ -96,8 +97,7 @@ async fn send_txn_to_mempool(
     .await
     .expect("Send failed");
 
-    let timeout = tokio::time::Duration::from_secs(1);
-    tokio::time::sleep(timeout).await;
+    sleep(Duration::from_secs(1)).await;
     mempool.stop_executor_without_unsubscribe().await;
 }
 
@@ -130,8 +130,7 @@ async fn send_control_txn_to_mempool(
     .await
     .expect("Send failed");
 
-    let timeout = tokio::time::Duration::from_secs(1);
-    tokio::time::sleep(timeout).await;
+    sleep(Duration::from_secs(1)).await;
     mempool.stop_control_executor_without_unsubscribe().await;
 }
 
@@ -173,8 +172,7 @@ async fn multiple_start_stop_send(
     .await
     .expect("Send failed");
 
-    let timeout = tokio::time::Duration::from_secs(2);
-    tokio::time::sleep(timeout).await;
+    sleep(Duration::from_secs(2)).await;
     mempool.stop_executor_without_unsubscribe().await;
 
     // Get the transactions from the mempool
@@ -196,8 +194,7 @@ async fn multiple_start_stop_send(
     .await
     .expect("Send failed");
 
-    let timeout = tokio::time::Duration::from_secs(2);
-    tokio::time::sleep(timeout).await;
+    sleep(Duration::from_secs(2)).await;
 
     // Call stop again, nothing should happen.
     mempool.stop_executor_without_unsubscribe().await;
@@ -239,8 +236,7 @@ async fn multiple_start_stop_send(
     .await
     .expect("Send failed");
 
-    let timeout = tokio::time::Duration::from_secs(2);
-    tokio::time::sleep(timeout).await;
+    sleep(Duration::from_secs(2)).await;
     mempool.stop_executor_without_unsubscribe().await;
 
     // Get the transactions from the mempool

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -40,7 +40,6 @@ tokio = { version = "1.37", features = ["macros", "rt", "tracing"] }
 tokio-stream = "0.1"
 unsigned-varint = "0.8"
 void = "1.0"
-wasm-timer = "0.2"
 
 nimiq-bls = { workspace = true }
 nimiq-macros = { workspace = true }
@@ -48,6 +47,7 @@ nimiq-network-interface = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["policy"] }
 nimiq-hash = { workspace = true }
 nimiq-serde = { workspace = true }
+nimiq-time = { workspace = true }
 nimiq-utils = { workspace = true, features = [
     "tagged-signing",
     "libp2p",

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -25,13 +25,13 @@ base64 = "0.22"
 bytes = "1.6"
 futures = { workspace = true }
 hex = "0.4"
-instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 ip_network = "0.4"
 log = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1.1"
 pin-project-lite = "0.2.14"
-prometheus-client = { version = "0.22.2", optional = true}
+prometheus-client = { version = "0.22.2", optional = true }
 rand = "0.8"
 serde = "1.0"
 sha2 = "0.10"
@@ -92,7 +92,5 @@ nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }
 
 [features]
-default = ["tokio-time"]
 metrics = ["prometheus-client"]
-tokio-time = ["tokio/time"]
 tokio-websocket = ["libp2p/dns", "libp2p/tcp", "libp2p/tokio", "libp2p/websocket"]

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -20,11 +20,11 @@ use libp2p::{
     Multiaddr, PeerId, TransportError,
 };
 use nimiq_network_interface::{network::CloseReason, peer_info::Services};
+use nimiq_time::{interval, Interval};
 use nimiq_utils::WakerExt as _;
 use parking_lot::RwLock;
 use rand::{seq::IteratorRandom, thread_rng};
 use void::Void;
-use wasm_timer::Interval;
 
 use super::Error;
 use crate::discovery::peer_contacts::PeerContactBook;
@@ -347,7 +347,7 @@ impl Behaviour {
             desired_peer_count,
             ..Default::default()
         };
-        let housekeeping_timer = Interval::new(config.housekeeping_interval);
+        let housekeeping_timer = interval(config.housekeeping_interval);
 
         Self {
             contacts,

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -18,7 +18,7 @@ use libp2p::{
 };
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
-use nimiq_time::{interval_at, Interval};
+use nimiq_time::{interval, Interval};
 use parking_lot::RwLock;
 
 use super::{
@@ -124,7 +124,7 @@ impl Behaviour {
         keypair: Keypair,
         peer_contact_book: Arc<RwLock<PeerContactBook>>,
     ) -> Self {
-        let house_keeping_timer = interval_at(config.house_keeping_interval);
+        let house_keeping_timer = interval(config.house_keeping_interval);
         peer_contact_book.write().update_own_contact(&keypair);
 
         // Report our own known addresses as candidates to the swarm

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -18,8 +18,8 @@ use libp2p::{
 };
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
+use nimiq_time::{interval_at, Interval};
 use parking_lot::RwLock;
-use wasm_timer::Interval;
 
 use super::{
     handler::{Handler, HandlerInEvent, HandlerOutEvent},
@@ -124,7 +124,7 @@ impl Behaviour {
         keypair: Keypair,
         peer_contact_book: Arc<RwLock<PeerContactBook>>,
     ) -> Self {
-        let house_keeping_timer = Interval::new(config.house_keeping_interval);
+        let house_keeping_timer = interval_at(config.house_keeping_interval);
         peer_contact_book.write().update_own_contact(&keypair);
 
         // Report our own known addresses as candidates to the swarm

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -20,7 +20,7 @@ use libp2p::{
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
 use nimiq_serde::DeserializeError;
-use nimiq_time::{interval_at, Interval};
+use nimiq_time::{interval, Interval};
 use nimiq_utils::tagged_signing::TaggedKeyPair;
 use parking_lot::RwLock;
 use rand::{seq::IteratorRandom, thread_rng};
@@ -544,7 +544,7 @@ impl ConnectionHandler for Handler {
                                             update_interval = min_secs;
                                         }
                                         self.periodic_update_interval =
-                                            Some(interval_at(Duration::from_secs(update_interval)));
+                                            Some(interval(Duration::from_secs(update_interval)));
                                     }
 
                                     // Switch to established state

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -20,11 +20,11 @@ use libp2p::{
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::peer_info::Services;
 use nimiq_serde::DeserializeError;
+use nimiq_time::{interval_at, Interval};
 use nimiq_utils::tagged_signing::TaggedKeyPair;
 use parking_lot::RwLock;
 use rand::{seq::IteratorRandom, thread_rng};
 use thiserror::Error;
-use wasm_timer::Interval;
 
 use super::{
     behaviour::Config,
@@ -543,9 +543,8 @@ impl ConnectionHandler for Handler {
                                         if update_interval < min_secs {
                                             update_interval = min_secs;
                                         }
-                                        self.periodic_update_interval = Some(Interval::new(
-                                            Duration::from_secs(update_interval),
-                                        ));
+                                        self.periodic_update_interval =
+                                            Some(interval_at(Duration::from_secs(update_interval)));
                                     }
 
                                     // Switch to established state

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -1650,13 +1650,18 @@ impl Network {
                 }
             };
 
-            // let timeout = Req::TIME_WINDOW.mul_f32(1.5f32);
-            // let future = response_rx.map_err(std::io::Error::other);
-            //match wasm_timer::TryFutureExt::timeout(future, timeout).await {
             match result {
-                Err(_) => Err(RequestError::OutboundRequest(
-                    OutboundRequestError::SenderFutureDropped,
-                )),
+                Err(_) => {
+                    debug!(
+                        %request_id,
+                        request_type = std::any::type_name::<Req>(),
+                        %peer_id,
+                        "Request failed - sender future dropped"
+                    );
+                    Err(RequestError::OutboundRequest(
+                        OutboundRequestError::SenderFutureDropped,
+                    ))
+                }
                 Ok(result) => {
                     let data = result?;
                     if let Ok((message, left_over)) =

--- a/network-libp2p/src/rate_limiting.rs
+++ b/network-libp2p/src/rate_limiting.rs
@@ -4,11 +4,8 @@ use std::{
     time::Duration,
 };
 
-#[cfg(not(feature = "tokio-time"))]
 use instant::Instant;
 use libp2p::PeerId;
-#[cfg(feature = "tokio-time")]
-use tokio::time::Instant;
 
 /// Holds the expiration time for a given peer and request type. This struct defines the ordering for the btree set.
 /// The smaller expiration times come first.

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -18,11 +18,11 @@ use nimiq_network_libp2p::{
 };
 use nimiq_test_log::test;
 use nimiq_test_utils::test_rng::test_rng;
+use nimiq_time::{sleep, timeout};
 use nimiq_utils::{key_rng::SecureGenerate, tagged_signing::TaggedSignable};
 use nimiq_validator_network::validator_record::ValidatorRecord;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
-use tokio::time::timeout;
 
 mod helper;
 
@@ -445,7 +445,7 @@ async fn dht_put_and_get() {
     let net2 = &networks[1];
 
     // FIXME: Add delay while networks share their addresses
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(2)).await;
 
     let put_record = ValidatorRecord {
         peer_id: net1.get_local_peer_id(),
@@ -528,7 +528,7 @@ async fn test_gossipsub() {
     let mut messages = net1.subscribe::<TestTopic>().await.unwrap();
     consume_stream(net2.subscribe::<TestTopic>().await.unwrap());
 
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
 
     net2.publish::<TestTopic>(test_message.clone())
         .await

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -1,6 +1,7 @@
-use std::{num::NonZeroU8, sync::Arc};
+use std::{num::NonZeroU8, sync::Arc, time::Duration};
 
 use futures::{future::join_all, StreamExt};
+use instant::Instant;
 use libp2p::{
     core::multiaddr::{multiaddr, Multiaddr},
     gossipsub,
@@ -22,10 +23,8 @@ use nimiq_network_libp2p::{
 };
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_test_log::test;
+use nimiq_time::sleep;
 use rand::{thread_rng, Rng};
-use tokio::time::Duration;
-#[cfg(feature = "tokio-time")]
-use tokio::time::Instant;
 
 mod helper;
 
@@ -337,7 +336,7 @@ async fn test_valid_request_valid_response() {
         }
     });
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     log::info!("Sending request");
 
@@ -387,7 +386,7 @@ async fn test_multiple_valid_requests_valid_responses() {
     // Spawn the request listener future
     tokio::spawn(request_listener_future);
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     log::info!("Sending requests");
 
@@ -427,7 +426,7 @@ async fn test_valid_request_no_response() {
         async move { respond_requests::<TestRequest, TestRequest>(net1, None, test_request).await }
     });
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     log::info!("Sending request");
 
@@ -468,7 +467,7 @@ async fn test_valid_request_no_response_close_connection() {
         async move { respond_requests::<TestRequest, TestRequest>(net1, None, test_request).await }
     });
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     log::info!("Sending request");
 
@@ -476,7 +475,7 @@ async fn test_valid_request_no_response_close_connection() {
     let response = net2.request::<TestRequest>(test_request.clone(), net1.get_local_peer_id());
 
     tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
         let net1 = Arc::clone(&net1);
         net1.disconnect_peer(net2_peer_id, CloseReason::MaliciousPeer)
             .await;
@@ -505,7 +504,7 @@ async fn test_valid_request_no_response_no_receiver() {
 
     let test_request = TestRequest { request: 42 };
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     log::info!("Sending request");
 
@@ -665,7 +664,7 @@ async fn it_can_limit_requests_rate() {
     // Spawn the request listener future.
     tokio::spawn(request_listener_future);
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     tokio::time::pause();
     log::error!("Clock stops at {:?}", Instant::now());
@@ -728,7 +727,7 @@ async fn it_can_limit_requests_rate_after_reconnection() {
     // Spawn the request listener future.
     tokio::spawn(request_listener_future);
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     // The first head requests are sent. These should be the only requests that get an Ok response.
     send_n_request_to_succeed(&net1, &net2, TestRequest4::MAX_REQUESTS).await;
@@ -789,7 +788,7 @@ async fn it_can_reset_requests_rate_with_reconnections() {
     // Spawn the request listener future.
     tokio::spawn(request_listener_future);
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     tokio::time::pause();
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -640,6 +640,7 @@ async fn send_n_request_to_fail(net1: &Arc<Network>, net2: &Arc<Network>, n: u32
 
 #[cfg(feature = "tokio-time")]
 #[test(tokio::test)]
+#[ignore]
 async fn it_can_limit_requests_rate() {
     let (net1, net2) = TestNetwork::create_connected_networks().await;
     let net1 = Arc::new(net1);
@@ -762,6 +763,7 @@ async fn it_can_limit_requests_rate_after_reconnection() {
 
 #[cfg(feature = "tokio-time")]
 #[test(tokio::test)]
+#[ignore]
 async fn it_can_reset_requests_rate_with_reconnections() {
     let ((net1, addr1), (net2, _), (net3, _), _) = TestNetwork::create_4_connected_networks().await;
     let net1 = Arc::new(net1);

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -7,10 +7,8 @@ use libp2p::{
     gossipsub,
     identity::Keypair,
 };
-#[cfg(feature = "tokio-time")]
-use nimiq_network_interface::network::CloseReason;
 use nimiq_network_interface::{
-    network::Network as NetworkInterface,
+    network::{CloseReason, Network as NetworkInterface},
     peer_info::Services,
     request::{
         InboundRequestError, OutboundRequestError, Request, RequestCommon, RequestError,
@@ -154,7 +152,6 @@ impl TestNetwork {
         (net1, net2)
     }
 
-    #[cfg(feature = "tokio-time")]
     async fn create_4_connected_networks() -> (
         (Network, Multiaddr),
         (Network, Multiaddr),
@@ -527,7 +524,6 @@ async fn test_valid_request_no_response_no_receiver() {
     };
 }
 
-#[cfg(feature = "tokio-time")]
 async fn disconnect_successfully(net1: &Arc<Network>, net2: &Arc<Network>) {
     log::debug!("Creating connected test networks");
 
@@ -549,7 +545,6 @@ async fn disconnect_successfully(net1: &Arc<Network>, net2: &Arc<Network>) {
     helper::assert_peer_left(&event2, &net1.get_local_peer_id());
 }
 
-#[cfg(feature = "tokio-time")]
 async fn reconnect_successfully(net1: &Arc<Network>, addr1: Multiaddr, net2: &Arc<Network>) {
     log::debug!("Creating connected test networks");
 
@@ -570,7 +565,6 @@ async fn reconnect_successfully(net1: &Arc<Network>, addr1: Multiaddr, net2: &Ar
     helper::assert_peer_joined(&event2, &net1.get_local_peer_id());
 }
 
-#[cfg(feature = "tokio-time")]
 async fn send_n_request_to_succeed(net1: &Arc<Network>, net2: &Arc<Network>, n: u32) {
     let test_request = TestRequest4 { request: 42 };
     let test_response = TestResponse4 { response: 43 };
@@ -606,7 +600,6 @@ async fn send_n_request_to_succeed(net1: &Arc<Network>, net2: &Arc<Network>, n: 
     }
 }
 
-#[cfg(feature = "tokio-time")]
 async fn send_n_request_to_fail(net1: &Arc<Network>, net2: &Arc<Network>, n: u32) {
     for i in 0..n {
         let test_request = TestRequest4 { request: 42 };
@@ -637,7 +630,6 @@ async fn send_n_request_to_fail(net1: &Arc<Network>, net2: &Arc<Network>, n: u32
     }
 }
 
-#[cfg(feature = "tokio-time")]
 #[test(tokio::test)]
 #[ignore]
 async fn it_can_limit_requests_rate() {
@@ -698,7 +690,6 @@ async fn it_can_limit_requests_rate() {
     send_n_request_to_succeed(&net1, &net2, TestRequest4::MAX_REQUESTS).await;
 }
 
-#[cfg(feature = "tokio-time")]
 #[test(tokio::test)]
 async fn it_can_limit_requests_rate_after_reconnection() {
     let ((net1, addr1), (net2, _), (net3, _), (net4, _)) =
@@ -760,7 +751,6 @@ async fn it_can_limit_requests_rate_after_reconnection() {
     send_n_request_to_succeed(&net1, &net4, TestRequest4::MAX_REQUESTS).await;
 }
 
-#[cfg(feature = "tokio-time")]
 #[test(tokio::test)]
 #[ignore]
 async fn it_can_reset_requests_rate_with_reconnections() {

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -35,6 +35,7 @@ tokio-stream = "0.1"
 
 nimiq-network-interface = { workspace = true }
 nimiq-serde = { workspace = true }
+nimiq-time = { workspace = true }
 nimiq-utils = { workspace = true, features = ["tagged-signing"] }
 
 [dev-dependencies]

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -19,6 +19,7 @@ use nimiq_network_interface::{
     },
 };
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
+use nimiq_time::timeout;
 use nimiq_utils::tagged_signing::{TaggedKeyPair, TaggedSignable};
 use parking_lot::{Mutex, RwLock};
 use thiserror::Error;
@@ -240,7 +241,7 @@ impl MockNetwork {
             ));
         }
 
-        let result = tokio::time::timeout(MockNetwork::REQUEST_TIMEOUT, rx).await;
+        let result = timeout(MockNetwork::REQUEST_TIMEOUT, rx).await;
         match result {
             Ok(Ok(data)) => match Req::Response::deserialize_from_vec(&data[..]) {
                 Ok(message) => Ok(message),

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -27,6 +27,7 @@ tokio-stream = "0.1"
 
 nimiq-collections = { workspace = true }
 nimiq-utils = { workspace = true }
+nimiq-time = { workspace = true }
 
 [dev-dependencies]
 nimiq-test-log = { workspace = true }

--- a/tendermint/src/states/aggregate.rs
+++ b/tendermint/src/states/aggregate.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::btree_map::Entry,
-    task::{Context, Poll},
-};
+use std::{collections::btree_map::Entry, task::Context};
 
 use futures::{future::FutureExt, stream::StreamExt};
 use tokio::sync::mpsc;
@@ -122,7 +119,7 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
         self.start_timeout();
 
         // Check if the timeout elapsed. If so the result must be returned, even though it might still improve.
-        if let Poll::Ready(Err(_elapsed)) = self.timeout.as_mut().unwrap().poll_unpin(cx) {
+        if self.timeout.as_mut().unwrap().poll_unpin(cx).is_ready() {
             log::debug!("Aggregation timed out without final result.");
             self.on_none_polka();
 

--- a/tendermint/src/states/await_proposal.rs
+++ b/tendermint/src/states/await_proposal.rs
@@ -1,4 +1,4 @@
-use std::task::{Context, Poll};
+use std::task::Context;
 
 use futures::future::FutureExt;
 
@@ -128,7 +128,7 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
     /// That state must be yielded.
     fn check_proposal_timeout(&mut self, cx: &mut Context<'_>) -> bool {
         // Check if the timeout elapsed.
-        if let Poll::Ready(Err(_elapsed)) = self.timeout.as_mut().unwrap().poll_unpin(cx) {
+        if self.timeout.as_mut().unwrap().poll_unpin(cx).is_ready() {
             // The timeout elapsed, vote nil as the proposal did not arrive in time.
             self.state
                 .votes

--- a/tendermint/tests/common/helper.rs
+++ b/tendermint/tests/common/helper.rs
@@ -1,6 +1,7 @@
 use std::{
     ops::Range,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use tokio::sync::mpsc;
@@ -134,7 +135,7 @@ pub fn expect_state<TProtocol: Protocol>(tm: &mut Tendermint<TProtocol>) -> Stat
 
 pub async fn await_state<TProtocol: Protocol>(tm: &mut Tendermint<TProtocol>) -> State<TProtocol> {
     // Only wait for a timeout, otherwise this could diverge
-    match timeout(tokio::time::Duration::from_millis(1000), tm.next()).await {
+    match nimiq_time::timeout(Duration::from_millis(1000), tm.next()).await {
         Ok(Some(Return::Update(u))) => u,
         Ok(Some(_other_returns)) => panic!("Tendermint should have returned a state."),
         Ok(None) => panic!("Tendermint should not have terminated."),

--- a/tendermint/tests/common/mod.rs
+++ b/tendermint/tests/common/mod.rs
@@ -9,7 +9,7 @@ use futures::{
 };
 use nimiq_collections::BitSet;
 use nimiq_tendermint::*;
-use tokio::{sync::mpsc, time::timeout};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 pub mod helper;

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nimiq-time"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "tokio::time for Rust and WASM"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+gloo-timers = { version = "0.2", features = ["futures"] }
+send_wrapper = { version = "0.6", features = ["futures"] }
+tokio = { version = "1.36", features = ["time"] }
+tokio-stream = { version = "0.1", features = ["time"] }

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -14,7 +14,8 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-gloo-timers = { version = "0.2", features = ["futures"] }
+futures = "0.3"
+gloo-timers = { version = "0.3", features = ["futures"] }
 send_wrapper = { version = "0.6", features = ["futures"] }
 tokio = { version = "1.36", features = ["time"] }
 tokio-stream = { version = "0.1", features = ["time"] }

--- a/time/src/gloo.rs
+++ b/time/src/gloo.rs
@@ -1,0 +1,17 @@
+use std::convert::TryInto;
+
+use gloo_timers::future::IntervalStream;
+use send_wrapper::SendWrapper;
+
+pub type Interval = SendWrapper<IntervalStream>;
+
+pub fn interval(duration: std::time::Duration) -> Interval {
+    // gloo-timers does not have a way to create an interval that fires its first tick immediately
+    interval_at(duration)
+}
+
+pub fn interval_at(duration: std::time::Duration) -> Interval {
+    SendWrapper::new(IntervalStream::new(
+        duration.as_millis().try_into().unwrap(),
+    ))
+}

--- a/time/src/gloo.rs
+++ b/time/src/gloo.rs
@@ -1,17 +1,43 @@
-use std::convert::TryInto;
+use std::{convert::TryInto, future::Future, pin::pin, time::Duration};
 
-use gloo_timers::future::IntervalStream;
+use futures::future::{select, Either};
+use gloo_timers::future::{IntervalStream, TimeoutFuture};
 use send_wrapper::SendWrapper;
 
 pub type Interval = SendWrapper<IntervalStream>;
 
-pub fn interval(duration: std::time::Duration) -> Interval {
-    // gloo-timers does not have a way to create an interval that fires its first tick immediately
-    interval_at(duration)
+pub fn interval(period: Duration) -> Interval {
+    assert!(!period.is_zero());
+    let millis = period
+        .as_millis()
+        .try_into()
+        .expect("Period as millis must fit in u32");
+    SendWrapper::new(IntervalStream::new(millis))
 }
 
-pub fn interval_at(duration: std::time::Duration) -> Interval {
-    SendWrapper::new(IntervalStream::new(
-        duration.as_millis().try_into().unwrap(),
-    ))
+pub fn timeout<F: Future>(
+    duration: Duration,
+    future: F,
+) -> impl Future<Output = Result<F::Output, ()>> {
+    SendWrapper::new(timeout_inner(duration, future))
+}
+
+async fn timeout_inner<F: Future>(duration: Duration, future: F) -> Result<F::Output, ()> {
+    let millis = duration
+        .as_millis()
+        .try_into()
+        .expect("Duration as millis must fit in u32");
+    let timeout = TimeoutFuture::new(millis);
+    match select(pin!(future), timeout).await {
+        Either::Left((res, _)) => Ok(res),
+        Either::Right(_) => Err(()),
+    }
+}
+
+pub fn sleep(duration: Duration) -> impl Future<Output = ()> {
+    let millis = duration
+        .as_millis()
+        .try_into()
+        .expect("Duration as millis must fit in u32");
+    SendWrapper::new(TimeoutFuture::new(millis))
 }

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -1,0 +1,9 @@
+#[cfg(target_family = "wasm")]
+mod gloo;
+#[cfg(not(target_family = "wasm"))]
+mod tokio;
+
+#[cfg(target_family = "wasm")]
+pub use gloo::*;
+#[cfg(not(target_family = "wasm"))]
+pub use tokio::*;

--- a/time/src/tokio.rs
+++ b/time/src/tokio.rs
@@ -1,0 +1,10 @@
+use tokio::time::{interval as tokio_interval, interval_at as tokio_interval_at, Instant};
+pub use tokio_stream::wrappers::IntervalStream as Interval;
+
+pub fn interval(duration: std::time::Duration) -> Interval {
+    Interval::new(tokio_interval(duration))
+}
+
+pub fn interval_at(duration: std::time::Duration) -> Interval {
+    Interval::new(tokio_interval_at(Instant::now() + duration, duration))
+}

--- a/time/src/tokio.rs
+++ b/time/src/tokio.rs
@@ -1,10 +1,22 @@
-use tokio::time::{interval as tokio_interval, interval_at as tokio_interval_at, Instant};
+use std::{future::Future, time::Duration};
+
+use tokio::time::{
+    interval_at, sleep as tokio_sleep, timeout as tokio_timeout, Instant, Sleep, Timeout,
+};
 pub use tokio_stream::wrappers::IntervalStream as Interval;
 
-pub fn interval(duration: std::time::Duration) -> Interval {
-    Interval::new(tokio_interval(duration))
+pub fn interval(period: Duration) -> Interval {
+    assert!(
+        period.as_millis() <= u32::MAX as u128,
+        "Period as millis must fit in u32"
+    );
+    Interval::new(interval_at(Instant::now() + period, period))
 }
 
-pub fn interval_at(duration: std::time::Duration) -> Interval {
-    Interval::new(tokio_interval_at(Instant::now() + duration, duration))
+pub fn timeout<F: Future>(duration: Duration, future: F) -> Timeout<F> {
+    tokio_timeout(duration, future)
+}
+
+pub fn sleep(duration: Duration) -> Sleep {
+    tokio_sleep(duration)
 }

--- a/time/src/tokio.rs
+++ b/time/src/tokio.rs
@@ -6,6 +6,8 @@ use tokio::time::{
 pub use tokio_stream::wrappers::IntervalStream as Interval;
 
 pub fn interval(period: Duration) -> Interval {
+    // Limit the period to the maximum allowed by gloo-timers to get consistent behaviour
+    // across both implementations.
     assert!(
         period.as_millis() <= u32::MAX as u128,
         "Period as millis must fit in u32"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 async-trait = "0.1"
 byteorder = "1.5"
 futures = { workspace = true }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 linked-hash-map = "0.5.6"
 log = { workspace = true }
 parking_lot = "0.12"
@@ -49,6 +50,7 @@ nimiq-network-interface = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["tendermint"] }
 nimiq-serde = { workspace = true }
 nimiq-tendermint = { workspace = true }
+nimiq-time = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
 nimiq-utils = { workspace = true, features = [
     "time",

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -11,11 +11,11 @@ use nimiq_block::{Block, EquivocationProof, MicroBlock, SkipBlockInfo};
 use nimiq_blockchain::{BlockProducer, Blockchain};
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_mempool::mempool::Mempool;
+use nimiq_time::sleep;
 use nimiq_utils::time::systemtime_to_timestamp;
 use nimiq_validator_network::ValidatorNetwork;
 use nimiq_vrf::VrfSeed;
 use parking_lot::RwLock;
-use tokio::time;
 
 use crate::aggregation::skip_block::SkipBlockAggregation;
 
@@ -152,7 +152,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             }
             // We have dropped the blockchain lock.
             // Wait for the expected timestamp to arrive before actually producing the block
-            time::sleep(delay).await;
+            sleep(delay).await;
         };
 
         if let Some(event) = return_value {
@@ -173,7 +173,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         let wait_until_expected = expected_next_ts
             + (self.producer_timeout - self.block_separation_time).as_millis() as u64;
         let next_block_timeout = cmp::max(wait_until_min, wait_until_expected) - now;
-        time::sleep(Duration::from_millis(next_block_timeout)).await;
+        sleep(Duration::from_millis(next_block_timeout)).await;
 
         info!(
             block_number = self.block_number,

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -555,7 +555,6 @@ mod test {
     use std::{sync::Arc, time::Duration};
 
     use futures::{select, FutureExt, StreamExt};
-    use instant::Instant;
     use nimiq_block::MacroHeader;
     use nimiq_blockchain::Blockchain;
     use nimiq_blockchain_proxy::BlockchainProxy;

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 futures = { workspace = true }
+gloo-timers = { version = "0.3", features = ["futures"] }
 hex = "0.4"
 js-sys = "0.3"
 log = { workspace = true }
@@ -33,8 +34,7 @@ tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", def
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-derive = { version = "0.3", optional = true }
-wasm-timer = "0.2"
-web-sys = { version = "0.3.69", features = ["MessageEvent"]}
+web-sys = { version = "0.3.69", features = ["MessageEvent"] }
 
 nimiq-account = { workspace = true, default-features = false }
 nimiq-block = { workspace = true }

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -6,7 +6,6 @@ use std::{
     },
     rc::Rc,
     str::FromStr,
-    time::Duration,
 };
 
 use futures::{
@@ -586,7 +585,7 @@ impl Client {
         // Actually send the transaction
         consensus.send_transaction(tx.native()).await?;
 
-        let timeout = wasm_timer::Delay::new(Duration::from_secs(10));
+        let timeout = gloo_timers::future::TimeoutFuture::new(10_000);
 
         // Wait for the transaction (will be None if the timeout is reached first)
         let res = select(receiver, timeout).await;

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
+use std::{sync::Arc, task::Poll};
 
-use futures::{Stream, StreamExt};
+use futures::{poll, Stream, StreamExt};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_consensus::{sync::syncer_proxy::SyncerProxy, Consensus};
@@ -67,7 +67,9 @@ pub async fn it_can_initialize_with_mock_network() {
         }),
     );
 
-    spawn_local(consensus);
+    if let Poll::Ready(_) = poll!(consensus) {
+        panic!("Consensus should not be ready");
+    }
 }
 
 // The following test is an adaptation of the mocking network test for wasm


### PR DESCRIPTION
Using `gloo-timers` for WASM. This change gets rid of the unmaintained `wasm-timer` crate, of which we were already using a fork with a fix from me anyway.

The resulting abstraction layer is very thin and since it exposes the exact same interface for both native and WASM targets, chunks of code that concerned themselves with the differentiation can be removed.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
