### PR TITLE
primitives: Improve `KeyNibbles` serialization

### DIFF
--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -363,6 +363,7 @@ mod serde_derive {
         de::{Deserialize, Deserializer, Error, SeqAccess, Unexpected, Visitor},
         ser::{Serialize, SerializeStruct, Serializer},
     };
+    use serde_bytes::ByteBuf;
 
     use super::KeyNibbles;
 
@@ -387,7 +388,7 @@ mod serde_derive {
                 return Err(A::Error::invalid_length(length as usize, &self)); // length too high
             }
             let bytes_length = (length as usize + 1) / 2;
-            let bytes: Vec<u8> = seq
+            let bytes: ByteBuf = seq
                 .next_element()?
                 .ok_or_else(|| A::Error::invalid_length(1, &self))?;
             if bytes.len() > bytes_length {
@@ -395,7 +396,7 @@ mod serde_derive {
             }
             if length % 2 == 1 && bytes[bytes_length - 1] & 0x0f != 0 {
                 return Err(A::Error::invalid_value(
-                    Unexpected::Other("Unused nubble not zeroed"),
+                    Unexpected::Other("Unused nibble not zeroed"),
                     &self,
                 ));
             }
@@ -415,7 +416,7 @@ mod serde_derive {
         {
             let mut state = serializer.serialize_struct("KeyNibbles", FIELDS.len())?;
             state.serialize_field(FIELDS[0], &self.length)?;
-            state.serialize_field(FIELDS[1], &self.bytes[..self.bytes_len()])?;
+            state.serialize_field(FIELDS[1], &ByteBuf::from(&self.bytes[..self.bytes_len()]))?;
             state.end()
         }
     }

--- a/primitives/src/trie/trie_node.rs
+++ b/primitives/src/trie/trie_node.rs
@@ -396,6 +396,7 @@ mod serde_derive {
         de::{Deserialize, Deserializer, Error, SeqAccess, Unexpected, Visitor},
         ser::{Serialize, SerializeStruct, Serializer},
     };
+    use serde_bytes::ByteBuf;
 
     use super::{KeyNibbles, RootData, TrieNode, TrieNodeChild};
 
@@ -428,8 +429,9 @@ mod serde_derive {
                 )); // Mismatch flags for root data
             }
             let value: Option<Vec<u8>> = seq
-                .next_element()?
-                .ok_or_else(|| A::Error::invalid_length(2, &self))?;
+                .next_element::<Option<ByteBuf>>()?
+                .ok_or_else(|| A::Error::invalid_length(2, &self))?
+                .map(|v| v.into_vec());
             if has_value != value.is_some() {
                 return Err(A::Error::invalid_value(
                     Unexpected::Other("Flags mismatch for value"),
@@ -478,10 +480,7 @@ mod serde_derive {
             let mut state = serializer.serialize_struct("TrieNode", FIELDS.len())?;
             state.serialize_field(FIELDS[0], &flags)?;
             state.serialize_field(FIELDS[1], &self.root_data)?;
-            state.serialize_field(
-                FIELDS[2],
-                &self.value.as_ref().map(|v| serde_bytes::Bytes::new(v)),
-            )?;
+            state.serialize_field(FIELDS[2], &self.value.as_deref().map(ByteBuf::from))?;
             state.serialize_field(FIELDS[3], &child_count)?;
             state.serialize_field(FIELDS[4], &self.children)?;
             state.end()


### PR DESCRIPTION
- Improve `KeyNibbles` serialization performance by using`serde_byte`s `ByteBuf`.
- Commit e983d05 introduced a `TrieNode` serialization performance improvement by using `serde_byte`'s `Bytes` but forgot to also use it for deserizalization. But the problem is that we're deserializing into a `Vec<u8>` and we can't use `Bytes` since the size is unknown. So this commit changes (de)serialization to use `ByteBuf` instead.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
