### PR TITLE
Make the address book available to web clients

### DIFF
--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -11,7 +11,7 @@ use libp2p::{
     multiaddr::Protocol,
     Multiaddr, PeerId,
 };
-use nimiq_network_interface::peer_info::Services;
+use nimiq_network_interface::peer_info::{PeerInfo, Services};
 use nimiq_utils::tagged_signing::{TaggedKeyPair, TaggedSignable, TaggedSignature};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -433,6 +433,28 @@ impl PeerContactBook {
                 .cloned()
                 .collect()
         })
+    }
+
+    /// Retrieves a single PeerInfo object for every known peer.
+    /// Additional addresses aside from the first are omitted.
+    ///
+    /// The returned Vec may be empty.
+    pub fn known_peers(&self) -> Vec<PeerInfo> {
+        self.peer_contacts
+            .values()
+            .map(|contact| {
+                PeerInfo::new(
+                    contact
+                        .contact
+                        .inner
+                        .addresses
+                        .first()
+                        .expect("every peer should have at least one address")
+                        .clone(),
+                    contact.contact.inner.services,
+                )
+            })
+            .collect()
     }
 
     /// Gets a set of peer contacts given a services filter.

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -439,19 +439,22 @@ impl PeerContactBook {
     /// Additional addresses aside from the first are omitted.
     ///
     /// The returned Vec may be empty.
-    pub fn known_peers(&self) -> Vec<PeerInfo> {
+    pub fn known_peers(&self) -> Vec<(PeerId, PeerInfo)> {
         self.peer_contacts
-            .values()
-            .map(|contact| {
-                PeerInfo::new(
-                    contact
-                        .contact
-                        .inner
-                        .addresses
-                        .first()
-                        .expect("every peer should have at least one address")
-                        .clone(),
-                    contact.contact.inner.services,
+            .iter()
+            .map(|(peer_id, contact)| {
+                (
+                    *peer_id,
+                    PeerInfo::new(
+                        contact
+                            .contact
+                            .inner
+                            .addresses
+                            .first()
+                            .expect("every peer should have at least one address")
+                            .clone(),
+                        contact.contact.inner.services,
+                    ),
                 )
             })
             .collect()

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -154,7 +154,7 @@ impl Network {
 
     /// Retrieves a single PeerInfo peer existing in the PeerAddressBook.
     /// If that peer has multiple associated addresses all but the first are omitted.
-    pub fn get_address_book(&self) -> Vec<PeerInfo> {
+    pub fn get_address_book(&self) -> Vec<(PeerId, PeerInfo)> {
         self.contacts.read().known_peers()
     }
 

--- a/web-client/example/index.html
+++ b/web-client/example/index.html
@@ -25,6 +25,9 @@
       <!-- Run an animation on the main thread (CPU) with JS -->
       <div id="dead-mans-switch"></div>
     </div>
+    <div>
+      <button id="address-book">Query address book</button>
+    </div>
     <script>
       const deadMansSwitch = document.querySelector('#dead-mans-switch');
 

--- a/web-client/example/module.js
+++ b/web-client/example/module.js
@@ -46,7 +46,7 @@ init().then(async () => {
 
     document.querySelector('#address-book').addEventListener("click", async () => {
         let contacts = await client.getAddressBook();
-        console.log(contacts);
+        console.table(contacts);
     });
 
     /**

--- a/web-client/example/module.js
+++ b/web-client/example/module.js
@@ -44,6 +44,11 @@ init().then(async () => {
         document.querySelector('#peers').textContent = numPeers;
     });
 
+    document.querySelector('#address-book').addEventListener("click", async () => {
+        let contacts = await client.getAddressBook();
+        console.log(contacts);
+    });
+
     /**
      * @param {string} privateKey
      * @param {string} recipient

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -45,7 +45,7 @@ use crate::{
             PlainValidatorType,
         },
         block::{PlainBlock, PlainBlockType},
-        peer_info::PlainPeerInfo,
+        peer_info::{PlainPeerInfo, PlainPeerInfoArrayType},
     },
     client_configuration::{
         ClientConfiguration, PlainClientConfiguration, PlainClientConfigurationType,
@@ -389,6 +389,23 @@ impl Client {
     pub async fn get_head_block(&self) -> Result<PlainBlockType, JsError> {
         let block = self.inner.blockchain_head();
         Ok(serde_wasm_bindgen::to_value(&PlainBlock::from_block(&block))?.into())
+    }
+
+    /// Returns the current address books peers.
+    /// Each peer will have one address and currently no guarantee for the usefulness of that address can be given.
+    ///
+    /// The resulting Array may be empty if there is no peers in the address book.
+    #[wasm_bindgen(js_name = getAddressBook)]
+    pub async fn get_address_book(&self) -> PlainPeerInfoArrayType {
+        let contacts: Vec<_> = self
+            .inner
+            .network()
+            .get_address_book()
+            .into_iter()
+            .map(PlainPeerInfo::from)
+            .collect();
+
+        serde_wasm_bindgen::to_value(&contacts).unwrap().into()
     }
 
     /// Fetches a block by its hash.

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -402,7 +402,7 @@ impl Client {
             .network()
             .get_address_book()
             .into_iter()
-            .map(PlainPeerInfo::from)
+            .map(|(peer_id, peer_info)| PlainPeerInfo::from(peer_id.to_string(), peer_info))
             .collect();
 
         serde_wasm_bindgen::to_value(&contacts).unwrap().into()
@@ -966,8 +966,11 @@ impl Client {
                             peer_id.to_string(),
                             "joined",
                             Some(
-                                serde_wasm_bindgen::to_value(&PlainPeerInfo::from(peer_info))
-                                    .unwrap(),
+                                serde_wasm_bindgen::to_value(&PlainPeerInfo::from(
+                                    peer_id.to_string(),
+                                    peer_info,
+                                ))
+                                .unwrap(),
                             ),
                         ))
                     }

--- a/web-client/src/client/peer_info.rs
+++ b/web-client/src/client/peer_info.rs
@@ -6,6 +6,7 @@ use wasm_bindgen::prelude::*;
 #[derive(serde::Serialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 pub struct PlainPeerInfo {
+    pub peer_id: String,
     /// Address of the peer in `Multiaddr` format
     address: String,
     /// Node type of the peer
@@ -14,8 +15,8 @@ pub struct PlainPeerInfo {
     node_type: String,
 }
 
-impl From<nimiq_network_interface::peer_info::PeerInfo> for PlainPeerInfo {
-    fn from(peer_info: nimiq_network_interface::peer_info::PeerInfo) -> Self {
+impl PlainPeerInfo {
+    pub fn from(peer_id: String, peer_info: nimiq_network_interface::peer_info::PeerInfo) -> Self {
         let node_type = if peer_info
             .get_services()
             .contains(Services::provided(NodeType::History))
@@ -31,6 +32,7 @@ impl From<nimiq_network_interface::peer_info::PeerInfo> for PlainPeerInfo {
         };
 
         Self {
+            peer_id,
             address: peer_info.get_address().to_string(),
             node_type: node_type.to_string(),
         }

--- a/web-client/src/client/peer_info.rs
+++ b/web-client/src/client/peer_info.rs
@@ -1,5 +1,6 @@
 use nimiq_network_interface::peer_info::{NodeType, Services};
 use tsify::Tsify;
+use wasm_bindgen::prelude::*;
 
 /// Information about a networking peer.
 #[derive(serde::Serialize, Tsify)]
@@ -34,4 +35,10 @@ impl From<nimiq_network_interface::peer_info::PeerInfo> for PlainPeerInfo {
             node_type: node_type.to_string(),
         }
     }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "PlainPeerInfo[]")]
+    pub type PlainPeerInfoArrayType;
 }


### PR DESCRIPTION
This PR adds the address book to the network in order to make it available for web client to query. 

Ultimately it would potentially also make sense to add that functionality on RPC.

Completes #2186.