### PR TITLE
Light History Store for full nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,7 +3601,6 @@ version = "0.1.0"
 dependencies = [
  "futures-util",
  "hex",
- "itertools 0.10.5",
  "nimiq-account",
  "nimiq-block",
  "nimiq-blockchain-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,6 +3601,7 @@ version = "0.1.0"
 dependencies = [
  "futures-util",
  "hex",
+ "itertools 0.10.5",
  "nimiq-account",
  "nimiq-block",
  "nimiq-blockchain-interface",

--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -150,7 +150,7 @@ impl BlockProducer {
 
         let (history_root, _) = blockchain
             .history_store
-            .add_to_history(&mut txn, Policy::epoch_at(block_number), &hist_txs)
+            .add_to_history(&mut txn, block_number, &hist_txs)
             .expect("Failed to compute history root during block production.");
 
         // Not strictly necessary to drop the lock here, but sign as well as compress might be somewhat expensive
@@ -327,7 +327,7 @@ impl BlockProducer {
 
         macro_block.header.history_root = blockchain
             .history_store
-            .add_to_history(&mut txn, Policy::epoch_at(block_number), &hist_txs)
+            .add_to_history(&mut txn, block_number, &hist_txs)
             .expect("Failed to compute history root during block production.")
             .0;
 

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -97,11 +97,8 @@ impl Blockchain {
     pub fn extend_validity_sync(
         this: RwLockUpgradableReadGuard<Blockchain>,
         history: &[HistoricTransaction],
-    ) -> Option<Blake2bHash> {
+    ) -> Blake2bHash {
         let mut txn = this.write_transaction();
-
-        //let mut txns_per_block: HashMap<u32, Vec<HistoricTransaction>> = HashMap::new();
-
         let mut txns_per_block: BTreeMap<u32, Vec<HistoricTransaction>> = BTreeMap::new();
 
         for txn in history {
@@ -128,7 +125,7 @@ impl Blockchain {
         }
 
         txn.commit();
-        Some(root)
+        root
     }
 
     /// Extends the current chain with a macro block (election or checkpoint) during history sync.

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -169,7 +169,7 @@ impl Blockchain {
         // Verify the history root when we have the full transaction history of the epoch.
         let real_history_root = self
             .history_store
-            .get_history_tree_root(block.epoch_number(), Some(txn))
+            .get_history_tree_root(block.block_number(), Some(txn))
             .ok_or_else(|| {
                 error!(
                     %block,

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -678,7 +678,10 @@ impl HistoryInterface for HistoryStore {
 
         for hist_tx in ext_hash_vec {
             // If the transaction is inside the validity window, return true.
-            if hist_tx.block_number >= validity_window_start {
+            if hist_tx.block_number >= validity_window_start
+                && hist_tx.block_number
+                    <= validity_window_start + Policy::transaction_validity_window_blocks()
+            {
                 return true;
             }
         }
@@ -1194,7 +1197,7 @@ impl HistoryInterface for HistoryStore {
     ) -> Option<(Blake2bHash, u64)> {
         match block {
             nimiq_block::Block::Macro(macro_block) => {
-                // Store the transactions and the inherents into the History tree.
+                // Store the the inherents into the History tree.
                 let hist_txs = HistoricTransaction::from(
                     self.network_id,
                     macro_block.header.block_number,

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1257,9 +1257,17 @@ impl HistoryInterface for HistoryStore {
         Some(total_size)
     }
 
-    fn history_store_range(&self) -> (u32, u32) {
-        let read_txn = self.db.read_transaction();
-        let mut cursor = read_txn.cursor(&self.last_leaf_table);
+    fn history_store_range(&self, txn_option: Option<&TransactionProxy>) -> (u32, u32) {
+        let read_txn: TransactionProxy;
+        let txn = match txn_option {
+            Some(txn) => txn,
+            None => {
+                read_txn = self.db.read_transaction();
+                &read_txn
+            }
+        };
+
+        let mut cursor = txn.cursor(&self.last_leaf_table);
 
         let first = if let Some((key, _)) = cursor.first::<u32, u32>() {
             key

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1256,6 +1256,25 @@ impl HistoryInterface for HistoryStore {
 
         Some(total_size)
     }
+
+    fn history_store_range(&self) -> (u32, u32) {
+        let read_txn = self.db.read_transaction();
+        let mut cursor = read_txn.cursor(&self.last_leaf_table);
+
+        let first = if let Some((key, _)) = cursor.first::<u32, u32>() {
+            key
+        } else {
+            0
+        };
+
+        let last = if let Some((key, _)) = cursor.last::<u32, u32>() {
+            key
+        } else {
+            0
+        };
+
+        (first, last)
+    }
 }
 
 #[cfg(test)]

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -55,6 +55,9 @@ pub trait HistoryInterface {
     fn total_len_at_epoch(&self, epoch_number: u32, txn_option: Option<&TransactionProxy>)
         -> usize;
 
+    /// Returns the first and last block number stored in the history store
+    fn history_store_range(&self) -> (u32, u32);
+
     /// Add a list of historic transactions to an existing history tree. It returns the root of the
     /// resulting tree and the total size of the transactions added.
     /// This function assumes that:

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -56,7 +56,7 @@ pub trait HistoryInterface {
         -> usize;
 
     /// Returns the first and last block number stored in the history store
-    fn history_store_range(&self) -> (u32, u32);
+    fn history_store_range(&self, txn_option: Option<&TransactionProxy>) -> (u32, u32);
 
     /// Add a list of historic transactions to an existing history tree. It returns the root of the
     /// resulting tree and the total size of the transactions added.

--- a/blockchain/src/history/mmr_store.rs
+++ b/blockchain/src/history/mmr_store.rs
@@ -108,7 +108,7 @@ fn get_size(hist_tree_table: &TableProxy, tx: &TransactionProxy, epoch_number: u
 /// Obtains the first and last block number stored in the history tree table
 pub fn get_range(hist_tree_table: &TableProxy, tx: &TransactionProxy) -> (u32, u32) {
     // Initialize the cursor for the database.
-    let mut cursor = tx.cursor(&hist_tree_table);
+    let mut cursor = tx.cursor(hist_tree_table);
 
     let first = if let Some((key, _)) = cursor.first::<Vec<u8>, Blake2bHash>() {
         key_to_index(key).unwrap().0
@@ -263,7 +263,11 @@ pub fn remove_block_from_store(
 }
 
 /// Copies the mmr entries of the previous block number
-/// This is used to initialize the tree for the given block number, using the previous tree as a baseline
+/// Used to initialize the tree for the given block number, using the previous tree as a baseline
+/// This is because for the light history store, we are not mantaining a single tree for the
+/// entire epoch, instead, we are storing individual trees for each block, but the information from
+/// block number N needs to be propagated to block number N + 1, as we need to compute a root
+/// for the entire epoch.
 pub fn init_mmr_from_block_number(
     hist_tree_table: &TableProxy,
     txn: &mut WriteTransactionProxy,

--- a/blockchain/src/history/mod.rs
+++ b/blockchain/src/history/mod.rs
@@ -4,7 +4,7 @@ pub use history_tree_chunk::{HistoryTreeChunk, CHUNK_SIZE};
 mod history_store;
 mod history_tree_chunk;
 pub mod interface;
-mod light_history_store;
+pub(crate) mod light_history_store;
 mod mmr_store;
 mod ordered_hash;
 mod validity_store;

--- a/blockchain/src/history/validity_store.rs
+++ b/blockchain/src/history/validity_store.rs
@@ -135,7 +135,7 @@ impl ValidityStore {
             // We need to prune the validity store
             let count = num_blocks - Policy::transaction_validity_window_blocks();
 
-            for bn in [first_bn, first_bn + count] {
+            for bn in first_bn..first_bn + count {
                 self.delete_block_transactions(db_txn, bn);
             }
         }

--- a/blockchain/src/history/validity_store.rs
+++ b/blockchain/src/history/validity_store.rs
@@ -2,28 +2,35 @@ use std::collections::{HashMap, HashSet};
 
 use nimiq_block::Block;
 use nimiq_hash::Blake2bHash;
-use nimiq_transaction::historic_transaction::RawTransactionHash;
+use nimiq_primitives::policy::Policy;
 
 /// The validity store is used by full nodes to keep track of which
 /// transactions have occurred within the validity window without
 /// having to store the full transactions
 pub struct ValidityStore {
     /// The set of all raw transactions of the current validity window.
-    pub(crate) _txs: HashSet<Blake2bHash>,
+    pub(crate) txs: HashSet<Blake2bHash>,
 
-    pub(crate) _block_txs: HashMap<u32, HashSet<Blake2bHash>>,
+    // A map of txns hashes associated to each block number
+    pub(crate) block_txs: HashMap<u32, HashSet<Blake2bHash>>,
+
+    pub(crate) first_bn: u32,
+
+    pub(crate) latest_bn: u32,
 }
 
 impl ValidityStore {
-    pub(crate) fn _new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            _txs: HashSet::new(),
-            _block_txs: HashMap::new(),
+            txs: HashSet::new(),
+            block_txs: HashMap::new(),
+            first_bn: 0,
+            latest_bn: 0,
         }
     }
 
-    pub(crate) fn _has_transaction(&self, raw_tx_hash: RawTransactionHash) -> bool {
-        self._txs.contains(&raw_tx_hash.into())
+    pub(crate) fn has_transaction(&self, raw_tx_hash: Blake2bHash) -> bool {
+        self.txs.contains(&raw_tx_hash)
     }
 
     pub(crate) fn _add_block_transactions(&mut self, block: &Block) {
@@ -31,25 +38,81 @@ impl ValidityStore {
             for tx in txs {
                 let raw_tx_hash = tx.raw_tx_hash();
 
-                if let Some(block_txs) = self._block_txs.get_mut(&block.block_number()) {
+                if let Some(block_txs) = self.block_txs.get_mut(&block.block_number()) {
                     block_txs.insert(raw_tx_hash.clone().into());
                 } else {
                     let mut block_txns = HashSet::new();
                     block_txns.insert(raw_tx_hash.clone().into());
 
-                    self._block_txs.insert(block.block_number(), block_txns);
+                    self.block_txs.insert(block.block_number(), block_txns);
                 }
 
-                self._txs.insert(raw_tx_hash.into());
+                self.txs.insert(raw_tx_hash.into());
             }
         }
     }
 
-    pub(crate) fn _delete_block_transactions(&mut self, block_number: u32) {
-        if let Some(block_txns) = self._block_txs.remove(&block_number) {
+    pub(crate) fn add_transaction(&mut self, block_number: u32, transaction: Blake2bHash) {
+        if let Some(block_txs) = self.block_txs.get_mut(&block_number) {
+            block_txs.insert(transaction.clone());
+        } else {
+            let mut block_txns = HashSet::new();
+            block_txns.insert(transaction.clone());
+
+            self.block_txs.insert(block_number, block_txns);
+        }
+
+        self.txs.insert(transaction);
+    }
+
+    // We should only delete blocks from the front or back
+    pub(crate) fn delete_block_transactions(&mut self, block_number: u32) {
+        log::trace!(bn = block_number, "Deleting block from validity store");
+
+        if self.first_bn == self.latest_bn {
+            return;
+        }
+
+        // We are deleting from the back
+        if block_number == self.first_bn {
+            self.first_bn += 1;
+        } else if block_number == self.latest_bn {
+            self.latest_bn -= 1;
+        } else {
+            panic!("Trying to remove a block from the middle of the validity store");
+        }
+
+        if let Some(block_txns) = self.block_txs.remove(&block_number) {
             for tx in block_txns {
-                self._txs.remove(&tx);
+                self.txs.remove(&tx);
             }
+        }
+    }
+
+    pub(crate) fn prune_validity_store(&mut self) {
+        // Compute the number of blocks we currently have in the store
+        let mut diff = self.latest_bn - self.first_bn;
+
+        log::trace!(
+            first = self.first_bn,
+            latest = self.latest_bn,
+            diff = diff,
+            "Calculated diff for pruning validity store"
+        );
+
+        // We only need to keep up to VALIDITY_WINDOW_BLOCKS in the store
+        while diff > Policy::transaction_validity_window_blocks() {
+            self.delete_block_transactions(self.first_bn);
+            diff = self.latest_bn - self.first_bn;
+        }
+    }
+
+    pub(crate) fn update_validity_store(&mut self, latest_bn: u32) {
+        if latest_bn > self.latest_bn {
+            self.latest_bn = latest_bn;
+        }
+        if self.first_bn == 0 {
+            self.first_bn = latest_bn;
         }
     }
 }

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -195,6 +195,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                             let previous_election_block =
                                 blockchain_rg.election_head().header.parent_election_hash;
                             drop(blockchain_rg);
+
                             self.request_single_macro_block(
                                 epoch_ids.sender,
                                 previous_election_block,

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -64,7 +64,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                 BlockchainProxy::Full(blockchain) => {
                     let blockchain_wr = blockchain.read();
 
-                    let (first_bn, last_bn) = blockchain_wr.history_store.history_store_range();
+                    let (first_bn, last_bn) = blockchain_wr.history_store.history_store_range(None);
 
                     // This means we already know the first epoch so we need to request the missing items from the current epoch
                     if last_bn >= verifier_block_number {

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -225,7 +225,6 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 
                                 let history_root = Blockchain::extend_validity_sync(
                                     blockchain.upgradable_read(),
-                                    Policy::epoch_at(verifier_block_number),
                                     &chunk.history[starting_index..],
                                 )
                                 .unwrap();

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -395,9 +395,9 @@ impl ClientInner {
             }
             #[cfg(feature = "full-consensus")]
             SyncMode::Full => {
-                // TODO this is a temporary fix for the issue of full nodes taking forever pruning the epoch history.
-                // should be set to false when the light history store is implemented.
-                blockchain_config.keep_history = true;
+                blockchain_config.keep_history = false;
+                blockchain_config.light_history_store = true;
+
                 let blockchain = match Blockchain::new(
                     environment.clone(),
                     blockchain_config,

--- a/network-interface/src/peer_info.rs
+++ b/network-interface/src/peer_info.rs
@@ -66,7 +66,9 @@ impl Services {
                     | Services::TRANSACTION_INDEX
             }
             NodeType::Light => Services::empty(),
-            NodeType::Full => Services::ACCOUNTS_PROOF | Services::FULL_BLOCKS,
+            NodeType::Full => {
+                Services::ACCOUNTS_PROOF | Services::FULL_BLOCKS | Services::ACCOUNTS_CHUNKS
+            }
         }
     }
 
@@ -75,7 +77,7 @@ impl Services {
         match node_type {
             NodeType::History => Services::HISTORY | Services::FULL_BLOCKS,
             NodeType::Light => Services::ACCOUNTS_PROOF,
-            NodeType::Full => Services::FULL_BLOCKS | Services::ACCOUNTS_CHUNKS,
+            NodeType::Full => Services::FULL_BLOCKS | Services::HISTORY | Services::ACCOUNTS_CHUNKS,
         }
     }
 }

--- a/network-interface/src/peer_info.rs
+++ b/network-interface/src/peer_info.rs
@@ -66,9 +66,7 @@ impl Services {
                     | Services::TRANSACTION_INDEX
             }
             NodeType::Light => Services::empty(),
-            NodeType::Full => {
-                Services::ACCOUNTS_PROOF | Services::FULL_BLOCKS | Services::ACCOUNTS_CHUNKS
-            }
+            NodeType::Full => Services::ACCOUNTS_PROOF | Services::FULL_BLOCKS,
         }
     }
 

--- a/pow-migration/src/genesis/mod.rs
+++ b/pow-migration/src/genesis/mod.rs
@@ -55,7 +55,7 @@ pub async fn get_pos_genesis(
         "Building history tree. This may take some time"
     );
     let start = Instant::now();
-    let history_root = get_history_root(env)
+    let history_root = get_history_root(env, network_id)
         .await
         .map(|history_root| {
             let duration = start.elapsed();

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -234,13 +234,14 @@ async fn main() {
         // Create channels in order to communicate with the PoW-to-PoS history migrator
         let (tx_candidate_block, rx_candidate_block) = mpsc::channel(16);
         let (tx_migration_completed, rx_migration_completed) =
-            watch::channel(get_history_store_height(env.clone()).await);
+            watch::channel(get_history_store_height(env.clone(), config.network_id).await);
 
         // Spawn PoW-to-PoS migrator as seperate task
         tokio::spawn(migrate_history(
             rx_candidate_block,
             tx_migration_completed,
             env.clone(),
+            config.network_id,
             pow_client.clone(),
             block_windows.block_confirmations,
         ));

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -267,7 +267,7 @@ where
             if (matches!(staking_state, ValidatorStakingState::Inactive(..)))
                 && blockchain.block_number()
                     >= tx_validity_window_start + Policy::blocks_per_epoch()
-                && !blockchain.tx_in_validity_window(
+                && !blockchain.history_store.tx_in_validity_window(
                     &validator_state.inactive_tx_hash,
                     tx_validity_window_start,
                     None,


### PR DESCRIPTION
Use the light history store for full node clients
Necessary changes to use the history interface
Several changes to the usage of the history store


...
#### This fixes #1704.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
