### PR TITLE
Catch if peer sends an invalid epoch_number instead of panicking

### DIFF
--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -100,6 +100,8 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
 }
 
 impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for HistoryMacroSync<TNetwork> {
+    const MAX_REQUEST_EPOCHS: u16 = 1000; // TODO: Use other value
+
     fn add_peer(&mut self, peer_id: TNetwork::PeerId) {
         // Ignore peer if we already know it.
         if self.peers.contains_key(&peer_id) {

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -52,7 +52,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
             Arc::clone(&network),
             peer_id,
             locators,
-            1000, // TODO: Use other value
+            Self::MAX_REQUEST_EPOCHS,
         )
         .await;
 
@@ -68,6 +68,19 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                 })
             }
             Ok(Ok(mut macro_chain)) => {
+                // Validate that the maximum number of epochs is not exceeded.
+                if macro_chain.epochs.len() > Self::MAX_REQUEST_EPOCHS as usize {
+                    log::warn!(
+                        num_epochs = macro_chain.epochs.len(),
+                        %peer_id,
+                        "Request macro chain failed: too many epochs returned"
+                    );
+                    network
+                        .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                        .await;
+                    return None;
+                }
+
                 // Clear checkpoint if epochs were returned. This avoids processing checkpoints that
                 // become outdated while the epochs preceding it are being downloaded and applied.
                 if !macro_chain.epochs.is_empty() {
@@ -86,7 +99,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                         || Policy::is_election_block_at(checkpoint.block_number)
                     {
                         // Peer provided an invalid checkpoint block number, close connection.
-                        log::error!(
+                        log::warn!(
                             given_checkpoint_epoch,
                             expected_checkpoint_epoch,
                             peer = %peer_id,
@@ -116,7 +129,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                 })
             }
             Err(e) => {
-                log::error!("Request macro chain failed: {:?}", e);
+                log::warn!("Request macro chain failed: {:?}", e);
                 network.disconnect_peer(peer_id, CloseReason::Error).await;
                 None
             }

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -258,6 +258,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 }
 
 impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for LightMacroSync<TNetwork> {
+    const MAX_REQUEST_EPOCHS: u16 = 1000; // TODO: Use other value
+
     fn add_peer(&mut self, peer_id: TNetwork::PeerId) {
         info!(%peer_id, "Requesting zkp from peer");
 

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -236,7 +236,6 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 
                     // Calculate an upper bound on the peer's head block.
                     // The upper bound is the last micro block of the latest batch of the peer.
-                    #[cfg(feature = "full")]
                     let peer_head_upper_bound = epoch_ids
                         .checkpoint
                         .as_ref()
@@ -245,12 +244,11 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                             if epoch_ids.checkpoint_epoch_number() == 0 {
                                 return 0;
                             }
-                            // FIXME: Ban peer if it sends an invalid epoch_number instead of panicking.
                             Policy::first_block_of(epoch_ids.checkpoint_epoch_number() as u32)
-                                .expect("The supplied epoch number is out of bounds")
+                                .unwrap_or(u32::MAX)
                         })
-                        + Policy::blocks_per_batch()
-                        - 1;
+                        .saturating_add(Policy::blocks_per_batch())
+                        .saturating_sub(1);
 
                     if peer_head_upper_bound.saturating_sub(our_head) <= self.full_sync_threshold {
                         log::debug!(

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -247,8 +247,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                             Policy::first_block_of(epoch_ids.checkpoint_epoch_number() as u32)
                                 .unwrap_or(u32::MAX)
                         })
-                        .saturating_add(Policy::blocks_per_batch())
-                        .saturating_sub(1);
+                        .saturating_add(Policy::blocks_per_batch() - 1);
 
                     if peer_head_upper_bound.saturating_sub(our_head) <= self.full_sync_threshold {
                         log::debug!(

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -24,6 +24,8 @@ use crate::{consensus::ResolveBlockRequest, messages::RequestHead};
 /// The quantity of macro blocks needed or extra metadata associated are defined by each
 /// implementor of these trait.
 pub trait MacroSync<TPeerId>: Stream<Item = MacroSyncReturn<TPeerId>> + Unpin + Send {
+    /// The maximum amount of epochs we request for MacroSync
+    const MAX_REQUEST_EPOCHS: u16;
     /// Adds a peer to synchronize macro blocks
     fn add_peer(&mut self, peer_id: TPeerId);
 }

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -56,6 +56,8 @@ impl Stream for MockHistorySyncStream {
 }
 
 impl MacroSync<MockPeerId> for MockHistorySyncStream {
+    const MAX_REQUEST_EPOCHS: u16 = 3;
+
     fn add_peer(&mut self, peer_id: MockPeerId) {
         self.peers.write().push(peer_id);
     }


### PR DESCRIPTION
This fixes #2509 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
