### PR TITLE
network-libp2p: Add fixes and improvements to discovery protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4207,6 +4207,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
+ "futures-timer",
  "futures-util",
  "hex",
  "instant",

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -237,7 +237,8 @@ impl ClientInner {
             identity_keypair.public(),
             provided_services,
             None,
-        );
+        )
+        .map_err(|e| Error::Network(nimiq_network_libp2p::NetworkError::PeerContactError(e)))?;
         peer_contact.set_current_time();
 
         let seeds: Vec<Multiaddr> = config

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.6"
 futures = { workspace = true }
+futures-timer = "3.0"
 hex = "0.4"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 ip_network = "0.4"

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -549,7 +549,8 @@ impl Behaviour {
 
         let num_seeds = 1;
         let contacts = self.contacts.read();
-        let own_addresses: HashSet<&Multiaddr> = contacts.get_own_contact().addresses().collect();
+        let own_contact = contacts.get_own_contact();
+        let own_addresses: HashSet<&Multiaddr> = own_contact.addresses().collect();
         self.seeds
             .iter()
             .filter(|address| !own_addresses.contains(address) && self.addresses.can_dial(*address))

--- a/network-libp2p/src/discovery/behaviour.rs
+++ b/network-libp2p/src/discovery/behaviour.rs
@@ -143,7 +143,7 @@ impl Behaviour {
         }
     }
 
-    /// Adds our own addresses into our own contact within the peer contact book
+    /// Adds addresses into our own contact within the peer contact book
     pub fn add_own_addresses(&self, addresses: Vec<Multiaddr>) {
         self.peer_contact_book
             .write()

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -379,14 +379,6 @@ impl ConnectionHandler for Handler {
                                         );
                                     }
 
-                                    let mut peer_contact_book = self.peer_contact_book.write();
-
-                                    // Update our own peer contact given the observed addresses we received
-                                    peer_contact_book.add_own_addresses(
-                                        vec![observed_address.clone()],
-                                        &self.keypair,
-                                    );
-
                                     // Send the HandshakeAck
                                     let response_signature =
                                         self.keypair.tagged_sign(&challenge_nonce);
@@ -394,6 +386,8 @@ impl ConnectionHandler for Handler {
                                     // Remember peer's filter
                                     self.peer_list_limit = Some(limit);
                                     self.services_filter = services;
+
+                                    let peer_contact_book = self.peer_contact_book.read();
 
                                     let msg = DiscoveryMessage::HandshakeAck {
                                         peer_contact: peer_contact_book

--- a/network-libp2p/src/discovery/protocol.rs
+++ b/network-libp2p/src/discovery/protocol.rs
@@ -37,8 +37,8 @@ impl TaggedSignable for ChallengeNonce {
 #[repr(u8)]
 pub enum DiscoveryMessage {
     Handshake {
-        /// The addresses of the receiver as observed by the sender.
-        observed_addresses: Vec<Multiaddr>,
+        /// The address of the receiver as observed by the sender.
+        observed_address: Multiaddr,
 
         /// The challenge that the receiver must use for the response in `HandshakeAck`.
         challenge_nonce: ChallengeNonce,

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::dispatch::codecs::MessageCodec;
+use crate::{discovery::peer_contacts::PeerContactError, dispatch::codecs::MessageCodec};
 
 #[derive(Debug, Error)]
 pub enum NetworkError {
@@ -50,6 +50,9 @@ pub enum NetworkError {
     },
     #[error("Response channel closed: {0:?}")]
     ResponseChannelClosed(<MessageCodec as libp2p::request_response::Codec>::Response),
+
+    #[error("Peer contact error: {0}")]
+    PeerContactError(#[from] PeerContactError),
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for NetworkError {

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -229,7 +229,7 @@ async fn create_network_with_n_peers(n_peers: usize) -> Vec<Network> {
             };
         });
 
-    if timeout(Duration::from_secs(120), all_joined).await.is_err() {
+    if timeout(Duration::from_secs(180), all_joined).await.is_err() {
         assert!(false, "Timeout triggered while waiting for peers to join");
     };
 
@@ -318,7 +318,7 @@ async fn create_network_with_n_peers(n_peers: usize) -> Vec<Network> {
 
 #[test(tokio::test)]
 async fn connections_stress_and_reconnect() {
-    let peers: usize = 15;
+    let peers: usize = 10;
     let networks = create_network_with_n_peers(peers).await;
 
     assert_eq!(peers, networks.len());

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -60,7 +60,8 @@ impl TestNetwork for Network {
             peer_key.public(),
             Services::all(),
             None,
-        );
+        )
+        .expect("Could not create peer contact");
         peer_contact.set_current_time();
         let config = Config::new(
             peer_key,


### PR DESCRIPTION
## What's in this pull request?

- Add verification of peer contacts received from the different messages that can transmit a list of peer contacts in the discovery protocol. The verification includes checks for appropriate lengths, signatures and number of addresses.
- Add timeout for the state transition in the discovery handler such that a peer don't hold us in a state indefinitely if it doesn't send us back a message we expect.
  This fixes #2458.
- Do not use the observed addresses sent through the discovery protocol since these addresses are not authenticated and it's been observed that they are not adding any useful address to a peer and instead were adding addresses with incorrect TCP/UDP ports.
- Reduce the reported observed addresses to a single address within the discovery protocol. This avoids DoS attacks from a peer sending several observed addresses for a specific connection. In terms of functionality, it stays the same since we were only reporting a single observed address (the address that got us a connection). Also reduced the interaction between the handler and the behaviour by setting handler attributes on the constructor instead of using events to the handler.
- Add limits to the peer contact addresses and add the ability to verify that these limits are followed when a peer contact is received from the network (discovery protocol).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
