### PR TITLE
keys: Fix feature compilation for the `serde-derive` feature

### DIFF
--- a/keys/src/lib.rs
+++ b/keys/src/lib.rs
@@ -1,6 +1,5 @@
-use nimiq_serde::SerializedMaxSize;
 #[cfg(feature = "serde-derive")]
-use nimiq_serde::{Deserialize, Serialize};
+use nimiq_serde::{Deserialize, Serialize, SerializedMaxSize};
 pub use nimiq_utils::key_rng::{SecureGenerate, SecureRng};
 
 pub use self::{


### PR DESCRIPTION
Fix feature compilation when the `serde-derive` feature is not enabled for the `keys` subcrate.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
