### PR TITLE
Unban banned peers after a duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ version = "0.23.0"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
+ "instant",
  "send_wrapper 0.6.0",
  "tokio",
  "tokio-stream",

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -191,18 +191,6 @@ impl Network {
         }
     }
 
-    /// Tells the network to un-ban a peer ID
-    pub async fn unban_peer(&self, peer_id: PeerId) {
-        if let Err(error) = self
-            .action_tx
-            .clone()
-            .send(NetworkAction::UnbanPeer { peer_id })
-            .await
-        {
-            error!(%error, "Failed to send NetworkAction::UnbanPeer");
-        }
-    }
-
     async fn request_impl<Req: RequestCommon>(
         &self,
         request: Req,

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -99,9 +99,6 @@ pub(crate) enum NetworkAction {
         peer_id: PeerId,
         reason: CloseReason,
     },
-    UnbanPeer {
-        peer_id: PeerId,
-    },
 }
 
 pub(crate) struct ValidateMessage<P: Clone> {

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -1196,9 +1196,6 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
         NetworkAction::DisconnectPeer { peer_id, reason } => {
             swarm.behaviour_mut().pool.close_connection(peer_id, reason)
         }
-        NetworkAction::UnbanPeer { peer_id } => {
-            swarm.behaviour_mut().pool.unban_connection(peer_id)
-        }
     }
 }
 

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 futures = "0.3"
 gloo-timers = { version = "0.3", features = ["futures"] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 send_wrapper = { version = "0.6", features = ["futures"] }
 tokio = { version = "1.39", features = ["time"] }
 tokio-stream = { version = "0.1", features = ["time"] }

--- a/time/src/gloo.rs
+++ b/time/src/gloo.rs
@@ -2,6 +2,7 @@ use std::{convert::TryInto, future::Future, pin::pin, time::Duration};
 
 use futures::future::{select, Either};
 use gloo_timers::future::{IntervalStream, TimeoutFuture};
+use instant::Instant;
 use send_wrapper::SendWrapper;
 
 pub type Interval = SendWrapper<IntervalStream>;
@@ -40,4 +41,8 @@ pub fn sleep(duration: Duration) -> impl Future<Output = ()> {
         .try_into()
         .expect("Duration as millis must fit in u32");
     SendWrapper::new(TimeoutFuture::new(millis))
+}
+
+pub fn sleep_until(deadline: Instant) -> impl Future<Output = ()> {
+    sleep(deadline.saturating_duration_since(Instant::now()))
 }

--- a/time/src/tokio.rs
+++ b/time/src/tokio.rs
@@ -1,7 +1,9 @@
 use std::{future::Future, time::Duration};
 
+use instant::Instant;
 use tokio::time::{
-    interval_at, sleep as tokio_sleep, timeout as tokio_timeout, Instant, Sleep, Timeout,
+    interval_at, sleep as tokio_sleep, sleep_until as tokio_sleep_until, timeout as tokio_timeout,
+    Instant as TokioInstant, Sleep, Timeout,
 };
 pub use tokio_stream::wrappers::IntervalStream as Interval;
 
@@ -12,7 +14,7 @@ pub fn interval(period: Duration) -> Interval {
         period.as_millis() <= u32::MAX as u128,
         "Period as millis must fit in u32"
     );
-    Interval::new(interval_at(Instant::now() + period, period))
+    Interval::new(interval_at(TokioInstant::now() + period, period))
 }
 
 pub fn timeout<F: Future>(duration: Duration, future: F) -> Timeout<F> {
@@ -21,4 +23,8 @@ pub fn timeout<F: Future>(duration: Duration, future: F) -> Timeout<F> {
 
 pub fn sleep(duration: Duration) -> Sleep {
     tokio_sleep(duration)
+}
+
+pub fn sleep_until(deadline: Instant) -> Sleep {
+    tokio_sleep_until(TokioInstant::from_std(deadline))
 }


### PR DESCRIPTION
## What's in this pull request?
Until now we don't unban a peer in any way after we ban it. This PR now will unban a banned peer after 10 minutes allowing the banned peer to dial us again.

#### This fixes #2660 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
