### PR TITLE
Improve performance of history tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -87,6 +88,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansiterm"
@@ -752,6 +759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +778,12 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -836,6 +855,33 @@ dependencies = [
  "num-traits",
  "serde",
  "winapi",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1054,6 +1100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1124,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1278,6 +1369,15 @@ checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -1618,6 +1718,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2155,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2425,6 +2553,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash",
+ "indexmap 2.2.1",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2614,17 @@ name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itertools"
@@ -3200,6 +3357,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,9 +3809,12 @@ name = "nimiq-database"
 version = "0.22.1"
 dependencies = [
  "bitflags 2.5.0",
+ "criterion",
  "libmdbx",
  "nimiq-database-value",
  "nimiq-test-log",
+ "pprof",
+ "rand",
  "tempfile",
  "thiserror",
  "tracing",
@@ -4946,6 +5115,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5030,6 +5210,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec 0.7.4",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5077,7 +5267,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -5104,6 +5294,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -5317,6 +5513,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5376,6 +5600,28 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -5528,6 +5774,15 @@ dependencies = [
  "quick-protobuf",
  "thiserror",
  "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5782,6 +6037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5820,7 +6084,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix",
+ "nix 0.24.3",
  "thiserror",
  "tokio",
 ]
@@ -5960,6 +6224,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -6437,6 +6710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6453,6 +6732,29 @@ name = "subtle"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+
+[[package]]
+name = "symbolic-common"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71297dc3e250f7dbdf8adb99e235da783d690f5819fdeb4cce39d9cfb0aca9f1"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424fa2c9bf2c862891b9cfd354a752751a6730fd838a4691e7f6c2c7957b9daf"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -6613,6 +6915,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7136,6 +7448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "uuid"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea73390fe27785838dcbf75b91b1d84799e28f1ce71e6f372a5dc2200c80de5"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7158,6 +7476,16 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/blockchain/src/history/mmr_store.rs
+++ b/blockchain/src/history/mmr_store.rs
@@ -145,7 +145,7 @@ impl<'a, 'env> Store<Blake2bHash> for MMRStore<'a, 'env> {
     fn push(&mut self, elem: Blake2bHash) {
         if let Tx::Write(ref mut tx) = self.tx {
             let key = index_to_key(self.epoch_number, self.size);
-            tx.put(self.hist_tree_table, &key, &elem);
+            tx.append(self.hist_tree_table, &key, &elem);
             self.size += 1;
         }
     }

--- a/blockchain/src/history/mmr_store.rs
+++ b/blockchain/src/history/mmr_store.rs
@@ -165,6 +165,8 @@ impl<'a, 'env> Store<Blake2bHash> for MMRStore<'a, 'env> {
             let key = index_to_key(self.epoch_number, self.size);
             cursor.append(&key, &elem);
             self.size += 1;
+        } else {
+            panic!("Cannot push to a read-only store");
         }
     }
 
@@ -180,6 +182,8 @@ impl<'a, 'env> Store<Blake2bHash> for MMRStore<'a, 'env> {
                 cursor.prev::<Vec<u8>, Blake2bHash>();
                 self.size -= 1;
             }
+        } else {
+            panic!("Cannot push to a read-only store");
         }
     }
 
@@ -360,6 +364,8 @@ impl<'a, 'env> LightStore<Blake2bHash> for LightMMRStore<'a, 'env> {
         if let Tx::Write(ref mut tx) = self.tx {
             let key = index_to_key(self.block_number, pos);
             tx.put(self.hist_tree_table, &key, &elem);
+        } else {
+            panic!("Cannot push to a read-only store");
         }
     }
 
@@ -367,6 +373,8 @@ impl<'a, 'env> LightStore<Blake2bHash> for LightMMRStore<'a, 'env> {
         if let Tx::Write(ref mut tx) = self.tx {
             let key = index_to_key(self.block_number, pos);
             tx.remove(self.hist_tree_table, &key);
+        } else {
+            panic!("Cannot push to a read-only store");
         }
     }
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "nimiq-database"
 version.workspace = true
