### PR TITLE
Handle unsupported light history store functionality

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1277,6 +1277,10 @@ impl HistoryInterface for HistoryStore {
 
         (first, last)
     }
+
+    fn is_light(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -44,6 +44,9 @@ pub trait HistoryInterface {
     /// Clears the history store.
     fn clear(&self, txn: &mut WriteTransactionProxy);
 
+    /// Returns true if the history store is the light version
+    fn is_light(&self) -> bool;
+
     /// Returns the length (i.e. the number of leaves) of the History Tree at a given block height.
     /// Note that this returns the number of leaves for only the epoch of the given block height,
     /// this is because we have separate History Trees for separate epochs.

--- a/blockchain/src/history/light_history_store.rs
+++ b/blockchain/src/history/light_history_store.rs
@@ -276,7 +276,7 @@ impl HistoryInterface for LightHistoryStore {
         _epoch_number: u32,
         _num_hist_txs: usize,
     ) -> Option<(Blake2bHash, u64)> {
-        None
+        unimplemented!()
     }
 
     fn tx_in_validity_window(
@@ -294,7 +294,7 @@ impl HistoryInterface for LightHistoryStore {
         _tx_hash: &Blake2bHash,
         _txn_option: Option<&TransactionProxy>,
     ) -> Vec<HistoricTransaction> {
-        todo!()
+        unimplemented!()
     }
 
     fn get_block_transactions(
@@ -302,7 +302,7 @@ impl HistoryInterface for LightHistoryStore {
         _block_number: u32,
         _txn_option: Option<&TransactionProxy>,
     ) -> Vec<HistoricTransaction> {
-        todo!()
+        unimplemented!()
     }
 
     fn get_epoch_transactions(
@@ -424,6 +424,10 @@ impl HistoryInterface for LightHistoryStore {
         nimiq_mmr::error::Error,
     > {
         unimplemented!()
+    }
+
+    fn is_light(&self) -> bool {
+        true
     }
 }
 

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -123,13 +123,18 @@ impl<N: Network> ConsensusProxy<N> {
                 .await;
 
             match response {
-                Ok(response) => {
-                    log::debug!(
-                        "Obtained txn receipts response, length {} ",
-                        response.receipts.len()
-                    );
-                    obtained_receipts.extend(response.receipts);
-                }
+                Ok(response_result) => match response_result {
+                    Ok(response) => {
+                        log::debug!(
+                            "Obtained txn receipts response, length {} ",
+                            response.receipts.len()
+                        );
+                        obtained_receipts.extend(response.receipts);
+                    }
+                    Err(error) => {
+                        log::error!(peer=%peer_id, err=%error,"The peer does not support this request, even though it had the TRANSACTION_INDEX flag");
+                    }
+                },
                 Err(error) => {
                     // If there was a request error with this peer we log an error
                     log::error!(peer=%peer_id, err=%error,"There was an error requesting transaction receipts from peer");

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -415,8 +415,18 @@ pub struct RequestTransactionReceiptsByAddress {
 impl RequestCommon for RequestTransactionReceiptsByAddress {
     type Kind = RequestMarker;
     const TYPE_ID: u16 = 214;
-    type Response = ResponseTransactionReceiptsByAddress;
+    type Response =
+        Result<ResponseTransactionReceiptsByAddress, ResponseTransactionReceiptsByAddressError>;
     const MAX_REQUESTS: u32 = MAX_REQUEST_TRANSACTIONS_BY_ADDRESS;
+}
+
+#[derive(Clone, Debug, Deserialize, Error, Serialize)]
+pub enum ResponseTransactionReceiptsByAddressError {
+    #[error("not implemented")]
+    NotImplemented,
+    #[error("unknown error")]
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -155,6 +155,11 @@ impl BlockchainInterface for BlockchainDispatcher {
         hash: Blake2bHash,
     ) -> RPCResult<ExecutedTransaction, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
+            if blockchain.history_store.is_light() {
+                log::warn!("Transaction by hash is not supported by the light history store");
+                return Err(Error::NotImplemented);
+            }
+
             // Get all the historic transactions that correspond to this hash.
             let mut hist_txs = blockchain.history_store.get_hist_tx_by_hash(&hash, None);
 
@@ -184,6 +189,13 @@ impl BlockchainInterface for BlockchainDispatcher {
         block_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
+            if blockchain.history_store.is_light() {
+                log::warn!(
+                    "Transaction hashes by address is not supported by the light history store"
+                );
+                return Err(Error::NotImplemented);
+            }
+
             // Get all the historic transactions that correspond to this block.
             let hist_txs = blockchain
                 .history_store
@@ -210,6 +222,13 @@ impl BlockchainInterface for BlockchainDispatcher {
         block_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
+            if blockchain.history_store.is_light() {
+                log::warn!(
+                    "Transaction hashes by address is not supported by the light history store"
+                );
+                return Err(Error::NotImplemented);
+            }
+
             // Get all the historic transactions that correspond to this block.
             let historic_tx_vec = blockchain
                 .history_store
@@ -235,6 +254,13 @@ impl BlockchainInterface for BlockchainDispatcher {
         batch_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
+            if blockchain.history_store.is_light() {
+                log::warn!(
+                    "Transaction hashes by address is not supported by the light history store"
+                );
+                return Err(Error::NotImplemented);
+            }
+
             // Calculate the numbers for the micro blocks in the batch.
             let first_block = Policy::first_block_of_batch(batch_number).ok_or(
                 Error::InvalidArgument("Batch number out of bounds".to_string()),
@@ -268,6 +294,13 @@ impl BlockchainInterface for BlockchainDispatcher {
         batch_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
+            if blockchain.history_store.is_light() {
+                log::warn!(
+                    "Transaction hashes by address is not supported by the light history store"
+                );
+                return Err(Error::NotImplemented);
+            }
+
             let macro_block_number = Policy::macro_block_of(batch_number).ok_or(
                 Error::InvalidArgument("Batch number out of bounds".to_string()),
             )?;
@@ -311,8 +344,16 @@ impl BlockchainInterface for BlockchainDispatcher {
         max: Option<u16>,
     ) -> RPCResult<Vec<Blake2bHash>, (), Self::Error> {
         if let BlockchainProxy::Full(blockchain) = &self.blockchain {
+            let blockchain = blockchain.read();
+
+            if blockchain.history_store.is_light() {
+                log::warn!(
+                    "Transaction hashes by address is not supported by the light history store"
+                );
+                return Err(Error::NotImplemented);
+            }
+
             Ok(blockchain
-                .read()
                 .history_store
                 .get_tx_hashes_by_address(&address, max.unwrap_or(500), None)
                 .into())
@@ -327,6 +368,11 @@ impl BlockchainInterface for BlockchainDispatcher {
         max: Option<u16>,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
+            if blockchain.history_store.is_light() {
+                log::warn!("Transactions by address is not supported by the light history store");
+                return Err(Error::NotImplemented);
+            }
+
             // Get the transaction hashes for this address.
             let tx_hashes = blockchain.history_store.get_tx_hashes_by_address(
                 &address,


### PR DESCRIPTION
Dont panic if a request that is not supported by the light history store is performed Fixes #2639


...
#### This fixes #2639 

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
