### PR TITLE
pow-migration: Fix genesis block timestamp calculation

### DIFF
--- a/pow-migration/src/genesis/mod.rs
+++ b/pow-migration/src/genesis/mod.rs
@@ -15,11 +15,8 @@ use time::OffsetDateTime;
 use crate::{
     genesis::types::{Error, PoSRegisteredAgents, PoWRegistrationWindow},
     history::get_history_root,
-    state::{get_accounts, get_stakers, get_validators},
+    state::{get_accounts, get_stakers, get_validators, POW_BLOCK_TIME},
 };
-
-// POW estimated block time in milliseconds
-const POW_BLOCK_TIME_MS: u64 = 60 * 1000; // 1 min
 
 /// Gets the genesis config file
 pub async fn get_pos_genesis(
@@ -75,7 +72,7 @@ pub async fn get_pos_genesis(
 
     // The PoS genesis timestamp is the cutting block timestamp plus a custom delay
     let pos_genesis_ts =
-        pow_reg_window.confirmations as u64 * POW_BLOCK_TIME_MS + final_block.timestamp as u64;
+        pow_reg_window.confirmations as u64 * POW_BLOCK_TIME + final_block.timestamp as u64;
     // The parent election hash of the PoS genesis is the hash of the PoW genesis block
     let parent_election_hash = Blake2bHash::from_str(&pow_genesis.hash)?;
     // The parent hash of the PoS genesis is the hash of cutting block

--- a/pow-migration/src/state/mod.rs
+++ b/pow-migration/src/state/mod.rs
@@ -20,8 +20,11 @@ use nimiq_transaction::account::htlc_contract::{AnyHash, AnyHash32, AnyHash64};
 
 use crate::state::types::{Error, GenesisAccounts, GenesisValidator};
 
-// PoW estimated block time in milliseconds
-const POW_BLOCK_TIME_MS: u64 = 60 * 1000; // 1 min
+// POW estimated block time in seconds
+pub(crate) const POW_BLOCK_TIME: u64 = 60; // 1 min
+
+// POW estimated block time in milliseconds
+pub(crate) const POW_BLOCK_TIME_MS: u64 = POW_BLOCK_TIME * 1000; // 1 min
 
 // PoW maximum amount of snapshots. This is a constant that needs to be set in the PoW client
 // such that we can get accounts snapshots of blocks within [head - `POW_MAX_SNAPSHOTS`, head].


### PR DESCRIPTION
Fix genesis block timestamp calculation since it was assuming that PoW block timestamps where in milliseconds when they are actually in seconds.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