-authors = ["Pascal B <git@paberr.net>", "The Nimiq Core Development Team <info@nimiq.com>"]
+authors = [
+    "Pascal B <git@paberr.net>",
+    "The Nimiq Core Development Team <info@nimiq.com>",
+]
 license.workspace = true
 edition.workspace = true
 description = "A LMDB database wrapper with support for volatile storage"
@@ -29,4 +32,16 @@ thiserror = "1.0"
 nimiq-database-value = { workspace = true }
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+pprof = { version = "0.13", features = [
+    "flamegraph",
+    "frame-pointer",
+    "criterion",
+] }
+rand = "0.8"
+
 nimiq-test-log = { workspace = true }
+
+[[bench]]
+name = "hash_keys"
+harness = false

--- a/database/benches/hash_keys.rs
+++ b/database/benches/hash_keys.rs
@@ -1,0 +1,243 @@
+use std::{borrow::Cow, collections::HashSet, hash::Hash};
+
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+};
+use nimiq_database::{
+    traits::{Database, WriteCursor, WriteTransaction},
+    volatile::VolatileDatabase,
+    DatabaseProxy, TableFlags,
+};
+use nimiq_database_value::AsDatabaseBytes;
+use pprof::criterion::{Output, PProfProfiler};
+use rand::{
+    distributions::{Distribution, Standard},
+    thread_rng, Rng,
+};
+
+const TABLE: &'static str = "bench";
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = hash_keys
+}
+criterion_main!(benches);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Blake2bHash([u8; 32]);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Address([u8; 20]);
+
+impl Distribution<Blake2bHash> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Blake2bHash {
+        Blake2bHash(rng.gen())
+    }
+}
+
+impl Distribution<Address> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Address {
+        Address(rng.gen())
+    }
+}
+
+impl AsDatabaseBytes for Blake2bHash {
+    fn as_database_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self.0)
+    }
+}
+
+impl AsDatabaseBytes for Address {
+    fn as_database_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self.0)
+    }
+}
+
+/// It benchmarks the insertion of rows into a table where `Keys` are hashes.
+/// * `append`: Table is empty. Sorts during benchmark.
+/// * `insert_sorted`: Table is preloaded with rows (same as batch size). Sorts during benchmark.
+/// * `insert_unsorted`: Table is preloaded with rows (same as batch size).
+/// * `put_sorted`: Table is preloaded with rows (same as batch size). Sorts during benchmark.
+/// * `put_unsorted`: Table is preloaded with rows (same as batch size).
+///
+/// It does the above steps with different batches of rows. `10_000`, `100_000`, `1_000_000`. In the
+/// end, the table statistics are shown (eg. number of pages, table size...)
+pub fn hash_keys(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Hash-Keys Table Insertion");
+
+    group.sample_size(10);
+
+    for size in [10_000, 100_000, 1_000_000] {
+        measure_table_insertion::<u32>(&mut group, size, "u32", TableFlags::UINT_KEYS);
+        measure_table_insertion::<Address>(&mut group, size, "Address", TableFlags::empty());
+        measure_table_insertion::<Blake2bHash>(
+            &mut group,
+            size,
+            "Blake2bHash",
+            TableFlags::empty(),
+        );
+    }
+}
+
+fn measure_table_insertion<K: Eq + PartialEq + PartialOrd + Ord + Hash + Clone + AsDatabaseBytes>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    size: usize,
+    ty: &'static str,
+    table_flags: TableFlags,
+) where
+    Standard: Distribution<K>,
+{
+    let scenarios: Vec<(fn(_, _, _) -> _, &str)> = vec![
+        (append, "append_all"),
+        (append, "append_input"),
+        (insert, "insert_unsorted"),
+        (insert, "insert_sorted"),
+        (put, "put_unsorted"),
+        (put, "put_sorted"),
+    ];
+
+    // `preload` is to be inserted into the database during the setup phase in all scenarios but
+    // `append`.
+    let (preload, unsorted_input) = generate_batches::<K>(size);
+
+    for (scenario, scenario_str) in scenarios {
+        // Append does not preload the table
+        let mut preload_size = size;
+        let mut input_size = size;
+        if scenario_str.contains("append") {
+            if scenario_str == "append_all" {
+                input_size = size * 2;
+            }
+            preload_size = 0;
+        }
+
+        // Setup phase before each benchmark iteration
+        let setup = || {
+            // Reset DB
+            let db = VolatileDatabase::new(2).unwrap();
+            let table = db.open_table_with_flags(TABLE.to_string(), table_flags);
+
+            let mut unsorted_input = unsorted_input.clone();
+            if scenario_str == "append_all" {
+                unsorted_input.extend_from_slice(&preload);
+            }
+
+            if preload_size > 0 {
+                let mut txn = db.write_transaction();
+
+                for (key, value) in &preload {
+                    let _ = txn.put(&table, key, value);
+                }
+
+                txn.commit();
+            }
+
+            (unsorted_input, db)
+        };
+
+        // Iteration to be benchmarked
+        let execution = |(input, db)| {
+            let mut input: Vec<(K, Vec<u8>)> = input;
+            if scenario_str.contains("_sorted") || scenario_str.contains("append") {
+                input.sort_by(|a, b| a.0.cmp(&b.0));
+            }
+            scenario(db, input, table_flags)
+        };
+
+        group.bench_function(
+            format!(
+                "{} |  {ty} | {scenario_str} | preload: {} | writing: {} ",
+                TABLE, preload_size, input_size
+            ),
+            |b| {
+                b.iter_with_setup(setup, execution);
+            },
+        );
+    }
+}
+
+/// Generates two batches. The first is to be inserted into the database before running the
+/// benchmark. The second is to be benchmarked with.
+fn generate_batches<K: Eq + Hash + Clone>(size: usize) -> (Vec<(K, Vec<u8>)>, Vec<(K, Vec<u8>)>)
+where
+    Standard: Distribution<K>,
+{
+    let mut preload = Vec::with_capacity(size);
+    let mut input = Vec::with_capacity(size);
+    for _ in 0..size {
+        let mut rng = thread_rng();
+        let key1: K = rng.gen();
+        let key2: K = rng.gen();
+
+        let value1: Vec<u8> = (0..32).map(|_| rng.gen::<u8>()).collect();
+        let value2: Vec<u8> = (0..32).map(|_| rng.gen::<u8>()).collect();
+
+        preload.push((key1, value1));
+        input.push((key2, value2));
+    }
+
+    let mut unique_keys = HashSet::new();
+    preload.retain(|(k, _)| unique_keys.insert(k.clone()));
+    input.retain(|(k, _)| unique_keys.insert(k.clone()));
+
+    (preload, input)
+}
+
+fn append<K: AsDatabaseBytes>(
+    db: DatabaseProxy,
+    input: Vec<(K, Vec<u8>)>,
+    table_flags: TableFlags,
+) -> DatabaseProxy {
+    {
+        let table = db.open_table_with_flags(TABLE.to_string(), table_flags);
+        let txn = db.write_transaction();
+        let mut cursor = txn.cursor(&table);
+        black_box({
+            for (k, v) in input {
+                cursor.append(&k, &v);
+            }
+
+            txn.commit();
+        });
+    }
+    db
+}
+
+fn insert<K: AsDatabaseBytes>(
+    db: DatabaseProxy,
+    input: Vec<(K, Vec<u8>)>,
+    table_flags: TableFlags,
+) -> DatabaseProxy {
+    {
+        let table = db.open_table_with_flags(TABLE.to_string(), table_flags);
+        let txn = db.write_transaction();
+        let mut cursor = txn.cursor(&table);
+        black_box({
+            for (k, v) in input {
+                cursor.put(&k, &v);
+            }
+
+            txn.commit();
+        });
+    }
+    db
+}
+
+fn put<K: AsDatabaseBytes>(
+    db: DatabaseProxy,
+    input: Vec<(K, Vec<u8>)>,
+    table_flags: TableFlags,
+) -> DatabaseProxy {
+    {
+        let table = db.open_table_with_flags(TABLE.to_string(), table_flags);
+        let mut txn = db.write_transaction();
+        black_box({
+            for (k, v) in input {
+                txn.put(&table, &k, &v);
+            }
+
+            txn.commit();
+        });
+    }
+    db
+}

