### PR TITLE
Add log message to state sync

### DIFF
--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -523,6 +523,16 @@ impl<N: Network> Stream for StateQueue<N> {
         loop {
             match self.chunk_request_component.poll_next_unpin(cx) {
                 Poll::Ready(Some((chunk, start_key, peer_id))) => {
+                    let key = u32::from_str_radix(&format!("{}00000000", start_key)[..8], 16)
+                        .unwrap_or(0);
+
+                    let percentage = (key as f32 / u32::MAX as f32) * 100.0;
+                    log::debug!(
+                        ?start_key,
+                        "Received state sync chunk, ~{}% complete",
+                        percentage,
+                    );
+
                     if let Some(state_chunks) = self.on_chunk_received(chunk, start_key, peer_id) {
                         return Poll::Ready(Some(state_chunks));
                     }


### PR DESCRIPTION
Add a small log message to know if state sync is progressing. 


## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
