### PR TITLE
TransactionBuilder: Return Transaction instead of Result if creation can't fail

### DIFF
--- a/blockchain/tests/block_production.rs
+++ b/blockchain/tests/block_production.rs
@@ -246,8 +246,7 @@ fn it_can_produce_macro_block_after_punishment() {
         100.try_into().unwrap(),
         1 + Policy::genesis_block_number(),
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
     producer.next_block_with_txs(vec![], false, vec![reactivate_tx]);
 
     // Produce next checkpoint block.
@@ -826,8 +825,7 @@ fn it_can_revert_reactivate_transaction() {
         100.try_into().unwrap(),
         blockchain.read().block_number() + 1,
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
 
     transactions.push(tx.clone());
 
@@ -867,8 +865,7 @@ fn it_can_revert_reactivate_transaction() {
         100.try_into().unwrap(),
         blockchain.read().block_number() + 1,
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
 
     transactions.push(tx);
 
@@ -943,8 +940,7 @@ fn it_can_consume_all_validator_deposit() {
         Coin::ZERO,
         blockchain.read().block_number() + 1,
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
 
     // Create a vesting contract to make the delete transaction fail by causing a type mismatch.
     let vesting_tx = TransactionBuilder::new_create_vesting(
@@ -1156,8 +1152,7 @@ fn it_can_revert_failed_delete_validator() {
         Coin::ZERO,
         blockchain.read().block_number() + 1,
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
 
     // Create a vesting contract to make the delete transaction fail by causing a type mismatch.
     let vesting_tx = TransactionBuilder::new_create_vesting(

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1634,8 +1634,7 @@ async fn mempool_basic_prioritization_control_tx() {
         1.try_into().unwrap(),
         1 + Policy::genesis_block_number(),
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
 
     // This is the transaction produced in the block
     let tx = TransactionBuilder::new_create_staker(

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -920,7 +920,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        )?;
+        );
 
         Ok(transaction_to_hex_string(&transaction).into())
     }
@@ -972,7 +972,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        )?;
+        );
 
         Ok(transaction_to_hex_string(&transaction).into())
     }
@@ -1017,7 +1017,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        )?;
+        );
 
         Ok(transaction_to_hex_string(&transaction).into())
     }
@@ -1080,7 +1080,7 @@ impl ConsensusInterface for ConsensusDispatcher {
             fee,
             self.validity_start_height(validity_start_height),
             self.get_network_id(),
-        )?;
+        );
 
         Ok(transaction_to_hex_string(&transaction).into())
     }

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -1300,7 +1300,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Result<Transaction, TransactionBuilderError> {
+    ) -> Transaction {
         let mut recipient = Recipient::new_staking_builder();
         recipient.update_validator(
             new_signing_key,
@@ -1318,13 +1318,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate()?;
+        let proof_builder = builder.generate().unwrap();
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(cold_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                Ok(builder.generate().unwrap())
+                builder.generate().unwrap()
             }
             _ => unreachable!(),
         }
@@ -1358,7 +1358,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Result<Transaction, TransactionBuilderError> {
+    ) -> Transaction {
         let mut recipient = Recipient::new_staking_builder();
         recipient.deactivate_validator(validator_address);
 
@@ -1371,13 +1371,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate()?;
+        let proof_builder = builder.generate().unwrap();
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(signing_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                Ok(builder.generate().unwrap())
+                builder.generate().unwrap()
             }
             _ => unreachable!(),
         }
@@ -1411,7 +1411,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Result<Transaction, TransactionBuilderError> {
+    ) -> Transaction {
         let mut recipient = Recipient::new_staking_builder();
         recipient.reactivate_validator(validator_address);
 
@@ -1424,13 +1424,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate()?;
+        let proof_builder = builder.generate().unwrap();
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(signing_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                Ok(builder.generate().unwrap())
+                builder.generate().unwrap()
             }
             _ => unreachable!(),
         }
@@ -1462,7 +1462,7 @@ impl TransactionBuilder {
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,
-    ) -> Result<Transaction, TransactionBuilderError> {
+    ) -> Transaction {
         let mut recipient = Recipient::new_staking_builder();
         recipient.retire_validator();
 
@@ -1475,13 +1475,13 @@ impl TransactionBuilder {
             .with_validity_start_height(validity_start_height)
             .with_network_id(network_id);
 
-        let proof_builder = builder.generate()?;
+        let proof_builder = builder.generate().unwrap();
         match proof_builder {
             TransactionProofBuilder::InStaking(mut builder) => {
                 builder.sign_with_key_pair(cold_key_pair);
                 let mut builder = builder.generate().unwrap().unwrap_basic();
                 builder.sign_with_key_pair(key_pair);
-                Ok(builder.generate().unwrap())
+                builder.generate().unwrap()
             }
             _ => unreachable!(),
         }

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -202,8 +202,7 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    )
-    .unwrap();
+    );
 
     assert_eq!(tx, tx2);
 
@@ -224,8 +223,7 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    )
-    .unwrap();
+    );
 
     assert_eq!(tx, tx2);
 
@@ -246,8 +244,7 @@ fn it_can_create_validator_transactions() {
         100.try_into().unwrap(),
         1,
         NetworkId::Dummy,
-    )
-    .unwrap();
+    );
 
     assert_eq!(tx, tx2);
 

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -770,8 +770,7 @@ where
             Coin::ZERO,
             validity_start_height,
             blockchain.network_id(),
-        )
-        .unwrap(); // TODO: Handle transaction creation error
+        );
         let tx_hash = reactivate_transaction.hash();
 
         let cn = self.consensus.clone();

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -50,8 +50,7 @@ async fn validator_update() {
         Coin::ZERO,
         blockchain.read().block_number(),
         NetworkId::UnitAlbatross,
-    )
-    .unwrap();
+    );
     let new_micro_block = producer1.next_micro_block(
         &blockchain.read(),
         blockchain.read().head().timestamp() + Policy::BLOCK_SEPARATION_TIME,


### PR DESCRIPTION
Closes #2544

I don't think this error needs to be handled:

`new_reactivate_validator` only returns an error if `builder.generate()` returns an error. `builder.generate()` returns an error iff:
- Certain fields are not set: sender, recipient, value, validity_start_height, network_id
- It is a signaling transaction with a non-zero ~fee~ value

However, in `new_reactivate_validator`
- All those mandatory fields are set
- A signaling transaction is created, but the ~fee~ value is set to zero and can't be specified via parameters

Thus, the function call can never return an error and we don't have to handle it.

I addressed this by unwrapping the result of `builder.generate()` and changing the return type of `new_reactivate_validator` to `Transaction` instead of `Result`. Same for `new_update_validator`, `new_deactivate_validator` and `new_retire_validator`.