### PR TITLE
Increase mempool tests wait time

### DIFF
--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -97,7 +97,7 @@ async fn send_txn_to_mempool(
     .await
     .expect("Send failed");
 
-    sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(2)).await;
     mempool.stop_executor_without_unsubscribe().await;
 }
 


### PR DESCRIPTION
Increase the time we wait to send and process txns in the mempool for mempool's tests. This is needed because sometimes, specially in slow machines (CI), the mempool tests fails because it has not finished processing all txns

