### PR TITLE
Define Dependabot groups for bundling package version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,12 @@ version: 2
 updates:
 - package-ecosystem: github-actions
   directory: "/"
+  groups:
+    minor-and-patch-updates:
+    applies-to: version-updates
+    update-types:
+    - "minor"
+    - "patch"
   schedule:
     interval: daily
     timezone: America/Costa_Rica
@@ -12,6 +18,12 @@ updates:
   - jsdanielh
 - package-ecosystem: cargo
   directory: "/"
+  groups:
+    minor-and-patch-updates:
+    applies-to: version-updates
+    update-types:
+    - "minor"
+    - "patch"
   schedule:
     interval: daily
     timezone: America/Costa_Rica


### PR DESCRIPTION
## What's in this pull request?

Introduce Dependabot groups for cargo crates and Github Actions to bundle version updates.

- It only bundles minor and patch updates as major ones usually are considered breaking a need their own PR.
- It only bundles version updates. Security updates still receive their own PR to not be depended on anything and can get merged easier.

`By default, Dependabot raises a single pull request for each dependency that needs to be updated to a newer version. You can use groups to create sets of dependencies (per package manager), so that Dependabot opens a single pull request to update multiple dependencies at the same time.`