### PR TITLE
Fix history sync to use additional non prunable checkpoints

### DIFF
--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -133,7 +133,9 @@ impl RequestCommon for RequestBatchSet {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BatchSet {
+    /// Verifying macro block
     pub macro_block: MacroBlock,
+    /// Total history length at the height of the specified macro block
     pub history_len: SizeProof<Blake2bHash, HistoricTransaction>,
 }
 

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -210,8 +210,8 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             let blockchain = blockchain.read();
             BatchSetVerifyState {
                 network: blockchain.network_id,
-                predecessor: Block::Macro(blockchain.macro_head()),
-                validators: blockchain.current_validators().unwrap(),
+                predecessor: Block::Macro(blockchain.election_head()),
+                validators: blockchain.election_head().get_validators().unwrap(),
             }
         };
         let epoch_ids_queue = epoch_ids
@@ -574,8 +574,8 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         let blockchain = self.blockchain.read();
         let verify_state = BatchSetVerifyState {
             network: blockchain.network_id,
-            predecessor: Block::Macro(blockchain.macro_head()),
-            validators: blockchain.current_validators().unwrap(),
+            predecessor: Block::Macro(blockchain.election_head()),
+            validators: blockchain.election_head().get_validators().unwrap(),
         };
         self.batch_set_queue.set_verify_state(verify_state);
     }


### PR DESCRIPTION
- Fix implementation of `get_epoch_chunks` since it was only returning a single block and not really looking for all non-prunable macro blocks in the same epoch as it should have.
  This fixes #2502.
- Fix the computation of history chunk indexes when making `HistoryChunkRequest` requests in history sync.
- Use election macro head for validating batch sets instead of using the macro head. This is because we could ask for a batch set of an epoch containing checkpoint macro blocks we already know and in this case, the verification of batch sets would fail since it may contain checkpoint macro blocks we already know and that has a block number lower than our macro head.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