--- a/database/src/mdbx/cursor.rs
+++ b/database/src/mdbx/cursor.rs
@@ -265,4 +265,14 @@ impl<'txn> WriteCursor<'txn> for MdbxWriteCursor<'txn> {
         let value = AsDatabaseBytes::as_database_bytes(value);
         self.cursor.put(&key, &value, WriteFlags::APPEND).unwrap();
     }
+
+    fn put<K, V>(&mut self, key: &K, value: &V)
+    where
+        K: AsDatabaseBytes + ?Sized,
+        V: AsDatabaseBytes + ?Sized,
+    {
+        let key = AsDatabaseBytes::as_database_bytes(key);
+        let value = AsDatabaseBytes::as_database_bytes(value);
+        self.cursor.put(&key, &value, WriteFlags::empty()).unwrap();
+    }
 }

--- a/database/src/mdbx/cursor.rs
+++ b/database/src/mdbx/cursor.rs
@@ -255,4 +255,14 @@ impl<'txn> WriteCursor<'txn> for MdbxWriteCursor<'txn> {
     fn remove(&mut self) {
         self.cursor.del(WriteFlags::empty()).unwrap();
     }
+
+    fn append<K, V>(&mut self, key: &K, value: &V)
+    where
+        K: AsDatabaseBytes + ?Sized,
+        V: AsDatabaseBytes + ?Sized,
+    {
+        let key = AsDatabaseBytes::as_database_bytes(key);
+        let value = AsDatabaseBytes::as_database_bytes(value);
+        self.cursor.put(&key, &value, WriteFlags::APPEND).unwrap();
+    }
 }

