### PR TITLE
Tiny fixes to Macro blocks

### DIFF
--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -648,7 +648,7 @@ where
                             update_block_number = update.block_number,
                             "Discarding obsolete Tendermint state update"
                         );
-                        return;
+                        continue;
                     }
 
                     let mut write_transaction = self.env.write_transaction();

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -721,7 +721,7 @@ impl Client {
         limit: Option<u16>,
         min_peers: Option<usize>,
     ) -> Result<PlainTransactionDetailsArrayType, JsError> {
-        let mut since_block_height = since_block_height.unwrap_or(0);
+        let since_block_height = since_block_height.unwrap_or(0);
         let min_peers = min_peers.unwrap_or(1);
 
         if let Some(max) = limit {


### PR DESCRIPTION
While looking for performance improvements I came across two smaller problems.

* The Validator should keep on polling the macro producer even if it encounters an outdated state. Without it no repolling will be done until a subsequent wake. 
* Tendermint should make a better choice of the next future contribution to verify as some of them have a subset (or equal) contributors than those which have already been verified, making the work done to verify them again pointless. This is not causing any actual wrong behaviour, just does some unnecessary work. 

The selection criteria could be more sophisticated than that and if it is considered necessary to improve it, I will create an issue for it, as I don't think it is at this point necessary to do so.