### PR TITLE
RPC transaction size, web-client confirmations fix and desired peer count

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -196,6 +196,7 @@ impl Block {
                         block_number: Some(macro_block.block_number()),
                         timestamp: Some(macro_block.timestamp()),
                         confirmations: cur_block_height.map(|h| h - macro_block.block_number()),
+                        size: tx.serialized_size(),
                         from: Address::default(),
                         from_type: 0,
                         to: tx.unwrap_reward().reward_address.clone(),
@@ -553,6 +554,7 @@ pub struct Transaction {
     pub timestamp: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confirmations: Option<u32>,
+    pub size: usize,
 
     pub from: Address,
     pub from_type: u8,
@@ -604,6 +606,7 @@ impl Transaction {
                 Some(height) => block_number.map(|block| height.saturating_sub(block) + 1),
                 None => None,
             },
+            size: transaction.serialized_size(),
             from: transaction.sender,
             from_type: transaction.sender_type as u8,
             to: transaction.recipient,

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -157,7 +157,7 @@ impl Client {
         config.network.seeds = seed_nodes;
         config.network.only_secure_ws_connections = true;
         config.network_id = web_config.network_id;
-        config.network.desired_peer_count = 12;
+        config.network.desired_peer_count = 6;
 
         log::info!(?config, "Final configuration");
 

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -1148,7 +1148,7 @@ impl PlainTransactionDetails {
             execution_result: Some(executed_transaction.succeeded()),
             block_height: Some(block_number),
             timestamp: Some(block_time),
-            confirmations: Some(block_number - current_block + 1),
+            confirmations: Some(current_block - block_number + 1),
         }
     }
 }


### PR DESCRIPTION
## What's in this pull request?

1. Add a field called `size` to transaction objects returned from RPC. That field already exists on web-client transactions.
2. Fix `confirmations` in web-client transactions. It was calculated the wrong way around and the `u32` consequently underflowed.
3. Reduce `desired_peer_count` for web-clients to 6 to reduce data over the wire for _lightweight_ web-clients. In my testing the client still connected to 8-9 peers regardless.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
