### PR TITLE
transaction: Optimize MMR hash for `HistoricTransaction`

### DIFF
--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -227,7 +227,7 @@ impl FromDatabaseValue for Address {
 mod serde_derive {
     use std::borrow::Cow;
 
-    use nimiq_serde::SerializedSize;
+    use nimiq_serde::{FixedSizeByteArray, SerializedSize};
     use serde::{
         de::{Deserialize, Deserializer, Error},
         ser::{Serialize, Serializer},
@@ -247,7 +247,7 @@ mod serde_derive {
             if serializer.is_human_readable() {
                 serializer.serialize_str(&self.to_user_friendly_address())
             } else {
-                Serialize::serialize(&self.0, serializer)
+                FixedSizeByteArray::from(self.0).serialize(serializer)
             }
         }
     }
@@ -261,7 +261,8 @@ mod serde_derive {
                 let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
                 Address::from_any_str(&s).map_err(Error::custom)
             } else {
-                let data: [u8; Self::SIZE] = Deserialize::deserialize(deserializer)?;
+                let data: [u8; Self::SIZE] =
+                    FixedSizeByteArray::deserialize(deserializer)?.into_inner();
                 Ok(Address(data))
             }
         }

--- a/primitives/transaction/src/historic_transaction.rs
+++ b/primitives/transaction/src/historic_transaction.rs
@@ -298,9 +298,10 @@ impl MMRHash<Blake2bHash> for HistoricTransaction {
     /// to include it into the History Tree.
     /// This returns the executed transaction hash prefixed with 'prefix' number of leaves.
     fn hash(&self, prefix: u64) -> Blake2bHash {
-        let mut message = prefix.to_be_bytes().to_vec();
-        message.append(&mut self.serialize_to_vec());
-        message.hash()
+        let mut hasher = Blake2bHasher::new();
+        hasher.write_all(&prefix.to_be_bytes()).unwrap();
+        self.serialize_to_writer(&mut hasher).unwrap();
+        hasher.finish()
     }
 }
 


### PR DESCRIPTION
Optimize MMR hash for `HistoricTransaction` by removing unnecessary vector allocation and writing all the data directly to the hasher.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
