### PR TITLE
Extend transaction topic mesh to non-validator nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4040,6 +4040,7 @@ dependencies = [
  "nimiq-light-blockchain",
  "nimiq-log",
  "nimiq-mempool",
+ "nimiq-mempool-task",
  "nimiq-metrics-server",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
@@ -4155,6 +4156,23 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "tokio-metrics",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "nimiq-mempool-task"
+version = "0.22.3"
+dependencies = [
+ "futures-util",
+ "nimiq-blockchain",
+ "nimiq-blockchain-interface",
+ "nimiq-consensus",
+ "nimiq-mempool",
+ "nimiq-network-interface",
+ "nimiq-utils",
+ "parking_lot",
  "tokio-metrics",
  "tokio-stream",
  "tracing",
@@ -4771,6 +4789,7 @@ dependencies = [
  "nimiq-hash",
  "nimiq-keys",
  "nimiq-mempool",
+ "nimiq-mempool-task",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
  "nimiq-network-mock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "log",
   "macros",
   "mempool",
+  "mempool/mempool-task",
   "metrics-server",
   "mnemonic",
   "network-interface",
@@ -200,6 +201,7 @@ nimiq-light-blockchain = { path = "light-blockchain", default-features = false }
 nimiq-log = { path = "log", default-features = false }
 nimiq-macros = { path = "macros", default-features = false }
 nimiq-mempool = { path = "mempool", default-features = false }
+nimiq-mempool-task = { path = "mempool/mempool-task", default-features = false }
 nimiq-metrics-server = { path = "metrics-server", default-features = false }
 nimiq-mmr = { path = "primitives/mmr", default-features = false }
 nimiq-mnemonic = { path = "mnemonic", default-features = false }

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -11,6 +11,8 @@ pub enum ForkEvent {
     Detected(ForkProof),
 }
 
+/// Events from the blockchain.
+/// Note that `Finalized` and `EpochFinalized` will be sent **in addition** to `Extended` events.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockchainEvent {
     Extended(Blake2bHash),

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,7 +21,9 @@ workspace = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-console-subscriber = { version = "0.3", features = ["parking_lot"], optional = true }
+console-subscriber = { version = "0.3", features = [
+    "parking_lot",
+], optional = true }
 derive_builder = "0.20"
 directories = "5.0"
 hex = "0.4"
@@ -41,8 +43,11 @@ time = { version = "0.3", optional = true }
 tokio = { version = "1.38", features = ["rt"], optional = true }
 toml = "0.8"
 tracing-loki = { version = "0.2.5", optional = true }
-tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "std"] }
-tracing-web = { version = "0.1", optional = true}
+tracing-subscriber = { version = "0.3", optional = true, features = [
+    "env-filter",
+    "std",
+] }
+tracing-web = { version = "0.1", optional = true }
 url = { version = "2.5", features = ["serde"] }
 
 nimiq-block = { workspace = true }
@@ -60,6 +65,7 @@ nimiq-keys = { workspace = true }
 nimiq-light-blockchain = { workspace = true }
 nimiq-log = { workspace = true, optional = true }
 nimiq-mempool = { workspace = true, optional = true }
+nimiq-mempool-task = { workspace = true, optional = true }
 nimiq-metrics-server = { workspace = true, optional = true }
 nimiq-network-libp2p = { workspace = true }
 nimiq-network-interface = { workspace = true }
@@ -67,7 +73,9 @@ nimiq-primitives = { workspace = true, features = ["networks"] }
 nimiq-rpc-server = { workspace = true, optional = true }
 nimiq-serde = { workspace = true }
 nimiq-utils = { workspace = true, features = ["time", "key-store"] }
-nimiq-validator = { workspace = true, optional = true, features = ["trusted_push"] }
+nimiq-validator = { workspace = true, optional = true, features = [
+    "trusted_push",
+] }
 nimiq-validator-network = { workspace = true, optional = true }
 nimiq-wallet = { workspace = true, optional = true, features = ["store"] }
 nimiq-zkp = { workspace = true }
@@ -82,18 +90,54 @@ nimiq-test-log = { workspace = true }
 database-storage = ["nimiq-database", "nimiq-zkp-component/database-storage"]
 deadlock = ["parking_lot/deadlock_detection"]
 default = ["full-consensus"]
-full-consensus = ["database-storage", "nimiq-blockchain", "nimiq-consensus/full"]
+full-consensus = [
+    "database-storage",
+    "nimiq-blockchain",
+    "nimiq-consensus/full",
+]
 launcher = []
 logging = ["nimiq-log", "serde_json", "tokio", "tracing-subscriber"]
 loki = ["logging", "tracing-loki"]
-metrics-server = ["nimiq-metrics-server", "nimiq-network-libp2p/metrics", "nimiq-validator/metrics"]
+metrics-server = [
+    "nimiq-metrics-server",
+    "nimiq-network-libp2p/metrics",
+    "nimiq-validator/metrics",
+]
 panic = ["log-panics"]
-parallel = ["nimiq-zkp/parallel", "nimiq-zkp-circuits/parallel", "nimiq-zkp-component/parallel", "nimiq-zkp-primitives/parallel"]
-rpc-server = ["nimiq-jsonrpc-core", "nimiq-jsonrpc-server", "nimiq-rpc-server", "nimiq-wallet", "validator"]
+parallel = [
+    "nimiq-zkp/parallel",
+    "nimiq-zkp-circuits/parallel",
+    "nimiq-zkp-component/parallel",
+    "nimiq-zkp-primitives/parallel",
+]
+rpc-server = [
+    "nimiq-jsonrpc-core",
+    "nimiq-jsonrpc-server",
+    "nimiq-rpc-server",
+    "nimiq-wallet",
+    "validator",
+]
 signal-handling = ["signal-hook", "tokio"]
 tokio-console = ["console-subscriber", "logging", "tokio/tracing"]
 tokio-websocket = ["nimiq-network-libp2p/tokio-websocket"]
-validator = ["database-storage", "nimiq-mempool", "nimiq-validator", "nimiq-validator-network", "nimiq-rpc-server"]
+validator = [
+    "database-storage",
+    "nimiq-mempool",
+    "nimiq-mempool-task",
+    "nimiq-validator",
+    "nimiq-validator-network",
+    "nimiq-rpc-server",
+]
 wallet = ["database-storage", "nimiq-wallet"]
-web-logging = ["nimiq-log", "time/wasm-bindgen", "tracing-subscriber", "tracing-web"]
-zkp-prover = ["nimiq-zkp/zkp-prover", "nimiq-zkp-circuits/zkp-prover", "nimiq-zkp-component/zkp-prover", "nimiq-zkp-primitives/zkp-prover"]
+web-logging = [
+    "nimiq-log",
+    "time/wasm-bindgen",
+    "tracing-subscriber",
+    "tracing-web",
+]
+zkp-prover = [
+    "nimiq-zkp/zkp-prover",
+    "nimiq-zkp-circuits/zkp-prover",
+    "nimiq-zkp-component/zkp-prover",
+    "nimiq-zkp-primitives/zkp-prover",
+]

--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -53,7 +53,10 @@ pub fn initialize_rpc_server(
     }
     dispatcher.add(PolicyDispatcher {});
     if let Some(validator_proxy) = client.validator_proxy() {
-        dispatcher.add(ValidatorDispatcher::new(validator_proxy));
+        dispatcher.add(ValidatorDispatcher::new(
+            validator_proxy,
+            client.consensus_proxy(),
+        ));
     }
     dispatcher.add(wallet_dispatcher);
 

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -25,7 +25,7 @@ keyed_priority_queue = "0.4"
 linked-hash-map = "0.5.6"
 log = { workspace = true }
 parking_lot = "0.12"
-prometheus-client = { version = "0.22.2", optional = true}
+prometheus-client = { version = "0.22.2", optional = true }
 serde = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.38", features = ["rt", "rt-multi-thread", "sync", "tracing"] }

--- a/mempool/mempool-task/Cargo.toml
+++ b/mempool/mempool-task/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "nimiq-mempool-task"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Mempool task implementation for Nimiq"
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[badges]
+travis-ci = { repository = "nimiq/core-rs", branch = "master" }
+is-it-maintained-issue-resolution = { repository = "nimiq/core-rs" }
+is-it-maintained-open-issues = { repository = "nimiq/core-rs" }
+maintenance = { status = "experimental" }
+
+[lints]
+workspace = true
+
+[dependencies]
+futures = { workspace = true }
+log = { workspace = true }
+parking_lot = "0.12"
+tokio-metrics = { version = "0.3", optional = true }
+tokio-stream = { version = "0.1", features = ["sync"] }
+
+nimiq-blockchain = { workspace = true }
+nimiq-blockchain-interface = { workspace = true }
+nimiq-consensus = { workspace = true }
+nimiq-mempool = { workspace = true }
+nimiq-network-interface = { workspace = true }
+nimiq-utils = { workspace = true, features = ["time"] }
+
+[features]
+metrics = ["nimiq-mempool/metrics", "tokio-metrics"]

--- a/mempool/mempool-task/src/lib.rs
+++ b/mempool/mempool-task/src/lib.rs
@@ -1,0 +1,218 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{stream::BoxStream, Future, Stream, StreamExt};
+use log::{debug, trace, warn};
+use nimiq_blockchain::Blockchain;
+use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
+use nimiq_consensus::{Consensus, ConsensusEvent, ConsensusProxy};
+use nimiq_mempool::{config::MempoolConfig, mempool::Mempool};
+use nimiq_network_interface::network::Network;
+use nimiq_utils::spawn::spawn;
+use parking_lot::RwLock;
+#[cfg(feature = "metrics")]
+use tokio_metrics::TaskMonitor;
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+
+/// Emits a mempool event after a blockchain event has been processed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MempoolEvent(BlockchainEvent);
+
+impl From<MempoolEvent> for BlockchainEvent {
+    fn from(event: MempoolEvent) -> Self {
+        event.0
+    }
+}
+
+/// This struct wraps the mempool and is responsible for updating the mempool based on external events.
+/// It can be spawned as a task individually or be polled by the validator as a stream.
+pub struct MempoolTask<N: Network> {
+    pub consensus: ConsensusProxy<N>,
+    pub blockchain: Arc<RwLock<Blockchain>>,
+
+    consensus_event_rx: BroadcastStream<ConsensusEvent>,
+    blockchain_event_rx: BoxStream<'static, BlockchainEvent>,
+
+    pub mempool: Arc<Mempool>,
+    mempool_active: bool,
+    #[cfg(feature = "metrics")]
+    mempool_monitor: TaskMonitor,
+    #[cfg(feature = "metrics")]
+    control_mempool_monitor: TaskMonitor,
+}
+
+impl<N: Network> MempoolTask<N> {
+    pub fn new(
+        consensus: &Consensus<N>,
+        blockchain: Arc<RwLock<Blockchain>>,
+        mempool_config: MempoolConfig,
+    ) -> Self {
+        let consensus_event_rx = consensus.subscribe_events();
+
+        let blockchain_rg = blockchain.read();
+        let blockchain_event_rx = blockchain_rg.notifier_as_stream();
+        drop(blockchain_rg);
+
+        let mempool = Arc::new(Mempool::new(Arc::clone(&blockchain), mempool_config));
+        let mempool_active = false;
+
+        Self {
+            consensus: consensus.proxy(),
+            blockchain,
+
+            consensus_event_rx,
+            blockchain_event_rx,
+
+            mempool: Arc::clone(&mempool),
+            mempool_active,
+            #[cfg(feature = "metrics")]
+            mempool_monitor: TaskMonitor::new(),
+            #[cfg(feature = "metrics")]
+            control_mempool_monitor: TaskMonitor::new(),
+        }
+    }
+
+    pub fn mempool(&self) -> Arc<Mempool> {
+        Arc::clone(&self.mempool)
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn get_mempool_monitor(&self) -> TaskMonitor {
+        self.mempool_monitor.clone()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn get_control_mempool_monitor(&self) -> TaskMonitor {
+        self.control_mempool_monitor.clone()
+    }
+
+    fn init_mempool(&mut self) {
+        if self.mempool_active || !self.consensus.is_ready_for_validation() {
+            return;
+        }
+
+        let mempool = Arc::clone(&self.mempool);
+        let network = Arc::clone(&self.consensus.network);
+        #[cfg(not(feature = "metrics"))]
+        spawn({
+            async move {
+                // The mempool is not updated while consensus is lost.
+                // Thus, we need to check all transactions if they are still valid.
+                mempool.cleanup();
+                mempool.start_executors(network, None, None).await;
+            }
+        });
+        #[cfg(feature = "metrics")]
+        spawn({
+            let mempool_monitor = self.mempool_monitor.clone();
+            let ctrl_mempool_monitor = self.control_mempool_monitor.clone();
+            async move {
+                // The mempool is not updated while consensus is lost.
+                // Thus, we need to check all transactions if they are still valid.
+                mempool.cleanup();
+
+                mempool
+                    .start_executors(network, Some(mempool_monitor), Some(ctrl_mempool_monitor))
+                    .await;
+            }
+        });
+
+        self.mempool_active = true;
+    }
+
+    fn pause(&mut self) {
+        if !self.mempool_active {
+            return;
+        }
+
+        let mempool = Arc::clone(&self.mempool);
+        let network = Arc::clone(&self.consensus.network);
+        spawn(async move {
+            mempool.stop_executors(network).await;
+        });
+
+        self.mempool_active = false;
+    }
+
+    fn on_blockchain_event(&mut self, event: &BlockchainEvent) {
+        match event {
+            BlockchainEvent::HistoryAdopted(_) => {
+                // Mempool updates are only done once we are synced.
+                if self.consensus.is_ready_for_validation() {
+                    self.mempool.cleanup();
+                    debug!("Performed a mempool clean up because new history was adopted");
+                }
+            }
+            BlockchainEvent::Extended(hash) => {
+                // Mempool updates are only done once we are synced.
+                if self.consensus.is_ready_for_validation() {
+                    let block = self
+                        .consensus
+                        .blockchain
+                        .read()
+                        .get_block(hash, true)
+                        .expect("Head block not found");
+
+                    self.mempool
+                        .update(&vec![(hash.clone(), block)], [].as_ref());
+                }
+            }
+            BlockchainEvent::Rebranched(old_chain, new_chain) => {
+                // Mempool updates are only done once we are synced.
+                if self.consensus.is_ready_for_validation() {
+                    self.mempool.update(new_chain, old_chain);
+                }
+            }
+            _ => {
+                // Nothing to do here.
+            }
+        }
+    }
+}
+
+impl<N: Network> Stream for MempoolTask<N> {
+    type Item = MempoolEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Process consensus updates.
+        // Start mempool as soon as we have consensus and can enforce the validity window.
+        // Stop the mempool if we lose consensus or cannot enforce the validity window.
+        while let Poll::Ready(Some(event)) = self.consensus_event_rx.poll_next_unpin(cx) {
+            match event {
+                Ok(ConsensusEvent::Established {
+                    synced_validity_window: true,
+                }) => self.init_mempool(),
+                Ok(ConsensusEvent::Lost)
+                | Ok(ConsensusEvent::Established {
+                    synced_validity_window: false,
+                }) => self.pause(),
+                Err(BroadcastStreamRecvError::Lagged(num)) => {
+                    warn!("Consensus event stream lagging behind by {} messages", num);
+                }
+            }
+        }
+
+        // Process blockchain updates.
+        if let Poll::Ready(Some(event)) = self.blockchain_event_rx.poll_next_unpin(cx) {
+            trace!(?event, is_active = self.mempool_active, "blockchain event");
+            self.on_blockchain_event(&event);
+            return Poll::Ready(Some(MempoolEvent(event)));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<N: Network> Future for MempoolTask<N> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Poll until the stream is exhausted.
+        while let Poll::Ready(Some(_event)) = self.poll_next_unpin(cx) {}
+
+        Poll::Pending
+    }
+}

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -243,7 +243,7 @@ async fn main_inner() -> Result<(), Error> {
     // Start Spammer
     let mempool = if let Some(validator) = client.take_validator() {
         log::info!("Spawning spammer");
-        let mempool = Arc::clone(&validator.mempool);
+        let mempool = Arc::clone(&validator.mempool_task.mempool);
         tokio::spawn(validator);
         mempool
     } else {

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -46,15 +46,14 @@ nimiq-handel = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }
 nimiq-mempool = { workspace = true }
+nimiq-mempool-task = { workspace = true }
 nimiq-network-interface = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["tendermint"] }
 nimiq-serde = { workspace = true }
 nimiq-tendermint = { workspace = true }
 nimiq-time = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
-nimiq-utils = { workspace = true, features = [
-    "time",
-] }
+nimiq-utils = { workspace = true, features = ["time"] }
 nimiq-validator-network = { workspace = true }
 nimiq-vrf = { workspace = true }
 
@@ -76,5 +75,5 @@ nimiq-zkp-component = { workspace = true }
 
 [features]
 expensive-tests = []
-metrics = ["nimiq-mempool/metrics"]
+metrics = ["nimiq-mempool/metrics", "nimiq-mempool-task/metrics"]
 trusted_push = []

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -675,7 +675,7 @@ mod test {
                 // Any event which is None or Some(Err(_)) must be considered failures.
                 event = consensus_events1.next() => {
                     match event {
-                        Some(Ok(ConsensusEvent::Established)) => {
+                        Some(Ok(ConsensusEvent::Established {..})) => {
                             if established.1 {
                                 break
                             }
@@ -686,7 +686,7 @@ mod test {
                 }
                 event = consensus_events2.next() => {
                     match event {
-                        Some(Ok(ConsensusEvent::Established)) => {
+                        Some(Ok(ConsensusEvent::Established {..})) => {
                             if established.0 {
                                 break;
                             }

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -356,7 +356,7 @@ impl Client {
             .subscribe_events()
             .any(|event| async move {
                 if let Ok(state) = event {
-                    matches!(state, ConsensusEvent::Established)
+                    matches!(state, ConsensusEvent::Established { .. })
                 } else {
                     self.is_consensus_established().await
                 }
@@ -911,7 +911,9 @@ impl Client {
         spawn_local(async move {
             loop {
                 let state = match consensus_events.next().await {
-                    Some(Ok(ConsensusEvent::Established)) => Some(ConsensusState::Established),
+                    Some(Ok(ConsensusEvent::Established { .. })) => {
+                        Some(ConsensusState::Established)
+                    }
                     Some(Ok(ConsensusEvent::Lost)) => {
                         if network.peer_count() >= 1 {
                             Some(ConsensusState::Syncing)


### PR DESCRIPTION
## What's in this pull request?

This PR extends the nodes that listen to and validate transactions on the network.
This is done by:
- Separating the mempool from the validator.
- Moving the "can validate" logic from the validator/consensus/blockchain into the consensus.
- Initialising the mempool also for non-validator history and full clients.

#### This fixes #2615.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
