### PR TITLE
genesis: Fix network ID for `NetworkId::Main`

### DIFF
--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -175,7 +175,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                 }
             }
             static INFO: NetworkInfo = NetworkInfo {
-                network_id: NetworkId::UnitAlbatross,
+                network_id: NetworkId::MainAlbatross,
                 name: "main-albatross",
                 genesis: include!(concat!(
                     env!("OUT_DIR"),


### PR DESCRIPTION
Fix network ID for `NetworkId::Main` as it was using `NetworkId::UnitAlbatross` instead of `NetworkId::MainAlbatross`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
