### PR TITLE
Remove performance marks in web-client

### DIFF
--- a/lib/src/extras/web_logging.rs
+++ b/lib/src/extras/web_logging.rs
@@ -1,9 +1,7 @@
 use log::{level_filters::LevelFilter, Level};
 use nimiq_log::{Formatting, MaybeSystemTime, TargetsExt};
-use tracing_subscriber::{
-    filter::Targets, fmt::format::Pretty, layer::SubscriberExt, util::SubscriberInitExt, Layer,
-};
-use tracing_web::{performance_layer, MakeConsoleWriter};
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt, Layer};
+use tracing_web::MakeWebConsoleWriter;
 
 use crate::{config::config_file::LogSettings, error::Error};
 
@@ -48,17 +46,14 @@ pub fn initialize_web_logging(settings_opt: Option<&LogSettings>) -> Result<(), 
     // Set logging level from the environment
     filter = filter.with_env();
 
-    let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
-
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .with_writer(MakeConsoleWriter)
+                .with_writer(MakeWebConsoleWriter::new())
                 .with_ansi(false)
                 .event_format(Formatting(MaybeSystemTime(settings.timestamps)))
                 .with_filter(filter),
         )
-        .with(perf_layer)
         .init();
     Ok(())
 }

--- a/web-client/dist/nodejs/worker.js
+++ b/web-client/dist/nodejs/worker.js
@@ -13,14 +13,6 @@ global.WebSocket = w3cwebsocket;
 // a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
 global.WorkerGlobalScope = global;
 
-// Clean up performance measurements created by tracing.
-// TODO: find a solution to disable creating these measurements.
-setInterval(() => {
-    global.performance.clearMarks();
-    global.performance.clearMeasures();
-    global.performance.clearResourceTimings();
-}, 300 * 1000);
-
 // Prevent NodeJS exiting on an uncaught exception that we currently expect,
 // until it is fixed in upstream libp2p websocket-websys transport.
 process.on('uncaughtException', error => {

--- a/web-client/dist/nodejs/worker.mjs
+++ b/web-client/dist/nodejs/worker.mjs
@@ -13,14 +13,6 @@ global.WebSocket = websocket.w3cwebsocket;
 // a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
 global.WorkerGlobalScope = global;
 
-// Clean up performance measurements created by tracing.
-// TODO: find a solution to disable creating these measurements.
-setInterval(() => {
-    global.performance.clearMarks();
-    global.performance.clearMeasures();
-    global.performance.clearResourceTimings();
-}, 300 * 1000);
-
 // Prevent NodeJS exiting on an uncaught exception that we currently expect,
 // until it is fixed in upstream libp2p websocket-websys transport.
 process.on('uncaughtException', error => {


### PR DESCRIPTION
## What's in this pull request?

- Remove unbounded [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance) measurements being created when every tracing span is entered or exited. This caused the memory consumption to grow rapidly as they never get cleaned up by default.
- Replace deprecated `tracing_web::MakeConsoleWriter` in favour of `tracing_web::MakeWebConsoleWriter`.
- Remove periodic clean-up of `Performance` measurements in NodeJS environment.

#### This fixes #2443  

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
