### PR TITLE
Use PoW memory cost for Argon2d KDF

### DIFF
--- a/hash/src/argon2kdf.rs
+++ b/hash/src/argon2kdf.rs
@@ -1,8 +1,10 @@
 use argon2::Config;
 pub use argon2::{Error as Argon2Error, Variant as Argon2Variant};
 
+// Taken from https://github.com/nimiq/core-js/blob/c98d56b2dd967d9a9c9a97fe4c54bfaac743aa0c/src/main/generic/utils/crypto/CryptoWorkerImpl.js#L146
+const MEMORY_COST_ARGON2D: u32 = 512;
 // Taken from https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id, 2024-06-20.
-const MEMORY_COST: u32 = 12288;
+const MEMORY_COST_ARGON2ID: u32 = 12288;
 
 pub fn compute_argon2_kdf(
     password: &[u8],
@@ -14,7 +16,10 @@ pub fn compute_argon2_kdf(
     let config = Config {
         time_cost: iterations,
         hash_length: derived_key_length as u32,
-        mem_cost: MEMORY_COST,
+        mem_cost: match variant {
+            Argon2Variant::Argon2d => MEMORY_COST_ARGON2D,
+            Argon2Variant::Argon2i | Argon2Variant::Argon2id => MEMORY_COST_ARGON2ID,
+        },
         variant,
         ..Default::default()
     };

--- a/hash/tests/mod.rs
+++ b/hash/tests/mod.rs
@@ -83,7 +83,7 @@ fn it_can_compute_argon2_kdf() {
     let password = "test";
     let salt = "nimiqrocks!";
 
-    let res = argon2kdf::compute_argon2_kdf(
+    let res2d = argon2kdf::compute_argon2_kdf(
         password.as_bytes(),
         salt.as_bytes(),
         1,
@@ -91,7 +91,19 @@ fn it_can_compute_argon2_kdf() {
         argon2::Variant::Argon2d,
     );
     assert_eq!(
-        res.unwrap(),
-        hex::decode("a4c0069f36c090e78efecd0fc86d3a7ae62bc169648f480bbf78e16f9f08d680").unwrap()
-    )
+        res2d.unwrap(),
+        hex::decode("8c259fdcc2ad6799df728c11e895a3369e9dbae6a3166ebc3b353399fc565524").unwrap()
+    );
+
+    let res2id = argon2kdf::compute_argon2_kdf(
+        password.as_bytes(),
+        salt.as_bytes(),
+        1,
+        32,
+        argon2::Variant::Argon2id,
+    );
+    assert_eq!(
+        res2id.unwrap(),
+        hex::decode("8d8a0ac8da6f305cfc505411db3d3d17cda3aa1773e4c63b85aade07fdfa637e").unwrap()
+    );
 }


### PR DESCRIPTION
But keep the updated cost for Argon2id.

This makes the function backward-compatible with the PoW JS library, to support decoding existing LoginFiles.

Partly reverses 9f8db328a368c689bb5a1366f92d39da52e5d2f4 (#2653) and changes it to be in the spirit of #2377, which meant to preserve backward-compatibility.