### PR TITLE
Use argon2id by default

### DIFF
--- a/hash/src/argon2kdf.rs
+++ b/hash/src/argon2kdf.rs
@@ -1,5 +1,5 @@
 use argon2::Config;
-pub use argon2::Error as Argon2Error;
+pub use argon2::{Error as Argon2Error, Variant as Argon2Variant};
 
 // Taken from https://github.com/nimiq/core-js/blob/c98d56b2dd967d9a9c9a97fe4c54bfaac743aa0c/src/main/generic/utils/crypto/CryptoWorkerImpl.js#L146
 const MEMORY_COST: u32 = 512;
@@ -9,12 +9,13 @@ pub fn compute_argon2_kdf(
     salt: &[u8],
     iterations: u32,
     derived_key_length: usize,
+    variant: Argon2Variant,
 ) -> Result<Vec<u8>, Argon2Error> {
     let config = Config {
         time_cost: iterations,
         hash_length: derived_key_length as u32,
         mem_cost: MEMORY_COST,
-        variant: argon2::Variant::Argon2d,
+        variant,
         ..Default::default()
     };
 

--- a/hash/tests/mod.rs
+++ b/hash/tests/mod.rs
@@ -101,7 +101,13 @@ fn it_can_compute_argon2_kdf() {
     let password = "test";
     let salt = "nimiqrocks!";
 
-    let res = argon2kdf::compute_argon2_kdf(password.as_bytes(), salt.as_bytes(), 1, 32);
+    let res = argon2kdf::compute_argon2_kdf(
+        password.as_bytes(),
+        salt.as_bytes(),
+        1,
+        32,
+        argon2::Variant::Argon2d,
+    );
     assert_eq!(
         res.unwrap(),
         hex::decode("8c259fdcc2ad6799df728c11e895a3369e9dbae6a3166ebc3b353399fc565524").unwrap()


### PR DESCRIPTION
## What's in this pull request?
Replaces `argon2d` with `argon2id` while remaining backwards compatible with existing wallets.
`argon2id` has additional side-channel protection.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
