### PR TITLE
Remove TODO about network ID needing to be checked

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -535,7 +535,6 @@ impl Blockchain {
         txn: &mut WriteTransactionProxy,
         block_logger: &mut BlockLogger,
     ) -> Result<u64, PushError> {
-        // TODO: check block.network somewhere!
         // Check transactions against replay attacks. This is only necessary for micro blocks.
         if block.is_micro() {
             let transactions = block.transactions();

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -13,7 +13,8 @@ use nimiq_bls::AggregateSignature;
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput};
 use nimiq_keys::KeyPair;
 use nimiq_primitives::{
-    key_nibbles::KeyNibbles, policy::Policy, TendermintIdentifier, TendermintStep,
+    key_nibbles::KeyNibbles, networks::NetworkId, policy::Policy, TendermintIdentifier,
+    TendermintStep,
 };
 use nimiq_test_log::test;
 use nimiq_test_utils::{
@@ -265,6 +266,17 @@ fn it_works_with_valid_blocks() {
 
     // A simple push of a macro block
     simply_push_macro_block(&config, &Ok(PushResult::Extended));
+}
+
+#[test]
+fn it_validates_network() {
+    expect_push_micro_block(
+        BlockConfig {
+            network: Some(NetworkId::Main),
+            ..Default::default()
+        },
+        Err(InvalidBlock(BlockError::NetworkMismatch)),
+    );
 }
 
 #[test]


### PR DESCRIPTION
The check for correct network ID has already been in place since the initial commit of putting network IDs into headers: 558e222777d44dee9c0a90b838f2add4c4df7acb.

It's inside the `BlockHeader::verify` function called by the `Block::verify` function which itself needs to be called in all the relevant places, e.g. via the `Blockchain::verify_block` function in `Blockchain::do_push`.

Fixes #2507.
