### PR TITLE
Remove unnecessary tokio::spawn

### DIFF
--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -253,16 +253,10 @@ pub fn message_handler<
             .for_each_concurrent(MAX_CONCURRENT_HANDLERS, |(msg, peer_id)| {
                 let req_environment = req_environment.clone();
                 async move {
-                    let req_environment = req_environment.clone();
+                    log::trace!("{:?} {:#?}", peer_id, msg);
 
-                    tokio::spawn(async move {
-                        log::trace!("{:?} {:#?}", peer_id, msg);
-
-                        // Messages do not have a response (so the response is ignored)
-                        msg.message_handle(peer_id, &req_environment);
-                    })
-                    .await
-                    .expect("Request handler panicked")
+                    // Messages do not have a response (so the response is ignored)
+                    msg.message_handle(peer_id, &req_environment);
                 }
             })
             .await

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -217,27 +217,20 @@ pub fn request_handler<T: Send + Sync + Clone + 'static, Req: Handle<N, T>, N: N
                 let network = Arc::clone(&network);
                 let req_environment = req_environment.clone();
                 async move {
-                    let req_environment = req_environment.clone();
-                    let network = Arc::clone(&network);
+                    log::trace!("[{:?}] {:?} {:#?}", request_id, peer_id, msg);
 
-                    tokio::spawn(async move {
-                        log::trace!("[{:?}] {:?} {:#?}", request_id, peer_id, msg);
-
-                        // Try to send the response, logging to debug if it fails
-                        if let Err(err) = network
-                            .respond::<Req>(request_id, msg.handle(peer_id, &req_environment))
-                            .await
-                        {
-                            log::debug!(
-                                "[{:?}] Failed to send {} response: {:?}",
-                                request_id,
-                                std::any::type_name::<Req>(),
-                                err
-                            );
-                        };
-                    })
-                    .await
-                    .expect("Request handler panicked")
+                    // Try to send the response, logging to debug if it fails
+                    if let Err(err) = network
+                        .respond::<Req>(request_id, msg.handle(peer_id, &req_environment))
+                        .await
+                    {
+                        log::debug!(
+                            "[{:?}] Failed to send {} response: {:?}",
+                            request_id,
+                            std::any::type_name::<Req>(),
+                            err
+                        );
+                    };
                 }
             })
             .await


### PR DESCRIPTION
- Unnecessary tokio spawn
- This is not compatible with web clients (WASM)

This could explain the failure mentioned in #2404 

Before [this change](https://github.com/nimiq/core-rs-albatross/commit/e7a0319fafaa10fcc7256061b89c2ad7e086c8c9) regular nodes didn't try to connect to web clients, because they were filtered: web clients do not provide any service to regular nodes. This can be observed in this [code](https://github.com/nimiq/core-rs-albatross/commit/e7a0319fafaa10fcc7256061b89c2ad7e086c8c9#diff-26b6d741d633ef4dcc78ac3d521f89ea1ead7110cad61ef8a987e23c5a12012cL528).

This means that before, **web clients were not responding to any of the consensus handlers**.

However, after the _handle incompatible peers_ commit, regular nodes can now perform head requests to web clients, which causes web clients to execute a `tokio::spawn`, which is not allowed (a special task executor is necessary in web environments).

This `tokio::spawn` seems unnecessary or superfluous (at least) according to the logic around it.

#### This fixes #2404 .

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
