### PR TITLE
Fix in validity window condition log

### DIFF
--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -250,13 +250,15 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                             if Policy::epoch_at(verifier_block_number)
                                 < Policy::epoch_at(latest_macro_head_number)
                             {
-                                // If the new macro head belongs to the next epoch, we still need to finish syncing the current epoch.
-                                log::debug!(
-                                    new_macro_head = latest_macro_head_number,
-                                    new_epoch = Policy::epoch_at(latest_macro_head_number),
-                                    "We have a new macro head that belongs to the next epoch"
-                                );
-                                peer_request.election_in_window = true;
+                                if !peer_request.election_in_window {
+                                    // If the new macro head belongs to the next epoch, we still need to finish syncing the current epoch.
+                                    log::debug!(
+                                        new_macro_head = latest_macro_head_number,
+                                        new_epoch = Policy::epoch_at(latest_macro_head_number),
+                                        "We have a new macro head that belongs to the next epoch"
+                                    );
+                                    peer_request.election_in_window = true;
+                                }
                             } else {
                                 log::debug!(new_macro_head=latest_macro_head_number, new_history_root=%latest_history_root, current_epoch = Policy::epoch_at(latest_macro_head_number), "We have a new macro head, updating the validity sync target for our current epoch");
                                 verifier_block_number = latest_macro_head_number;


### PR DESCRIPTION
When a new macro head was adopted, a log message was continuously printed while syncing the previous epoch.
Changed the condition such that this log message is only printed once.



## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
