### PR TITLE
Get rid of unnecessary `Waker::wake_by_ref` calls

### DIFF
--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -8,6 +8,7 @@ use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
 use nimiq_blockchain::Blockchain;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
+use nimiq_utils::WakerExt as _;
 use parking_lot::RwLock;
 
 use crate::{
@@ -119,8 +120,6 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for HistoryMacroSync<TNetwor
 
         // Pushing the future to FuturesUnordered above does not wake the task that
         // polls `epoch_ids_stream`. Therefore, we need to wake the task manually.
-        if let Some(waker) = &self.waker {
-            waker.wake_by_ref();
-        }
+        self.waker.wake();
     }
 }

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -8,6 +8,7 @@ use nimiq_network_interface::{
     request::RequestError,
 };
 use nimiq_primitives::policy::Policy;
+use nimiq_utils::WakerExt as _;
 use parking_lot::RwLock;
 
 use crate::{
@@ -448,9 +449,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
 
         // If we made space in epoch_clusters, wake the task.
         if cluster.is_some() {
-            if let Some(waker) = self.waker.take() {
-                waker.wake();
-            }
+            self.waker.wake();
             return cluster;
         }
 

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -158,9 +158,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                         self.job_queue
                             .push_back(Job::FinishCluster(cluster, result));
 
-                        if let Some(waker) = self.waker.take() {
-                            waker.wake();
-                        }
+                        self.waker.wake();
                         break;
                     }
                 }
@@ -213,9 +211,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                 }
             }
 
-            if let Some(waker) = self.waker.take() {
-                waker.wake();
-            }
+            self.waker.wake();
         }
     }
 

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -12,7 +12,7 @@ use nimiq_network_interface::{
     network::{CloseReason, Network, SubscribeEvents},
     request::RequestError,
 };
-use nimiq_utils::spawn::spawn;
+use nimiq_utils::{spawn::spawn, WakerExt as _};
 use nimiq_zkp_component::{
     types::{Error, ZKPRequestEvent},
     zkp_component::ZKPComponentProxy,
@@ -268,8 +268,6 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for LightMacroSync<TNetwork>
 
         // Pushing the future to FuturesUnordered above does not wake the task that
         // polls `epoch_ids_stream`. Therefore, we need to wake the task manually.
-        if let Some(waker) = &self.waker {
-            waker.wake_by_ref();
-        }
+        self.waker.wake();
     }
 }

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -375,9 +375,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 
                             // Pushing the future to FuturesUnordered above does not wake the task that
                             // polls `epoch_ids_stream`. Therefore, we need to wake the task manually.
-                            if let Some(waker) = &self.waker {
-                                waker.wake_by_ref();
-                            }
+                            self.waker.wake();
                         }
                     } else {
                         // If we don't have any pending requests from this peer, we proceed requesting epoch ids
@@ -391,9 +389,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 
                         // Pushing the future to FuturesUnordered above does not wake the task that
                         // polls `epoch_ids_stream`. Therefore, we need to wake the task manually.
-                        if let Some(waker) = &self.waker {
-                            waker.wake_by_ref();
-                        }
+                        self.waker.wake();
                     }
                 }
                 (Ok(Err(error)), peer_id) => {

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -260,9 +260,7 @@ where
                 self.peers.read().len(),
             );
 
-            if let Some(waker) = self.waker.take() {
-                waker.wake();
-            }
+            self.waker.wake();
         }
     }
 
@@ -329,9 +327,7 @@ where
         }
 
         // Adding new ids needs to wake the task that is polling the SyncQueue.
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
+        self.waker.wake();
     }
 
     /// Truncates the stored ids, retaining only the first `len` elements.

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -96,9 +96,7 @@ impl<TNetwork: Network> LevelUpdateSender<TNetwork> {
             }
         }
         // wake as a new message was added.
-        if let Some(waker) = &self.waker {
-            waker.wake_by_ref();
-        }
+        self.waker.wake();
     }
 }
 

--- a/handel/src/todo.rs
+++ b/handel/src/todo.rs
@@ -111,13 +111,7 @@ where
             contribution,
             level,
         });
-        self.wake();
-    }
-
-    fn wake(&mut self) {
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
+        self.waker.wake();
     }
 
     pub fn into_stream(self) -> BoxStream<'static, LevelUpdate<TProtocol::Contribution>> {
@@ -211,13 +205,13 @@ where
                         best_score = score;
                         if let Some(best_todo) = best_todo {
                             self.list.insert(best_todo);
-                            self.wake();
+                            self.waker.wake();
                         }
                         best_todo = Some(aggregate_todo);
                     } else {
                         // If the score is not a new best put the TodoItem in the list.
                         self.list.insert(aggregate_todo);
-                        self.wake();
+                        self.waker.wake();
                     }
                 }
                 // Some of the LevelUpdates also contain an individual Signature in which case it is also converted into a TodoItem.
