### PR TITLE
Switch to wasm-bindgen's newly included TryFromJsValue trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,7 +4904,6 @@ dependencies = [
  "tracing",
  "tsify",
  "wasm-bindgen",
- "wasm-bindgen-derive",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
@@ -7558,28 +7557,6 @@ dependencies = [
  "quote",
  "syn 2.0.72",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8fdb87408dab27d43267c311c89135b35d13f8b3081e88451ddeff742c93a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-derive-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-derive-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fbc080f15cb38f447d52bbae64630c2d4925a9ecb5d140d56c0910b69b4cc7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -33,7 +33,6 @@ tokio = { version = "1.39", features = ["sync"] }
 tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-wasm-bindgen-derive = { version = "0.3", optional = true }
 web-sys = { version = "0.3.69", features = ["MessageEvent"] }
 
 nimiq-account = { workspace = true, default-features = false }
@@ -75,4 +74,4 @@ nimiq-zkp-component = { workspace = true, default-features = false }
 [features]
 client = []
 default = ["client", "primitives"]
-primitives = ["wasm-bindgen-derive"]
+primitives = []

--- a/web-client/src/address.rs
+++ b/web-client/src/address.rs
@@ -3,15 +3,13 @@ use std::str::FromStr;
 use nimiq_serde::Deserialize;
 #[cfg(feature = "primitives")]
 use nimiq_serde::Serialize;
-use wasm_bindgen::prelude::*;
 #[cfg(feature = "primitives")]
-use wasm_bindgen_derive::TryFromJsValue;
+use wasm_bindgen::convert::TryFromJsValue;
+use wasm_bindgen::prelude::*;
 
 /// An object representing a Nimiq address.
 /// Offers methods to parse and format addresses from and to strings.
-#[cfg_attr(feature = "primitives", derive(TryFromJsValue))]
 #[wasm_bindgen]
-#[cfg_attr(feature = "primitives", derive(Clone))]
 pub struct Address {
     inner: nimiq_keys::Address,
 }
@@ -33,7 +31,7 @@ impl Address {
         let js_value: &JsValue = addr.unchecked_ref();
 
         #[cfg(feature = "primitives")]
-        if let Ok(address) = Address::try_from(js_value) {
+        if let Ok(address) = Address::try_from_js_value(js_value.to_owned()) {
             return Ok(address);
         }
 

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate alloc; // Required for wasm-bindgen-derive
-
 mod address;
 #[cfg(feature = "client")]
 mod client;

--- a/web-client/src/primitives/es256_public_key.rs
+++ b/web-client/src/primitives/es256_public_key.rs
@@ -2,14 +2,11 @@ use std::str::FromStr;
 
 use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_derive::TryFromJsValue;
 
 use crate::{address::Address, primitives::es256_signature::ES256Signature};
 
 /// The non-secret (public) part of an ES256 asymmetric key pair that is typically used to digitally verify or encrypt data.
-#[derive(TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(Clone)]
 pub struct ES256PublicKey {
     inner: nimiq_keys::ES256PublicKey,
 }

--- a/web-client/src/primitives/es256_signature.rs
+++ b/web-client/src/primitives/es256_signature.rs
@@ -1,13 +1,10 @@
 use std::str::FromStr;
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_derive::TryFromJsValue;
 
 /// An ES256 Signature represents a cryptographic proof that an ES256 private key signed some data.
 /// It can be verified with the private key's public key.
-#[derive(TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(Clone)]
 pub struct ES256Signature {
     inner: nimiq_keys::ES256Signature,
 }

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_derive::TryFromJsValue;
 
 use crate::{
     address::Address,
@@ -10,9 +9,7 @@ use crate::{
 };
 
 /// The non-secret (public) part of an asymmetric key pair that is typically used to digitally verify or encrypt data.
-#[derive(TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(Clone)]
 pub struct PublicKey {
     inner: nimiq_keys::Ed25519PublicKey,
 }

--- a/web-client/src/primitives/signature.rs
+++ b/web-client/src/primitives/signature.rs
@@ -1,13 +1,10 @@
 use std::str::FromStr;
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_derive::TryFromJsValue;
 
 /// An Ed25519 Signature represents a cryptographic proof that a private key signed some data.
 /// It can be verified with the private key's public key.
-#[derive(TryFromJsValue)]
 #[wasm_bindgen]
-#[derive(Clone)]
 pub struct Signature {
     inner: nimiq_keys::Ed25519Signature,
 }

--- a/web-client/src/primitives/signature_proof.rs
+++ b/web-client/src/primitives/signature_proof.rs
@@ -2,7 +2,7 @@ use std::str;
 
 use js_sys::Array;
 use nimiq_serde::Serialize;
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{convert::TryFromJsValue, prelude::*};
 
 use crate::{
     address::Address,
@@ -215,9 +215,9 @@ impl SignatureProof {
 
     fn unpack_public_key(public_key: &PublicKeyUnion) -> Result<nimiq_keys::PublicKey, JsError> {
         let js_value: &JsValue = public_key.unchecked_ref();
-        let public_key = if let Ok(key) = PublicKey::try_from(js_value) {
+        let public_key = if let Ok(key) = PublicKey::try_from_js_value(js_value.to_owned()) {
             nimiq_keys::PublicKey::Ed25519(*key.native_ref())
-        } else if let Ok(key) = ES256PublicKey::try_from(js_value) {
+        } else if let Ok(key) = ES256PublicKey::try_from_js_value(js_value.to_owned()) {
             nimiq_keys::PublicKey::ES256(*key.native_ref())
         } else {
             return Err(JsError::new("Invalid public key"));
@@ -228,9 +228,9 @@ impl SignatureProof {
 
     fn unpack_signature(signature: &SignatureUnion) -> Result<nimiq_keys::Signature, JsError> {
         let js_value: &JsValue = signature.unchecked_ref();
-        let signature = if let Ok(sig) = Signature::try_from(js_value) {
+        let signature = if let Ok(sig) = Signature::try_from_js_value(js_value.to_owned()) {
             nimiq_keys::Signature::Ed25519(sig.native_ref().clone())
-        } else if let Ok(sig) = ES256Signature::try_from(js_value) {
+        } else if let Ok(sig) = ES256Signature::try_from_js_value(js_value.to_owned()) {
             nimiq_keys::Signature::ES256(sig.native_ref().clone())
         } else {
             return Err(JsError::new("Invalid signature"));

--- a/web-client/src/transaction.rs
+++ b/web-client/src/transaction.rs
@@ -27,9 +27,9 @@ use nimiq_transaction_builder::TransactionProofBuilder;
 #[cfg(feature = "client")]
 use serde::ser::SerializeStruct;
 use tsify::Tsify;
-use wasm_bindgen::prelude::*;
 #[cfg(feature = "primitives")]
-use wasm_bindgen_derive::TryFromJsValue;
+use wasm_bindgen::convert::TryFromJsValue;
+use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "primitives")]
 use crate::primitives::key_pair::KeyPair;
@@ -45,9 +45,7 @@ use crate::{
 ///
 /// Transactions require a valid signature proof over their serialized content.
 /// Furthermore, transactions are only valid for 2 hours after their validity-start block height.
-#[cfg_attr(feature = "primitives", derive(TryFromJsValue))]
 #[wasm_bindgen]
-#[cfg_attr(feature = "primitives", derive(Clone))]
 pub struct Transaction {
     inner: nimiq_transaction::Transaction,
 }
@@ -380,7 +378,7 @@ impl Transaction {
         let js_value: &JsValue = tx.unchecked_ref();
 
         #[cfg(feature = "primitives")]
-        if let Ok(transaction) = Transaction::try_from(js_value) {
+        if let Ok(transaction) = Transaction::try_from_js_value(js_value.to_owned()) {
             return Ok(transaction);
         }
 


### PR DESCRIPTION
I don't know what's better: one extra dependency less (with this PR), or not having to clone (`.to_owned()`) JsValues (without this PR)?

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
