### PR TITLE
HistoryStore: fix `get_nonfinal_epoch_transactions()` returning incorrect results for batch 0

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -187,7 +187,7 @@ impl Blockchain {
         // We might already know the given epoch partially.
         // Revert our chain to a common ancestor state in case we have adopted a different history.
         // Also skip over any transactions that we already know.
-        let first_new_hist_tx = this.revert_to_common_state(&block, history, &mut txn);
+        let first_new_hist_tx = this.revert_to_common_state(history, &mut txn);
 
         // Separate the historic transactions by block number and type.
         // We know it comes sorted because we already checked it against the history root and
@@ -468,7 +468,6 @@ impl Blockchain {
 
     fn revert_to_common_state(
         &self,
-        block: &Block,
         history: &[HistoricTransaction],
         txn: &mut WriteTransactionProxy,
     ) -> usize {
@@ -483,7 +482,7 @@ impl Blockchain {
         // Revert any blocks that don't match.
         let known_history = self
             .history_store
-            .get_nonfinal_epoch_transactions(block.epoch_number(), Some(txn));
+            .get_epoch_transactions_after(last_macro_block, Some(txn));
         if !known_history.is_empty() {
             // Iterate over the known history and the given history in parallel to find the block
             // where the histories diverge (if they do).

--- a/blockchain/src/history/history_store_index.rs
+++ b/blockchain/src/history/history_store_index.rs
@@ -382,31 +382,22 @@ impl HistoryInterface for HistoryStoreIndex {
             .num_epoch_transactions(epoch_number, txn_option)
     }
 
-    fn get_final_epoch_transactions(
+    fn num_epoch_transactions_before(
         &self,
-        epoch_number: u32,
-        txn_option: Option<&TransactionProxy>,
-    ) -> Vec<HistoricTransaction> {
-        self.history_store
-            .get_final_epoch_transactions(epoch_number, txn_option)
-    }
-
-    fn get_number_final_epoch_transactions(
-        &self,
-        epoch_number: u32,
+        block_number: u32,
         txn_option: Option<&TransactionProxy>,
     ) -> usize {
         self.history_store
-            .get_number_final_epoch_transactions(epoch_number, txn_option)
+            .num_epoch_transactions_before(block_number, txn_option)
     }
 
-    fn get_nonfinal_epoch_transactions(
+    fn get_epoch_transactions_after(
         &self,
-        epoch_number: u32,
+        block_number: u32,
         txn_option: Option<&TransactionProxy>,
     ) -> Vec<HistoricTransaction> {
         self.history_store
-            .get_nonfinal_epoch_transactions(epoch_number, txn_option)
+            .get_epoch_transactions_after(block_number, txn_option)
     }
 
     fn prove_chunk(

--- a/blockchain/src/history/history_store_proxy.rs
+++ b/blockchain/src/history/history_store_proxy.rs
@@ -232,52 +232,36 @@ impl HistoryInterface for HistoryStoreProxy {
         }
     }
 
-    /// Gets all finalized historic transactions for a given epoch.
-    fn get_final_epoch_transactions(
+    /// Returns the number of historic transactions within the given block's epoch that occurred
+    /// before the given block (inclusive).
+    fn num_epoch_transactions_before(
         &self,
-        epoch_number: u32,
-        txn_option: Option<&TransactionProxy>,
-    ) -> Vec<HistoricTransaction> {
-        match self {
-            HistoryStoreProxy::WithIndex(index) => {
-                index.get_final_epoch_transactions(epoch_number, txn_option)
-            }
-            HistoryStoreProxy::WithoutIndex(store) => {
-                store.get_final_epoch_transactions(epoch_number, txn_option)
-            }
-        }
-    }
-
-    /// Gets the number of all finalized historic transactions for a given epoch.
-    /// This is basically an optimization of calling `get_final_epoch_transactions(..).len()`
-    /// since the latter is very expensive
-    fn get_number_final_epoch_transactions(
-        &self,
-        epoch_number: u32,
+        block_number: u32,
         txn_option: Option<&TransactionProxy>,
     ) -> usize {
         match self {
             HistoryStoreProxy::WithIndex(index) => {
-                index.get_number_final_epoch_transactions(epoch_number, txn_option)
+                index.num_epoch_transactions_before(block_number, txn_option)
             }
             HistoryStoreProxy::WithoutIndex(store) => {
-                store.get_number_final_epoch_transactions(epoch_number, txn_option)
+                store.num_epoch_transactions_before(block_number, txn_option)
             }
         }
     }
 
-    /// Gets all non-finalized historic transactions for a given epoch.
-    fn get_nonfinal_epoch_transactions(
+    /// Returns all historic transactions within the given block's epoch that occurred after the
+    /// given block (exclusive).
+    fn get_epoch_transactions_after(
         &self,
-        epoch_number: u32,
+        block_number: u32,
         txn_option: Option<&TransactionProxy>,
     ) -> Vec<HistoricTransaction> {
         match self {
             HistoryStoreProxy::WithIndex(index) => {
-                index.get_nonfinal_epoch_transactions(epoch_number, txn_option)
+                index.get_epoch_transactions_after(block_number, txn_option)
             }
             HistoryStoreProxy::WithoutIndex(store) => {
-                store.get_nonfinal_epoch_transactions(epoch_number, txn_option)
+                store.get_epoch_transactions_after(block_number, txn_option)
             }
         }
     }

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -108,26 +108,19 @@ pub trait HistoryInterface {
         txn_option: Option<&TransactionProxy>,
     ) -> usize;
 
-    /// Gets all finalized historic transactions for a given epoch.
-    fn get_final_epoch_transactions(
+    /// Returns the number of historic transactions within the given block's epoch that occurred
+    /// before the given block (inclusive).
+    fn num_epoch_transactions_before(
         &self,
-        epoch_number: u32,
-        txn_option: Option<&TransactionProxy>,
-    ) -> Vec<HistoricTransaction>;
-
-    /// Gets the number of all finalized historic transactions for a given epoch.
-    /// This is basically an optimization of calling `get_final_epoch_transactions(..).len()`
-    /// since the latter is very expensive
-    fn get_number_final_epoch_transactions(
-        &self,
-        epoch_number: u32,
+        block_number: u32,
         txn_option: Option<&TransactionProxy>,
     ) -> usize;
 
-    /// Gets all non-finalized historic transactions for a given epoch.
-    fn get_nonfinal_epoch_transactions(
+    /// Returns all historic transactions within the given block's epoch that occurred after the
+    /// given block (exclusive).
+    fn get_epoch_transactions_after(
         &self,
-        epoch_number: u32,
+        block_number: u32,
         txn_option: Option<&TransactionProxy>,
     ) -> Vec<HistoricTransaction>;
 

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -365,9 +365,10 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
 
         let current_epoch_number = blockchain.epoch_number();
         let num_known_txs = if epoch_number == current_epoch_number {
+            let last_macro_block = Policy::last_macro_block(current_block_number);
             blockchain
                 .history_store
-                .get_number_final_epoch_transactions(epoch_number, None) as u64
+                .num_epoch_transactions_before(last_macro_block, None) as u64
         } else {
             0
         };


### PR DESCRIPTION
Refactor related functions and remove dead/duplicate code.

Closes #2740
