### PR TITLE
Move faster to a new activation window

### DIFF
--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -232,6 +232,17 @@ pub async fn migrate(
         let current_height = pow_client.block_number().await.unwrap();
         log::info!(current_height);
 
+        let next_candidate = candidate_block + block_windows.readiness_window;
+
+        if current_height > next_candidate {
+            log::info!(
+                next_candidate = next_candidate,
+                "The activation window already finished, moving to the next one"
+            );
+
+            return Ok(None);
+        }
+
         // We are past the election candidate, so we are now in one of the activation windows
         if current_height > candidate_block + block_windows.block_confirmations {
             // Start the PoS genesis generation process


### PR DESCRIPTION
If we are already in a new activation window, there is no need to generate the previous genesis.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
