### PR TITLE
GH action for publishing OpenRPC document on new version

### DIFF
--- a/.github/workflows/github_release_docker.yml
+++ b/.github/workflows/github_release_docker.yml
@@ -12,10 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+      - name: Build binaries in release mode
+        run: |
+          cargo build --release
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - uses: jetli/wasm-bindgen-action@v0.2.0

--- a/.github/workflows/publish_openrpc_document.yml
+++ b/.github/workflows/publish_openrpc_document.yml
@@ -1,0 +1,30 @@
+name: Publish OpenRPC document
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build_release_binary_and_publish_document:
+    name: Build nimiq-rpc-schema with release flag
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build binary in release mode
+        run: |
+          cargo build --release --bin nimiq-rpc-schema
+      - name: Get release information
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run nimiq-rpc-schema and save JSON output
+        run: |
+          cargo run --release --bin nimiq-rpc-schema -- -o ${{ steps.get_release.outputs.tag_name }} > openrpc-document.json
+      - name: Upload OpenRPC document to latest release
+        uses: JasonEtco/upload-to-release@v0.1.1
+        with:
+          args: openrpc-document.json application/json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What's in this pull request?
This PR contains a new Github Action that with every release will publish a new OpenRPC document to the latest release tag.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
