### PR TITLE
Run wasm tests in headless Chrome instead of NodeJS

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -91,7 +91,7 @@ jobs:
         # this might remove tools that are actually needed,
         # if set to "true" but frees about 6 GB
         tool-cache: true
-        
+
         # all of these default to true, but feel free to set to
         # "false" if necessary for your workflow
         android: true
@@ -109,7 +109,7 @@ jobs:
       run: wasm-pack build --target web
     - name: Execute wasm unittests
       working-directory: ./web-client
-      run: wasm-pack test --node
+      run: wasm-pack test --chrome --headless
 
   reconnect-test:
     runs-on: ubuntu-22.04

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -21,6 +21,8 @@ mod tests {
         },
     };
 
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
     #[wasm_bindgen_test]
     pub fn it_can_create_and_sign_basic_transactions() {
         let keypair = KeyPair::generate();

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -15,8 +15,9 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen_futures::spawn_local;
 use wasm_bindgen_test::wasm_bindgen_test;
 
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
 #[wasm_bindgen_test]
-#[ignore]
 pub async fn it_can_initialize_with_mock_network() {
     let mut hub = MockHub::new();
 


### PR DESCRIPTION
The wasm-pack test instrumentation doesn't play nice with `wasm-timer` on NodeJS, failing on the return value of `setTimeout` or `setInterval`. Browsers return a `number`, which the test instrumentation expects, whereas NodeJS returns an `object`.

Running the tests in a browser means we can re-enable a test that was disabled for the above reason.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
