### PR TITLE
Log reason of peer banning

### DIFF
--- a/consensus/src/consensus/remote_data_store.rs
+++ b/consensus/src/consensus/remote_data_store.rs
@@ -103,7 +103,7 @@ impl<N: Network> RemoteDataStore<N> {
                                 .collect());
                         } else {
                             // If the proof does not verify, we disconnect from the peer
-                            log::debug!(peer = %peer_id, "Disconnecting from peer because the accounts proof didn't verify");
+                            log::warn!(%peer_id, "Banning peer because the accounts proof didn't verify");
                             network
                                 .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
                                 .await;

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -73,7 +73,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                     log::warn!(
                         num_epochs = macro_chain.epochs.len(),
                         %peer_id,
-                        "Request macro chain failed: too many epochs returned"
+                        "Banning peer because requesting macro chain failed: too many epochs returned"
                     );
                     network
                         .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
@@ -102,8 +102,8 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                         log::warn!(
                             given_checkpoint_epoch,
                             expected_checkpoint_epoch,
-                            peer = %peer_id,
-                            "Request macro chain failed: invalid checkpoint",
+                            %peer_id,
+                            "Banning peer because requesting macro chain failed: invalid checkpoint",
                         );
                         network
                             .disconnect_peer(peer_id, CloseReason::MaliciousPeer)

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -98,7 +98,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     log::warn!(
                         num_epochs = macro_chain.epochs.len(),
                         %peer_id,
-                        "Request macro chain failed: too many epochs returned"
+                        "Banning peer because requesting macro chain failed: too many epochs returned"
                     );
                     network
                         .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
@@ -120,7 +120,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                             block_number = checkpoint.block_number,
                             checkpoint_epoch,
                             %peer_id,
-                            "Request macro chain failed: invalid checkpoint"
+                            "Banning peer because requesting macro chain failed: invalid checkpoint"
                         );
                         network
                             .disconnect_peer(peer_id, CloseReason::MaliciousPeer)

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -126,7 +126,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                 self.epoch_ids_stream.push(future);
                             }
                             Err(result) => {
-                                log::debug!(?result, "Failed applying ZKP proof to the blockchain",);
+                                log::warn!(?result, %peer_id, "Banning peer because failed applying ZKP proof to the blockchain",);
 
                                 // Since it failed applying the ZKP from this peer, we disconnect
                                 self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
@@ -280,8 +280,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     if let Some(peer_requests) = self.peer_requests.get_mut(&peer_id) {
                         if !peer_requests.update_request(block) {
                             // We received a block we were not expecting from this peer
-                            log::trace!(%peer_id,
-                                "Disconnecting peer due to a non expected response",
+                            log::warn!(%peer_id,
+                                "Banning peer due to a non expected response",
                             );
                             self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
                             return Poll::Ready(None);
@@ -357,10 +357,11 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                         );
                                     }
                                     Err(error) => {
-                                        log::debug!(
+                                        log::warn!(
                                             block_number = block.block_number(),
                                             ?error,
-                                            "Failed to push macro block",
+                                            %peer_id,
+                                            "Banning peer because failed to push macro block",
                                         );
                                         // We failed applying a block from this peer, so we disconnect it
                                         self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -370,11 +370,11 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                         self.validity_queue.add_ids(vec![(request, None)]);
                     } else {
                         // If the chunk doesn't verify we disconnect from the peer
-                        log::error!(peer=?peer_id,
+                        log::warn!(%peer_id,
                                     chunk=request.chunk_index,
                                     verifier_block=request.block_number,
                                     epoch=request.epoch_number,
-                                    "The validity history chunk didn't verify, disconnecting from peer");
+                                    "Banning peer because the validity history chunk didn't verify");
 
                         // Remove the peer from the syncing process
                         self.validity_queue.remove_peer(&peer_id);


### PR DESCRIPTION
## What's in this pull request?
All paths to a `CloseReason::MaliciousPeer` as reason for closing the connection now contain a WARN log message to annotate the reason for banning a peer.

I chose for WARN as log level for now but can easily changed if one believes there is a reason for it.

#### This fixes #2661 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