@@ -236,13 +230,13 @@ where
                             best_score = score;
                             if let Some(best_todo) = best_todo {
                                 self.list.insert(best_todo);
-                                self.wake();
+                                self.waker.wake();
                             }
                             best_todo = Some(individual_todo);
                         } else {
                             // If the score is not a new best put the TodoItem in the list.
                             self.list.insert(individual_todo);
-                            self.wake();
+                            self.waker.wake();
                         }
                     }
                 }

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -368,12 +368,6 @@ impl Behaviour {
         }
     }
 
-    fn wake(&mut self) {
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
-    }
-
     fn get_ip_info_from_multiaddr(&self, address: &Multiaddr) -> Option<IpInfo> {
         // Get IP from multiaddress if it exists.
         match address.iter().next() {
@@ -445,7 +439,7 @@ impl Behaviour {
             }
         }
 
-        self.wake();
+        self.waker.wake();
     }
 
     /// Tells the behaviour to start connecting to other peers.
@@ -471,7 +465,7 @@ impl Behaviour {
             peer_id,
             connection: CloseConnection::All,
         });
-        self.wake();
+        self.waker.wake();
 
         match reason {
             CloseReason::MaliciousPeer => self.ban_connection(peer_id),
@@ -639,7 +633,7 @@ impl Behaviour {
                     peer_id: *peer_id,
                     connection: CloseConnection::One(*connection_id),
                 });
-                self.wake();
+                self.waker.wake();
             }
             return;
         }
@@ -669,7 +663,7 @@ impl Behaviour {
         self.addresses
             .mark_connected(address.clone(), peer_services);
 
-        self.wake();
+        self.waker.wake();
 
         self.maintain_peers();
     }

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -626,9 +626,7 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
 
                         // Pushing the future to FuturesUnordered above does not wake the task that
                         // polls `requested_proposals`. Therefore, we need to wake the task manually.
-                        if let Some(waker) = &self.waker {
-                            waker.wake_by_ref();
-                        }
+                        self.waker.wake();
                     }
                 }
             }

--- a/test-utils/src/mock_node.rs
+++ b/test-utils/src/mock_node.rs
@@ -16,7 +16,7 @@ use nimiq_database::volatile::VolatileDatabase;
 use nimiq_network_interface::{network::Network as NetworkInterface, request::Handle};
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::{networks::NetworkId, trie::TrieItem};
-use nimiq_utils::time::OffsetTime;
+use nimiq_utils::{time::OffsetTime, WakerExt as _};
 use parking_lot::RwLock;
 
 use crate::test_network::TestNetwork;
@@ -54,9 +54,7 @@ impl<N: NetworkInterface + TestNetwork, Req: Handle<N, T>, T: Send + Sync + Unpi
         self.paused = true;
     }
     pub fn unpause(&mut self) {
-        if let Some(waker) = self.pause_waker.take() {
-            waker.wake();
-        }
+        self.pause_waker.wake();
         self.paused = false;
     }
     pub fn set(&mut self, request_handler: fn(N::PeerId, &Req, &T) -> Req::Response) {

--- a/utils/src/waker.rs
+++ b/utils/src/waker.rs
@@ -2,6 +2,7 @@ use std::task::{Context, Waker};
 
 pub trait WakerExt {
     fn store_waker(&mut self, context: &Context);
+    fn wake(&mut self);
 }
 
 impl WakerExt for Option<Waker> {
@@ -10,6 +11,11 @@ impl WakerExt for Option<Waker> {
         match self {
             Some(stored) => stored.clone_from(waker),
             None => *self = Some(waker.clone()),
+        }
+    }
+    fn wake(&mut self) {
+        if let Some(waker) = self.take() {
+            waker.wake();
         }
     }
 }

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -452,9 +452,7 @@ where
             }
 
             // A new proposal was admitted into the buffer. Potential waiting tasks can be woken.
-            if let Some(waker) = shared.waker.take() {
-                waker.wake()
-            }
+            shared.waker.wake();
         } else {
             // The signature verification did not succeed.
 
@@ -486,9 +484,7 @@ where
 
             // Wake, as a new future was added and needs to be polled.
             // A new proposal was admitted into the buffer. Potential waiting tasks can be woken.
-            if let Some(waker) = shared.waker.take() {
-                waker.wake()
-            }
+            shared.waker.wake();
         }
     }
 }

--- a/zkp-component/src/zkp_requests.rs
+++ b/zkp-component/src/zkp_requests.rs
@@ -112,9 +112,7 @@ impl<N: Network + 'static> ZKPRequests<N> {
         );
         // Pushing to the futures unordered above does not wake the task that polls zkp_requests_results
         // So we need to wake the task manually
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
+        self.waker.wake();
     }
 }
 


### PR DESCRIPTION
Add `WakerExt::wake` to conveniently call `wake` on `Option<Waker>`. Remove self-wake from `read_to_buf`.