### PR TITLE
Migrate PoW to PoS history proactively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,19 +950,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "console-api"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,12 +1549,6 @@ name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2347,19 +2328,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
  "serde",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
 ]
 
 [[package]]
@@ -4092,7 +4060,6 @@ dependencies = [
  "convert_case 0.6.0",
  "hex",
  "humantime",
- "indicatif",
  "nimiq-blockchain",
  "nimiq-bls",
  "nimiq-database",
@@ -4993,12 +4960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,12 +5261,6 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postcard"

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -24,7 +24,6 @@ clap = { version = "4.5", features = ["derive"] }
 convert_case = "0.6"
 hex = "0.4"
 humantime = "2.1"
-indicatif = "0.17"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 nimiq-blockchain = { workspace = true }
 nimiq-bls = { workspace = true }
@@ -47,11 +46,11 @@ nimiq-lib = { workspace = true, features = [
     "zkp-prover",
     "parallel",
 ] }
-nimiq-primitives = { workspace = true, features = ["policy"]}
+nimiq-primitives = { workspace = true, features = ["policy"] }
 nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true }
 nimiq-vrf = { workspace = true }
-nimiq_rpc = "0.3"
+nimiq_rpc = "0.3.1"
 percentage = "0.1"
 rand = "0.8"
 serde = "1.0"

--- a/pow-migration/src/genesis/mod.rs
+++ b/pow-migration/src/genesis/mod.rs
@@ -54,7 +54,7 @@ pub async fn get_pos_genesis(
         "Building history tree. This may take some time"
     );
     let start = Instant::now();
-    let history_root = match get_history_root(client, final_block.number, env).await {
+    let history_root = match get_history_root(env).await {
         Ok(history_root) => {
             let duration = start.elapsed();
             log::info!(


### PR DESCRIPTION
## What's in this pull request?
This PR adds the functionality for the `nimiq-pow-migration` client to start the PoW to PoS migration before the pre-stake window is closed. Additionally it is responsible for continuing to migrate the PoW history if instructed when for example a new activation window is started.

#### This fixes #2355 

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
