### PR TITLE
Improve state sync log

### DIFF
--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -529,7 +529,7 @@ impl<N: Network> Stream for StateQueue<N> {
                     let percentage = (key as f32 / u32::MAX as f32) * 100.0;
                     log::debug!(
                         ?start_key,
-                        "Received state sync chunk, ~{}% complete",
+                        "Received state sync chunk, ~{:.2}% complete",
                         percentage,
                     );
 


### PR DESCRIPTION
Use a better format for the state sync %complete log introduced in #2532.

