### PR TITLE
web-client: Rename `npm` package

### DIFF
--- a/web-client/dist/README.md
+++ b/web-client/dist/README.md
@@ -10,13 +10,13 @@ A very light Nimiq Proof-of-Stake client for browsers and NodeJS, compiled from 
 You need to install this package from the `next` tag:
 
 ```sh
-npm install @nimiq/core-web@next
+npm install @nimiq/core@next
 ```
 
 or
 
 ```sh
-yarn add @nimiq/core-web@next
+yarn add @nimiq/core@next
 ```
 
 ## 🛠️ Usage
@@ -39,7 +39,7 @@ If you use any bundler for your project, like Webpack or Vite, you should probab
 > ```ts
 > // vite.config.ts
 > optimizeDeps: {
->    exclude: ['@nimiq/core-web'],
+>    exclude: ['@nimiq/core'],
 > }
 > ```
 
@@ -51,7 +51,7 @@ If you use any bundler for your project, like Webpack or Vite, you should probab
 > // nuxt.config.ts
 > vite: {
 >   optimizeDeps: {
->      exclude: ['@nimiq/core-web'],
+>      exclude: ['@nimiq/core'],
 >   }
 > }
 > ```
@@ -59,9 +59,9 @@ If you use any bundler for your project, like Webpack or Vite, you should probab
 
 ```js
 // With Webpack: import the package asynchronously:
-const Nimiq = await import('@nimiq/core-web');
+const Nimiq = await import('@nimiq/core');
 // With Vite, import at the top of your file:
-import * as Nimiq from '@nimiq/core-web';
+import * as Nimiq from '@nimiq/core';
 
 // Create a configuration builder:
 const config = new Nimiq.ClientConfiguration();
@@ -86,7 +86,7 @@ const client = await Nimiq.Client.create(config.build());
 
 ```js
 // Import the loader and package from the /web path:
-import init, * as Nimiq from '@nimiq/core-web/web';
+import init, * as Nimiq from '@nimiq/core/web';
 
 // Load and initialize the WASM file
 init().then(() => {
@@ -107,9 +107,9 @@ For NodeJS, this package includes both CommonJS and ESM builds. You can either `
 
 ```js
 // Import as CommonJS module
-const Nimiq = require("@nimiq/core-web");
+const Nimiq = require("@nimiq/core");
 // Or import as ESM module
-import * as Nimiq from "@nimiq/core-web";
+import * as Nimiq from "@nimiq/core";
 
 // In ESM modules you can use await at the top-level and do not need an async wrapper function.
 async function main() {

--- a/web-client/dist/package.json
+++ b/web-client/dist/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@nimiq/core-web",
+  "name": "@nimiq/core",
   "contributors": [
     "The Nimiq Core Development Team <info@nimiq.com>"
   ],
   "description": "Nimiq's Rust-to-WASM web client",
-  "version": "2.0.0-alpha.21.1",
+  "version": "2.0.0-next.21.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/web-client/example/node/index.js
+++ b/web-client/example/node/index.js
@@ -1,4 +1,4 @@
-const Nimiq = require("@nimiq/core-web");
+const Nimiq = require("@nimiq/core");
 
 async function main() {
     const config = new Nimiq.ClientConfiguration();

--- a/web-client/example/node/index.mjs
+++ b/web-client/example/node/index.mjs
@@ -1,4 +1,4 @@
-import * as Nimiq from "@nimiq/core-web";
+import * as Nimiq from "@nimiq/core";
 
 const config = new Nimiq.ClientConfiguration();
 // config.logLevel('debug');

--- a/web-client/example/node/package.json
+++ b/web-client/example/node/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@nimiq/core-web-example",
-  "description": "A NodeJS example for @nimiq/core-web Albatross",
+  "name": "@nimiq/core-example",
+  "description": "A NodeJS example for @nimiq/core Albatross",
   "main": "index.js",
   "module": "index.mjs",
   "dependencies": {
-    "@nimiq/core-web": "../../dist"
+    "@nimiq/core": "../../dist"
   },
   "scripts": {
     "preinstall": "cd ../.. && ./scripts/build-launcher.sh"


### PR DESCRIPTION
Rename `npm` package from `core-web` to `core` and use a better versioning scheme: from `2.0.0-alpha.21.1` to `2.0.0-next.21.1`.

This closes #2449.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
