### PR TITLE
Change serialization order of KeyPair to have the private key first

### DIFF
--- a/keys/src/key_pair.rs
+++ b/keys/src/key_pair.rs
@@ -9,8 +9,8 @@ use crate::{Ed25519PublicKey, Ed25519Signature, PrivateKey};
 #[derive(Default, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-derive", derive(Serialize, Deserialize))]
 pub struct KeyPair {
-    pub public: Ed25519PublicKey,
     pub private: PrivateKey,
+    pub public: Ed25519PublicKey,
 }
 
 impl KeyPair {
@@ -34,9 +34,10 @@ impl SecureGenerate for KeyPair {
 
 impl From<PrivateKey> for KeyPair {
     fn from(private_key: PrivateKey) -> Self {
+        let public_key = Ed25519PublicKey::from(&private_key);
         KeyPair {
-            public: Ed25519PublicKey::from(&private_key),
             private: private_key,
+            public: public_key,
         }
     }
 }


### PR DESCRIPTION
This is the same order of serialization that core-js used. This makes (de)serializing KeyPairs backwards-compatible.

It's also the same order that BLS KeyPairs have:
https://github.com/nimiq/core-rs-albatross/blob/de902e5ea9f2e6fe6180988977c5081b70d7f35d/bls/src/types/keypair.rs#L8-L11

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
