### PR TITLE
network-libp2p: Increase maximum request size to 20kB

### DIFF
--- a/network-libp2p/src/dispatch/codecs/mod.rs
+++ b/network-libp2p/src/dispatch/codecs/mod.rs
@@ -11,8 +11,8 @@ use std::io;
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::{request_response, StreamProtocol};
 
-/// Maximum request size in bytes (5 kB)
-const MAX_REQUEST_SIZE: u64 = 5 * 1024;
+/// Maximum request size in bytes (20 kB)
+const MAX_REQUEST_SIZE: u64 = 20 * 1024;
 /// Maximum response size in bytes (10 MB)
 const MAX_RESPONSE_SIZE: u64 = 10 * 1024 * 1024;
 /// Size of a u64


### PR DESCRIPTION
Increase the maximum request size from 5kB to 20kB since it was seen that `RequestTransactionsProof` can easily exceed the 5kB limit when the amount of transactions to prove is close to 500.

This fixes #2422.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
