### PR TITLE
Fix some clippy warnings

### DIFF
--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -491,6 +491,7 @@ impl GenesisBuilder {
         info!(path = %block_path.display(), "Writing block to");
         let mut file = OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .open(&block_path)?;
         block.serialize_to_writer(&mut file)?;
@@ -499,6 +500,7 @@ impl GenesisBuilder {
         info!(path = %accounts_path.display(), "Writing accounts to");
         let mut file = OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .open(&accounts_path)?;
         accounts.serialize_to_writer(&mut file)?;

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -380,7 +380,7 @@ impl PeerContactBook {
     /// Gets a peer contact if it exists given its peer_id.
     /// If the peer_id is not found, `None` is returned.
     pub fn get(&self, peer_id: &PeerId) -> Option<Arc<PeerContactInfo>> {
-        self.peer_contacts.get(peer_id).map(Arc::clone)
+        self.peer_contacts.get(peer_id).cloned()
     }
 
     /// Gets the peer contact's addresses if it exists given its peer_id.

--- a/primitives/src/trie/trie_proof.rs
+++ b/primitives/src/trie/trie_proof.rs
@@ -38,7 +38,7 @@ pub struct TrieProof {
 }
 
 #[derive(Debug)]
-pub struct Error(&'static str);
+pub struct Error(pub &'static str);
 
 impl TrieProof {
     pub fn new(

--- a/utils/src/file_store.rs
+++ b/utils/src/file_store.rs
@@ -43,6 +43,7 @@ impl FileStore {
         let file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&self.path)?;
         let mut buf_writer = BufWriter::new(file);
         Serialize::serialize(item, &mut buf_writer)?;


### PR DESCRIPTION
Fix some clippy warnings that appeared after the upgrade to version 1.77 of `rust` stable in the following subcrates:
- `genesis-builder`
- `network-libp2p`
- `primitives`
- `utils`

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
