### PR TITLE
Set argon2id params

### DIFF
--- a/hash/src/argon2kdf.rs
+++ b/hash/src/argon2kdf.rs
@@ -1,8 +1,8 @@
 use argon2::Config;
 pub use argon2::{Error as Argon2Error, Variant as Argon2Variant};
 
-// Taken from https://github.com/nimiq/core-js/blob/c98d56b2dd967d9a9c9a97fe4c54bfaac743aa0c/src/main/generic/utils/crypto/CryptoWorkerImpl.js#L146
-const MEMORY_COST: u32 = 512;
+// Taken from https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id, 2024-06-20.
+const MEMORY_COST: u32 = 12288;
 
 pub fn compute_argon2_kdf(
     password: &[u8],

--- a/hash/tests/mod.rs
+++ b/hash/tests/mod.rs
@@ -92,6 +92,6 @@ fn it_can_compute_argon2_kdf() {
     );
     assert_eq!(
         res.unwrap(),
-        hex::decode("8c259fdcc2ad6799df728c11e895a3369e9dbae6a3166ebc3b353399fc565524").unwrap()
+        hex::decode("a4c0069f36c090e78efecd0fc86d3a7ae62bc169648f480bbf78e16f9f08d680").unwrap()
     )
 }

--- a/utils/src/otp.rs
+++ b/utils/src/otp.rs
@@ -337,10 +337,9 @@ pub enum OtpLock<T: Clear + Deserialize + Serialize> {
 }
 
 impl<T: Clear + Deserialize + Serialize> OtpLock<T> {
-    // Taken from Nimiq's JS implementation.
-    // TODO: Adjust.
-    pub const DEFAULT_ITERATIONS: u32 = 256;
     pub const DEFAULT_SALT_LENGTH: usize = 32;
+    // Taken from https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id, 2024-06-20.
+    pub const DEFAULT_ITERATIONS: u32 = 3;
 
     /// Calling code should make sure to clear the password from memory after use.
     pub fn new_unlocked(


### PR DESCRIPTION
The values are taken from
https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id.

Fixes #2472.

Thanks to @Eligioo for finding these values.