### PR TITLE
Tendermint impl use policy consts

### DIFF
--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -18,16 +18,6 @@ pub struct Policy {
     /// How many batches constitute an epoch
     #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub batches_per_epoch: u16,
-    /// Tendermint's initial timeout, in milliseconds.
-    ///
-    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
-    pub tendermint_timeout_init: u64,
-    /// Tendermint's timeout delta, in milliseconds.
-    ///
-    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
-    pub tendermint_timeout_delta: u64,
     /// Maximum size of accounts trie chunks.
     #[cfg_attr(feature = "ts-types", wasm_bindgen(skip))]
     pub state_chunks_max_size: u32,
@@ -102,6 +92,16 @@ impl Policy {
 
     /// The optimal time in milliseconds between blocks (1s)
     pub const BLOCK_SEPARATION_TIME: u64 = 1000;
+
+    /// Tendermint's initial timeout, in milliseconds.
+    ///
+    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
+    pub const TENDERMINT_TIMEOUT_INIT: u64 = 1000;
+
+    /// Tendermint's timeout delta, in milliseconds.
+    ///
+    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
+    pub const TENDERMINT_TIMEOUT_DELTA: u64 = 1000;
 
     /// Minimum number of epochs that the ChainStore will store fully
     pub const MIN_EPOCHS_STORED: u32 = 1;
@@ -214,28 +214,6 @@ impl Policy {
         GLOBAL_POLICY
             .get_or_init(Self::default)
             .genesis_block_number
-    }
-
-    /// Tendermint's initial timeout, in milliseconds.
-    ///
-    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
-    #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TENDERMINT_TIMEOUT_INIT))]
-    pub fn tendermint_timeout_init() -> u64 {
-        GLOBAL_POLICY
-            .get_or_init(Self::default)
-            .tendermint_timeout_init
-    }
-
-    /// Tendermint's timeout delta, in milliseconds.
-    ///
-    /// See <https://arxiv.org/abs/1807.04938v3> for more information.
-    #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = TENDERMINT_TIMEOUT_DELTA))]
-    pub fn tendermint_timeout_delta() -> u64 {
-        GLOBAL_POLICY
-            .get_or_init(Self::default)
-            .tendermint_timeout_delta
     }
 
     /// Maximum size of accounts trie chunks.
@@ -688,8 +666,6 @@ impl Default for Policy {
         Policy {
             blocks_per_batch: 60,
             batches_per_epoch: 720,
-            tendermint_timeout_init: 1000,
-            tendermint_timeout_delta: 1000,
             state_chunks_max_size: 1000,
             transaction_validity_window: 120,
             genesis_block_number: 0,
@@ -700,8 +676,6 @@ impl Default for Policy {
 pub const TEST_POLICY: Policy = Policy {
     blocks_per_batch: 32,
     batches_per_epoch: 4,
-    tendermint_timeout_init: 1000,
-    tendermint_timeout_delta: 1000,
     state_chunks_max_size: 2,
     transaction_validity_window: 2,
     genesis_block_number: 0,

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -175,8 +175,8 @@ where
 
     const F_PLUS_ONE: usize = Policy::F_PLUS_ONE as usize;
     const TWO_F_PLUS_ONE: usize = Policy::TWO_F_PLUS_ONE as usize;
-    const TIMEOUT_DELTA: u64 = 1000;
-    const TIMEOUT_INIT: u64 = 1000;
+    const TIMEOUT_DELTA: u64 = Policy::TENDERMINT_TIMEOUT_DELTA;
+    const TIMEOUT_INIT: u64 = Policy::TENDERMINT_TIMEOUT_INIT;
 
     fn is_proposer(&self, round: u32) -> Result<bool, ProtocolError> {
         let blockchain = self.blockchain.read();


### PR DESCRIPTION
## What's in this pull request?
Currently the `TENDERMINT_TIMEOUT_DELTA` and `TENDERMINT_TIMEOUT_INIT` constants are defined at two places. This PR fixes this by letting the Tendermint impl use the constants that are defined in the Policy.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
