### PR TITLE
Dont move incompatible peers to live sync too early.

### DIFF
--- a/blockchain-interface/src/abstract_blockchain.rs
+++ b/blockchain-interface/src/abstract_blockchain.rs
@@ -69,6 +69,9 @@ pub trait AbstractBlockchain {
     /// Returns a flag indicating if the accounts tree is complete.
     fn accounts_complete(&self) -> bool;
 
+    /// Returns true if we have enough state to enforce the validity window and verify the state root.
+    fn can_enforce_validity_window(&self) -> bool;
+
     /// Returns the current set of validators.
     fn current_validators(&self) -> Option<Validators>;
 

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -115,6 +115,10 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         gen_blockchain_match!(self, BlockchainReadProxy, election_head)
     }
 
+    fn can_enforce_validity_window(&self) -> bool {
+        gen_blockchain_match!(self, BlockchainReadProxy, can_enforce_validity_window)
+    }
+
     fn accounts_complete(&self) -> bool {
         gen_blockchain_match!(self, BlockchainReadProxy, accounts_complete)
     }

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -234,22 +234,6 @@ impl Blockchain {
         self.state.accounts.tree.get_missing_range(txn)
     }
 
-    /// Check if we have enough state to check for duplicate transactions during the validity window
-    pub fn can_enforce_validity_window(&self) -> bool {
-        // If we are at the genesis block, we can enforce the validity window
-        if self.block_number() == Policy::genesis_block_number() {
-            true
-        } else {
-            // We can enforce the validity window when our history store root equals our head one.
-
-            *self.head().history_root()
-                == self
-                    .history_store
-                    .get_history_tree_root(self.block_number(), None)
-                    .unwrap()
-        }
-    }
-
     /// Removes the history of a given epoch
     pub fn remove_epoch_history(&mut self, epoch_number: u32) {
         let mut txn = self.write_transaction();

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -32,6 +32,10 @@ impl AbstractBlockchain for LightBlockchain {
         self.election_head.clone()
     }
 
+    fn can_enforce_validity_window(&self) -> bool {
+        true
+    }
+
     fn accounts_complete(&self) -> bool {
         false
     }


### PR DESCRIPTION
If peers are classified as incompatible and moved to live sync before the validity sync is complete, this creates issues where missing blocks can be pushed from the state sync, even though, we cannot verify the history root yet.
With this change, we first complete the validity sync and after that, we move the incompatible peers to live sync.

Fixes #2675

...
#### This fixes #2675 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
