### PR TITLE
network-libp2p: Update `kad` configuration

### DIFF
--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -15,6 +15,7 @@ mod rate_limiting;
 mod swarm;
 
 pub const DISCOVERY_PROTOCOL: &str = "/nimiq/discovery/0.0.1";
+pub const DHT_PROTOCOL: &str = "/nimiq/kad/0.0.1";
 
 pub use config::{Config, TlsConfig};
 pub use error::NetworkError;

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -911,7 +911,7 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
                 key: key.into(),
                 value,
                 publisher: Some(*local_peer_id),
-                expires: None, // TODO: Records should expire at some point in time
+                expires: None, // This only affects local storage. Records are replicated with configured TTL.
             };
 
             match swarm.behaviour_mut().dht.put_record(record, Quorum::One) {


### PR DESCRIPTION
Update the `kad` (DHT) configuration to have larger TTLs (and thus larger publication intervals). Also set the provider TTLs and publication intervals to slightly smaller values than the regular TTLs and publication intervals.
Also set the replication interval to a value significant less than the publication interval as suggested by the libp2p documentation. Remove `TODO` related to not setting an expiration when putting a record.

This closes #2530.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
