### PR TITLE
metrics-server: Re-add http1 support

### DIFF
--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -23,8 +23,8 @@ workspace = true
 bytes = "1.6"
 futures = "0.3"
 http-body-util = { version = "0.1" }
-hyper = { version = "1.3", features = ["server", "http2"] }
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper = { version = "1.3" }
+hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 log = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = "0.22.2"


### PR DESCRIPTION
Re-add support for http1 for the metrics server.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
