### PR TITLE
State sync not required for live sync instead of  macro sync

### DIFF
--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -252,9 +252,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                         + Policy::blocks_per_batch()
                         - 1;
 
-                    if peer_head_upper_bound.saturating_sub(our_head) <= self.full_sync_threshold
-                        && blockchain.accounts_complete()
-                    {
+                    if peer_head_upper_bound.saturating_sub(our_head) <= self.full_sync_threshold {
                         log::debug!(
                             our_head,
                             peer_head = peer_head_upper_bound,


### PR DESCRIPTION
Remove the accounts complete requisite when determining that a peer is sufficiently close for live sync instead of macro sync.

#### This fixes #2347 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
