### PR TITLE
Add command to list pre-stakers and optionally filter by validator

### DIFF
--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -4,8 +4,9 @@ pub mod monitor;
 pub mod state;
 
 use std::{
+    fmt::Debug,
     path::PathBuf,
-    process::{Command, ExitStatus},
+    process::{exit, Command, ExitStatus},
     time::Duration,
 };
 
@@ -430,4 +431,10 @@ pub fn launch_pos_client(
             Err(error.into())
         }
     }
+}
+
+/// Logs the error message and exits the program with exit code 1.
+pub fn exit_with_error<E: Debug>(error: E, message: &'static str) -> ! {
+    log::error!(?error, "{}", message);
+    exit(1);
 }


### PR DESCRIPTION
## What's in this pull request?
Add the command `list-stakers`, similar to `list-validators`, to dump the stake allocation with optionally the choice to only get the allocations by providing a validator address.

#### This fixes #2387 

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
