### PR TITLE
Specify crate versions in a single place

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ rust.unused_qualifications = "warn"
 futures = { package = "futures-util", version = "0.3.30" }
 log = { package = "tracing", version = "0.1.40", features = ["log"] }
 
+nimiq = { path = "lib", package = "nimiq-lib", default-features = false }
 nimiq-account = { path = "primitives/account", default-features = false }
 nimiq-block = { path = "primitives/block", default-features = false }
 nimiq-blockchain = { path = "blockchain", default-features = false }
@@ -196,7 +197,6 @@ nimiq-jsonrpc-derive = { git = "https://github.com/nimiq/jsonrpc.git", default-f
 nimiq-jsonrpc-server = { git = "https://github.com/nimiq/jsonrpc.git", default-features = false }
 nimiq-key-derivation = { path = "key-derivation", default-features = false }
 nimiq-keys = { path = "keys", default-features = false }
-nimiq-lib = { path = "lib", default-features = false }
 nimiq-light-blockchain = { path = "light-blockchain", default-features = false }
 nimiq-log = { path = "log", default-features = false }
 nimiq-macros = { path = "macros", default-features = false }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,9 +27,7 @@ tokio = { version = "1.38", features = ["macros", "rt-multi-thread", "time", "tr
 tokio-metrics = "0.3"
 
 [dependencies.nimiq]
-package = "nimiq-lib"
-path = "../lib"
-version = "0.23.0"
+workspace = true
 features = [
     "database-storage",
     "deadlock",

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -31,7 +31,7 @@ nimiq-database = { workspace = true }
 nimiq-genesis-builder = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }
-nimiq-lib = { workspace = true, features = [
+nimiq = { workspace = true, features = [
     "database-storage",
     "deadlock",
     "full-consensus",

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -3,8 +3,8 @@ use std::{fs, process::exit, time::Duration};
 use clap::{Parser, Subcommand};
 use convert_case::{Case, Casing};
 use log::{info, level_filters::LevelFilter};
+use nimiq::config::{config::ClientConfig, config_file::ConfigFile};
 use nimiq_keys::Address;
-use nimiq_lib::config::{config::ClientConfig, config_file::ConfigFile};
 use nimiq_pow_migration::{
     exit_with_error,
     genesis::write_pos_genesis,

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -40,7 +40,5 @@ nimiq-transaction = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
 
 [dependencies.nimiq]
-package = "nimiq-lib"
-path = "../lib"
-version = "0.23.0"
+workspace = true
 features = [ "database-storage", "deadlock", "full-consensus", "logging", "metrics-server", "panic", "rpc-server", "signal-handling", "tokio-websocket", "validator", "wallet"]

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -52,10 +52,7 @@ nimiq-transaction-builder = { workspace = true }
 nimiq-utils = { workspace = true, features = ["merkle"] }
 
 [dependencies.nimiq]
-package = "nimiq-lib"
-path = "../lib"
-version = "0.23.0"
-default-features = false
+workspace = true
 features = [
     "panic",
     "web-logging",


### PR DESCRIPTION
Change some of the `Cargo.toml` files that depend on `nimiq-lib` to use the workspace definitions.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
