### PR TITLE
Make the full_sync_threshold configurable

### DIFF
--- a/consensus/src/sync/light/mod.rs
+++ b/consensus/src/sync/light/mod.rs
@@ -3,11 +3,4 @@ mod sync_requests;
 mod sync_stream;
 mod validity_window;
 
-use nimiq_primitives::policy::Policy;
 pub use sync::LightMacroSync;
-
-/// Minimum distance to light sync in #blocks from the peers head.
-pub fn full_sync_threshold() -> u32 {
-    // TODO: Experimental value that should be improved based on data collected from the testnet.
-    Policy::blocks_per_epoch() / 4
-}

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -7,9 +7,8 @@ use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_consensus::{
-    sync::{light::full_sync_threshold, syncer_proxy::SyncerProxy},
-    Consensus as AbstractConsensus, ConsensusProxy as AbstractConsensusProxy,
-    Error::BlockchainError,
+    sync::syncer_proxy::SyncerProxy, Consensus as AbstractConsensus,
+    ConsensusProxy as AbstractConsensusProxy, Error::BlockchainError,
 };
 #[cfg(feature = "zkp-prover")]
 use nimiq_genesis::NetworkId;
@@ -438,7 +437,7 @@ impl ClientInner {
                     bls_cache,
                     zkp_component.proxy(),
                     network_events,
-                    full_sync_threshold(),
+                    config.consensus.full_sync_threshold,
                 )
                 .await;
                 (blockchain_proxy, syncer, zkp_component)

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -81,6 +81,9 @@ pub struct ConsensusConfig {
     #[builder(default = "1")]
     /// Maximum number of epochs that are stored in the client
     pub max_epochs_stored: u32,
+    #[builder(default = "10800")]
+    /// Minimum distance away, in number of blocks, from the head to switch from state sync to live sync
+    pub full_sync_threshold: u32,
 }
 
 impl Default for ConsensusConfig {
@@ -89,6 +92,7 @@ impl Default for ConsensusConfig {
             sync_mode: SyncMode::default(),
             min_peers: 3,
             max_epochs_stored: Policy::MIN_EPOCHS_STORED,
+            full_sync_threshold: 10800,
         }
     }
 }
@@ -756,6 +760,9 @@ impl ClientConfigBuilder {
             .unwrap();
         if let Some(min_peers) = config_file.consensus.min_peers {
             consensus.min_peers = min_peers;
+        }
+        if let Some(full_sync_threshold) = config_file.consensus.full_sync_threshold {
+            consensus.full_sync_threshold = full_sync_threshold;
         }
         self.consensus(consensus);
 

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -80,9 +80,15 @@ seed_nodes = [
 # Possible values: "main", "test", "dev", "test-albatross", "dev-albatross"
 # Default: "dev-albatross"
 network = "test-albatross"
+
 # Specify the sync menchanism according to the client type
 # Possible values: history, full or light
 sync_mode = "full"
+
+# Specify the minimum distance away, in number of blocks, from the head to switch from state sync to live sync.
+# This property only has an effect when the sync_mode has the value "full"
+# Default: 10800
+# full_sync_threshold = 1000
 
 ##############################################################################
 #

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -186,6 +186,8 @@ pub struct ConsensusSettings {
     pub network: Option<NetworkId>,
     /// Minimum number of peers necessary to reach consensus
     pub min_peers: Option<usize>,
+    /// Minimum distance away, in number of blocks, from the head to switch from state sync to live sync
+    pub full_sync_threshold: Option<u32>,
 }
 
 #[derive(Clone, Copy, Deserialize, Debug, Default, Eq, PartialEq)]


### PR DESCRIPTION
## What's in this pull request?
Make the value of the `full_sync_threshold` configurable from the configfile.

#### This fixes #2555 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
