### PR TITLE
Poll again after adding new block stream

### DIFF
--- a/consensus/src/sync/live/block_queue/live_sync.rs
+++ b/consensus/src/sync/live/block_queue/live_sync.rs
@@ -15,6 +15,7 @@ use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::Network;
+use nimiq_utils::WakerExt;
 use parking_lot::Mutex;
 
 use super::QueuedBlock;
@@ -175,6 +176,7 @@ impl<N: Network> LiveSyncQueue<N> for BlockQueue<N> {
         // We need to safely remove the old block stream first.
         let prev_block_stream = mem::replace(&mut self.block_stream, empty().boxed());
         self.block_stream = select(prev_block_stream, block_stream).boxed();
+        self.waker.wake();
     }
 
     fn include_micro_bodies(&self) -> bool {


### PR DESCRIPTION
## What's in this pull request?
With the PR #2702 the `BlockQueue` was moved into its own task so that it can be polled independently from the `Consensus`. This turned out to reveal a race against the `LiveSyncQueue` when adding a second stream to the `BlockQueue::block_stream`. This second stream is for example used when we want to push blocks received from `HeadRequests` into the `BlockQueue`. However since the `BlockQueue` now only is polled before the second stream got added, the second stream didn't get a chance to store a waker.

Before, when the BlockQueue was still part of the Consensus task, the BlockQueue would getting polled when the Consensus gets polled.

This PR fixes this by waking up the `BlockQueue` stream after a new stream to the `BlockQueue::block_stream` has been added.

#### This fixes #2745.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
