### PR TITLE
Use a patched libp2p-websocket-websys crate to avoid use-after-free errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,8 +3206,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f6c7ad3960dc9da18bead8468fc2dce9992d23d84557fd2345c86a992d70d"
+source = "git+https://github.com/sisou/rust-libp2p?branch=sisou/websocket-websys-drop#1b14ee1a5ae5375a11731328afce361fafa8ad6a"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ ark-ec = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-ff = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-r1cs-std = { git = "https://github.com/paberr/r1cs-std", branch = "pb/fix-pedersen" }
 libp2p-websocket = { git = "https://github.com/Eligioo/rust-libp2p", branch = "stefan/quicksink-no-panic" }
+libp2p-websocket-websys = { git = "https://github.com/sisou/rust-libp2p", branch = "sisou/websocket-websys-drop" }
 
 [workspace.package]
 version = "0.22.3"

--- a/web-client/dist/nodejs/worker.js
+++ b/web-client/dist/nodejs/worker.js
@@ -13,13 +13,6 @@ global.WebSocket = w3cwebsocket;
 // a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
 global.WorkerGlobalScope = global;
 
-// Prevent NodeJS exiting on an uncaught exception that we currently expect,
-// until it is fixed in upstream libp2p websocket-websys transport.
-process.on('uncaughtException', error => {
-    if (error.message.includes('closure invoked recursively')) return;
-    throw error;
-});
-
 // Defined both here and in main thread exports.js
 Comlink.transferHandlers.set('function', {
     canHandle: (_obj) => false, // Cannot send functions to main thread

--- a/web-client/dist/nodejs/worker.mjs
+++ b/web-client/dist/nodejs/worker.mjs
@@ -13,13 +13,6 @@ global.WebSocket = websocket.w3cwebsocket;
 // a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
 global.WorkerGlobalScope = global;
 
-// Prevent NodeJS exiting on an uncaught exception that we currently expect,
-// until it is fixed in upstream libp2p websocket-websys transport.
-process.on('uncaughtException', error => {
-    if (error.message.includes('closure invoked recursively')) return;
-    throw error;
-});
-
 // Defined both here and in main thread exports.js
 Comlink.transferHandlers.set('function', {
     canHandle: (_obj) => false, // Cannot send functions to main thread


### PR DESCRIPTION
Use a patched `libp2p-websocket-websys` crate to avoid https://github.com/libp2p/rust-libp2p/issues/5490
