### PR TITLE
Genesis block inclusion proofs

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -354,6 +354,7 @@ impl<N: Network> ConsensusProxy<N> {
                             let mut already_proven = false;
                             if election_head.hash() == block_hash
                                 || election_head.header.parent_election_hash == block_hash
+                                || response.block.block_number() == Policy::genesis_block_number()
                             {
                                 already_proven = true;
                             } else if let Some(ref interlink) = election_head.header.interlink {

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -724,6 +724,7 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestBlocksProof {
             if !Policy::is_election_block_at(block_number)
                 || block_number > self.election_head
                 || self.election_head > blockchain.election_head().block_number()
+                || block_number == Policy::genesis_block_number()
             {
                 return Err(ResponseBlocksProofError::BadBlockNumber(block_number));
             }


### PR DESCRIPTION
This prevents an issue that was observed in the PoS testnet, after the PoW testnet state was migrated.

This was caused by requests for block inclusion proofs of the genesis block, which caused the `get_interlink_hop` function to get into an infinite loop while holding the blockchain read lock.

This fixes #2421.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
