### PR TITLE
Add function to obtain genesis hash

### DIFF
--- a/blockchain-interface/src/abstract_blockchain.rs
+++ b/blockchain-interface/src/abstract_blockchain.rs
@@ -89,6 +89,9 @@ pub trait AbstractBlockchain {
     /// Fetches a given block, by its block number.
     fn get_block_at(&self, height: u32, include_body: bool) -> Result<Block, BlockchainError>;
 
+    /// Obtains the hash associated with the genesis block.
+    fn get_genesis_hash(&self) -> Blake2bHash;
+
     /// Fetches a given block, by its hash.
     fn get_block(&self, hash: &Blake2bHash, include_body: bool) -> Result<Block, BlockchainError>;
 

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -145,6 +145,10 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         gen_blockchain_match!(self, BlockchainReadProxy, get_block, hash, include_body)
     }
 
+    fn get_genesis_hash(&self) -> Blake2bHash {
+        gen_blockchain_match!(self, BlockchainReadProxy, get_genesis_hash)
+    }
+
     fn get_blocks(
         &self,
         start_block_hash: &Blake2bHash,

--- a/blockchain/src/blockchain/abstract_blockchain.rs
+++ b/blockchain/src/blockchain/abstract_blockchain.rs
@@ -70,6 +70,10 @@ impl AbstractBlockchain for Blockchain {
         self.get_block(hash, include_body, None)
     }
 
+    fn get_genesis_hash(&self) -> Blake2bHash {
+        self.genesis_hash.clone()
+    }
+
     fn get_blocks(
         &self,
         start_block_hash: &Blake2bHash,

--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -58,6 +58,8 @@ pub struct Blockchain {
     pub(crate) genesis_timestamp: u64,
     /// The Genesis block number
     pub(crate) genesis_block_number: u32,
+    /// The Genesis hash used for various checks
+    pub(crate) genesis_hash: Blake2bHash,
 }
 
 /// Contains various blockchain configuration knobs
@@ -179,6 +181,7 @@ impl Blockchain {
         }
 
         let genesis_block_number = genesis_block.block_number();
+        let genesis_hash = genesis_block.hash();
 
         let (genesis_supply, genesis_timestamp) =
             genesis_parameters(&genesis_block.unwrap_macro().header);
@@ -289,6 +292,7 @@ impl Blockchain {
             genesis_supply,
             genesis_timestamp,
             genesis_block_number,
+            genesis_hash,
         })
     }
 
@@ -308,6 +312,7 @@ impl Blockchain {
 
         let genesis_macro_block = genesis_block.unwrap_macro_ref().clone();
         let genesis_block_number = genesis_block.block_number();
+        let genesis_hash = genesis_block.hash();
         let current_slots = genesis_macro_block.get_validators().expect("Slots missing");
         let (genesis_supply, genesis_timestamp) = genesis_parameters(&genesis_macro_block.header);
 
@@ -354,6 +359,7 @@ impl Blockchain {
             genesis_supply,
             genesis_timestamp,
             genesis_block_number,
+            genesis_hash,
         })
     }
 

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -354,12 +354,7 @@ impl<N: Network> ConsensusProxy<N> {
                             let mut already_proven = false;
 
                             if response.block.block_number() == Policy::genesis_block_number() {
-                                let genesis_hash = self
-                                    .blockchain
-                                    .read()
-                                    .get_block_at(Policy::genesis_block_number(), false)
-                                    .unwrap()
-                                    .hash();
+                                let genesis_hash = self.blockchain.read().get_genesis_hash();
 
                                 if genesis_hash == response.block.hash() {
                                     already_proven = true;

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -63,6 +63,10 @@ impl AbstractBlockchain for LightBlockchain {
             .map(|chain_info| chain_info.head.clone())
     }
 
+    fn get_genesis_hash(&self) -> Blake2bHash {
+        self.genesis_block.hash()
+    }
+
     fn get_blocks(
         &self,
         start_block_hash: &Blake2bHash,


### PR DESCRIPTION
The genesis hash is used for various checks, it is now stored as part of the blockchain 
This fixes #2466

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
