### PR TITLE
Dynamic validator block producer timeout

### DIFF
--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -36,7 +36,7 @@ jobs:
         - test: Validators90sDownFullNodes
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_3.toml -dt 90 -R
         - test: LowBlockProducerTimeout
-          pre: "sed -i 's/BLOCK_PRODUCER_TIMEOUT: u64 = 4 * 1000;/BLOCK_PRODUCER_TIMEOUT: u64 = 2 * 1000;/g' primitives/src/policy.rs"
+          pre: "sed -i 's/MINIMUM_PRODUCER_TIMEOUT: u64 = 4 * 1000;/MINIMUM_PRODUCER_TIMEOUT: u64 = 2 * 1000;/g' primitives/src/policy.rs"
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_2.toml -k 0 -R
         - test: FiveValidatorsWithSpammer
           devnet_args: -t .github/devnet_topologies/five_validators_multi_spammer.toml -R -k 0

--- a/.github/workflows/devnet_release.yml
+++ b/.github/workflows/devnet_release.yml
@@ -36,7 +36,7 @@ jobs:
         - test: Validators90sDownFullNodes
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_3.toml -dt 90 -R
         - test: LowBlockProducerTimeout
-          pre: "sed -i 's/MINIMUM_PRODUCER_TIMEOUT: u64 = 4 * 1000;/MINIMUM_PRODUCER_TIMEOUT: u64 = 2 * 1000;/g' primitives/src/policy.rs"
+          pre: "sed -i 's/MIN_PRODUCER_TIMEOUT: u64 = 4 * 1000;/MIN_PRODUCER_TIMEOUT: u64 = 2 * 1000;/g' primitives/src/policy.rs"
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_2.toml -k 0 -R
         - test: FiveValidatorsWithSpammer
           devnet_args: -t .github/devnet_topologies/five_validators_multi_spammer.toml -R -k 0

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -38,8 +38,8 @@ jobs:
         - test: Validators90sDown
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -dt 90 -ut 100
         - test: LowBlockProducerTimeout
-          pre: "grep 'MINIMUM_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;' primitives/src/policy.rs &&
-                sed -i 's/MINIMUM_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;/MINIMUM_PRODUCER_TIMEOUT: u64 = 1000;/g' primitives/src/policy.rs"
+          pre: "grep 'MIN_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;' primitives/src/policy.rs &&
+                sed -i 's/MIN_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;/MIN_PRODUCER_TIMEOUT: u64 = 1000;/g' primitives/src/policy.rs"
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -k 0 -ut 100
 
     runs-on: ubuntu-22.04

--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -38,8 +38,8 @@ jobs:
         - test: Validators90sDown
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -dt 90 -ut 100
         - test: LowBlockProducerTimeout
