### PR TITLE
pow-migration: Allow stakers to increase stake and switch validators

### DIFF
--- a/pow-migration/src/state/mod.rs
+++ b/pow-migration/src/state/mod.rs
@@ -183,7 +183,10 @@ pub async fn get_validators(
             .or_insert(vec![txn]);
     }
     // First look for the 6 transactions that carries the validator data
-    for (_, txns) in txns_by_sender.iter() {
+    for (_, txns) in txns_by_sender.iter_mut() {
+        // First sort the transactions by this sender by timestamp
+        txns.sort_by_cached_key(|transaction| transaction.timestamp);
+
         let mut signing_key = SchnorrPublicKey::default();
         let mut address: Address = Address::default();
         let mut voting_key = vec![vec![0u8]; 5];


### PR DESCRIPTION
- Check that the registered stakers and stakers created from validator deposits that exceed the validator minimum deposit are always greater than the minimum stake. Otherwise keep them as burnt coins.
- Use the total balance used to register stakers and validators to decrease it from the burn address balance in the PoS genesis in order to preserve the total supply from the PoW chain.
- Allow stakers to increase stake and switch validators by ordering the transactions per sender, then keeping track of stakers being added and then increasing the staker and/or updating the delegation if there were previous valid transactions.
  This closes #2352, closes #2353 and closes #2362.
- Sort the possible validator registration transactions by timestamp before parsing them.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
