### PR TITLE
Verify sender account type in mempool

### DIFF
--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -160,11 +160,11 @@ impl Blockchain {
         if let Ok(account) = self.state.accounts.get(address, None) {
             Some(account)
         } else {
-            warn!(%address, "Could not get account for address");
             None
         }
     }
 
+    /// The given account must correspond to the sender of the given transaction.
     pub fn reserve_balance(
         &self,
         account: &Account,
@@ -181,6 +181,7 @@ impl Blockchain {
         )
     }
 
+    /// The given account must correspond to the sender of the given transaction.
     pub fn release_balance(
         &self,
         account: &Account,

--- a/mempool/src/mempool_state.rs
+++ b/mempool/src/mempool_state.rs
@@ -74,15 +74,11 @@ impl MempoolState {
 
         if let Some(sender_state) = self.state_by_sender.get_mut(&tx.sender) {
             let reserved_balance = &mut sender_state.reserved_balance;
-            blockchain
-                .reserve_balance(&sender_account, tx, reserved_balance)
-                .map_err(|_| VerifyErr::InsufficientFunds)?;
+            blockchain.reserve_balance(&sender_account, tx, reserved_balance)?;
             sender_state.txns.insert(tx.hash());
         } else {
             let mut reserved_balance = ReservedBalance::new(tx.sender.clone());
-            blockchain
-                .reserve_balance(&sender_account, tx, &mut reserved_balance)
-                .map_err(|_| VerifyErr::InsufficientFunds)?;
+            blockchain.reserve_balance(&sender_account, tx, &mut reserved_balance)?;
 
             let sender_state = SenderPendingState {
                 reserved_balance,

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_hash::Hash;
-use nimiq_primitives::{networks::NetworkId, transaction::TransactionError};
+use nimiq_primitives::{account::AccountError, networks::NetworkId, transaction::TransactionError};
 use nimiq_transaction::Transaction;
 use parking_lot::RwLock;
 use thiserror::Error;
@@ -20,8 +20,8 @@ pub enum VerifyErr {
     AlreadyIncluded,
     #[error("Transaction not valid at current block number")]
     InvalidBlockNumber,
-    #[error("Insufficient funds to execute transaction")]
-    InsufficientFunds,
+    #[error("Transaction cannot be applied to sender account: {0}")]
+    InvalidAccount(#[from] AccountError),
     #[error("Transaction already in mempool")]
     Known,
     #[error("Transaction is filtered")]

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -82,6 +82,7 @@ impl Accounts {
             .expect("Tree must be complete")
     }
 
+    /// The given account must correspond to the sender of the given transaction.
     pub fn reserve_balance(
         &self,
         account: &Account,
@@ -90,6 +91,14 @@ impl Accounts {
         block_state: &BlockState,
         txn_option: Option<&DBTransaction>,
     ) -> Result<(), AccountError> {
+        // Verify that the account type matches the one given in the transaction.
+        if account.account_type() != transaction.sender_type {
+            return Err(AccountError::TypeMismatch {
+                expected: transaction.sender_type,
+                got: account.account_type(),
+            });
+        }
+
         // This assumes that the given account corresponds to the sender of the given transaction.
         let store = DataStore::new(&self.tree, &transaction.sender);
 
@@ -106,6 +115,7 @@ impl Accounts {
         }
     }
 
+    /// The given account must correspond to the sender of the given transaction.
     pub fn release_balance(
         &self,
         account: &Account,

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -343,25 +343,7 @@ impl Transaction {
             return Ok(());
         }
 
-        if self.recipient == Policy::STAKING_CONTRACT_ADDRESS
-            && self.recipient_type != AccountType::Staking
-        {
-            return Err(TransactionError::InvalidForRecipient);
-        }
-
-        // Should not be necessary as the sender would have to sign the transaction
-        // and the private key for the staking contract is unknown
-        if self.sender == Policy::STAKING_CONTRACT_ADDRESS
-            && self.sender_type != AccountType::Staking
-        {
-            return Err(TransactionError::InvalidForSender);
-        }
-
         if self.sender == self.recipient {
-            error!(
-                "The following transaction can't have the same sender and recipient:\n{:?}",
-                self
-            );
             return Err(TransactionError::SenderEqualsRecipient);
         }
 


### PR DESCRIPTION
The account type on the sender side is now properly checked in the mempool via `reserve_balance()`.

The intrinsic staking contract account type check is removed entirely from the transaction verification. A mismatch on the recipient side will now result in a failed transaction, which brings it in line with other account type mismatches.

Closes #2605 