### PR TITLE
Remove `BlockHeader` enum

### DIFF
--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -236,7 +236,7 @@ impl Blockchain {
             Block::Micro(_) => return Err(BlockchainError::InconsistentState),
         };
 
-        if !election_head.is_election_block() {
+        if !election_head.is_election() {
             return Err(BlockchainError::InconsistentState);
         }
 

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -411,7 +411,7 @@ impl Blockchain {
         this.state.macro_head_hash = block_hash.clone();
 
         // Check if this block is an election block.
-        let is_election_block = macro_block.is_election_block();
+        let is_election_block = macro_block.is_election();
         if is_election_block {
             this.state.election_head = macro_block.clone();
             this.state.election_head_hash = block_hash.clone();

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -403,8 +403,8 @@ impl Blockchain {
         diff: Option<TrieDiff>,
         chunks: Vec<TrieChunkWithStart>,
     ) -> Result<(PushResult, Result<ChunksPushResult, ChunksPushError>), PushError> {
-        let target_block = chain_info.head.header();
-        debug!(block = %target_block, "Rebranching");
+        let target_block = chain_info.head.to_string();
+        debug!(block = target_block, "Rebranching");
         let mut this = RwLockUpgradableReadGuard::upgrade(this);
         let read_txn = this.read_transaction();
         // Find the common ancestor between our current main chain and the fork chain.
@@ -414,7 +414,7 @@ impl Blockchain {
         read_txn.close();
 
         debug!(
-            block = %target_block,
+            block = target_block,
             common_ancestor = %ancestor.1.head,
             no_blocks_up = fork_chain.len(),
             "Found common ancestor",

--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -29,7 +29,7 @@ impl Blockchain {
     > {
         // Walk up the fork chain until we find a block that is part of the main chain.
         // Store the chain along the way
-        let target = chain_info.head.header();
+        let target = chain_info.head.to_string();
 
         // Collects the chain on the way back to the common ancestor
         let mut fork_chain = vec![];
@@ -65,7 +65,7 @@ impl Blockchain {
         // Check if ancestor is in current batch.
         if current.1.head.block_number() < self.state.macro_info.head.block_number() {
             warn!(
-                block = %target,
+                block = target,
                 reason = "ancestor block already finalized",
                 ancestor_block = %current.1.head,
                 "Rejecting block",

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -46,7 +46,7 @@ impl Blockchain {
 
         // Verify the interlink (or its absence)
         if let Block::Macro(macro_) = &block {
-            if macro_.is_election_block() {
+            if macro_.is_election() {
                 if let Some(interlink) = &macro_.header.interlink {
                     let expected_interlink = self.election_head().get_next_interlink().unwrap();
 
@@ -60,7 +60,7 @@ impl Blockchain {
                 }
             }
 
-            if !macro_.is_election_block() && macro_.header.interlink.is_some() {
+            if !macro_.is_election() && macro_.header.interlink.is_some() {
                 warn!(reason = "Superfluous Interlink", "Rejecting block");
                 return Err(PushError::InvalidBlock(BlockError::InvalidInterlink));
             }
@@ -258,7 +258,7 @@ impl Blockchain {
             .expect("Block body must be present");
 
         // Verify validators.
-        let validators = match macro_block.is_election_block() {
+        let validators = match macro_block.is_election() {
             true => Some(self.next_validators(&macro_block.header.seed)),
             false => None,
         };

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -45,9 +45,9 @@ impl Blockchain {
         }
 
         // Verify the interlink (or its absence)
-        if let Block::Macro(macro_) = &block {
-            if macro_.is_election() {
-                if let Some(interlink) = &macro_.header.interlink {
+        if let Block::Macro(macro_block) = &block {
+            if macro_block.is_election() {
+                if let Some(interlink) = &macro_block.header.interlink {
                     let expected_interlink = self.election_head().get_next_interlink().unwrap();
 
                     if interlink != &expected_interlink {
@@ -60,7 +60,7 @@ impl Blockchain {
                 }
             }
 
-            if !macro_.is_election() && macro_.header.interlink.is_some() {
+            if !macro_block.is_election() && macro_block.header.interlink.is_some() {
                 warn!(reason = "Superfluous Interlink", "Rejecting block");
                 return Err(PushError::InvalidBlock(BlockError::InvalidInterlink));
             }

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -70,7 +70,7 @@ impl<N: Network> Handle<N, BlockchainProxy> for RequestMacroChain {
         let checkpoint_hash = blockchain.macro_head_hash();
         let caught_up = epochs.is_empty()
             || *epochs.last().unwrap() == checkpoint_block.header.parent_election_hash;
-        let checkpoint = if !checkpoint_block.is_election_block()
+        let checkpoint = if !checkpoint_block.is_election()
             && checkpoint_hash != start_block_hash
             && caught_up
         {
@@ -137,7 +137,7 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestBatchSet {
         };
 
         // FIXME Don't send the same macro block twice.
-        let election_macro_block = if block.is_election_block() {
+        let election_macro_block = if block.is_election() {
             Some(block)
         } else {
             None

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -236,7 +236,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
                 let macro_block = batch_set_info.final_macro_block();
                 verify_state.predecessor = Block::Macro(macro_block.clone());
 
-                if macro_block.is_election_block() {
+                if macro_block.is_election() {
                     match macro_block.get_validators() {
                         Some(validators) => verify_state.validators = validators,
                         None => {

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -187,7 +187,7 @@ impl LightBlockchain {
             this.macro_head = macro_block.clone();
 
             // If the block is also an election block, then we have more fields to update.
-            if macro_block.is_election_block() {
+            if macro_block.is_election() {
                 this.election_head = macro_block.clone();
 
                 this.current_validators = macro_block.get_validators();

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -232,8 +232,8 @@ impl LightBlockchain {
         // Upgrade the blockchain lock
         let mut this = RwLockUpgradableReadGuard::upgrade(this);
 
-        let target_block = chain_info.head.header();
-        log::debug!(block = %target_block, "Rebranching");
+        let target_block = chain_info.head.to_string();
+        log::debug!(block = target_block, "Rebranching");
 
         // Find the common ancestor between our current main chain and the fork chain.
         // Walk up the fork chain until we find a block that is part of the main chain.
@@ -255,7 +255,7 @@ impl LightBlockchain {
         }
 
         log::debug!(
-            block = %target_block,
+            block = target_block,
             common_ancestor = %current.1.head,
             no_blocks_up = fork_chain.len(),
             "Found common ancestor",
@@ -268,7 +268,7 @@ impl LightBlockchain {
         // Check if ancestor is in current batch.
         if ancestor.1.head.block_number() < this.macro_head.block_number() {
             log::warn!(
-                block = %target_block,
+                block = target_block,
                 reason = "ancestor block already finalized",
                 ancestor_block = %ancestor.1.head,
                 "Rejecting block",

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -355,7 +355,7 @@ impl Block {
     /// Returns true if the block is an election block, false otherwise.
     pub fn is_election(&self) -> bool {
         match self {
-            Block::Macro(block) => block.is_election_block(),
+            Block::Macro(block) => block.is_election(),
             Block::Micro(_) => false,
         }
     }
@@ -545,7 +545,7 @@ impl Block {
         //   parent election hash
         // - Predecessor is a checkpoint block: this block must have the same
         //   parent election hash
-        let expected_parent_election_hash = if predecessor.is_election_block() {
+        let expected_parent_election_hash = if predecessor.is_election() {
             predecessor.hash()
         } else {
             predecessor.header.parent_election_hash.clone()

--- a/primitives/block/src/block_proof.rs
+++ b/primitives/block/src/block_proof.rs
@@ -57,7 +57,7 @@ impl BlockInclusionProof {
 
     // Checks whether the BlockInclusionProof proofs `target` when starting from `election_head`
     pub fn is_block_proven(&self, election_head: &MacroBlock, target: &MacroBlock) -> bool {
-        if !target.is_election_block() {
+        if !target.is_election() {
             return false;
         }
 

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -54,7 +54,7 @@ impl MacroBlock {
 
     /// Computes the next interlink from self.header.interlink
     pub fn get_next_interlink(&self) -> Result<Vec<Blake2bHash>, BlockError> {
-        if !self.is_election_block() {
+        if !self.is_election() {
             return Err(BlockError::InvalidBlockType);
         }
         let mut interlink = self
@@ -86,7 +86,7 @@ impl MacroBlock {
     }
 
     /// Returns whether or not this macro block is an election block.
-    pub fn is_election_block(&self) -> bool {
+    pub fn is_election(&self) -> bool {
         Policy::is_election_block_at(self.header.block_number)
     }
 

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -299,7 +299,7 @@ async fn main_inner() -> Result<(), Error> {
                     .await;
                 }
 
-                let time = std::time::Duration::from_millis(block.header().timestamp());
+                let time = std::time::Duration::from_millis(block.timestamp());
                 let tx_count = block.transactions().map(|txs| txs.len()).unwrap_or(0);
                 let mempool_count = mempool.num_transactions();
 

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -747,8 +747,13 @@ mod test {
         );
 
         // Create a proposal from node 1 for node 2.
-        let proposal =
-            create_proposal_msg(nw1, nw2, signing_key, macro_block.header().unwrap_macro()).await;
+        let proposal = create_proposal_msg(
+            nw1,
+            nw2,
+            signing_key,
+            macro_block.unwrap_macro_ref().header.clone(),
+        )
+        .await;
 
         // Push the proposal into the ProposalBuffer
         proposal_sender.send(proposal);
@@ -791,8 +796,13 @@ mod test {
         );
 
         // Create a proposal from node 1 for node 2.
-        let proposal =
-            create_proposal_msg(nw1, nw2, signing_key, macro_block.header().unwrap_macro()).await;
+        let proposal = create_proposal_msg(
+            nw1,
+            nw2,
+            signing_key,
+            macro_block.unwrap_macro_ref().header.clone(),
+        )
+        .await;
 
         // Push the proposal into the ProposalBuffer
         proposal_sender.send(proposal);
@@ -850,8 +860,13 @@ mod test {
         );
 
         // Create a proposal from node 1 for node 2.
-        let proposal =
-            create_proposal_msg(nw1, nw2, signing_key, macro_block.header().unwrap_macro()).await;
+        let proposal = create_proposal_msg(
+            nw1,
+            nw2,
+            signing_key,
+            macro_block.unwrap_macro_ref().header.clone(),
+        )
+        .await;
 
         // Push the proposal into the ProposalBuffer
         proposal_sender.send(proposal);
@@ -912,8 +927,13 @@ mod test {
         );
 
         // Create a proposal from node 1 for node 2.
-        let proposal =
-            create_proposal_msg(nw1, nw2, signing_key, macro_block.header().unwrap_macro()).await;
+        let proposal = create_proposal_msg(
+            nw1,
+            nw2,
+            signing_key,
+            macro_block.unwrap_macro_ref().header.clone(),
+        )
+        .await;
 
         // Push the proposal into the ProposalBuffer
         proposal_sender.send(proposal);

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -620,7 +620,7 @@ where
                     if result == Some(PushResult::Extended)
                         || result == Some(PushResult::Rebranched)
                     {
-                        if block_copy.is_election_block() {
+                        if block_copy.is_election() {
                             info!(
                                 block_number = &block_copy.header.block_number,
                                 "Publishing Election MacroBlock"

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -319,7 +319,7 @@ async fn validator_can_catch_up() {
         if let Ok(block) = blockchain.read().get_block_at(1, false, None) {
             // the hash needs to be the one the extended event returned.
             // (the chain itself i.e blockchain.header_hash() might have already progressed further)
-            assert_eq!(block.header().hash(), hash);
+            assert_eq!(block.hash(), hash);
             // now in that case the validator producing this block has progressed the 2nd skip block without having seen the first skip block.
             return;
         }

--- a/web-client/src/client/block.rs
+++ b/web-client/src/client/block.rs
@@ -163,7 +163,7 @@ impl PlainBlock {
             Block::Macro(block) => PlainBlock::Macro(PlainMacroBlock {
                 common: common_fields,
 
-                is_election_block: block.is_election_block(),
+                is_election_block: block.is_election(),
                 round: block.round(),
                 prev_election_hash: block.header.parent_election_hash.to_hex(),
             }),


### PR DESCRIPTION
It was essentially unused except for the single `BlockHeader::verify` function which was instead moved to `Block::verify_header`.

`BlockComponents` was also unused and removed.

Also rename `MacroBlock::is_election_block` to `is_election`. This unifies the naming with `Block::is_election` and a couple of other functions.