### PR TITLE
Add genesis config hash as extra data to migration ready transaction

### DIFF
--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -55,7 +55,7 @@ pub struct GenesisConfig {
     pub htlc_accounts: Vec<GenesisHTLC>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenesisValidator {
     pub validator_address: Address,
     pub signing_key: SchnorrPublicKey,
@@ -67,7 +67,7 @@ pub struct GenesisValidator {
     pub retired: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenesisStaker {
     pub staker_address: Address,
     pub balance: Coin,
@@ -77,14 +77,14 @@ pub struct GenesisStaker {
     pub inactive_from: Option<u32>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenesisAccount {
     pub address: Address,
     pub balance: Coin,
 }
 
 /// Struct that represents a vesting contract in the toml file that is used to generate the genesis
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenesisVestingContract {
     /// Vesting contract account address
     pub address: Address,
@@ -103,7 +103,7 @@ pub struct GenesisVestingContract {
 }
 
 /// Struct that represents an HTLC in the toml file that is used to generate the genesis
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenesisHTLC {
     /// HTLC account address
     pub address: Address,

--- a/pow-migration/src/history/mod.rs
+++ b/pow-migration/src/history/mod.rs
@@ -130,7 +130,9 @@ pub async fn migrate_history(
         );
 
         // Get transactions of each block and add them to the PoS history store
-        for block_height in (history_store_height + 1)..=candidate_block {
+        // Migrate up to the candidate_block (exclusive) as this block number eventually becomes
+        // the block number for the genesis block on the PoS chain.
+        for block_height in (history_store_height + 1)..candidate_block {
             // Check if we are closing in on the PoW head block.
             // If this is true, we may need to take some extra time in order to make sure
             // that blocks leading up to the head block are confirmed before we

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -338,8 +338,7 @@ async fn main() {
                     }
                 },
                 Err(error) => {
-                    log::error!(?error, "Could not migrate");
-                    exit(1);
+                    exit_with_error(error, "Could not migrate");
                 }
             }
         }


### PR DESCRIPTION
## What's in this pull request?
* Fix PoW to PoS chain migration where the candidate block was also migrated into the PoS history store
* Migration ready transactions now include a genesis config hash as extra data. This way validator ready transactions that have a different starting point are not counted towards the total validator readiness.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
