### PR TITLE
Fix genesis block number init

### DIFF
--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -114,7 +114,7 @@ impl GenesisBuilder {
             basic_accounts: vec![],
             vesting_accounts: vec![],
             htlc_accounts: vec![],
-            block_number: Policy::genesis_block_number(),
+            block_number: 0,
         }
     }
 
@@ -139,6 +139,14 @@ impl GenesisBuilder {
     /// Sets [`MacroHeader::network`].
     pub fn with_network(&mut self, network: NetworkId) -> &mut Self {
         self.network = network;
+        self
+    }
+
+    /// The block number for the genesis block.
+    ///
+    /// Sets [`MacroHeader::block_number`].
+    pub fn with_genesis_block_number(&mut self, block_number: u32) -> &mut Self {
+        self.block_number = block_number;
         self
     }
 

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -10,7 +10,7 @@ use nimiq_keys::{Address, KeyPair as SchnorrKeyPair, SecureGenerate};
 use nimiq_mempool::config::MempoolConfig;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_network_mock::MockHub;
-use nimiq_primitives::networks::NetworkId;
+use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_validator::validator::Validator;
 use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
@@ -90,15 +90,17 @@ where
     let mut genesis_builder = GenesisBuilder::default();
     genesis_builder.with_network(NetworkId::UnitAlbatross);
     for i in 0..num_validators {
-        genesis_builder.with_genesis_validator(
-            Address::from(&validator_keys[i]),
-            signing_keys[i].public,
-            voting_keys[i].public_key,
-            Address::default(),
-            None,
-            None,
-            false,
-        );
+        genesis_builder
+            .with_genesis_validator(
+                Address::from(&validator_keys[i]),
+                signing_keys[i].public,
+                voting_keys[i].public_key,
+                Address::default(),
+                None,
+                None,
+                false,
+            )
+            .with_genesis_block_number(Policy::genesis_block_number());
     }
     let genesis = genesis_builder.generate(env).unwrap();
 

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -49,6 +49,7 @@ async fn one_validator_can_create_micro_blocks() {
     let signing_key = KeyPair::generate(&mut seeded_rng(0));
     let genesis = GenesisBuilder::default()
         .with_network(NetworkId::UnitAlbatross)
+        .with_genesis_block_number(Policy::genesis_block_number())
         .with_genesis_validator(
             Address::from(&validator_key),
             signing_key.public,


### PR DESCRIPTION
Genesis Builder initializes the block number to 0 to avoid calling Policy too early Unittests should initialize the genesis block number Fixes #2388


...
#### This fixes #2388 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
