### PR TITLE
Ensure parent folder exists before writing files to it

### DIFF
--- a/utils/src/file_store.rs
+++ b/utils/src/file_store.rs
@@ -1,6 +1,5 @@
 use std::{
-    fs,
-    fs::OpenOptions,
+    fs::{self, create_dir, OpenOptions},
     io::{BufWriter, Error as IoError, Write},
     path::{Path, PathBuf},
 };
@@ -39,7 +38,12 @@ impl FileStore {
     }
 
     pub fn store<T: Serialize>(&self, item: &T) -> Result<(), Error> {
-        log::debug!(path = ?self.path.display(), "Writing tof file");
+        log::debug!(path = ?self.path.display(), "Writing to file");
+        let parent_folder = self.path.parent().expect("File must have a parent folder");
+        if !parent_folder.exists() {
+            create_dir(parent_folder)?;
+        }
+
         let file = OpenOptions::new()
             .write(true)
             .create(true)


### PR DESCRIPTION
## What's in this pull request?
Check if `.nimiq` folder exists before writing to files to it. If it's not created yet, try to do so.

#### This fixes #2400 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
