### PR TITLE
Add block stream log in case we don't push a block

### DIFF
--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -899,6 +899,8 @@ impl<N: Network> Stream for BlockQueue<N> {
                         if let Some(block) = self.check_announced_block(block, peer_id, pubsub_id) {
                             return Poll::Ready(Some(block));
                         }
+                    } else {
+                        log::warn!(%block, %peer_id, "Rejecting block as it doesn't come from a synced peer");
                     }
                 }
                 // If the block_stream is exhausted, we quit as well.


### PR DESCRIPTION
Add log message in the case where we don't push a block into the blockchain.