### PR TITLE
Introduce `Sensitive` which can be used for hiding `Debug` impls

### DIFF
--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -12,6 +12,7 @@ use nimiq_mempool::{
 use nimiq_network_interface::Multiaddr;
 use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_serde::Deserialize;
+use nimiq_utils::Sensitive;
 use thiserror::Error;
 use url::Url;
 
@@ -124,7 +125,7 @@ impl FromStr for ConfigFile {
 #[serde(deny_unknown_fields)]
 pub struct NetworkSettings {
     pub peer_key_file: Option<String>,
-    pub peer_key: Option<String>,
+    pub peer_key: Option<Sensitive<String>>,
 
     #[serde(default)]
     pub listen_addresses: Vec<String>,
@@ -241,7 +242,7 @@ pub struct RpcServerSettings {
     #[serde(default)]
     pub methods: Vec<String>,
     pub username: Option<String>,
-    pub password: Option<String>,
+    pub password: Option<Sensitive<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -252,7 +253,7 @@ pub struct MetricsServerSettings {
     pub bind: Option<String>,
     pub port: Option<u16>,
     pub username: Option<String>,
-    pub password: Option<String>,
+    pub password: Option<Sensitive<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -403,33 +404,18 @@ impl From<MempoolFilterSettings> for MempoolRules {
     }
 }
 
-#[derive(Clone, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ValidatorSettings {
     pub validator_address: String,
     pub signing_key_file: Option<String>,
-    pub signing_key: Option<String>,
+    pub signing_key: Option<Sensitive<String>>,
     pub voting_key_file: Option<String>,
-    pub voting_key: Option<String>,
+    pub voting_key: Option<Sensitive<String>>,
     pub fee_key_file: Option<String>,
-    pub fee_key: Option<String>,
+    pub fee_key: Option<Sensitive<String>>,
     #[serde(default)]
     pub automatic_reactivate: bool,
-}
-
-impl Debug for ValidatorSettings {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ValidatorSettings")
-            .field("validator_address", &self.validator_address)
-            .field("signing_key_file", &self.signing_key_file)
-            .field("signing_key", &self.signing_key.as_ref().map(|_| "***"))
-            .field("voting_key_file", &self.voting_key_file)
-            .field("voting_key", &self.voting_key.as_ref().map(|_| "***"))
-            .field("fee_key_file", &self.fee_key_file)
-            .field("fee_key", &self.fee_key.as_ref().map(|_| "***"))
-            .field("automatic_reactivate", &self.automatic_reactivate)
-            .finish()
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]

--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -23,7 +23,7 @@ pub fn initialize_rpc_server(
     // Configure RPC server
     let basic_auth = config.credentials.map(|credentials| Credentials {
         username: credentials.username,
-        password: credentials.password,
+        password: credentials.password.0,
     });
 
     let allowed_methods = config.allowed_methods.unwrap_or_default();

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::VecDeque,
+    ops::Deref,
     path::PathBuf,
     str::FromStr,
     sync::{Arc, RwLock},
@@ -181,7 +182,11 @@ async fn main_inner() -> Result<(), Error> {
     let private_key = match config.network_id {
         NetworkId::UnitAlbatross => UNIT_KEY,
         // First try to get it from the "fee_key" field in the config file, if that's not set, then use the hardcoded default.
-        NetworkId::DevAlbatross => validator_settings.fee_key.as_deref().unwrap_or(DEV_KEY),
+        NetworkId::DevAlbatross => validator_settings
+            .fee_key
+            .as_deref()
+            .map(Deref::deref)
+            .unwrap_or(DEV_KEY),
         _ => panic!("Unsupported network"),
     };
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -15,6 +15,7 @@ pub mod tagged_signing;
 #[cfg(feature = "time")]
 pub mod time;
 
+mod sensitive;
 mod waker;
 
-pub use self::waker::WakerExt;
+pub use self::{sensitive::Sensitive, waker::WakerExt};

--- a/utils/src/sensitive.rs
+++ b/utils/src/sensitive.rs
@@ -1,0 +1,52 @@
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{
+    de::{Deserialize, Deserializer},
+    ser::{Serialize, Serializer},
+};
+
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Sensitive<T>(pub T);
+
+impl<T> fmt::Debug for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("***")
+    }
+}
+
+impl<T, U: ?Sized> AsRef<U> for Sensitive<T>
+where
+    T: AsRef<U>,
+{
+    fn as_ref(&self) -> &U {
+        self.0.as_ref()
+    }
+}
+
+impl<T> Deref for Sensitive<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Sensitive<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Sensitive<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Sensitive<T>, D::Error> {
+        T::deserialize(deserializer).map(Sensitive)
+    }
+}
+
+impl<T: Serialize> Serialize for Sensitive<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}


### PR DESCRIPTION
Use it everywhere where we used to manually implement `Debug` on types to hide information.

Alternative to #2463.

Fixes #2459.