### PR TITLE
pow-migration: Fix burnt registration balance calculation and fix accounts migration

### DIFF
--- a/pow-migration/src/genesis/mod.rs
+++ b/pow-migration/src/genesis/mod.rs
@@ -110,12 +110,10 @@ pub async fn get_pos_genesis(
         };
 
     // Calculate how much stake was burnt into registering validators and stakers
-    let mut burnt_registration_balance = genesis_stakers
+    // (the validator's `total_stake` here already includes its staker's delegated balance)
+    let burnt_registration_balance = genesis_validators
         .iter()
-        .fold(Coin::ZERO, |acc, staker| acc + staker.balance);
-    burnt_registration_balance += genesis_validators
-        .iter()
-        .fold(Coin::ZERO, |acc, validator| acc + validator.balance);
+        .fold(Coin::ZERO, |acc, validator| acc + validator.total_stake);
 
     let genesis_accounts = get_accounts(
         client,

--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -22,7 +22,7 @@ use crate::{
         check_validators_ready, generate_ready_tx, get_ready_txns, send_tx,
         types::ValidatorsReadiness,
     },
-    state::{get_stakers, get_validators},
+    state::{get_stakers, get_validators, setup_pow_rpc_server},
 };
 
 static TESTNET_BLOCK_WINDOWS: &BlockWindows = &BlockWindows {
@@ -150,7 +150,10 @@ pub async fn migrate(
     validator_address: &Address,
     network_id: NetworkId,
 ) -> Result<Option<GenesisConfig>, Error> {
-    // First we obtain the list of registered validators
+    // First set up the PoW client for accounts migration
+    setup_pow_rpc_server(pow_client).await?;
+
+    // Now we obtain the list of registered validators
     let registered_validators = get_validators(
         pow_client,
         block_windows.registration_start..block_windows.registration_end,

--- a/pow-migration/src/monitor/mod.rs
+++ b/pow-migration/src/monitor/mod.rs
@@ -83,7 +83,10 @@ pub async fn check_validators_ready(
     activation_block_window: Range<u32>,
 ) -> ValidatorsReadiness {
     // First calculate the total amount of stake
-    let total_stake: Coin = validators.iter().map(|validator| validator.balance).sum();
+    let total_stake: Coin = validators
+        .iter()
+        .map(|validator| validator.total_stake)
+        .sum();
 
     log::debug!(registered_stake = %total_stake);
 
@@ -127,14 +130,14 @@ pub async fn check_validators_ready(
     let mut ready_stake = Coin::ZERO;
 
     for ready_validator in ready_validators {
-        ready_stake += ready_validator.balance;
+        ready_stake += ready_validator.total_stake;
 
         info!(
             address = ready_validator
                 .validator
                 .validator_address
                 .to_user_friendly_address(),
-            stake = %ready_validator.balance,
+            stake = %ready_validator.total_stake,
             "Validator is ready",
         );
     }

--- a/pow-migration/src/state/types.rs
+++ b/pow-migration/src/state/types.rs
@@ -25,6 +25,9 @@ pub enum Error {
     /// Invalid Genesis timestamp
     #[error("Invalid genesis timestamp: {0}")]
     InvalidTimestamp(u64),
+    /// RPC server not ready
+    #[error("RPC server is not ready")]
+    RPCServerNotReady,
 }
 
 /// Genesis accounts for the genesis state

--- a/pow-migration/src/state/types.rs
+++ b/pow-migration/src/state/types.rs
@@ -47,5 +47,5 @@ pub struct GenesisValidator {
     pub validator: nimiq_genesis_builder::config::GenesisValidator,
 
     /// Validator stake
-    pub balance: Coin,
+    pub total_stake: Coin,
 }


### PR DESCRIPTION
- Fix accounts migration by setting the `Policy.NUM_SNAPSHOTS_MAX` constant that allows to get accounts tree chunks for blocks that are this value below the head of the chain.
- Fix math for `burnt_registration_balance` since it was incorrectly summing the validator balance twice. Also rename the `balance` field to `total_stake` in the `GenesisValidator` struct to clarify that this balance includes the total stake of this validator (validator deposit and staker's delegated stake).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
