### PR TITLE
Limiting transactions sender and recipient data.

### DIFF
--- a/keys/src/lib.rs
+++ b/keys/src/lib.rs
@@ -1,3 +1,4 @@
+use nimiq_serde::SerializedMaxSize;
 #[cfg(feature = "serde-derive")]
 use nimiq_serde::{Deserialize, Serialize};
 pub use nimiq_utils::key_rng::{SecureGenerate, SecureRng};
@@ -8,14 +9,20 @@ pub use self::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-derive", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde-derive",
+    derive(Serialize, Deserialize, SerializedMaxSize)
+)]
 pub enum PublicKey {
     Ed25519(Ed25519PublicKey),
     ES256(ES256PublicKey),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-derive", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde-derive",
+    derive(Serialize, Deserialize, SerializedMaxSize)
+)]
 pub enum Signature {
     Ed25519(Ed25519Signature),
     ES256(ES256Signature),

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -58,6 +58,22 @@ impl Policy {
     /// The maximum allowed size, in bytes, for a micro block body.
     pub const MAX_SIZE_MICRO_BODY: usize = 100_000;
 
+    // Maximum lengths for transaction sender_data and recipient_data fields used during deserialization.
+    /// Maximum size for the sender data field of the transactions.
+    /// The only transactions using this field are RemoveStake and Delete Validator.
+    pub const MAX_TX_SENDER_DATA_SIZE: usize = 1;
+    /// Maximum size for the recipient data field of the transactions.
+    /// This is used by the HTLC, Vesting and staking contract transactions. Basic transactions are allowed to use it as well.
+    /// The biggest transactions are the create validator and update validator with a web auth signature.
+    pub const MAX_TX_RECIPIENT_DATA_SIZE: usize = 2112;
+    /// Maximum length for basic transaction recipient_data used during intrinsic transaction verification.
+    pub const MAX_BASIC_TX_RECIPIENT_DATA_SIZE: usize = 64;
+    /// Maximum size for transaction's merkle path proofs.
+    /// 32 bytes for Merkle Path Node * 32 max length + 4 bytes to encode the bools for left/right + 1 byte for the serialize vec count.
+    pub const MAX_MERKLE_PATH_SIZE: usize = 1029;
+    /// Maximum size for the total web auth fields.
+    pub const MAX_SUPPORTED_WEB_AUTH_SIZE: usize = 512;
+
     /// The current version number of the protocol. Changing this always results in a hard fork.
     pub const VERSION: u16 = 1;
 

--- a/primitives/transaction/src/account/staking_contract/mod.rs
+++ b/primitives/transaction/src/account/staking_contract/mod.rs
@@ -48,6 +48,9 @@ impl AccountTransactionVerification for StakingContractVerifier {
     fn verify_outgoing_transaction(transaction: &Transaction) -> Result<(), TransactionError> {
         assert_eq!(transaction.sender_type, AccountType::Staking);
 
+        // Outgoing transactions require the data field to be set correctly.
+        _ = OutgoingStakingTransactionData::parse(transaction)?;
+
         // Verify signature.
         let proof = SignatureProof::deserialize_all(&transaction.proof)?;
         if !proof.verify(&transaction.serialize_content()) {

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -2,7 +2,7 @@ use nimiq_bls::{CompressedPublicKey as BlsPublicKey, CompressedSignature as BlsS
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, Ed25519PublicKey as SchnorrPublicKey};
 use nimiq_primitives::{coin::Coin, policy::Policy};
-use nimiq_serde::{Deserialize, DeserializeError, Serialize};
+use nimiq_serde::{Deserialize, DeserializeError, Serialize, SerializedMaxSize};
 
 use crate::{SignatureProof, Transaction, TransactionError};
 
@@ -29,7 +29,7 @@ use crate::{SignatureProof, Transaction, TransactionError};
 /// It is important to note that all `signature` fields contain the signature
 /// over the complete transaction with the `signature` field set to `Default::default()`.
 /// The field is populated only after computing the signature.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, SerializedMaxSize)]
 #[repr(u8)]
 pub enum IncomingStakingTransactionData {
     CreateValidator {
@@ -236,7 +236,7 @@ impl IncomingStakingTransactionData {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, SerializedMaxSize)]
 #[repr(u8)]
 pub enum OutgoingStakingTransactionData {
     DeleteValidator,

--- a/primitives/transaction/tests/serialization.rs
+++ b/primitives/transaction/tests/serialization.rs
@@ -1,10 +1,13 @@
 use std::convert::{TryFrom, TryInto};
 
+use log::error;
+use nimiq_hash::Blake2bHasher;
 use nimiq_keys::{Address, ES256PublicKey, ES256Signature, PublicKey, Signature};
-use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
-use nimiq_serde::{Deserialize, DeserializeError, Serialize};
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
+use nimiq_serde::{Deserialize, DeserializeError, Serialize, SerializedMaxSize};
 use nimiq_test_log::test;
 use nimiq_transaction::*;
+use nimiq_utils::merkle::MerklePath;
 
 const EXTENDED_TRANSACTION: &str = "014a88aaad038f9b8248865c4b9249efc554960e160000ad25610feb43d75307763d3f010822a757027429000000000746a52880000000000000000000000136c32a00e2010e4712ea5b1703873529dd195b2b8f014c295ab352a12e3332d8f30cfc2db9680480c77af04feb0d89bdb5d5d9432d4ca17866abf3b4d6c1a05fa0fbdaed056181eaff68db063c759a0964bceb5f262f7335ed97c5471e773429926c106eae50881b998c516581e6d93933bb92feb2edcdbdb1b118fc000f8f1df8715538840b79e74721c631efe0f9977ccd88773b022a07b3935f2e8546e20ed7f7e1a0c77da7a7e1737bf0625170610846792ea16bc0f6d8cf9ded8a9da1d467f4191a3a97d5fc17d08d699dfa486787f70eb09e2cdbd5b63fd1a8357e1cd24cd37aa2f3408400";
 const BASIC_TRANSACTION: &str = "00000222666efadc937148a6d61589ce6d4aeecca97fda4c32348d294eab582f14a0754d1260f15bea0e8fb07ab18f45301483599e34000000000000c350000000000000008a00019640023fecb82d3aef4be76853d5c5b263754b7d495d9838f6ae5df60cf3addd3512a82988db0056059c7a52ae15285983ef0db8229ae446c004559147686d28f0a30a";
@@ -104,4 +107,46 @@ fn it_can_serialize_and_deserialize_signature_proofs() {
     assert_eq!(deserialized.merkle_path, proof.merkle_path);
     assert_eq!(deserialized.signature, proof.signature);
     assert_eq!(deserialized.webauthn_fields, proof.webauthn_fields);
+}
+
+#[test]
+fn it_cannot_deserialize_webuath_proofs_exceeding_max_size() {
+    let mut proof = SignatureProof::default();
+    proof.webauthn_fields = Some(
+        WebauthnExtraFields {
+            origin_json_str: format!("www.test.i.am.a.veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery.looooooooooooooooooooooooooong.url.auth.example/123456789/sadfuhijkddesjfhghjswakd"),
+            has_cross_origin_field: false,
+            client_data_extra_json: format!("sdfgbhngfdsdfvhjndskldmjfnvhdskfngfdksadnfbghjdnksmjnfhbgdjksmjnfhbgjadfghnfdseawdfgdseawqdfgnhbgfdsawqSDFGFDSAWqaswdfgfdsawdfghfdseawqswDFGDSEAFGHNBGF"),
+            authenticator_data_suffix: vec![0u8; 209] }
+    );
+
+    let serialized = proof.serialize_to_vec();
+
+    assert!(serialized.len() < SignatureProof::MAX_SIZE);
+    assert!(proof.webauthn_fields.serialized_size() > WebauthnExtraFields::MAX_SIZE);
+    error!("{:?}", proof.webauthn_fields.serialized_size());
+
+    let deserialized: Result<SignatureProof, DeserializeError> =
+        Deserialize::deserialize_from_vec(&serialized[..]);
+
+    assert!(deserialized.is_err());
+}
+
+#[test]
+fn it_cannot_deserialize_merkle_proofs_exceeding_max_size() {
+    let mut proof = SignatureProof::default();
+    let values = vec![""; 34];
+    error!("{}", proof.serialized_size());
+
+    proof.merkle_path = MerklePath::new::<Blake2bHasher, &str>(&values, &values[1]);
+
+    let serialized = proof.serialize_to_vec();
+
+    assert!(proof.merkle_path.serialized_size() > Policy::MAX_MERKLE_PATH_SIZE);
+    assert!(serialized.len() < SignatureProof::MAX_SIZE);
+
+    let deserialized: Result<SignatureProof, DeserializeError> =
+        Deserialize::deserialize_from_vec(&serialized[..]);
+
+    assert!(deserialized.is_err());
 }


### PR DESCRIPTION
## What's in this pull request?
Sets a maximum for the sender and recipient data. The check is added on deserialization and the transaction verification steps as discussed on the issue.

- The sender data can only have 1 byte for the staking contract outgoing transactions
- The recipient data can have all the validator fields in the case of the Create Validator and Update Validator which are the biggest ones

The Incoming Staking Transaction Data has for these cases 464 bytes (SchnorrPublicKey :32, BlsPublicKey : 285, reward_address :20, signal_data: 32, BlsSignature: 95) + the SignatureProof.

The Signature Proof is technically unbounded due to the web auth fields and Merkle proof. So this PR adds limits to those as well. 

The proposal is to set these Limits
Recipient data total size 2112 bytes (464 +6 + Signature Proof = 1641)
Web auth total size ~~500 bytes as suggested in #2686 by @sisou~~ changed to 512 by feedback.
Merkle proof max 32 items. 1029 bytes

#### This fixes #2604 and #2686.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
