### PR TITLE
`protoc` isn't needed by `libp2p` anymore

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -37,8 +37,6 @@ jobs:
       with:
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Install cargo-nextest
       run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
     # Coverage is disabled for now since at the moment it has a considerable performance impact in the CI
@@ -77,8 +75,6 @@ jobs:
       with:
         components: clippy
     - uses: Swatinem/rust-cache@v2
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - uses: actions-rs/clippy-check@v1
       with:
         name: Clippy Report
@@ -106,8 +102,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Install wasm-pack
       run: cargo install wasm-pack
     - name: Compile to wasm and generate bindings
@@ -130,8 +124,6 @@ jobs:
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Build the code
       run: cargo build
     - name: Executes the 4 validators reconnecting scenario

--- a/.github/workflows/build_crate_features.yml
+++ b/.github/workflows/build_crate_features.yml
@@ -14,8 +14,6 @@ jobs:
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Set up python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -55,8 +55,6 @@ jobs:
     - uses: taiki-e/install-action@cargo-llvm-cov
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Remove possible stale artifacts
       run: cargo llvm-cov clean --workspace
     - name: Disk Space

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -63,8 +63,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Optionally patch the source
       run: ${{ matrix.pre }}
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Build the code
       run: cargo build --release
     - name: Retrieve initial timestamp

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -56,8 +56,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Optionally patch the source
       run: ${{ matrix.pre }}
-    - name: Install Protoc
-      run: sudo apt-get install protobuf-compiler
     - name: Build the code
       run: cargo build
     - name: Retrieve initial timestamp

--- a/.github/workflows/github_release_docker.yml
+++ b/.github/workflows/github_release_docker.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install protoc
-        run: |
-          sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -17,8 +17,6 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Install Protoc
-        run: sudo apt-get install protobuf-compiler
       - uses: jetli/wasm-bindgen-action@v0.2.0
         with:
           version: 'latest'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ the following packages are required to be able to compile the source code:
 - `cmake`
 - `libssl-dev` (in Debian/Ubuntu) or `openssl-devel` (in Fedora/Red Hat)
 - `pkg-config`
-- `protobuf-compiler`
 
 After installing the previous packages, compiling the project is achieved through [`cargo`](https://doc.rust-lang.org/cargo/):
 


### PR DESCRIPTION
Hasn't been needed since libp2p 0.51.1.

https://github.com/libp2p/rust-libp2p/pull/3312