### PR TITLE
pow-migration: Add a 'viewer' mode

### DIFF
--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -170,13 +170,17 @@ async fn main() {
         }
     } else {
         let validator_address = if let Some(validator_settings) = config.validator {
-            validator_settings.validator_address
+            info!(
+                validator_address = %validator_settings.validator_address,
+                "This is our validator address"
+            );
+            Some(validator_settings.validator_address)
         } else {
-            log::error!("Missing validator section in the configuration file");
-            exit(1);
+            log::warn!(
+                "Missing validator section in the configuration file. Running in 'viewer' mode."
+            );
+            None
         };
-
-        info!("This is our validator address: {}", validator_address);
 
         // Create DB environment
         let env = match config.storage.database(


### PR DESCRIPTION
Add a 'viewer' mode to the tool such as non-validators can generate the PoS genesis and then launch the client when it's ready.

This closes #2385.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
