### PR TITLE
Make vesting contract creation parsing more resilient

### DIFF
--- a/primitives/account/src/account/vesting_contract.rs
+++ b/primitives/account/src/account/vesting_contract.rs
@@ -32,7 +32,7 @@ pub struct VestingContract {
     /// The frequency at which funds are released.
     #[serde(with = "nimiq_serde::fixint::be")]
     pub time_step: u64,
-    /// The amount released at each time_step.
+    /// The amount released at each [`time_step`](Self::time_step).
     pub step_amount: Coin,
     /// Initially locked balance.
     pub total_amount: Coin,

--- a/primitives/transaction/src/account/vesting_contract.rs
+++ b/primitives/transaction/src/account/vesting_contract.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// The verifier trait for a basic account. This only uses data available in the transaction.
-pub struct VestingContractVerifier {}
+pub struct VestingContractVerifier;
 
 impl AccountTransactionVerification for VestingContractVerifier {
     fn verify_incoming_transaction(transaction: &Transaction) -> Result<(), TransactionError> {
@@ -58,12 +58,20 @@ impl AccountTransactionVerification for VestingContractVerifier {
     }
 }
 
+/// Data used to create vesting contracts.
+///
+/// Used in [`Transaction::recipient_data`].
 #[derive(Clone, Debug, Default)]
 pub struct CreationTransactionData {
+    /// The owner of the contract, the only address that can interact with it.
     pub owner: Address,
+    /// The block height at which the release schedule starts.
     pub start_time: u64,
+    /// The frequency at which funds are released.
     pub time_step: u64,
+    /// The amount released at each [`time_step`](Self::time_step).
     pub step_amount: Coin,
+    /// Initially locked balance.
     pub total_amount: Coin,
 }
 

--- a/primitives/transaction/src/account/vesting_contract.rs
+++ b/primitives/transaction/src/account/vesting_contract.rs
@@ -58,7 +58,7 @@ impl AccountTransactionVerification for VestingContractVerifier {
     }
 }
 
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default)]
 pub struct CreationTransactionData {
     pub owner: Address,
     pub start_time: u64,

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -474,26 +474,20 @@ impl Transaction {
         match self.recipient_type {
             AccountType::Basic => {}
             AccountType::Vesting => {
-                if let Ok(contract_data) =
-                    VestingCreationData::deserialize_from_vec(&self.recipient_data)
-                {
+                if let Ok(contract_data) = VestingCreationData::parse(self) {
                     // Add the owner of the new vesting contract
                     addresses.insert(contract_data.owner);
                 }
             }
             AccountType::HTLC => {
-                if let Ok(contract_data) =
-                    HtlcCreationData::deserialize_from_vec(&self.recipient_data)
-                {
+                if let Ok(contract_data) = HtlcCreationData::parse(self) {
                     // Add both the "sender" and "recipient" of the new HTLC
                     addresses.insert(contract_data.sender);
                     addresses.insert(contract_data.recipient);
                 }
             }
             AccountType::Staking => {
-                if let Ok(contract_data) =
-                    IncomingStakingTransactionData::deserialize_from_vec(&self.recipient_data)
-                {
+                if let Ok(contract_data) = IncomingStakingTransactionData::parse(self) {
                     match contract_data {
                         IncomingStakingTransactionData::CreateValidator {
                             signing_key,

--- a/primitives/transaction/tests/vesting_contract_verify.rs
+++ b/primitives/transaction/tests/vesting_contract_verify.rs
@@ -100,7 +100,7 @@ fn it_can_verify_creation_transaction() {
         step_amount: Coin::try_from(1000).unwrap(),
         total_amount: Coin::try_from(100).unwrap(),
     };
-    transaction.recipient_data = data.serialize_to_vec();
+    transaction.recipient_data = data.to_tx_data();
     transaction.recipient = transaction.contract_creation_address();
     assert_eq!(
         AccountType::verify_incoming_transaction(&transaction),

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -91,14 +91,22 @@ pub trait SerializedMaxSize {
     const MAX_SIZE: usize;
 }
 
+/// Types implementing this trait have an alternative fixed-size serialization length.
+pub trait SerializedFixedSize {
+    /// Size in bytes of the alternate, fixed-size serialization.
+    const FIXED_SIZE: usize;
+}
+
 impl<T: SerializedSize> SerializedMaxSize for T {
     const MAX_SIZE: usize = T::SIZE;
 }
 
 #[rustfmt::skip]
 mod integer_impls {
-    use super::SerializedSize;
+    use super::SerializedFixedSize;
     use super::SerializedMaxSize;
+    use super::SerializedSize;
+    use std::mem;
 
     impl SerializedSize for bool { const SIZE: usize = 1; }
 
@@ -111,6 +119,13 @@ mod integer_impls {
     impl SerializedMaxSize for u32 { const MAX_SIZE: usize = (32 + 6) / 7; }
     impl SerializedMaxSize for i64 { const MAX_SIZE: usize = (64 + 6) / 7; }
     impl SerializedMaxSize for u64 { const MAX_SIZE: usize = (64 + 6) / 7; }
+
+    impl SerializedFixedSize for i16 { const FIXED_SIZE: usize = mem::size_of::<Self>(); }
+    impl SerializedFixedSize for u16 { const FIXED_SIZE: usize = mem::size_of::<Self>(); }
+    impl SerializedFixedSize for i32 { const FIXED_SIZE: usize = mem::size_of::<Self>(); }
+    impl SerializedFixedSize for u32 { const FIXED_SIZE: usize = mem::size_of::<Self>(); }
+    impl SerializedFixedSize for i64 { const FIXED_SIZE: usize = mem::size_of::<Self>(); }
+    impl SerializedFixedSize for u64 { const FIXED_SIZE: usize = mem::size_of::<Self>(); }
 }
 
 impl<T: SerializedMaxSize> SerializedMaxSize for Option<T> {

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -285,7 +285,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 sender.into(),
                 sender_data,
                 recipient.into(),
-                parameters.serialize_to_vec(),
+                parameters.to_tx_data(),
                 value,
                 fee,
                 block_state.number,

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -90,7 +90,6 @@ pub enum TransactionBuilderError {
 /// [`generate`]: struct.TransactionBuilder.html#method.generate
 /// [`TransactionProofBuilder`]: proof/enum.TransactionProofBuilder.html
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransactionBuilder {
     sender: Option<Sender>,
     value: Option<Coin>,

--- a/transaction-builder/src/recipient/mod.rs
+++ b/transaction-builder/src/recipient/mod.rs
@@ -32,7 +32,6 @@ pub mod vesting_contract;
 /// [`new_vesting_builder`]: enum.Recipient.html#method.new_vesting_builder
 /// [`new_staking_builder`]: enum.Recipient.html#method.new_staking_builder
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub enum Recipient {
     Basic {
         address: Address,


### PR DESCRIPTION
Use `serde` to do it, but remove the `Deserialize` impl because it was error-prone.

Based on top of #2676, so this should wait until #2676 is approved.

Fixes #2690.