-          pre: "grep 'BLOCK_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;' primitives/src/policy.rs &&
-                sed -i 's/BLOCK_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;/BLOCK_PRODUCER_TIMEOUT: u64 = 1000;/g' primitives/src/policy.rs"
+          pre: "grep 'MINIMUM_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;' primitives/src/policy.rs &&
+                sed -i 's/MINIMUM_PRODUCER_TIMEOUT: u64 = 4 \\* 1000;/MINIMUM_PRODUCER_TIMEOUT: u64 = 1000;/g' primitives/src/policy.rs"
           devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -k 0 -ut 100
 
     runs-on: ubuntu-22.04

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -492,7 +492,7 @@ impl Block {
         // Handle skip blocks.
         if self.is_skip() {
             // Check that skip block has the expected timestamp.
-            let expected_timestamp = predecessor.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT;
+            let expected_timestamp = predecessor.timestamp() + Policy::MIN_PRODUCER_TIMEOUT;
             if self.timestamp() != expected_timestamp {
                 debug!(
                     block = %self,

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -492,7 +492,7 @@ impl Block {
         // Handle skip blocks.
         if self.is_skip() {
             // Check that skip block has the expected timestamp.
-            let expected_timestamp = predecessor.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT;
+            let expected_timestamp = predecessor.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT;
             if self.timestamp() != expected_timestamp {
                 debug!(
                     block = %self,

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -87,8 +87,8 @@ impl Policy {
     /// ceiling division.
     pub const F_PLUS_ONE: u16 = (Self::SLOTS + 3 - 1) / 3;
 
-    /// The timeout in milliseconds for a validator to produce a block (4s)
-    pub const BLOCK_PRODUCER_TIMEOUT: u64 = 4 * 1000;
+    /// The minimum timeout in milliseconds for a validator to produce a block (4s)
+    pub const MINIMUM_PRODUCER_TIMEOUT: u64 = 4 * 1000;
 
     /// The optimal time in milliseconds between blocks (1s)
     pub const BLOCK_SEPARATION_TIME: u64 = 1000;
@@ -576,10 +576,10 @@ impl Policy {
         Self::F_PLUS_ONE
     }
 
-    /// The timeout in milliseconds for a validator to produce a block (2s)
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = BLOCK_PRODUCER_TIMEOUT))]
-    pub fn wasm_block_producer_timeout() -> u64 {
-        Self::BLOCK_PRODUCER_TIMEOUT
+    /// The minimum timeout in milliseconds for a validator to produce a block (4s)
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = MINIMUM_PRODUCER_TIMEOUT))]
+    pub fn wasm_minimum_block_producer_timeout() -> u64 {
+        Self::MINIMUM_PRODUCER_TIMEOUT
     }
 
     /// The optimal time in milliseconds between blocks (1s)

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -88,7 +88,7 @@ impl Policy {
     pub const F_PLUS_ONE: u16 = (Self::SLOTS + 3 - 1) / 3;
 
     /// The minimum timeout in milliseconds for a validator to produce a block (4s)
-    pub const MINIMUM_PRODUCER_TIMEOUT: u64 = 4 * 1000;
+    pub const MIN_PRODUCER_TIMEOUT: u64 = 4 * 1000;
 
     /// The optimal time in milliseconds between blocks (1s)
     pub const BLOCK_SEPARATION_TIME: u64 = 1000;
@@ -347,6 +347,7 @@ impl Policy {
     }
 
     /// Returns the block number (height) of the next macro block after a given block number (height).
+    /// If the given block number is a macro block, it returns the macro block after it.
     #[inline]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = macroBlockAfter))]
     pub fn macro_block_after(block_number: u32) -> u32 {
@@ -577,9 +578,9 @@ impl Policy {
     }
 
     /// The minimum timeout in milliseconds for a validator to produce a block (4s)
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = MINIMUM_PRODUCER_TIMEOUT))]
-    pub fn wasm_minimum_block_producer_timeout() -> u64 {
-        Self::MINIMUM_PRODUCER_TIMEOUT
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(getter = MIN_PRODUCER_TIMEOUT))]
+    pub fn wasm_min_block_producer_timeout() -> u64 {
+        Self::MIN_PRODUCER_TIMEOUT
     }
 
     /// The optimal time in milliseconds between blocks (1s)

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -194,7 +194,7 @@ impl TemporaryBlockProducer {
                 self.producer
                     .next_micro_block(
                         &blockchain,
-                        blockchain.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT,
+                        blockchain.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT,
                         vec![],
                         vec![],
                         extra_data,

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -194,7 +194,7 @@ impl TemporaryBlockProducer {
                 self.producer
                     .next_micro_block(
                         &blockchain,
-                        blockchain.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT,
+                        blockchain.timestamp() + Policy::MIN_PRODUCER_TIMEOUT,
                         vec![],
                         vec![],
                         extra_data,

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -198,7 +198,7 @@ pub fn next_skip_block(
     let timestamp = if config.timestamp_offset != 0 {
         (blockchain.timestamp() as i64 + config.timestamp_offset) as u64
     } else {
-        blockchain.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT
+        blockchain.timestamp() + Policy::MIN_PRODUCER_TIMEOUT
     };
 
     let parent_hash = config

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -198,7 +198,7 @@ pub fn next_skip_block(
     let timestamp = if config.timestamp_offset != 0 {
         (blockchain.timestamp() as i64 + config.timestamp_offset) as u64
     } else {
-        blockchain.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT
+        blockchain.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT
     };
 
     let parent_hash = config

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -253,7 +253,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             if !in_current_state(head) {
                 None
             } else {
-                let timestamp = head.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT;
+                let timestamp = head.timestamp() + Policy::MIN_PRODUCER_TIMEOUT;
 
                 let skip_block = self.block_producer.next_micro_block(
                     &blockchain,


### PR DESCRIPTION
## What's in this pull request?
Introduce a dynamic micro block producer timeout based on the average block time of the node's head and its 30 immediate predecessor blocks.

Parameters:
Timeout: 4 x the average block time
Timeout lower bound: `Policy::MINIMUM_PRODUCER_TIMEOUT` (4000 ms)
Timeout upper bound: `Validator::MAXIMUM_PRODUCER_TIMEOUT` (30_000 ms)
Final, canonical skip block timestamp: `head.timestamp() + Policy::MINIMUM_PRODUCER_TIMEOUT`

#### This fixes #2664 

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
