### PR TITLE
Fix revert for trie diffs to include incomplete part as well

### DIFF
--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -200,7 +200,7 @@ impl Blockchain {
                 Err(e) => {
                     // If a block fails to apply here it does not verify fully.
                     // This block and all blocks after this thus should be removed from the store
-                    // as they are not verifying. 
+                    // as they are not verifying.
                     warn!(
                         block = %block.1.head,
                         reason = "failed to apply fork block while rebranching",

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -10,7 +10,7 @@ use nimiq_primitives::{
     trie::{
         error::IncompleteTrie,
         trie_chunk::{TrieChunk, TrieChunkPushResult},
-        trie_diff::TrieDiff,
+        trie_diff::{RevertTrieDiff, TrieDiff},
         trie_proof::TrieProof,
         TrieItem,
     },
@@ -307,7 +307,7 @@ impl Accounts {
         &self,
         txn: &mut WriteTransactionProxy,
         diff: TrieDiff,
-    ) -> Result<TrieDiff, AccountError> {
+    ) -> Result<RevertTrieDiff, AccountError> {
         let diff = self.tree.apply_diff(txn, diff)?;
         self.tree.update_root(txn).ok();
         Ok(diff)
@@ -569,9 +569,9 @@ impl Accounts {
     pub fn revert_diff(
         &self,
         txn: &mut WriteTransactionProxy,
-        diff: TrieDiff,
+        diff: RevertTrieDiff,
     ) -> Result<(), AccountError> {
-        self.tree.apply_diff(txn, diff)?;
+        self.tree.revert_diff(txn, diff)?;
         Ok(())
     }
 

--- a/primitives/account/src/receipts.rs
+++ b/primitives/account/src/receipts.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, io};
 
 use nimiq_database_value::{FromDatabaseValue, IntoDatabaseValue};
-use nimiq_primitives::{account::FailReason, trie::trie_diff::TrieDiff};
+use nimiq_primitives::{account::FailReason, trie::trie_diff::RevertTrieDiff};
 use nimiq_serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -71,7 +71,7 @@ pub struct Receipts {
 #[repr(u8)]
 pub enum RevertInfo {
     Receipts(Receipts),
-    Diff(TrieDiff),
+    Diff(RevertTrieDiff),
 }
 
 impl From<Receipts> for RevertInfo {
@@ -80,8 +80,8 @@ impl From<Receipts> for RevertInfo {
     }
 }
 
-impl From<TrieDiff> for RevertInfo {
-    fn from(diff: TrieDiff) -> RevertInfo {
+impl From<RevertTrieDiff> for RevertInfo {
+    fn from(diff: RevertTrieDiff) -> RevertInfo {
         RevertInfo::Diff(diff)
     }
 }


### PR DESCRIPTION
## What's in this pull request?
Fix `apply_diff` to also record changes to the unknown part of the trie to properly revert those.

#### This fixes #2539.
#### Also fixes parts of #2162.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
