### PR TITLE
Don't explicitly define rust toolchain input when using stable/nightly revs

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -16,9 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
         components: rustfmt
     - run: cargo fmt --all -- --check
 
@@ -36,7 +35,6 @@ jobs:
       run: "! grep -rEoh --exclude-dir tests --exclude-dir target 'TYPE_ID: u16 = [^;]+;' | sort | uniq -d | grep '^'"
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
@@ -77,7 +75,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: clippy
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
@@ -108,8 +105,6 @@ jobs:
         swap-storage: true
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler
@@ -134,8 +129,6 @@ jobs:
       run: pip install scripts/devnet
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler

--- a/.github/workflows/build_crate_features.yml
+++ b/.github/workflows/build_crate_features.yml
@@ -13,8 +13,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       run: sudo apt-get install protobuf-compiler

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -51,7 +51,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: llvm-tools-preview
     - uses: taiki-e/install-action@cargo-llvm-cov
     - uses: taiki-e/install-action@nextest

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -60,8 +60,6 @@ jobs:
       run: pip install scripts/devnet
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Optionally patch the source
       run: ${{ matrix.pre }}

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -53,8 +53,6 @@ jobs:
       run: pip install scripts/devnet
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - name: Optionally patch the source
       run: ${{ matrix.pre }}

--- a/.github/workflows/expensive_tests.yml
+++ b/.github/workflows/expensive_tests.yml
@@ -18,7 +18,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-nextest

--- a/.github/workflows/github_release_docker.yml
+++ b/.github/workflows/github_release_docker.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Install protoc
         run: |
           sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
## What's in this pull request?
As stated in the [documentation](https://github.com/marketplace/actions/rustup-toolchain-install#inputs) of dtolnay/rust-toolchain, you should only define the `toolchain` input when your GH Action rev is set to `master`. This PR removes those inputs and set the correct revs.

Fixing this for the `npm_publish` action happens in #2417 

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
