### PR TITLE
Use libp2p-websocket fork to circumvent Sink panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e2774cc104e198ef3d3e1ff4ab40f86fa3245d6cb6a3a46174f21463cee173"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e065e90a518ab5fedf79aa1e4b784e10f8e484a834f6bda85c42633a2cb7af"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
 dependencies = [
  "async-trait",
  "attohttpc",
@@ -3029,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963eb8a174f828f6a51927999a9ab5e45dfa9aa2aa5fed99aa65f79de6229464"
+checksum = "b49cc89949bf0e06869297cd4fe2c132358c23fe93e76ad43950453df4da3d35"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3046,8 +3046,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4846d51afd08180e164291c3754ba30dd4fbac6fac65571be56403c16431a5e"
+source = "git+https://github.com/Eligioo/rust-libp2p?branch=stefan/quicksink-no-panic#6e0657c2555dc849617214696be84b164b5dff83"
 dependencies = [
  "either",
  "futures",
@@ -3065,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket-websys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550e578dcc9cd572be9dd564831d1f5efe8e6661953768b1d56c1d462855bf6f"
+checksum = "7d6f6c7ad3960dc9da18bead8468fc2dce9992d23d84557fd2345c86a992d70d"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ opt-level = 2
 ark-ec = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-ff = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-r1cs-std = { git = "https://github.com/paberr/r1cs-std", branch = "pb/fix-pedersen" }
+libp2p-websocket = { git = "https://github.com/Eligioo/rust-libp2p", branch = "stefan/quicksink-no-panic" }
 
 [workspace.package]
 version = "0.22.1"


### PR DESCRIPTION
## What's in this pull request?
Currently we are observing issue https://github.com/libp2p/rust-libp2p/issues/5471 which causes a panic when reading/sending data to a peer where the connection already has errored. This PR forks libp2p with a hotfix that won't panic but rather throw an error.

Until https://github.com/libp2p/rust-libp2p/issues/5471 is properly solved, we can use this fix to more gracefully handle the unexpected error. The changes in the fork compared to libp2p v0.53.2 can be found here: [compare](https://github.com/libp2p/rust-libp2p/compare/libp2p-v0.53.2...Eligioo:rust-libp2p:stefan/quicksink-no-panic). It also includes a new test that mimics the behaviour we are observing (calling poll_ready after an error), and checks that it simply throws an error instead of a panic.

#### This fixes #732.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
