### PR TITLE
Move rate limiting to swarm to fix the unprotected buffer

### DIFF
--- a/.github/workflows/github_release_docker.yml
+++ b/.github/workflows/github_release_docker.yml
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
+        uses: docker/build-push-action@c382f710d39a5bb4e430307530a720f50c2d3318
         with:
           context: .
           file: Dockerfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,15 +1360,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -6,7 +6,7 @@ use std::{
 use futures::{
     future::{AbortHandle, Abortable},
     lock::{Mutex, MutexGuard},
-    stream::BoxStream,
+    stream::{BoxStream, StreamExt},
 };
 use nimiq_account::ReservedBalance;
 use nimiq_block::Block;
@@ -153,7 +153,9 @@ impl Mempool {
         let txn_stream = network
             .subscribe::<ControlTransactionTopic>()
             .await
-            .unwrap();
+            .unwrap()
+            .map(|(tx, pubsub_id)| (Transaction::from(tx), pubsub_id))
+            .boxed();
 
         self.start_executor::<N, ControlTransactionTopic>(
             network,

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -143,7 +143,7 @@ pub trait RequestCommon:
 pub trait RequestSerialize: RequestCommon {
     /// Serializes a request.
     /// A serialized request is composed of:
-    /// - A variant for the Type ID of the request
+    /// - A variable sized integer for the Type ID of the request
     /// - Serialized content of the inner type.
     fn serialize_request(&self) -> Vec<u8> {
         let mut data = Vec::with_capacity(self.serialized_request_size());
@@ -167,7 +167,7 @@ pub trait RequestSerialize: RequestCommon {
 
     /// Deserializes a request
     /// A serialized request is composed of:
-    /// - A variant for the Type ID of the request
+    /// - A variable sized integer for the Type ID of the request
     /// - Serialized content of the inner type.
     fn deserialize_request(buffer: &[u8]) -> Result<Self, DeserializeError> {
         // Check for correct type.

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -143,7 +143,7 @@ pub trait RequestCommon:
 pub trait RequestSerialize: RequestCommon {
     /// Serializes a request.
     /// A serialized request is composed of:
-    /// - A varint for the Type ID of the request
+    /// - A variant for the Type ID of the request
     /// - Serialized content of the inner type.
     fn serialize_request(&self) -> Vec<u8> {
         let mut data = Vec::with_capacity(self.serialized_request_size());

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -26,17 +26,17 @@ impl fmt::Display for RequestType {
 }
 
 impl RequestType {
-    const fn new(type_id: u16, requires_response: bool) -> RequestType {
-        RequestType((type_id << 1) | requires_response as u16)
+    const fn new(type_id: u16, requires_response: bool) -> Self {
+        Self((type_id << 1) | requires_response as u16)
     }
-    pub fn from_request<R: RequestCommon>() -> RequestType {
-        RequestType::new(R::TYPE_ID, R::Kind::EXPECT_RESPONSE)
+    pub fn from_request<R: RequestCommon>() -> Self {
+        Self::new(R::TYPE_ID, R::Kind::EXPECT_RESPONSE)
     }
-    pub const fn request(type_id: u16) -> RequestType {
-        RequestType::new(type_id, true)
+    pub const fn request(type_id: u16) -> Self {
+        Self::new(type_id, true)
     }
-    pub const fn message(type_id: u16) -> RequestType {
-        RequestType::new(type_id, false)
+    pub const fn message(type_id: u16) -> Self {
+        Self::new(type_id, false)
     }
     pub const fn type_id(self) -> u16 {
         self.0 >> 1
@@ -167,7 +167,7 @@ pub trait RequestSerialize: RequestCommon {
 
     /// Deserializes a request
     /// A serialized request is composed of:
-    /// - A varint for the Type ID of the request
+    /// - A variant for the Type ID of the request
     /// - Serialized content of the inner type.
     fn deserialize_request(buffer: &[u8]) -> Result<Self, DeserializeError> {
         // Check for correct type.

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use instant::Instant;
+use instant::{Duration, Instant};
 use libp2p::{
     gossipsub,
     kad::{QueryId, Record},
@@ -71,6 +71,8 @@ pub(crate) enum NetworkAction {
     ReceiveRequests {
         type_id: RequestType,
         output: mpsc::Sender<(Bytes, InboundRequestId, PeerId)>,
+        max_requests: u32,
+        time_window: Duration,
     },
     SendRequest {
         peer_id: PeerId,
@@ -248,8 +250,14 @@ pub(crate) struct TaskState {
     pub(crate) response_channels:
         HashMap<InboundRequestId, ResponseChannel<Option<OutgoingResponse>>>,
     /// Senders for replying to requests per `RequestType` for request-response
-    pub(crate) receive_requests:
-        HashMap<RequestType, mpsc::Sender<(Bytes, InboundRequestId, PeerId)>>,
+    pub(crate) receive_requests: HashMap<
+        RequestType,
+        (
+            mpsc::Sender<(Bytes, InboundRequestId, PeerId)>,
+            u32,
+            Duration,
+        ),
+    >,
     /// DHT quorum value
     pub(crate) dht_quorum: u8,
 }

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use instant::{Duration, Instant};
+use instant::Instant;
 use libp2p::{
     gossipsub,
     kad::{QueryId, Record},
@@ -23,6 +23,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     dispatch::codecs::{IncomingRequest, OutgoingResponse},
+    rate_limiting::RequestRateLimitData,
     NetworkError,
 };
 
@@ -71,8 +72,7 @@ pub(crate) enum NetworkAction {
     ReceiveRequests {
         type_id: RequestType,
         output: mpsc::Sender<(Bytes, InboundRequestId, PeerId)>,
-        max_requests: u32,
-        time_window: Duration,
+        request_rate_limit_data: RequestRateLimitData,
     },
     SendRequest {
         peer_id: PeerId,
@@ -254,8 +254,7 @@ pub(crate) struct TaskState {
         RequestType,
         (
             mpsc::Sender<(Bytes, InboundRequestId, PeerId)>,
-            u32,
-            Duration,
+            RequestRateLimitData,
         ),
     >,
     /// DHT quorum value

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -249,7 +249,7 @@ pub(crate) struct TaskState {
     /// Senders for receiving responses per `InboundRequestId` for request-response
     pub(crate) response_channels:
         HashMap<InboundRequestId, ResponseChannel<Option<OutgoingResponse>>>,
-    /// Senders for replying to requests per `RequestType` for request-response
+    /// Senders and respective rate limiting constants for replying to requests per `RequestType` for request-response
     pub(crate) receive_requests: HashMap<
         RequestType,
         (

--- a/network-libp2p/src/rate_limiting.rs
+++ b/network-libp2p/src/rate_limiting.rs
@@ -1,14 +1,32 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeSet, HashMap},
-    sync::Arc,
     time::Duration,
 };
 
 use instant::Instant;
 use libp2p::{request_response::InboundRequestId, PeerId};
-use nimiq_network_interface::request::RequestType;
+use nimiq_network_interface::request::{RequestCommon, RequestType};
 use parking_lot::Mutex;
+
+/// The rate limiting request metadata that will be passed on between the network and the swarm.
+/// This is not sent through the wire.
+#[derive(Debug, PartialEq)]
+pub(crate) struct RequestRateLimitData {
+    /// Maximum requests allowed by this request type.
+    max_requests: u32,
+    ///  The range/window of time of this request type.
+    time_window: Duration,
+}
+
+impl RequestRateLimitData {
+    pub(crate) fn new<Req: RequestCommon>() -> Self {
+        Self {
+            max_requests: Req::MAX_REQUESTS,
+            time_window: Req::TIME_WINDOW,
+        }
+    }
+}
 
 /// Holds the expiration time for a given peer and request type. This struct defines the ordering for the btree set.
 /// The smaller expiration times come first.
@@ -146,117 +164,128 @@ impl RateLimit {
 }
 
 // Network helpers for rate limiting
-
-pub(crate) fn is_under_the_rate_limits(
-    peer_request_limits: Arc<Mutex<HashMap<PeerId, HashMap<RequestType, RateLimit>>>>,
-    peer_id: PeerId,
-    request_type: RequestType,
-    request_id: InboundRequestId,
-    max_requests: u32,
-    time_window: Duration,
-) -> bool {
-    // Gets lock of peer requests limits read and write on it.
-    let mut peer_request_limits = peer_request_limits.lock();
-
-    // If the peer has never sent a request of this type, creates a new entry.
-    let requests_limit = peer_request_limits
-        .entry(peer_id)
-        .or_default()
-        .entry(request_type)
-        .or_insert_with(|| RateLimit::new(max_requests, time_window, Instant::now()));
-
-    // Ensures that the request is allowed based on the set limits and updates the counter.
-    // Returns early if not allowed.
-    if !requests_limit.increment_and_is_allowed(1) {
-        log::debug!(
-            "[{:?}][{:?}] {:?} Exceeded max requests rate {:?} requests per {:?} seconds",
-            request_id,
-            peer_id,
-            request_type,
-            max_requests,
-            time_window,
-        );
-        return false;
-    }
-    true
+#[derive(Default)]
+pub(crate) struct RateLimits {
+    peer_request_limits: Mutex<HashMap<PeerId, HashMap<RequestType, RateLimit>>>,
+    rate_limits_pending_deletion: Mutex<PendingDeletion>,
 }
 
-pub(crate) fn remove_rate_limits(
-    peer_request_limits: Arc<Mutex<HashMap<PeerId, HashMap<RequestType, RateLimit>>>>,
-    rate_limits_pending_deletion: Arc<Mutex<PendingDeletion>>,
-    peer_id: PeerId,
-) {
-    // Every time a peer disconnects, we delete all expired pending limits.
-    clean_up(
-        Arc::clone(&peer_request_limits),
-        Arc::clone(&rate_limits_pending_deletion),
-    );
+impl RateLimits {
+    pub(crate) fn exceeds_rate_limit(
+        &mut self,
+        peer_id: PeerId,
+        request_type: RequestType,
+        request_id: InboundRequestId,
+        request_rate_limit_data: &RequestRateLimitData,
+    ) -> bool {
+        // Gets lock of peer requests limits read and write on it.
+        let mut peer_request_limits = self.peer_request_limits.lock();
 
-    // Firstly we must acquire the lock of the pending deletes to avoid deadlocks.
-    let mut rate_limits_pending_deletion_l = rate_limits_pending_deletion.lock();
-    let mut peer_request_limits_l = peer_request_limits.lock();
+        // If the peer has never sent a request of this type, creates a new entry.
+        let requests_limit = peer_request_limits
+            .entry(peer_id)
+            .or_default()
+            .entry(request_type)
+            .or_insert_with(|| {
+                RateLimit::new(
+                    request_rate_limit_data.max_requests,
+                    request_rate_limit_data.time_window,
+                    Instant::now(),
+                )
+            });
 
-    // Go through all existing request types of the given peer and deletes the limit counters if possible or marks it for deletion.
-    if let Some(request_limits) = peer_request_limits_l.get_mut(&peer_id) {
-        request_limits.retain(|req_type, rate_limit| {
-            // Gets the requests limit and deletes it if no counter info would be lost, otherwise places it as pending deletion.
-            if !rate_limit.can_delete(Instant::now()) {
-                rate_limits_pending_deletion_l.insert(peer_id, *req_type, rate_limit);
-                true
-            } else {
-                false
+        // Ensures that the request is allowed based on the set limits and updates the counter.
+        // Returns early if not allowed.
+        if !requests_limit.increment_and_is_allowed(1) {
+            info!(
+                %request_id,
+                %peer_id,
+                %request_type,
+                "Rate limit was exceeded!",
+            );
+            log::debug!(
+                "[{:?}][{:?}] {:?} Exceeded max requests rate {:?} requests per {:?} seconds",
+                request_id,
+                peer_id,
+                request_type,
+                request_rate_limit_data.max_requests,
+                request_rate_limit_data.time_window,
+            );
+            return true;
+        }
+
+        false
+    }
+
+    pub(crate) fn remove_rate_limits(&mut self, peer_id: PeerId) {
+        // Every time a peer disconnects, we delete all expired pending limits.
+        self.clean_up();
+
+        // Firstly we must acquire the lock of the pending deletes to avoid deadlocks.
+        let mut rate_limits_pending_deletion_l = self.rate_limits_pending_deletion.lock();
+        let mut peer_request_limits_l = self.peer_request_limits.lock();
+
+        // Go through all existing request types of the given peer and deletes the limit counters if possible or marks it for deletion.
+        if let Some(request_limits) = peer_request_limits_l.get_mut(&peer_id) {
+            request_limits.retain(|req_type, rate_limit| {
+                // Gets the requests limit and deletes it if no counter info would be lost, otherwise places it as pending deletion.
+                if !rate_limit.can_delete(Instant::now()) {
+                    rate_limits_pending_deletion_l.insert(peer_id, *req_type, rate_limit);
+                    true
+                } else {
+                    false
+                }
+            });
+            // If the peer no longer has any pending rate limits, then it gets removed.
+            if request_limits.is_empty() {
+                peer_request_limits_l.remove(&peer_id);
             }
-        });
-        // If the peer no longer has any pending rate limits, then it gets removed.
-        if request_limits.is_empty() {
-            peer_request_limits_l.remove(&peer_id);
         }
     }
-}
 
-/// Deletes the rate limits that were previously marked as pending if its expiration time has passed.
-pub(crate) fn clean_up(
-    peer_request_limits: Arc<Mutex<HashMap<PeerId, HashMap<RequestType, RateLimit>>>>,
-    rate_limits_pending_deletion: Arc<Mutex<PendingDeletion>>,
-) {
-    let mut rate_limits_pending_deletion_l = rate_limits_pending_deletion.lock();
+    /// Deletes the rate limits that were previously marked as pending if its expiration time has passed.
+    fn clean_up(&mut self) {
+        let mut rate_limits_pending_deletion_l = self.rate_limits_pending_deletion.lock();
 
-    // Iterates from the oldest to the most recent expiration date and deletes the entries that have expired.
-    // The pending to deletion is ordered from the oldest to the most recent expiration date, thus we break early
-    // from the loop once we find a non expired rate limit.
-    while let Some(peer_expiration) = rate_limits_pending_deletion_l.first() {
-        let current_timestamp = Instant::now();
-        if peer_expiration.expiration_time <= current_timestamp {
-            let mut peer_request_limits_l = peer_request_limits.lock();
+        // Iterates from the oldest to the most recent expiration date and deletes the entries that have expired.
+        // The pending to deletion is ordered from the oldest to the most recent expiration date, thus we break early
+        // from the loop once we find a non expired rate limit.
+        while let Some(peer_expiration) = rate_limits_pending_deletion_l.first() {
+            let current_timestamp = Instant::now();
+            if peer_expiration.expiration_time <= current_timestamp {
+                let mut peer_request_limits_l = self.peer_request_limits.lock();
 
-            if let Some(peer_req_limits) = peer_request_limits_l
-                .get_mut(&peer_expiration.peer_id)
-                .and_then(|peer_req_limits| {
-                    if let Some(rate_limit) = peer_req_limits.get(&peer_expiration.req_type) {
-                        // If the peer has reconnected the rate limit may be enforcing a new limit. In this case we only remove
-                        // the pending deletion.
-                        if rate_limit.can_delete(current_timestamp) {
-                            peer_req_limits.remove(&peer_expiration.req_type);
+                if let Some(peer_req_limits) = peer_request_limits_l
+                    .get_mut(&peer_expiration.peer_id)
+                    .and_then(|peer_req_limits| {
+                        if let Some(rate_limit) = peer_req_limits.get(&peer_expiration.req_type) {
+                            // If the peer has reconnected the rate limit may be enforcing a new limit. In this case we only remove
+                            // the pending deletion.
+                            if rate_limit.can_delete(current_timestamp) {
+                                peer_req_limits.remove(&peer_expiration.req_type);
+                            }
+                            return Some(peer_req_limits);
                         }
-                        return Some(peer_req_limits);
+                        // Only returns None if no request type was found.
+                        None
+                    })
+                {
+                    // If the peer no longer has any pending rate limits, then it gets removed from both rate limits and pending deletion.
+                    if peer_req_limits.is_empty() {
+                        peer_request_limits_l.remove(&peer_expiration.peer_id);
                     }
-                    // Only returns None if no request type was found.
-                    None
-                })
-            {
-                // If the peer no longer has any pending rate limits, then it gets removed from both rate limits and pending deletion.
-                if peer_req_limits.is_empty() {
-                    peer_request_limits_l.remove(&peer_expiration.peer_id);
+                } else {
+                    // If the information is in pending deletion, that should mean it was not deleted from peer_request_limits yet, so that
+                    // reconnection doesn't bypass the limits we are enforcing.
+                    unreachable!(
+                        "Tried to remove a non existing rate limit from peer_request_limits."
+                    );
                 }
+                // Removes the entry from the pending for deletion.
+                rate_limits_pending_deletion_l.remove_first();
             } else {
-                // If the information is in pending deletion, that should mean it was not deleted from peer_request_limits yet, so that
-                // reconnection doesn't bypass the limits we are enforcing.
-                unreachable!("Tried to remove a non existing rate limit from peer_request_limits.");
+                break;
             }
-            // Removes the entry from the pending for deletion.
-            rate_limits_pending_deletion_l.remove_first();
-        } else {
-            break;
         }
     }
 }

--- a/primitives/transaction/src/control_transaction.rs
+++ b/primitives/transaction/src/control_transaction.rs
@@ -1,0 +1,65 @@
+use std::{error::Error, fmt, ops};
+
+use nimiq_primitives::account::AccountType;
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Transaction;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ControlTransaction(Transaction);
+
+#[derive(Clone, Debug)]
+pub struct ControlTransactionError(Transaction);
+
+impl fmt::Display for ControlTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "not a control transaction".fmt(f)
+    }
+}
+
+impl Error for ControlTransactionError {}
+
+impl ControlTransactionError {
+    pub fn into_inner(self) -> Transaction {
+        self.0
+    }
+}
+
+impl TryFrom<Transaction> for ControlTransaction {
+    type Error = ControlTransactionError;
+
+    fn try_from(tx: Transaction) -> Result<ControlTransaction, ControlTransactionError> {
+        if tx.sender_type == AccountType::Staking || tx.recipient_type == AccountType::Staking {
+            Ok(ControlTransaction(tx))
+        } else {
+            Err(ControlTransactionError(tx))
+        }
+    }
+}
+
+impl From<ControlTransaction> for Transaction {
+    fn from(tx: ControlTransaction) -> Transaction {
+        tx.0
+    }
+}
+
+impl ops::Deref for ControlTransaction {
+    type Target = Transaction;
+    fn deref(&self) -> &Transaction {
+        &self.0
+    }
+}
+
+impl Serialize for ControlTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let tx: &Transaction = self;
+        tx.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ControlTransaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<ControlTransaction, D::Error> {
+        let tx = Transaction::deserialize(deserializer)?;
+        ControlTransaction::try_from(tx).map_err(D::Error::custom)
+    }
+}

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -30,6 +30,7 @@ use crate::account::{
     AccountTransactionVerification,
 };
 
+mod control_transaction;
 mod equivocation_locator;
 
 pub mod account;
@@ -39,8 +40,11 @@ pub mod inherent;
 pub mod reward;
 pub mod signature_proof;
 
-pub use self::equivocation_locator::{
-    DoubleProposalLocator, DoubleVoteLocator, EquivocationLocator, ForkLocator,
+pub use self::{
+    control_transaction::ControlTransaction,
+    equivocation_locator::{
+        DoubleProposalLocator, DoubleVoteLocator, EquivocationLocator, ForkLocator,
+    },
 };
 
 /// Transaction topic for the Mempool to request transactions from the network
@@ -60,7 +64,7 @@ impl Topic for TransactionTopic {
 pub struct ControlTransactionTopic;
 
 impl Topic for ControlTransactionTopic {
-    type Item = Transaction;
+    type Item = ControlTransaction;
 
     const BUFFER_SIZE: usize = 1024;
     const NAME: &'static str = "control-transaction";

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -648,7 +648,7 @@ where
                             update_block_number = update.block_number,
                             "Discarding obsolete Tendermint state update"
                         );
-                        return;
+                        continue;
                     }
 
                     let mut write_transaction = self.env.write_transaction();

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -721,7 +721,7 @@ impl Client {
         limit: Option<u16>,
         min_peers: Option<usize>,
     ) -> Result<PlainTransactionDetailsArrayType, JsError> {
-        let mut since_block_height = since_block_height.unwrap_or(0);
+        let since_block_height = since_block_height.unwrap_or(0);
         let min_peers = min_peers.unwrap_or(1);
 
         if let Some(max) = limit {


### PR DESCRIPTION
## What's in this pull request?
Moving rate limiting to swarm to fix the unprotected buffer of the network when handling a request.
Rate limit refactoring

#### This fixes #2531.

## Pull request checklist
- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
