### PR TITLE
Increase uptime in `FourValidatorsReconnectSpammer` DevNet scenario

### DIFF
--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -27,7 +27,7 @@ jobs:
         - test: FourValidatorsReconnectRmDatabase
           devnet_args: -t .github/devnet_topologies/four_validators.toml -d -ut 100 -dt 20
         - test: FourValidatorsReconnectSpammer
-          devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -ut 100 -dt 20
+          devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -ut 250 -dt 10
         - test: MacroBlockProduction
           # The number of blocks per epoch needs to stay the same (because of the ZKP keys)
           pre: "grep 'blocks_per_batch: 60,' primitives/src/policy.rs &&


### PR DESCRIPTION
With the transaction spammer running, re-syncing in debug mode is really slow. The previous uptime setting of 100 seconds was not always sufficient for a node that had been killed to fully re-sync before another node would get killed, resulting in the chain to stall and a failed scenario run.

This PR increases the node uptime for the spammer scenario. It also reduces the downtime to make it easier for nodes to catch up.