### PR TITLE
BlockQueue: Restrict buffering of blocks per peer per height

### DIFF
--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -231,14 +231,6 @@ impl<N: Network> BlockQueue<N> {
             if self.request_component.take_peer(&peer_id).is_some() {
                 return Some(QueuedBlock::TooFarAhead(block, peer_id));
             }
-        } else if self.buffer.len() >= self.config.buffer_max {
-            // TODO: This does not account for the nested map
-            log::warn!(
-                "Discarding block {} - buffer full (max {})",
-                block,
-                self.buffer.len(),
-            );
-            self.report_validation_result(pubsub_id, MsgAcceptance::Ignore);
         } else if block_number <= macro_height {
             // Block is from a previous batch/epoch, discard it.
             log::warn!(


### PR DESCRIPTION
Changes the `insert_block_into_buffer` such that it checks if the propagation source of the block is already present twice for that block height. If so the block will be dropped as only malicious peers would propagate more than 2 blocks (original block and potential skip block superseding it).

If no `pubsub_id` is given as for example a `MissingBlockRequest` would result in no additional checks are introduced. 

Also changed the semantics of the functions return value to reflect if the block was added instead of the formerly used block was known. Removed an unnecessary check in the process as well.

This PR fixes #2510.