### PR TITLE
Fixing code coverage

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -94,9 +94,12 @@ jobs:
       run: cargo llvm-cov report --lcov --output-path coverage.lcov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: coverage.lcov
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         flags: unittests
         name: Nimiq code coverage
         verbose: true
+


### PR DESCRIPTION
Codcov made an update 3 months ago requiring the code coverage access token to be set on the github repo and added to the workflow. This adds the access token to the workflow.

Pascal will add the token to the repo since I don't have enough privileges for that.

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