--- a/database/src/mdbx/transaction.rs
+++ b/database/src/mdbx/transaction.rs
@@ -94,6 +94,21 @@ impl<'db> WriteTransaction<'db> for MdbxWriteTransaction<'db> {
             .unwrap();
     }
 
+    fn append<K, V>(&mut self, table: &MdbxTable, key: &K, value: &V)
+    where
+        K: AsDatabaseBytes + ?Sized,
+        V: AsDatabaseBytes + ?Sized,
+    {
+        let table = self.open_table(table);
+
+        let key = AsDatabaseBytes::as_database_bytes(key);
+        let value = AsDatabaseBytes::as_database_bytes(value);
+
+        self.txn
+            .put(&table, key, value, WriteFlags::APPEND)
+            .unwrap();
+    }
+
     fn remove<K>(&mut self, table: &MdbxTable, key: &K)
     where
         K: AsDatabaseBytes + ?Sized,

--- a/database/src/proxy/transaction.rs
+++ b/database/src/proxy/transaction.rs
@@ -111,6 +111,17 @@ impl<'db> WriteTransaction<'db> for WriteTransactionProxy<'db> {
         }
     }
 
+    fn append<K, V>(&mut self, table: &Self::Table, key: &K, value: &V)
+    where
+        K: nimiq_database_value::AsDatabaseBytes + ?Sized,
+        V: nimiq_database_value::AsDatabaseBytes + ?Sized,
+    {
+        match self.txn {
+            TransactionProxy::ReadTransaction(_) => unreachable!(),
+            TransactionProxy::WriteTransaction(ref mut txn) => txn.append(table, key, value),
+        }
+    }
+
     fn remove<K>(&mut self, table: &Self::Table, key: &K)
     where
         K: nimiq_database_value::AsDatabaseBytes + ?Sized,

