### PR TITLE
Propagate block headers and bodies through separate gossipsub topics

### DIFF
--- a/blockchain/src/blockchain/slots.rs
+++ b/blockchain/src/blockchain/slots.rs
@@ -66,8 +66,7 @@ impl Blockchain {
         let macro_block = self.get_block_at(Policy::macro_block_before(block_number), true, txn)?;
         let disabled_slots = macro_block
             .unwrap_macro()
-            .body
-            .unwrap()
+            .header
             .next_batch_initial_punished_set;
 
         // Compute the slot number of the next proposer.

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -406,7 +406,7 @@ impl Blockchain {
     }
 
     /// Given a transaction containing relevant change to the state this function will
-    /// take the state and compare it pre and post commit to the block.
+    /// take the state and compare it pre- and post-commit to the block.
     fn verify_proposal_state(
         &self,
         block: &mut Block,

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -1,6 +1,6 @@
 use std::{cmp, mem};
 
-use nimiq_block::{Block, BlockError};
+use nimiq_block::Block;
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, PushError, PushResult,
 };
@@ -28,11 +28,6 @@ impl Blockchain {
     ) -> Result<PushResult, PushError> {
         // Must be an election block.
         assert!(block.is_election());
-
-        // Checks if the body exists.
-        block
-            .body()
-            .ok_or(PushError::InvalidBlock(BlockError::MissingBody))?;
 
         let block_hash_blake2b = block.hash();
 
@@ -175,11 +170,6 @@ impl Blockchain {
             return Ok(PushResult::Ignored);
         }
 
-        // Checks if the body exists.
-        block
-            .body()
-            .ok_or(PushError::InvalidBlock(BlockError::MissingBody))?;
-
         let read_txn = this.read_transaction();
 
         // Check if we already know this block.
@@ -231,11 +221,6 @@ impl Blockchain {
     ) -> Result<PushResult, PushError> {
         // Must be a macro block.
         assert!(block.is_macro());
-
-        // Checks if the body exists.
-        block
-            .body()
-            .ok_or(PushError::InvalidBlock(BlockError::MissingBody))?;
 
         let read_txn = this.read_transaction();
 

--- a/blockchain/tests/block_production.rs
+++ b/blockchain/tests/block_production.rs
@@ -218,9 +218,7 @@ fn it_can_produce_macro_block_after_punishment() {
         .current_batch_punished_slots()
         .is_empty());
     assert!(!macro_block
-        .body
-        .as_ref()
-        .unwrap()
+        .header
         .next_batch_initial_punished_set
         .is_empty());
 
@@ -272,9 +270,7 @@ fn it_can_produce_macro_block_after_punishment() {
         .current_batch_punished_slots()
         .is_empty());
     assert!(macro_block
-        .body
-        .as_ref()
-        .unwrap()
+        .header
         .next_batch_initial_punished_set
         .is_empty());
 

--- a/blockchain/tests/blockchain.rs
+++ b/blockchain/tests/blockchain.rs
@@ -134,9 +134,7 @@ fn can_detect_invalid_punished_set() {
             next_macro_block_proposal(&temp_producer.producer.signing_key, &blockchain, &config);
         // Put a wrong value into the set.
         macro_block_proposal
-            .body
-            .as_mut()
-            .unwrap()
+            .header
             .next_batch_initial_punished_set
             .insert(2);
         macro_block_proposal.header.body_root = macro_block_proposal.body.as_ref().unwrap().hash();

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -603,7 +603,7 @@ impl<N: Network> ConsensusProxy<N> {
         self,
         block_number: u32,
         block_hash: Blake2bHash,
-        pubsub_id: N::PubsubId,
+        first_peer_id: N::PeerId,
     ) -> Result<Block, ResolveBlockError<N>> {
         // Create the oneshot sender whose receiver this fn will await and whose
         // sender will be given to the consensus proper to resolve the call.
@@ -613,7 +613,7 @@ impl<N: Network> ConsensusProxy<N> {
         let request = ResolveBlockRequest {
             block_number,
             block_hash,
-            pubsub_id,
+            first_peer_id,
             response_sender,
         };
 

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -592,10 +592,7 @@ impl<N: Network> ConsensusProxy<N> {
     }
 
     /// Attempts to resolve a block with `block_hash` header hash at the given `block_height`.
-    /// The `pubsub_id` must contain the pubsup id containing the information which referenced
-    /// the block being resolved here. One example is the predecessor, other could be possible.
-    /// The peers present in the id will be asked for the information as they should be able to
-    /// produce it.
+    /// The first resolution attempt is performed with the peer specified by `first_peer_id`.
     ///
     /// This function fails, if the consensus cannot accept more requests or if the consensus drops
     /// the request on its side, generally indicating that it is no longer of use.

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -148,7 +148,7 @@ impl Topic for BlockBodyTopic {
 
     const BUFFER_SIZE: usize = 16;
     const NAME: &'static str = "block-body";
-    const VALIDATE: bool = false;
+    const VALIDATE: bool = true;
 }
 
 /*
@@ -361,11 +361,8 @@ pub enum HistoryChunkError {
 pub struct RequestBlock {
     /// The hash of the block that is requested.
     pub hash: Blake2bHash,
-    /// Whether to include the body if the requested block is a micro block.
-    ///
-    /// If the requested block is a macro block, this flag has no effect and
-    /// the response will always contain the body.
-    pub include_micro_bodies: bool,
+    /// Whether to include the body.
+    pub include_body: bool,
 }
 
 /// Error response for [`RequestBlock`].
@@ -442,10 +439,8 @@ impl Debug for ResponseBlocks {
 pub struct RequestMissingBlocks {
     /// Target block hash.
     pub target_hash: Blake2bHash,
-    /// Whether to include bodies for micro blocks.
-    ///
-    /// Bodies of macro blocks are always included.
-    pub include_micro_bodies: bool,
+    /// Whether to include block bodies.
+    pub include_body: bool,
     /// Set of hashes of blocks known to the requester, possible starts of the
     /// answer chain.
     ///

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -61,22 +61,22 @@ impl BlockHeaderMessage {
             Block::Macro(block) => {
                 let header = BlockHeaderMessage::Macro {
                     header: block.header,
-                    justification: block.justification.unwrap(),
+                    justification: block.justification.expect("Justification is required"),
                 };
                 let body = BlockBodyMessage {
                     header_hash: header.hash(),
-                    body: BlockBody::Macro(block.body.unwrap()),
+                    body: BlockBody::Macro(block.body.expect("Body is required")),
                 };
                 (header, body)
             }
             Block::Micro(block) => {
                 let header = BlockHeaderMessage::Micro {
                     header: block.header,
-                    justification: block.justification.unwrap(),
+                    justification: block.justification.expect("Justification is required"),
                 };
                 let body = BlockBodyMessage {
                     header_hash: header.hash(),
-                    body: BlockBody::Micro(block.body.unwrap()),
+                    body: BlockBody::Micro(block.body.expect("Body is required")),
                 };
                 (header, body)
             }

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -296,7 +296,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             .request::<RequestBlock>(
                 RequestBlock {
                     hash,
-                    include_micro_bodies: false,
+                    include_body: false,
                 },
                 peer_id,
             )

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -646,7 +646,7 @@ mod tests {
 
             match sync.next().await {
                 Some(MacroSyncReturn::Good(_)) => {
-                    assert_eq!(chain1.read().head(), chain2.read().head());
+                    assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
                 }
                 res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
@@ -709,7 +709,7 @@ mod tests {
 
             match sync.next().await {
                 Some(MacroSyncReturn::Good(_)) => {
-                    assert_eq!(chain1.read().head(), chain2.read().head());
+                    assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
                 }
                 res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
@@ -765,7 +765,7 @@ mod tests {
 
             match sync.next().await {
                 Some(MacroSyncReturn::Good(_)) => {
-                    assert_eq!(chain1.read().head(), chain2.read().head());
+                    assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
                 }
                 res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }
@@ -865,7 +865,7 @@ mod tests {
 
             match sync.next().await {
                 Some(MacroSyncReturn::Good(_)) => {
-                    assert_eq!(chain1.read().head(), chain2.read().head());
+                    assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
                 }
                 res => panic!("Unexpected HistorySyncReturn: {res:?}"),
             }

--- a/consensus/src/sync/live/block_queue/assembler.rs
+++ b/consensus/src/sync/live/block_queue/assembler.rs
@@ -1,0 +1,221 @@
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{stream::BoxStream, Stream, StreamExt};
+use nimiq_block::{Block, BlockBody, MacroBlock, MicroBlock};
+use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
+use nimiq_network_interface::network::{Network, PubsubId};
+
+use crate::messages::{BlockBodyMessage, BlockHeaderMessage};
+
+type PubsubHeader<N> = (BlockHeaderMessage, <N as Network>::PubsubId);
+type PubsubBody<N> = (BlockBodyMessage, <N as Network>::PubsubId);
+
+pub struct BlockAssembler<N: Network> {
+    header_stream: BoxStream<'static, PubsubHeader<N>>,
+    body_stream: BoxStream<'static, PubsubBody<N>>,
+    cached_headers: HashMap<Blake2bHash, PubsubHeader<N>>,
+    cached_bodies: HashMap<Blake2sHash, HashMap<Blake2bHash, BlockBody>>,
+}
+
+impl<N: Network> BlockAssembler<N> {
+    pub fn new(
+        header_stream: BoxStream<'static, PubsubHeader<N>>,
+        body_stream: BoxStream<'static, PubsubBody<N>>,
+    ) -> Self {
+        Self {
+            header_stream,
+            body_stream,
+            cached_headers: HashMap::default(),
+            cached_bodies: HashMap::default(),
+        }
+    }
+
+    fn assemble_block(header: BlockHeaderMessage, body: BlockBody) -> Block {
+        match header {
+            BlockHeaderMessage::Macro {
+                header,
+                justification,
+            } => Block::Macro(MacroBlock {
+                header,
+                body: Some(body.unwrap_macro()),
+                justification: Some(justification),
+            }),
+            BlockHeaderMessage::Micro {
+                header,
+                justification,
+            } => Block::Micro(MicroBlock {
+                header,
+                body: Some(body.unwrap_micro()),
+                justification: Some(justification),
+            }),
+        }
+    }
+}
+
+impl<N: Network> Stream for BlockAssembler<N> {
+    type Item = (Block, N::PubsubId);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        while let Poll::Ready(item) = self.header_stream.poll_next_unpin(cx) {
+            let header = match item {
+                Some(header) => header,
+                None => return Poll::Ready(None),
+            };
+
+            let hash = header.0.hash();
+            if let Some(bodies) = self.cached_bodies.get_mut(header.0.body_root()) {
+                if let Some(body) = bodies.remove(&hash) {
+                    if bodies.is_empty() {
+                        self.cached_bodies.remove(header.0.body_root());
+                    }
+
+                    // Check that header and body type match.
+                    if header.0.ty() != body.ty() {
+                        debug!(
+                            block = %header.0,
+                            peer_id = %header.1.propagation_source(),
+                            "Discarding block - header and body types don't match"
+                        );
+                        // TODO ban peer
+                        continue;
+                    }
+
+                    return Poll::Ready(Some((Self::assemble_block(header.0, body), header.1)));
+                }
+            }
+
+            self.cached_headers.insert(hash, header);
+        }
+
+        while let Poll::Ready(item) = self.body_stream.poll_next_unpin(cx) {
+            let body = match item {
+                Some(body) => body,
+                None => return Poll::Ready(None),
+            };
+
+            let hash = body.0.body.hash();
+            if let Some(header) = self.cached_headers.get(&body.0.header_hash) {
+                if *header.0.body_root() == hash {
+                    let header = self.cached_headers.remove(&body.0.header_hash).unwrap();
+
+                    // Check that header and body type match.
+                    if header.0.ty() != body.0.body.ty() {
+                        debug!(
+                            block = %header.0,
+                            peer_id = %header.1.propagation_source(),
+                            "Discarding block - header and body types don't match"
+                        );
+                        // TODO ban peer
+                        continue;
+                    }
+
+                    return Poll::Ready(Some((
+                        Self::assemble_block(header.0, body.0.body),
+                        header.1,
+                    )));
+                }
+            }
+
+            self.cached_bodies
+                .entry(hash)
+                .or_default()
+                .insert(body.0.header_hash, body.0.body);
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::task::Poll;
+
+    use futures::{poll, stream::StreamExt};
+    use nimiq_block::{Block, MacroBlock};
+    use nimiq_network_interface::network::PubsubId;
+    use nimiq_network_mock::{MockId, MockNetwork, MockPeerId};
+    use nimiq_test_log::test;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    use crate::{messages::BlockHeaderMessage, sync::live::block_queue::assembler::BlockAssembler};
+
+    #[test(tokio::test)]
+    async fn it_assembles_header_and_body() {
+        let (header_tx, header_rx) = mpsc::channel(16);
+        let (body_tx, body_rx) = mpsc::channel(16);
+
+        let mut assembler = BlockAssembler::<MockNetwork>::new(
+            ReceiverStream::new(header_rx).boxed(),
+            ReceiverStream::new(body_rx).boxed(),
+        );
+
+        let block = Block::Macro(MacroBlock::non_empty_default());
+        let (header, body) = BlockHeaderMessage::split_block(block.clone());
+
+        let header_sender = MockId::new(MockPeerId::from(0));
+        header_tx.try_send((header, header_sender.clone())).unwrap();
+
+        let _ = poll!(assembler.next());
+        assert_eq!(assembler.cached_headers.len(), 1);
+
+        let body_sender = MockId::new(MockPeerId::from(1));
+        body_tx.try_send((body, body_sender)).unwrap();
+
+        match poll!(assembler.next()) {
+            Poll::Ready(Some((block1, sender))) => {
+                assert_eq!(block1, block);
+                assert_eq!(
+                    sender.propagation_source(),
+                    header_sender.propagation_source()
+                );
+            }
+            _ => panic!("Unexpected return value"),
+        }
+
+        assert!(assembler.cached_headers.is_empty());
+        assert!(assembler.cached_bodies.is_empty());
+    }
+
+    #[test(tokio::test)]
+    async fn it_assembles_body_and_header() {
+        let (header_tx, header_rx) = mpsc::channel(16);
+        let (body_tx, body_rx) = mpsc::channel(16);
+
+        let mut assembler = BlockAssembler::<MockNetwork>::new(
+            ReceiverStream::new(header_rx).boxed(),
+            ReceiverStream::new(body_rx).boxed(),
+        );
+
+        let block = Block::Macro(MacroBlock::non_empty_default());
+        let (header, body) = BlockHeaderMessage::split_block(block.clone());
+
+        let body_sender = MockId::new(MockPeerId::from(1));
+        body_tx.try_send((body, body_sender)).unwrap();
+
+        let _ = poll!(assembler.next());
+        assert_eq!(assembler.cached_bodies.len(), 1);
+        assert_eq!(assembler.cached_bodies.values().next().unwrap().len(), 1);
+
+        let header_sender = MockId::new(MockPeerId::from(0));
+        header_tx.try_send((header, header_sender.clone())).unwrap();
+
+        match poll!(assembler.next()) {
+            Poll::Ready(Some((block1, sender))) => {
+                assert_eq!(block1, block);
+                assert_eq!(
+                    sender.propagation_source(),
+                    header_sender.propagation_source()
+                );
+            }
+            _ => panic!("Unexpected return value"),
+        }
+
+        assert!(assembler.cached_headers.is_empty());
+        assert!(assembler.cached_bodies.is_empty());
+    }
+}

--- a/consensus/src/sync/live/block_queue/assembler.rs
+++ b/consensus/src/sync/live/block_queue/assembler.rs
@@ -34,7 +34,7 @@ pub struct BlockAssembler<N: Network> {
 }
 
 impl<N: Network> BlockAssembler<N> {
-    const CACHE_TTL: Duration = Duration::from_secs(5);
+    const CACHE_TTL: Duration = Duration::from_secs(10);
 
     pub fn new(
         network: Arc<N>,

--- a/consensus/src/sync/live/block_queue/assembler.rs
+++ b/consensus/src/sync/live/block_queue/assembler.rs
@@ -2,26 +2,32 @@ use std::{
     collections::HashMap,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::{stream::BoxStream, Stream, StreamExt};
+use instant::Instant;
 use nimiq_block::{Block, BlockBody, MacroBlock, MicroBlock};
 use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
 use nimiq_network_interface::network::{Network, PubsubId};
+use nimiq_time::{interval, Interval};
 
 use crate::messages::{BlockBodyMessage, BlockHeaderMessage};
 
 type PubsubHeader<N> = (BlockHeaderMessage, <N as Network>::PubsubId);
 type PubsubBody<N> = (BlockBodyMessage, <N as Network>::PubsubId);
+type BodyKey = (Blake2sHash, Blake2bHash);
 
 pub struct BlockAssembler<N: Network> {
     header_stream: BoxStream<'static, PubsubHeader<N>>,
     body_stream: BoxStream<'static, PubsubBody<N>>,
-    cached_headers: HashMap<Blake2bHash, PubsubHeader<N>>,
-    cached_bodies: HashMap<Blake2sHash, HashMap<Blake2bHash, BlockBody>>,
+    cached_headers: TimeLimitedCache<Blake2bHash, PubsubHeader<N>>,
+    cached_bodies: TimeLimitedCache<BodyKey, BlockBody>,
 }
 
 impl<N: Network> BlockAssembler<N> {
+    const CACHE_TTL: Duration = Duration::from_secs(5);
+
     pub fn new(
         header_stream: BoxStream<'static, PubsubHeader<N>>,
         body_stream: BoxStream<'static, PubsubBody<N>>,
@@ -29,8 +35,8 @@ impl<N: Network> BlockAssembler<N> {
         Self {
             header_stream,
             body_stream,
-            cached_headers: HashMap::default(),
-            cached_bodies: HashMap::default(),
+            cached_headers: TimeLimitedCache::new(Self::CACHE_TTL),
+            cached_bodies: TimeLimitedCache::new(Self::CACHE_TTL),
         }
     }
 
@@ -60,32 +66,36 @@ impl<N: Network> Stream for BlockAssembler<N> {
     type Item = (Block, N::PubsubId);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // The cache stream never returns None, so it's ok to ignore that case here.
+        while let Poll::Ready(Some(num_evicted)) = self.cached_headers.poll_next_unpin(cx) {
+            debug!(num_evicted, "Evicted {} headers from cache", num_evicted);
+        }
+        while let Poll::Ready(Some(num_evicted)) = self.cached_bodies.poll_next_unpin(cx) {
+            debug!(num_evicted, "Evicted {} bodies from cache", num_evicted);
+        }
+
         while let Poll::Ready(item) = self.header_stream.poll_next_unpin(cx) {
             let header = match item {
                 Some(header) => header,
                 None => return Poll::Ready(None),
             };
 
-            let hash = header.0.hash();
-            if let Some(bodies) = self.cached_bodies.get_mut(header.0.body_root()) {
-                if let Some(body) = bodies.remove(&hash) {
-                    if bodies.is_empty() {
-                        self.cached_bodies.remove(header.0.body_root());
-                    }
+            let hash: Blake2bHash = header.0.hash();
+            let body_key = (header.0.body_root().clone(), hash.clone());
 
-                    // Check that header and body type match.
-                    if header.0.ty() != body.ty() {
-                        debug!(
-                            block = %header.0,
-                            peer_id = %header.1.propagation_source(),
-                            "Discarding block - header and body types don't match"
-                        );
-                        // TODO ban peer
-                        continue;
-                    }
-
-                    return Poll::Ready(Some((Self::assemble_block(header.0, body), header.1)));
+            if let Some(body) = self.cached_bodies.remove(&body_key) {
+                // Check that header and body type match.
+                if header.0.ty() != body.ty() {
+                    debug!(
+                        block = %header.0,
+                        peer_id = %header.1.propagation_source(),
+                        "Discarding block - header and body types don't match"
+                    );
+                    // TODO ban peer
+                    continue;
                 }
+
+                return Poll::Ready(Some((Self::assemble_block(header.0, body), header.1)));
             }
 
             self.cached_headers.insert(hash, header);
@@ -120,12 +130,73 @@ impl<N: Network> Stream for BlockAssembler<N> {
                 }
             }
 
-            self.cached_bodies
-                .entry(hash)
-                .or_default()
-                .insert(body.0.header_hash, body.0.body);
+            let body_key = (hash, body.0.header_hash);
+            self.cached_bodies.insert(body_key, body.0.body);
         }
 
+        Poll::Pending
+    }
+}
+
+struct TimeLimitedCache<K, V> {
+    map: HashMap<K, (V, Instant)>,
+    ttl: Duration,
+    interval: Interval,
+}
+
+impl<K: Eq + std::hash::Hash, V> TimeLimitedCache<K, V> {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            map: HashMap::default(),
+            ttl,
+            interval: interval(ttl),
+        }
+    }
+
+    /// Returns the number of items that were evicted.
+    fn evict_expired_entries(&mut self) -> usize {
+        let initial_len = self.map.len();
+
+        let cutoff = Instant::now() - self.ttl;
+        self.map
+            .retain(|_, (_, insertion_time)| *insertion_time >= cutoff);
+
+        initial_len - self.map.len()
+    }
+
+    fn get(&self, k: &K) -> Option<&V> {
+        self.map.get(k).map(|v| &v.0)
+    }
+
+    fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.map.insert(k, (v, Instant::now())).map(|v| v.0)
+    }
+
+    fn remove(&mut self, k: &K) -> Option<V> {
+        self.map.remove(k).map(|v| v.0)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+impl<K: Eq + std::hash::Hash + Unpin, V: Unpin> Stream for TimeLimitedCache<K, V> {
+    type Item = usize;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        while self.interval.poll_next_unpin(cx).is_ready() {
+            let num_evicted = self.evict_expired_entries();
+            if num_evicted > 0 {
+                return Poll::Ready(Some(num_evicted));
+            }
+        }
         Poll::Pending
     }
 }
@@ -133,16 +204,21 @@ impl<N: Network> Stream for BlockAssembler<N> {
 #[cfg(test)]
 mod tests {
     use core::task::Poll;
+    use std::time::Duration;
 
     use futures::{poll, stream::StreamExt};
     use nimiq_block::{Block, MacroBlock};
     use nimiq_network_interface::network::PubsubId;
     use nimiq_network_mock::{MockId, MockNetwork, MockPeerId};
     use nimiq_test_log::test;
+    use nimiq_time::sleep;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
 
-    use crate::{messages::BlockHeaderMessage, sync::live::block_queue::assembler::BlockAssembler};
+    use crate::{
+        messages::BlockHeaderMessage,
+        sync::live::block_queue::assembler::{BlockAssembler, TimeLimitedCache},
+    };
 
     #[test(tokio::test)]
     async fn it_assembles_header_and_body() {
@@ -199,7 +275,6 @@ mod tests {
 
         let _ = poll!(assembler.next());
         assert_eq!(assembler.cached_bodies.len(), 1);
-        assert_eq!(assembler.cached_bodies.values().next().unwrap().len(), 1);
 
         let header_sender = MockId::new(MockPeerId::from(0));
         header_tx.try_send((header, header_sender.clone())).unwrap();
@@ -217,5 +292,38 @@ mod tests {
 
         assert!(assembler.cached_headers.is_empty());
         assert!(assembler.cached_bodies.is_empty());
+    }
+
+    #[test(tokio::test)]
+    async fn it_evicts_expired_items() {
+        let ttl = Duration::from_secs(1);
+        let mut cache = TimeLimitedCache::new(ttl);
+
+        cache.insert(1, 1);
+
+        sleep(ttl / 2).await;
+
+        assert!(matches!(poll!(cache.next()), Poll::Pending));
+
+        assert_eq!(cache.len(), 1);
+        assert!(matches!(cache.get(&1), Some(1)));
+
+        cache.insert(2, 2);
+        cache.insert(3, 3);
+
+        sleep(3 * ttl / 4).await;
+
+        assert!(matches!(poll!(cache.next()), Poll::Ready(Some(1))));
+
+        assert_eq!(cache.len(), 2);
+        assert!(matches!(cache.get(&1), None));
+        assert!(matches!(cache.get(&2), Some(2)));
+        assert!(matches!(cache.get(&3), Some(3)));
+
+        sleep(ttl).await;
+
+        assert!(matches!(poll!(cache.next()), Poll::Ready(Some(2))));
+
+        assert!(cache.is_empty());
     }
 }

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -53,7 +53,7 @@ impl<N: Network> BlockSource<N> {
     pub fn peer_id(&self) -> N::PeerId {
         match self {
             BlockSource::Announced { header_id, .. } => header_id.propagation_source(),
-            BlockSource::Requested { id } => id.clone(),
+            BlockSource::Requested { id } => *id,
         }
     }
 

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -1,10 +1,13 @@
 use futures::stream::BoxStream;
 use nimiq_block::Block;
-use nimiq_network_interface::network::Network;
+use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
 pub use proxy::BlockQueueProxy as BlockQueue;
 use tokio::sync::oneshot::Sender as OneshotSender;
 
-use crate::consensus::ResolveBlockError;
+use crate::{
+    consensus::ResolveBlockError,
+    messages::{BlockBodyTopic, BlockHeaderTopic},
+};
 
 mod assembler;
 pub mod block_request_component;
@@ -12,24 +15,89 @@ pub mod live_sync;
 mod proxy;
 mod queue;
 
-pub type BlockStream<N> = BoxStream<
-    'static,
-    (
-        Block,
-        <N as Network>::PeerId,
-        Option<<N as Network>::PubsubId>,
-    ),
->;
+pub type BlockStream<N> = BoxStream<'static, BlockAndSource<N>>;
 pub type GossipSubBlockStream<N> = BoxStream<'static, (Block, <N as Network>::PubsubId)>;
 
-pub type BlockAndId<N> = (Block, Option<<N as Network>::PubsubId>);
+pub type BlockAndSource<N> = (Block, BlockSource<N>);
 
 pub type ResolveBlockSender<N> = OneshotSender<Result<Block, ResolveBlockError<N>>>;
 
 pub enum QueuedBlock<N: Network> {
-    Head(BlockAndId<N>),
-    Buffered(Vec<BlockAndId<N>>),
-    Missing(Vec<Block>),
-    TooFarAhead(Block, N::PeerId),
-    TooFarBehind(Block, N::PeerId),
+    Head(BlockAndSource<N>),
+    Buffered(Vec<BlockAndSource<N>>),
+    Missing(Vec<BlockAndSource<N>>),
+    TooFarAhead(N::PeerId),
+    TooFarBehind(N::PeerId),
+}
+
+#[derive(Debug)]
+pub enum BlockSource<N: Network> {
+    Announced {
+        header_id: N::PubsubId,
+        body_id: Option<N::PubsubId>,
+    },
+    Requested {
+        id: N::PeerId,
+    },
+}
+
+impl<N: Network> BlockSource<N> {
+    pub fn announced(header_id: N::PubsubId, body_id: Option<N::PubsubId>) -> Self {
+        Self::Announced { header_id, body_id }
+    }
+
+    pub fn requested(id: N::PeerId) -> Self {
+        Self::Requested { id }
+    }
+
+    pub fn peer_id(&self) -> N::PeerId {
+        match self {
+            BlockSource::Announced { header_id, .. } => header_id.propagation_source(),
+            BlockSource::Requested { id } => id.clone(),
+        }
+    }
+
+    pub fn is_announced(&self) -> bool {
+        matches!(self, BlockSource::Announced { .. })
+    }
+
+    pub fn is_requested(&self) -> bool {
+        matches!(self, BlockSource::Requested { .. })
+    }
+
+    pub fn accept_block(&self, network: &N) {
+        self.validate_block(network, MsgAcceptance::Accept);
+    }
+
+    pub fn reject_block(&self, network: &N) {
+        self.validate_block(network, MsgAcceptance::Reject);
+    }
+
+    pub fn ignore_block(&self, network: &N) {
+        self.validate_block(network, MsgAcceptance::Ignore);
+    }
+
+    pub fn validate_block(&self, network: &N, acceptance: MsgAcceptance) {
+        match self {
+            BlockSource::Announced { header_id, body_id } => {
+                network.validate_message::<BlockHeaderTopic>(header_id.clone(), acceptance);
+                if let Some(body_id) = body_id {
+                    network.validate_message::<BlockBodyTopic>(body_id.clone(), acceptance);
+                }
+            }
+            BlockSource::Requested { .. } => {}
+        }
+    }
+}
+
+impl<N: Network> Clone for BlockSource<N> {
+    fn clone(&self) -> Self {
+        match self {
+            BlockSource::Requested { id } => BlockSource::Requested { id: *id },
+            BlockSource::Announced { header_id, body_id } => BlockSource::Announced {
+                header_id: header_id.clone(),
+                body_id: body_id.clone(),
+            },
+        }
+    }
 }

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -1,16 +1,16 @@
 use futures::stream::BoxStream;
 use nimiq_block::Block;
 use nimiq_network_interface::network::Network;
+pub use proxy::BlockQueueProxy as BlockQueue;
 use tokio::sync::oneshot::Sender as OneshotSender;
 
 use crate::consensus::ResolveBlockError;
 
+mod assembler;
 pub mod block_request_component;
 pub mod live_sync;
 mod proxy;
 mod queue;
-
-pub use proxy::BlockQueueProxy as BlockQueue;
 
 pub type BlockStream<N> = BoxStream<
     'static,

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -25,7 +25,11 @@ use crate::{
     consensus::ResolveBlockRequest,
     sync::{
         light::LightMacroSync,
-        live::{block_queue::BlockQueue, queue::QueueConfig, BlockLiveSync},
+        live::{
+            block_queue::{BlockQueue, BlockSource},
+            queue::QueueConfig,
+            BlockLiveSync,
+        },
         syncer::{LiveSyncPushEvent, Syncer},
     },
 };
@@ -168,7 +172,7 @@ impl<N: Network> SyncerProxy<N> {
         network_event_rx: SubscribeEvents<N::PeerId>,
     ) -> Self {
         let block_queue_config = QueueConfig {
-            include_micro_bodies: false,
+            include_body: false,
             ..Default::default()
         };
 
@@ -203,8 +207,8 @@ impl<N: Network> SyncerProxy<N> {
     }
 
     /// Pushes a block for the live sync method
-    pub fn push_block(&mut self, block: Block, peer_id: N::PeerId, pubsub_id: Option<N::PubsubId>) {
-        gen_syncer_match!(self, push_block, block, peer_id, pubsub_id)
+    pub fn push_block(&mut self, block: Block, block_source: BlockSource<N>) {
+        gen_syncer_match!(self, push_block, block, block_source)
     }
 
     /// Returns the number of peers doing live synchronization

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -637,7 +637,7 @@ async fn request_missing_blocks_across_macro_block() {
     // Run the block_queue one iteration, i.e. until it processed one batch.
     // Needs to be pulled again to send the request missing block over the network.
     syncer.next().await;
-    // syncer.next().await;
+
     let _ = poll!(syncer.next());
     // Yield to allow the internal BlockQueue task to proceed.
     yield_now().await;
@@ -705,7 +705,7 @@ async fn put_peer_back_into_sync_mode() {
             buffer_max: 10,
             window_ahead_max: 10,
             tolerate_past_max: 100,
-            include_micro_bodies: true,
+            include_body: true,
         },
     );
 

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -253,10 +253,6 @@ pub async fn sync_two_peers(
         consensus1_proxy.blockchain.read().election_head_hash(),
     );
     assert_eq!(
-        blockchain2_proxy.read().macro_head(),
-        consensus1_proxy.blockchain.read().macro_head(),
-    );
-    assert_eq!(
         blockchain2_proxy.read().macro_head_hash(),
         consensus1_proxy.blockchain.read().macro_head_hash(),
     );

--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -370,7 +370,6 @@ impl GenesisBuilder {
 
         // Body
         let body = MacroBody {
-            validators: Some(slots),
             ..Default::default()
         };
 
@@ -409,6 +408,8 @@ impl GenesisBuilder {
             body_root,
             diff_root: TreeProof::empty().root_hash(),
             history_root,
+            validators: Some(slots),
+            ..Default::default()
         };
 
         // Genesis hash

--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -92,7 +92,7 @@ impl LightBlockchain {
         } else {
             self.get_block_at(
                 Policy::election_block_of(epoch - 1).ok_or(BlockchainError::InvalidEpoch)?,
-                true,
+                false,
             )?
             .unwrap_macro()
             .get_validators()
@@ -109,7 +109,7 @@ impl LightBlockchain {
     ) -> Result<Slot, BlockchainError> {
         // Fetch the latest macro block that precedes the block at the given block_number.
         // We use the disabled_slots set from that macro block for the slot selection.
-        let macro_block = self.get_block_at(Policy::macro_block_before(block_number), true)?;
+        let macro_block = self.get_block_at(Policy::macro_block_before(block_number), false)?;
         let disabled_slots = macro_block
             .unwrap_macro()
             .header

--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -112,8 +112,7 @@ impl LightBlockchain {
         let macro_block = self.get_block_at(Policy::macro_block_before(block_number), true)?;
         let disabled_slots = macro_block
             .unwrap_macro()
-            .body
-            .unwrap()
+            .header
             .next_batch_initial_punished_set;
 
         // Compute the slot number of the next proposer.

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -73,14 +73,14 @@ impl ChainStore {
 
         // We only store in the ChainStore:
         // - Micro blocks: Headers and Justifications
-        // - Macro blocks: Headers and bodies.
+        // - Macro blocks: Headers
         match &mut chain_info.head {
             Block::Macro(ref mut block) => {
-                assert!(block.body.is_some());
+                block.body = None;
                 block.justification = None;
             }
             Block::Micro(ref mut block) => {
-                assert!(block.body.is_none());
+                block.body = None;
             }
         }
 

--- a/network-interface/src/network.rs
+++ b/network-interface/src/network.rs
@@ -40,7 +40,7 @@ pub trait Topic {
 /// Network implementations have to at least support messages of this size.
 pub const MIN_SUPPORTED_MSG_SIZE: usize = 1024 * 1024;
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum MsgAcceptance {
     Accept,
     Reject,

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -732,6 +732,8 @@ mod test {
             body_root: Blake2sHash::default(),
             diff_root: Blake2bHash::default(),
             history_root: Blake2bHash::default(),
+            validators: None,
+            next_batch_initial_punished_set: BitSet::default(),
         };
         let header2 = MacroHeader {
             network: NetworkId::UnitAlbatross,
@@ -748,6 +750,8 @@ mod test {
             body_root: "".hash(),
             diff_root: "".hash(),
             history_root: "".hash(),
+            validators: None,
+            next_batch_initial_punished_set: BitSet::default(),
         };
         let header3 = MacroHeader {
             network: NetworkId::UnitAlbatross,
@@ -764,6 +768,8 @@ mod test {
             body_root: "1".hash(),
             diff_root: "1".hash(),
             history_root: "1".hash(),
+            validators: None,
+            next_batch_initial_punished_set: BitSet::default(),
         };
 
         // Headers from a different block height.

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -228,13 +228,13 @@ impl MacroHeader {
         Ok(())
     }
 
-    fn legacy_body_root(&self) -> Blake2sHash {
+    fn zkp_body_root(&self) -> Blake2sHash {
         let mut h = <Blake2sHash as HashOutput>::Builder::default();
-        self.legacy_body_serialize_content(&mut h).unwrap();
+        self.zkp_body_serialize_content(&mut h).unwrap();
         h.finish()
     }
 
-    pub fn legacy_body_serialize_content<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    pub fn zkp_body_serialize_content<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         if let Some(ref validators) = self.validators {
             let pk_tree_root = validators.hash::<Blake2sHash>();
             pk_tree_root.serialize_to_writer(writer)?;
@@ -318,7 +318,7 @@ impl SerializeContent for MacroHeader {
 
         self.state_root.serialize_to_writer(writer)?;
         // This includes validators and next_batch_punished_set.
-        self.legacy_body_root().serialize_to_writer(writer)?;
+        self.zkp_body_root().serialize_to_writer(writer)?;
         self.history_root.serialize_to_writer(writer)?;
 
         Ok(())

--- a/primitives/block/tests/mod.rs
+++ b/primitives/block/tests/mod.rs
@@ -120,12 +120,11 @@ fn it_can_convert_macro_block_into_slots() {
             body_root: Blake2sHash::default(),
             diff_root: Blake2bHash::default(),
             history_root: Blake2bHash::default(),
+            validators: Some(validator_slots.clone()),
+            next_batch_initial_punished_set: BitSet::new(),
         },
         justification: None,
         body: Some(MacroBody {
-            validators: Some(validator_slots.clone()),
-
-            next_batch_initial_punished_set: BitSet::new(),
             transactions: vec![],
         }),
     };

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -498,11 +498,11 @@ fn test_verify_election_macro_body() {
         body_root: Blake2sHash::default(),
         diff_root: Blake2bHash::default(),
         history_root: Blake2bHash::default(),
-    };
-
-    let mut macro_body = MacroBody {
         validators: None,
         next_batch_initial_punished_set: BitSet::default(),
+    };
+
+    let macro_body = MacroBody {
         transactions: vec![],
     };
     macro_header.body_root = macro_body.hash();
@@ -529,7 +529,7 @@ fn test_verify_election_macro_body() {
             SchnorrPublicKey::default(),
         );
     }
-    macro_body.validators = Some(validators.build());
+    macro_header.validators = Some(validators.build());
 
     macro_header.body_root = macro_body.hash();
     let block = Block::Macro(MacroBlock {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -142,8 +142,7 @@ pub enum BlockAdditionalFields {
         interlink: Option<Vec<Blake2bHash>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         slots: Option<Vec<Slots>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        next_batch_initial_punished_set: Option<BitSet>,
+        next_batch_initial_punished_set: BitSet,
 
         #[serde(skip_serializing_if = "Option::is_none")]
         justification: Option<TendermintProof>,
@@ -173,11 +172,6 @@ impl Block {
         let block_number = macro_block.block_number();
 
         let slots = macro_block.get_validators().map(Slots::from_slots);
-
-        let next_batch_initial_punished_set = match macro_block.body.clone() {
-            None => None,
-            Some(body) => Some(body.next_batch_initial_punished_set),
-        };
 
         // Get the reward inherents and convert them to reward transactions.
         let mut transactions = None;
@@ -231,7 +225,7 @@ impl Block {
                 parent_election_hash: macro_block.header.parent_election_hash,
                 interlink: macro_block.header.interlink,
                 slots,
-                next_batch_initial_punished_set,
+                next_batch_initial_punished_set: macro_block.header.next_batch_initial_punished_set,
                 justification: macro_block.justification.map(TendermintProof::from),
             },
         })

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -301,7 +301,7 @@ where
             .resolve_block(
                 signed_proposal.proposal.block_number - 1,
                 hash,
-                pubsub_id.clone(),
+                pubsub_id.propagation_source(),
             )
             .map(move |result| {
                 match result {

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -651,8 +651,8 @@ mod test {
         let mut consensus_events1 = consensus1.subscribe_events().boxed().fuse();
         let mut consensus_events2 = consensus2.subscribe_events().boxed().fuse();
 
-        // At most wait 200 millis for them to connect and sync as there is nothing to do here.
-        let mut deadline = sleep(Duration::from_millis(200)).boxed().fuse();
+        // At most wait 1 second for them to connect and sync as there is nothing to do here.
+        let mut deadline = sleep(Duration::from_secs(1)).boxed().fuse();
 
         // Spawn both consensus before connecting them.
         spawn(consensus1);
@@ -770,7 +770,7 @@ mod test {
 
         // Poll the ProposalBuffer until it produces a proposal. This should resolve the so far unknown predecessor and resolve.
         // Do this with a timeout as it should really only take a single round trip.
-        let _signed_proposal = timeout(Duration::from_millis(400), proposal_receiver.next())
+        let _signed_proposal = timeout(Duration::from_secs(1), proposal_receiver.next())
             .await
             .expect("proposal buffer should have produced the proposal before the timeout")
             .expect("proposal buffer should have produced the proposal");
@@ -819,7 +819,7 @@ mod test {
 
         // Poll the ProposalBuffer until it produces a proposal. This should resolve the so far unknown predecessor and resolve.
         // Do this with a timeout as it should really only take a single round trip.
-        let signed_proposal = timeout(Duration::from_millis(400), proposal_receiver.next())
+        let signed_proposal = timeout(Duration::from_secs(1), proposal_receiver.next())
             .await
             .expect("proposal buffer should have resolved the proposal before the timeout")
             .expect("proposal buffer should have resolved the proposal");
@@ -883,7 +883,7 @@ mod test {
 
         // Poll the ProposalBuffer until it produces a proposal. This should resolve the so far unknown predecessor and resolve.
         // Do this with a timeout as it should really only take a single round trip.
-        let signed_proposal = timeout(Duration::from_millis(400), proposal_receiver.next())
+        let signed_proposal = timeout(Duration::from_secs(1), proposal_receiver.next())
             .await
             .expect("proposal buffer should have resolved the proposal before the timeout")
             .expect("proposal buffer should have resolved the proposal");
@@ -950,7 +950,7 @@ mod test {
 
         // Poll the ProposalBuffer until it produces a proposal. This should resolve the so far unknown predecessor and resolve.
         // Do this with a timeout as it should really only take a single round trip.
-        let signed_proposal = timeout(Duration::from_millis(400), proposal_receiver.next())
+        let signed_proposal = timeout(Duration::from_secs(1), proposal_receiver.next())
             .await
             .expect("proposal buffer should have resolved the proposal before the timeout")
             .expect("proposal buffer should have resolved the proposal");

--- a/zkp-circuits/src/gadgets/mnt6/macro_block.rs
+++ b/zkp-circuits/src/gadgets/mnt6/macro_block.rs
@@ -243,17 +243,16 @@ impl AllocVar<MacroBlock, MNT6Fq> for MacroBlockGadget {
             UInt8::<MNT6Fq>::new_input_vec(cs.clone(), value.header.history_root.as_bytes())?;
 
         // Body
-        let body = value
-            .body
-            .as_ref()
-            .ok_or(SynthesisError::AssignmentMissing)?;
-        let validators = body
+        let validators = value
+            .header
             .validators
             .as_ref()
             .ok_or(SynthesisError::AssignmentMissing)?;
 
         let mut body_bytes = Vec::new();
-        body.serialize_content::<_, Blake2sHash>(&mut body_bytes)
+        value
+            .header
+            .legacy_body_serialize_content(&mut body_bytes)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
 
         let pk_tree_root =
@@ -332,17 +331,16 @@ impl AllocVar<MacroBlock, MNT6Fq> for MacroBlockGadget {
             UInt8::<MNT6Fq>::new_witness_vec(cs.clone(), value.header.history_root.as_bytes())?;
 
         // Body
-        let body = value
-            .body
-            .as_ref()
-            .ok_or(SynthesisError::AssignmentMissing)?;
-        let validators = body
+        let validators = value
+            .header
             .validators
             .as_ref()
             .ok_or(SynthesisError::AssignmentMissing)?;
 
         let mut body_bytes = Vec::new();
-        body.serialize_content::<_, Blake2sHash>(&mut body_bytes)
+        value
+            .header
+            .legacy_body_serialize_content(&mut body_bytes)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
 
         let pk_tree_root =
@@ -425,11 +423,7 @@ mod tests {
             value: Coin::from_u64_unchecked(12),
         }];
 
-        let body = MacroBody {
-            validators,
-            next_batch_initial_punished_set: Default::default(),
-            transactions,
-        };
+        let body = MacroBody { transactions };
 
         // Initialize the header.
         let body_root = body.hash();
@@ -448,6 +442,8 @@ mod tests {
             body_root,
             diff_root: Blake2bHash(rng.gen()),
             history_root: Blake2bHash(rng.gen()),
+            validators,
+            next_batch_initial_punished_set: Default::default(),
         };
 
         MacroBlock {

--- a/zkp-circuits/src/gadgets/mnt6/macro_block.rs
+++ b/zkp-circuits/src/gadgets/mnt6/macro_block.rs
@@ -252,7 +252,7 @@ impl AllocVar<MacroBlock, MNT6Fq> for MacroBlockGadget {
         let mut body_bytes = Vec::new();
         value
             .header
-            .legacy_body_serialize_content(&mut body_bytes)
+            .zkp_body_serialize_content(&mut body_bytes)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
 
         let pk_tree_root =
@@ -340,7 +340,7 @@ impl AllocVar<MacroBlock, MNT6Fq> for MacroBlockGadget {
         let mut body_bytes = Vec::new();
         value
             .header
-            .legacy_body_serialize_content(&mut body_bytes)
+            .zkp_body_serialize_content(&mut body_bytes)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
 
         let pk_tree_root =

--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -258,7 +258,7 @@ impl<N: Network> Handle<N, Arc<ZKPStateEnvironment>> for RequestZKP {
         let block = if self.request_election_block {
             env.blockchain
                 .read()
-                .get_block_at(latest_block_number, true)
+                .get_block_at(latest_block_number, false)
                 .ok()
                 .map(|block| block.unwrap_macro())
         } else {


### PR DESCRIPTION
The current gossipsub topic structure for block propagation suffers from poor mesh quality on the `block-header` topic, duplicated messages due to re-publishing as well as data duplication across topics.

This PR replaces the `block`/`block-header` gossipsub topics by a `block-header` and a `block-body` topic, eliminating cross topic data duplication. All nodes subscribe to the `block-header` topic, improving mesh quality, while only full/history nodes subscribe to the `block-body` topic.

Additionally, `validators` and `next_batch_initial_punished_set` are moved from the macro body to the macro header while preserving ZKP circuit compatibility. These properties are always required by light nodes, so they need to be part of the header.

Finally, block source tracking was refactored to account for the fact that a single block can now have two pubsub ids associated with it.

Closes #2499, closes #2560