### PR TITLE
Update dependencies and use more specific versions for dependencies with known CVEs

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,0 +1,14 @@
+name: Security audit
+
+on:
+  schedule:
+    - cron: '0 2 * * WED'
+
+jobs:
+  audit:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4578,7 +4578,6 @@ dependencies = [
 name = "nimiq-web-client"
 version = "0.1.0"
 dependencies = [
- "futures",
  "futures-util",
  "hex",
  "js-sys",
@@ -4604,6 +4603,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "serde",
  "serde-wasm-bindgen 0.6.5",
+ "tokio",
  "tracing",
  "tsify",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,10 +1439,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -4206,7 +4206,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "dotenv",
+ "dotenvy",
  "futures-util",
  "nimiq-account",
  "nimiq-bls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,11 +1087,10 @@ checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -1121,12 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -6848,7 +6844,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,10 +89,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "ansiterm"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
 dependencies = [
  "winapi",
 ]
@@ -3937,7 +3937,7 @@ dependencies = [
 name = "nimiq-log"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
+ "ansiterm",
  "time",
  "tracing",
  "tracing-log 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3747,7 +3747,7 @@ dependencies = [
  "data-encoding",
  "ed25519-zebra",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "nimiq-database-value",
  "nimiq-hash",
  "nimiq-hash_derive",
@@ -4560,7 +4560,7 @@ version = "0.1.0"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nimiq-database",
  "nimiq-database-value",
  "nimiq-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6740,11 +6740,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -6753,13 +6752,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.61",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
 dependencies = [
- "http",
+ "http 0.2.9",
  "log",
  "url",
 ]
@@ -550,9 +550,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -576,8 +576,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1903,7 +1903,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
+ "indexmap 2.2.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
  "indexmap 2.2.1",
  "slab",
  "tokio",
@@ -1968,7 +1987,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.9",
  "httpdate",
  "mime",
  "sha1",
@@ -1980,7 +1999,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.9",
 ]
 
 [[package]]
@@ -2117,13 +2136,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2155,9 +2208,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -2170,14 +2223,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httpdate",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.28",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -2191,7 +2262,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2204,10 +2275,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
 ]
 
 [[package]]
@@ -2299,8 +2386,8 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.28",
  "log",
  "rand",
  "tokio",
@@ -2429,7 +2516,7 @@ dependencies = [
  "async-trait",
  "beef",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "jsonrpsee-types",
  "serde",
  "serde_json",
@@ -2445,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19dc795a277cff37f27173b3ca790d042afcc0372c34a7ca068d2e76de2cb6d1"
 dependencies = [
  "async-trait",
- "hyper",
+ "hyper 0.14.28",
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3169,7 +3256,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "memchr",
@@ -3668,7 +3755,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "futures",
- "http",
+ "http 0.2.9",
  "log",
  "nimiq-jsonrpc-core",
  "reqwest",
@@ -3715,7 +3802,7 @@ dependencies = [
  "bytes",
  "futures",
  "headers",
- "http",
+ "http 0.2.9",
  "log",
  "nimiq-jsonrpc-core",
  "serde",
@@ -3914,8 +4001,11 @@ dependencies = [
 name = "nimiq-metrics-server"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "futures",
- "hyper",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
  "nimiq-blockchain",
  "nimiq-blockchain-interface",
  "nimiq-blockchain-proxy",
@@ -5628,10 +5718,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -6230,9 +6320,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snap"
@@ -6690,10 +6780,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -6903,7 +6993,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand",
@@ -7085,8 +7175,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.28",
  "log",
  "mime",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,8 @@ clippy.empty_docs = "allow" # false positives: https://github.com/rust-lang/rust
 clippy.assigning_clones = "allow" # false positives: https://github.com/rust-lang/rust-clippy/issues/12709
 
 [workspace.dependencies]
+futures = { package = "futures-util", version = "0.3.30" }
+
 nimiq-account = { path = "primitives/account", default-features = false }
 nimiq-block = { path = "primitives/block", default-features = false }
 nimiq-blockchain = { path = "blockchain", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ clippy.assigning_clones = "allow" # false positives: https://github.com/rust-lan
 
 [workspace.dependencies]
 futures = { package = "futures-util", version = "0.3.30" }
+log = { package = "tracing", version = "0.1.40", features = ["log"] }
 
 nimiq-account = { path = "primitives/account", default-features = false }
 nimiq-block = { path = "primitives/block", default-features = false }

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 serde = "1.0"

--- a/blockchain-interface/Cargo.toml
+++ b/blockchain-interface/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 serde = "1.0"
 thiserror = "1.0"

--- a/blockchain-proxy/Cargo.toml
+++ b/blockchain-proxy/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 parking_lot = "0.12"
 tokio-stream = { version = "0.1", features = ["sync"] }
 

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = { version = "0.22.2", optional = true }
 rand = "0.8"

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 byteorder = "1.5.0"
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = { version = "0.12.2", optional = true }
 rand = "0.8"
 serde = { version = "1.0", optional = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "time", "tracing"] }
 tokio-metrics = "0.3"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "time", "tracing"] }
 tokio-metrics = "0.3"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1"
 futures = { workspace = true }
 futures-executor = { version = "0.3" }
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1.1"
 rand = "0.8"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 futures-executor = { version = "0.3" }
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [dependencies]
 bitflags = "2.5"
 libmdbx = "0.5.0"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 tempfile = "3"
 thiserror = "1.0"
 

--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
-log = { package = "tracing", version = "0.1" }
+log = { workspace = true }
 serde = "1.0"
 thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -39,7 +39,7 @@ nimiq-transaction = { workspace = true }
 nimiq-utils = { workspace = true, features = ["time"] }
 
 [build-dependencies]
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 nimiq-database = { workspace = true }

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 rand = "0.8"
 serde = "1.0"

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3", features = ["sink"] }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 rand = "0.8"

--- a/key-derivation/Cargo.toml
+++ b/key-derivation/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 byteorder = "1.5"
-regex = "1"
+regex = "1.10"
 serde = "1.0"
 
 nimiq-hash = { workspace = true }

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -30,14 +30,14 @@ curve25519-dalek = { version = "4", features = [
 data-encoding = "2.6"
 ed25519-zebra = "4.0"
 hex = "0.4"
+itertools = "0.10.3"
 p256 = "0.13"
 rand = "0.8"
-rand_core = "0.6"
+rand_core = "0.6.4"
 serde = { version = "1.0", optional = true }
 serde-big-array = { version = "0.5", optional = true }
 sha2 = "0.10"
 thiserror = "1.0"
-itertools = "0.10.3"
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
 
 nimiq-database-value = { workspace = true }

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -30,7 +30,7 @@ curve25519-dalek = { version = "4", features = [
 data-encoding = "2.6"
 ed25519-zebra = "4.0"
 hex = "0.4"
-itertools = "0.10.3"
+itertools = "0.12"
 p256 = "0.13"
 rand = "0.8"
 rand_core = "0.6.4"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,7 +26,7 @@ derive_builder = "0.20"
 directories = "5.0"
 hex = "0.4"
 # human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
 parking_lot = "0.12"
 rand = "0.8"

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["sync"] }

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 thiserror = "1.0"

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 ansi_term = "0.12"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["time"] }

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-ansi_term = "0.12"
+ansiterm = "0.12"
 log = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 tracing-log = "0.2"

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{env, fmt};
 
-use ansi_term::{Color, Style};
+use ansiterm::{Color, Style};
 use log::{level_filters::LevelFilter, Event, Level, Subscriber};
 use time::format_description::well_known::Iso8601;
 use tracing_log::NormalizeEvent;

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 futures = { workspace = true }
 keyed_priority_queue = "0.4"
 linked-hash-map = "0.5.6"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = { version = "0.22.2", optional = true}
 serde = "1.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 keyed_priority_queue = "0.4"
 linked-hash-map = "0.5.6"
 log = { package = "tracing", version = "0.1", features = ["log"] }

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [dependencies]
 futures = "0.3"
 hyper = { version = "0.14.28", features = ["server", "tcp", "http2"] }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = "0.22.2"
 tokio = { version = "1.37", features = [

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -20,13 +20,17 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
+bytes = "1.6"
 futures = "0.3"
-hyper = { version = "0.14.28", features = ["server", "tcp", "http2"] }
+http-body-util = { version = "0.1" }
+hyper = { version = "1.3", features = ["server", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 log = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = "0.22.2"
 tokio = { version = "1.37", features = [
     "macros",
+    "net",
     "rt-multi-thread",
     "tracing",
 ] }

--- a/metrics-server/src/server.rs
+++ b/metrics-server/src/server.rs
@@ -1,24 +1,38 @@
-use std::{
-    net::SocketAddr,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::{net::SocketAddr, sync::Arc};
 
+use bytes::Bytes;
 use futures::future::BoxFuture;
-use hyper::{http::StatusCode, service::Service, Body, Method, Request, Response, Server};
+use http_body_util::Full;
+use hyper::{
+    body::Incoming as IncomingBody, http::StatusCode, server::conn::http2, service::Service,
+    Method, Request, Response,
+};
+use hyper_util::rt::tokio::{TokioExecutor, TokioIo};
 use log::{error, info};
 use parking_lot::RwLock;
 use prometheus_client::{encoding::text::encode, registry::Registry};
+use tokio::net::TcpListener;
 
 pub async fn metrics_server(addr: SocketAddr, registry: Registry) -> Result<(), std::io::Error> {
-    let server = Server::bind(&addr).serve(MakeMetricService::new(registry));
-    info!("Metrics server on http://{}/metrics", server.local_addr());
-    if let Err(e) = server.await {
-        error!("server error: {}", e);
+    let listener = TcpListener::bind(&addr).await?;
+    info!("Metrics server on http://{}/metrics", addr);
+    let metrics_service = MetricService::new(registry);
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+        let svc_clone = metrics_service.clone();
+        tokio::spawn(async move {
+            if let Err(error) = http2::Builder::new(TokioExecutor::new())
+                .serve_connection(io, svc_clone)
+                .await
+            {
+                error!(%error, "server error",);
+            }
+        });
     }
-    Ok(())
 }
 
+#[derive(Debug, Clone)]
 pub struct MetricService {
     reg: Arc<RwLock<Registry>>,
 }
@@ -26,10 +40,15 @@ pub struct MetricService {
 type SharedRegistry = Arc<RwLock<Registry>>;
 
 impl MetricService {
-    fn get_reg(&mut self) -> SharedRegistry {
+    pub fn new(registry: Registry) -> Self {
+        Self {
+            reg: Arc::new(RwLock::new(registry)),
+        }
+    }
+    fn get_reg(&self) -> SharedRegistry {
         Arc::clone(&self.reg)
     }
-    fn respond_with_metrics(&mut self) -> Response<Body> {
+    fn respond_with_metrics(&self) -> Response<Full<Bytes>> {
         let mut encoded = String::new();
         let reg = self.get_reg();
         encode(&mut encoded, &reg.read()).unwrap();
@@ -37,27 +56,25 @@ impl MetricService {
         Response::builder()
             .status(StatusCode::OK)
             .header(hyper::header::CONTENT_TYPE, metrics_content_type)
-            .body(Body::from(encoded))
+            .body(Full::new(Bytes::from(encoded)))
             .unwrap()
     }
-    fn respond_with_404_not_found(&mut self) -> Response<Body> {
+    fn respond_with_404_not_found(&self) -> Response<Full<Bytes>> {
         Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(Body::from("Not found try localhost:[port]/metrics"))
+            .body(Full::new(Bytes::from(
+                "Not found try localhost:[port]/metrics",
+            )))
             .unwrap()
     }
 }
 
-impl Service<Request<Body>> for MetricService {
-    type Response = Response<Body>;
+impl Service<Request<IncomingBody>> for MetricService {
+    type Response = Response<Full<Bytes>>;
     type Error = hyper::Error;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    fn call(&self, req: Request<IncomingBody>) -> Self::Future {
         let req_path = req.uri().path();
         let req_method = req.method();
         let resp = if (req_method == Method::GET) && (req_path == "/metrics") {
@@ -67,33 +84,5 @@ impl Service<Request<Body>> for MetricService {
             self.respond_with_404_not_found()
         };
         Box::pin(async { Ok(resp) })
-    }
-}
-
-pub struct MakeMetricService {
-    reg: SharedRegistry,
-}
-
-impl MakeMetricService {
-    pub fn new(registry: Registry) -> MakeMetricService {
-        MakeMetricService {
-            reg: Arc::new(RwLock::new(registry)),
-        }
-    }
-}
-
-impl<T> Service<T> for MakeMetricService {
-    type Response = MetricService;
-    type Error = hyper::Error;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _: &mut Context) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, _: T) -> Self::Future {
-        let reg = self.reg.clone();
-        let fut = async move { Ok(MetricService { reg }) };
-        Box::pin(fut)
     }
 }

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 bitflags = { version = "2.5", features = ["serde"] }
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 multiaddr = "0.18"
 serde = "1.0"

--- a/network-interface/Cargo.toml
+++ b/network-interface/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 async-trait = "0.1"
 bitflags = { version = "2.5", features = ["serde"] }
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 multiaddr = "0.18"
 serde = "1.0"
 thiserror = "1.0"

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.6"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = "0.4"
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 ip_network = "0.4"

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -27,7 +27,7 @@ futures = { workspace = true }
 hex = "0.4"
 instant = { version = "0.1", features = [ "wasm-bindgen" ] }
 ip_network = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1.1"
 pin-project-lite = "0.2.14"

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 async-trait = "0.1"
 derive_more = "0.99"
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 serde = "1.0"
 thiserror = "1.0"

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 derive_more = "0.99"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 serde = "1.0"

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4.5", features = ["derive"] }
 convert_case = "0.6"
 hex = "0.4"
 humantime = "2.1"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 nimiq-blockchain = { workspace = true }
 nimiq-bls = { workspace = true }
 nimiq-database = { workspace = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -26,7 +26,7 @@ ark-serialize = "0.4"
 byteorder = "1.5"
 cfg_eval = "0.1"
 hex = { version = "0.4", optional = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 once_cell = "1.19"
 parking_lot = { version = "0.12.2", optional = true }
 regex = { version = "1.10", optional = true }

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 rand = "0.8"
 serde = "1.0"

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -22,7 +22,7 @@ ark-ec = "0.4"
 bitflags = { version = "2.5", features = ["serde"] }
 byteorder = "1.5"
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 serde = "1.0"
 serde_repr = "0.1"
 thiserror = "1.0"

--- a/primitives/subscription/Cargo.toml
+++ b/primitives/subscription/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 serde = "1.0"
 
 nimiq-bls = { workspace = true, features = ["serde-derive"] }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 [dependencies]
 base64 = "0.22"
 bitflags = { version = "2.5", features = ["serde"] }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 serde = "1.0"
 serde_json = "1.0"
 strum_macros = "0.26"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 serde = "1.0"
 thiserror = "1.0"
 

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 dotenv = "0.15"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 tokio = { version = "1.37", features = [
     "macros",
     "rt-multi-thread",

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/main.rs"
 async-trait = "0.1"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 futures = { workspace = true }
 tokio = { version = "1.37", features = [
     "macros",

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -138,7 +138,7 @@ async fn run_app(opt: Opt) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = dotenv::dotenv() {
+    if let Err(e) = dotenvy::dotenv() {
         if !e.not_found() {
             panic!("could not read .env file: {e}");
         }

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -24,7 +24,7 @@ ark-groth16 = { version = "0.4", default-features = false }
 ark-mnt6-753 = "0.4"
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive"] }
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = "0.4"
 parking_lot = "0.12"
 serde = "1.0"

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = "0.4.2"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 async-trait = "0.1"
 futures = { workspace = true }
 hex = "0.4.2"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 serde = "1.0"
 serde_json = "1.0"

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 rand = "0.8.5"
 serde = "1.0"
 tokio = { version = "1.37", features = ["rt-multi-thread", "time", "tracing"] }

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 rand = "0.8.5"
 serde = "1.0"

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 rand = "0.8"
 serde = "1.0"
 tokio = { version = "1.37", features = [

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 rand = "0.8"
 serde = "1.0"

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 workspace = true
 
 [dependencies]
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -21,7 +21,7 @@ ark-serialize = "0.4"
 async-trait = "0.1"
 futures = { workspace = true }
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 paste = "1.0"
 rand = "0.8"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -19,7 +19,7 @@ ark-groth16 = { version = "0.4", default-features = false }
 ark-mnt6-753 = "0.4"
 ark-serialize = "0.4"
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["cargo"] }
 convert_case = "0.6"
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 quote = "1.0"
 rand = "0.8"
 schemars = "0.8"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 clear_on_drop = { version = "0.2", optional = true }
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = { version = "0.4", optional = true }
 libp2p-identity = { version = "0.2", optional = true }
 log = { package = "tracing", version = "0.1", optional = true, features = ["log"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -24,7 +24,7 @@ clear_on_drop = { version = "0.2", optional = true }
 futures = { workspace = true }
 hex = { version = "0.4", optional = true }
 libp2p-identity = { version = "0.2", optional = true }
-log = { package = "tracing", version = "0.1", optional = true, features = ["log"] }
+log = { workspace = true, optional = true }
 parking_lot = "0.12"
 rand = { version = "0.8", optional = true }
 rand_core = { version = "0.6", optional = true }

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 futures = { workspace = true }
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 serde = "1.0"
 thiserror = "1.0"

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"
 serde = "1.0"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1"
 byteorder = "1.5"
 futures = { workspace = true }
 linked-hash-map = "0.5.6"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 rand = "0.8"
 rayon = "1.10"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 byteorder = "1.5"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 linked-hash-map = "0.5.6"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 byteorder = "1.5"
 curve25519-dalek = { version = "4", features = ["digest"] }
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 rand = "0.8"
 serde = { version = "1.0", optional = true }
 sha2 = "0.10"

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -22,13 +22,13 @@ workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-futures = "0.3"
-futures-util = "0.3"
+futures = { workspace = true }
 hex = "0.4"
 js-sys = "0.3"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 serde = "1.0"
 serde-wasm-bindgen = "0.6"
+tokio = { version = "1.37", features = ["sync"] }
 tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib"]
 futures = { workspace = true }
 hex = "0.4"
 js-sys = "0.3"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 serde = "1.0"
 serde-wasm-bindgen = "0.6"
 tokio = { version = "1.37", features = ["sync"] }

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -10,10 +10,9 @@ use std::{
 };
 
 use futures::{
-    channel::oneshot,
     future::{select, Either},
+    StreamExt,
 };
-use futures_util::StreamExt;
 use js_sys::{global, Array, Function, JsString};
 use log::level_filters::LevelFilter;
 pub use nimiq::{
@@ -31,6 +30,7 @@ use nimiq_network_interface::{
     Multiaddr,
 };
 use nimiq_primitives::policy::Policy;
+use tokio::sync::oneshot;
 use tsify::Tsify;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::spawn_local;

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["zkp-prover", "parallel", "cli"]
 [dependencies]
 clap = { version = "4.5", features = ["cargo", "string", "derive"] }
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_chacha = "0.3.1"
 rayon = { version = "^1.10", optional = true }

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -29,7 +29,7 @@ ark-mnt4-753 = "0.4"
 ark-mnt6-753 = "0.4"
 ark-serialize = "0.4"
 async-trait = "0.1"
-futures = { package = "futures-util", version = "0.3" }
+futures = { workspace = true }
 hex = "0.4"
 log = { package = "tracing", version = "0.1", features = ["log"] }
 parking_lot = "0.12"

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -31,7 +31,7 @@ ark-serialize = "0.4"
 async-trait = "0.1"
 futures = { workspace = true }
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 rand = "0.8"
 serde = "1.0"

--- a/zkp-component/zkp-test-gen/Cargo.toml
+++ b/zkp-component/zkp-test-gen/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 parking_lot = "0.12"
 serde = "1.0"
 tokio = { version = "1.37", features = ["macros", "rt", "sync"] }

--- a/zkp-primitives/Cargo.toml
+++ b/zkp-primitives/Cargo.toml
@@ -25,7 +25,7 @@ ark-r1cs-std = "0.4"
 ark-serialize = "0.4"
 ark-std = "0.4"
 hex = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log"] }
+log = { workspace = true }
 rand = { version = "0.8", features = ["small_rng"] }
 rayon = { version = "^1.10", optional = true }
 serde = { version = "1.0" }

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -24,7 +24,7 @@ ark-relations = "0.4"
 ark-r1cs-std = "0.4"
 ark-serialize = "0.4"
 ark-std = "0.4"
-log = { package = "tracing", version = "0.1", features = ["log", "attributes"] }
+log = { workspace = true }
 once_cell = "1.19"
 parking_lot = "0.12"
 rand = { version = "0.8", features = ["small_rng"] }


### PR DESCRIPTION
## What's in this pull request?

- Use a more specific version for the `rand_core` dependency than versions with known CVEs.
  This fixes #2454.
- Use a more specific version for the `futures-util` dependency than versions with known CVEs.
  This fixes #2457.
- Use a more specific version for the `tracing` dependency than versions with known CVEs.
  This fixes #2453.
- Use a more specific version for the `regex` dependency than versions with known CVEs.
- Update the `itertools` dependency to the latest version (0.12.1) as for some reason this hasn't been flagged by GH dependabot.
- Update the `hyper` dependency to the latest version (1.3.1) for the `metrics-server` subcrate.
- Updated the `crossbeam-channel` dependency from version 0.5.7 to 0.5.12 (latest) since the former version was already yanked as pointed by `cargo audit`.
- Switch to a maintained version of the `dotenv` dependency: `dotenvy` since the former is flagged by `cargo audit` as unmaintained.
- Switch to a maintained version of the `ansi-term` dependency: `ansiterm` since the former was flagged by `cargo audit` as unmaintained.
- Add Github workflow to check for security vulnerabilities using `cargo audit`.
  This workflow was set up to run every Wednesday at 2:00 UTC.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
