### PR TITLE
Fix merkle path generation for multisig signature proofs in web-client

### DIFF
--- a/web-client/src/primitives/signature_proof.rs
+++ b/web-client/src/primitives/signature_proof.rs
@@ -123,7 +123,10 @@ impl SignatureProof {
 
         nimiq_utils::merkle::Blake2bMerklePath::new::<nimiq_hash::Blake2bHasher, Vec<u8>>(
             &public_keys,
-            &leaf_value.serialize_to_vec(),
+            &match leaf_value {
+                nimiq_keys::PublicKey::Ed25519(public_key) => public_key.serialize_to_vec(),
+                nimiq_keys::PublicKey::ES256(public_key) => public_key.serialize_to_vec(),
+            },
         )
     }
 


### PR DESCRIPTION
In #1884 I introduced a bug that lead to the multisig signature proof methods to always generate an empty merkle path, which then led to invalid transaction proofs, as the computed signer of the signature proof does not match the sender of the transaction.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
