### PR TITLE
Make sure we don't overflow in reward calculation

### DIFF
--- a/blockchain/src/reward.rs
+++ b/blockchain/src/reward.rs
@@ -52,7 +52,7 @@ pub fn block_reward_for_batch(
         Policy::supply_at(genesis_supply_u64, genesis_timestamp, current_timestamp);
 
     // This is the maximum rewards that we can pay for this batch
-    let max_rewards = current_supply - prev_supply;
+    let max_rewards = current_supply.saturating_sub(prev_supply);
 
     // However, there is a penalty if the batch was not produced in time...
     // First we calculate the delay producing the batch:


### PR DESCRIPTION
This makes sure we don't hand out ~2**64 Luna when our reward curve isn't strictly monotone.

Our rewards curve should still be monotone as otherwise more than the total supply could be handed out.