### PR TITLE
Use faster byte array serialization for `Address`

### DIFF
--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -227,6 +227,7 @@ impl FromDatabaseValue for Address {
 mod serde_derive {
     use std::borrow::Cow;
 
+    use nimiq_serde::FixedSizeByteArray;
     use serde::{
         de::{Deserialize, Deserializer, Error},
         ser::{Serialize, Serializer},
@@ -242,7 +243,7 @@ mod serde_derive {
             if serializer.is_human_readable() {
                 serializer.serialize_str(&self.to_user_friendly_address())
             } else {
-                Serialize::serialize(&self.0, serializer)
+                FixedSizeByteArray::from(self.0).serialize(serializer)
             }
         }
     }
@@ -256,7 +257,8 @@ mod serde_derive {
                 let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
                 Address::from_any_str(&s).map_err(Error::custom)
             } else {
-                let data: [u8; Self::SIZE] = Deserialize::deserialize(deserializer)?;
+                let data: [u8; Self::SIZE] =
+                    FixedSizeByteArray::deserialize(deserializer)?.into_inner();
                 Ok(Address(data))
             }
         }


### PR DESCRIPTION
It was missed because the serialization wasn't derived.
