### PR TITLE
pow-migration: Fix test compilation

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -21,6 +21,15 @@ jobs:
         components: rustfmt
     - run: cargo fmt --all -- --check
 
+  check:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo check --all-features --tests --benches
+
   test:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -38,8 +38,8 @@ jobs:
         - test: Validators90sDown
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -dt 90 -ut 100
         - test: LowBlockProducerTimeout
-          pre: "grep 'BLOCK_PRODUCER_TIMEOUT: u64 = 2 \\* 1000;' primitives/src/policy.rs &&
-                sed -i 's/BLOCK_PRODUCER_TIMEOUT: u64 = 2 \\* 1000;/BLOCK_PRODUCER_TIMEOUT: u64 = 1000;/g' primitives/src/policy.rs"
+          pre: "grep 'BLOCK_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;' primitives/src/policy.rs &&
+                sed -i 's/BLOCK_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;/BLOCK_PRODUCER_TIMEOUT: u64 = 1000;/g' primitives/src/policy.rs"
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_0.toml -k 0 -ut 100
 
     runs-on: ubuntu-22.04

--- a/.github/workflows/github_release_docker.yml
+++ b/.github/workflows/github_release_docker.yml
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@31159d49c0d4756269a0940a750801a1ea5d7003
+        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1
         with:
           context: .
           file: Dockerfile

--- a/hash/src/argon2kdf.rs
+++ b/hash/src/argon2kdf.rs
@@ -1,8 +1,10 @@
 use argon2::Config;
 pub use argon2::{Error as Argon2Error, Variant as Argon2Variant};
 
+// Taken from https://github.com/nimiq/core-js/blob/c98d56b2dd967d9a9c9a97fe4c54bfaac743aa0c/src/main/generic/utils/crypto/CryptoWorkerImpl.js#L146
+const MEMORY_COST_ARGON2D: u32 = 512;
 // Taken from https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id, 2024-06-20.
-const MEMORY_COST: u32 = 12288;
+const MEMORY_COST_ARGON2ID: u32 = 12288;
 
 pub fn compute_argon2_kdf(
     password: &[u8],
@@ -14,7 +16,10 @@ pub fn compute_argon2_kdf(
     let config = Config {
         time_cost: iterations,
         hash_length: derived_key_length as u32,
-        mem_cost: MEMORY_COST,
+        mem_cost: match variant {
+            Argon2Variant::Argon2d => MEMORY_COST_ARGON2D,
+            Argon2Variant::Argon2i | Argon2Variant::Argon2id => MEMORY_COST_ARGON2ID,
+        },
         variant,
         ..Default::default()
     };

--- a/hash/tests/mod.rs
+++ b/hash/tests/mod.rs
@@ -83,7 +83,7 @@ fn it_can_compute_argon2_kdf() {
     let password = "test";
     let salt = "nimiqrocks!";
 
-    let res = argon2kdf::compute_argon2_kdf(
+    let res2d = argon2kdf::compute_argon2_kdf(
         password.as_bytes(),
         salt.as_bytes(),
         1,
@@ -91,7 +91,19 @@ fn it_can_compute_argon2_kdf() {
         argon2::Variant::Argon2d,
     );
     assert_eq!(
-        res.unwrap(),
-        hex::decode("a4c0069f36c090e78efecd0fc86d3a7ae62bc169648f480bbf78e16f9f08d680").unwrap()
-    )
+        res2d.unwrap(),
+        hex::decode("8c259fdcc2ad6799df728c11e895a3369e9dbae6a3166ebc3b353399fc565524").unwrap()
+    );
+
+    let res2id = argon2kdf::compute_argon2_kdf(
+        password.as_bytes(),
+        salt.as_bytes(),
+        1,
+        32,
+        argon2::Variant::Argon2id,
+    );
+    assert_eq!(
+        res2id.unwrap(),
+        hex::decode("8d8a0ac8da6f305cfc505411db3d3d17cda3aa1773e4c63b85aade07fdfa637e").unwrap()
+    );
 }

--- a/pow-migration/tests/mod.rs
+++ b/pow-migration/tests/mod.rs
@@ -23,12 +23,21 @@ mod pow_migration_test {
         block_windows: &BlockWindows,
         validator_address: &str,
         network_id: NetworkId,
-    ) -> Result<GenesisConfig, Error> {
+        candidate_block: u32,
+    ) -> Result<Option<GenesisConfig>, Error> {
         let env = VolatileDatabase::new(20).unwrap();
         let client = setup_pow_client();
         let address = Address::from_user_friendly_address(&validator_address)
             .expect("Could not parse provided validator address");
-        migrate(&client, block_windows, env, &address, network_id).await
+        migrate(
+            &client,
+            block_windows,
+            candidate_block,
+            env,
+            &Some(address),
+            network_id,
+        )
+        .await
     }
 
     #[test(tokio::test)]
@@ -44,9 +53,16 @@ mod pow_migration_test {
             readiness_window: 10,
         };
         let network_id = NetworkId::TestAlbatross;
-        let genesis = test_pow_migration(&block_windows, &validator_address, network_id)
-            .await
-            .unwrap();
+        let candidate_block = 2664100;
+        let genesis = test_pow_migration(
+            &block_windows,
+            &validator_address,
+            network_id,
+            candidate_block,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(genesis.validators.len(), 2);
         assert_eq!(genesis.stakers.len(), 2);
         assert!(


### PR DESCRIPTION
- Fix compilation of tests in the `pow-migration` subcrate. This fixes #2680.
- Check for compilation errors in tests with all features enabled and benchmarks. This was added as a step into the `build+test` workflow in GH Actions.


## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