--- a/database/src/traits/cursor.rs
+++ b/database/src/traits/cursor.rs
@@ -96,11 +96,17 @@ pub trait ReadCursor<'txn>: Clone {
 ///
 /// Closely follows `libmdbx`'s [cursor API](https://docs.rs/libmdbx/0.3.3/libmdbx/struct.Cursor.html).
 pub trait WriteCursor<'txn>: ReadCursor<'txn> {
+    fn put<K, V>(&mut self, key: &K, value: &V)
+    where
+        K: AsDatabaseBytes + ?Sized,
+        V: AsDatabaseBytes + ?Sized;
+
     /// Appends a key/value pair to the end of the database.
     /// This operation fails if the key is less than the last key.
     fn append<K, V>(&mut self, key: &K, value: &V)
     where
         K: AsDatabaseBytes + ?Sized,
         V: AsDatabaseBytes + ?Sized;
+
     fn remove(&mut self);
 }

--- a/database/src/traits/cursor.rs
+++ b/database/src/traits/cursor.rs
@@ -96,5 +96,11 @@ pub trait ReadCursor<'txn>: Clone {
 ///
 /// Closely follows `libmdbx`'s [cursor API](https://docs.rs/libmdbx/0.3.3/libmdbx/struct.Cursor.html).
 pub trait WriteCursor<'txn>: ReadCursor<'txn> {
+    /// Appends a key/value pair to the end of the database.
+    /// This operation fails if the key is less than the last key.
+    fn append<K, V>(&mut self, key: &K, value: &V)
+    where
+        K: AsDatabaseBytes + ?Sized,
+        V: AsDatabaseBytes + ?Sized;
     fn remove(&mut self);
 }

--- a/database/src/traits/transaction.rs
+++ b/database/src/traits/transaction.rs
@@ -42,6 +42,13 @@ pub trait WriteTransaction<'db>: ReadTransaction<'db> + Sized {
         K: AsDatabaseBytes + ?Sized,
         V: AsDatabaseBytes + ?Sized;
 
+    /// Appends a key/value pair to the end of the database.
+    /// This operation fails if the key is less than the last key.
+    fn append<K, V>(&mut self, table: &Self::Table, key: &K, value: &V)
+    where
+        K: AsDatabaseBytes + ?Sized,
+        V: AsDatabaseBytes + ?Sized;
+
     fn remove<K>(&mut self, table: &Self::Table, key: &K)
     where
         K: AsDatabaseBytes + ?Sized;

--- a/primitives/mmr/src/mmr/position.rs
+++ b/primitives/mmr/src/mmr/position.rs
@@ -143,7 +143,15 @@ impl Ord for Position {
 /// Calculate whether a number only consists of 1-bits (except the leading zeros).
 /// That means 00000111 is considered all-ones but 00001110 is not.
 fn all_ones(num: usize) -> bool {
-    num != 0 && num.count_zeros() == num.leading_zeros()
+    if num == 0 {
+        return false;
+    }
+    // Find the highest set bit
+    let highest_set_bit = usize::BITS - num.leading_zeros();
+    // Create a mask with all 1s from the highest set bit to the least significant bit
+    let mask = (1 << highest_set_bit) - 1;
+    // Check if the number matches the mask
+    num == mask
 }
 
 /// In order to move left on the same level, we subtract the index by its most significant bit

--- a/primitives/mmr/src/mmr/position.rs
+++ b/primitives/mmr/src/mmr/position.rs
@@ -146,12 +146,7 @@ fn all_ones(num: usize) -> bool {
     if num == 0 {
         return false;
     }
-    // Find the highest set bit
-    let highest_set_bit = usize::BITS - num.leading_zeros();
-    // Create a mask with all 1s from the highest set bit to the least significant bit
-    let mask = (1 << highest_set_bit) - 1;
-    // Check if the number matches the mask
-    num == mask
+    (num + 1).is_power_of_two()
 }
 
 /// In order to move left on the same level, we subtract the index by its most significant bit


### PR DESCRIPTION
## What's in this pull request?
Keys we insert into the history tree are always sorted.
We can thus take advantage of the `append` functionality of mdbx which adds the key to the end of the database without a linear search.
Also add optimization for `all_ones` function since a profiling of the code revealed that `usize::count_zeros` is expensive and changing the operation to only rely on `usize::leading_zeros` and a mask is cheaper.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
