### PR TITLE
pow-migration: Wait for the child process launching the client

### DIFF
--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -3,7 +3,11 @@ pub mod history;
 pub mod monitor;
 pub mod state;
 
-use std::{path::PathBuf, process::Command, time::Duration};
+use std::{
+    path::PathBuf,
+    process::{Command, ExitStatus},
+    time::Duration,
+};
 
 use nimiq_database::DatabaseProxy;
 use nimiq_genesis_builder::config::GenesisConfig;
@@ -359,7 +363,7 @@ pub fn launch_pos_client(
     genesis_file: &PathBuf,
     config_file: &str,
     genesis_env_var_name: &str,
-) -> Result<u32, Error> {
+) -> Result<ExitStatus, Error> {
     // Start the nimiq PoS client with the generated genesis file
     log::info!(
         filename = ?genesis_file,
@@ -391,7 +395,7 @@ pub fn launch_pos_client(
         Ok(None) => {
             let pid = child.id();
             log::info!(pid, "Pos client running");
-            Ok(pid)
+            Ok(child.wait()?)
         }
         Err(error) => {
             log::error!(?error, "Error waiting for the PoS client to run");


### PR DESCRIPTION
Wait for the child process when launching the PoS client from the migration tool to address the warning in the
[documentation](https://doc.rust-lang.org/std/process/struct.Child.html#warning) where they don't recommend to drop `Child` handles without waiting on them first.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
