### PR TITLE
Various Clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ clippy.empty_docs = "allow" # false positives: https://github.com/rust-lang/rust
 clippy.large_enum_variant = "allow"
 clippy.too_many_arguments = "allow"
 clippy.type_complexity = "allow"
+rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 rust.unused_qualifications = "warn"
 
 [workspace.dependencies]

--- a/bls/src/types/compressed_signature.rs
+++ b/bls/src/types/compressed_signature.rs
@@ -93,7 +93,7 @@ impl fmt::Display for CompressedSignature {
 impl From<G1Projective> for CompressedSignature {
     fn from(signature: G1Projective) -> Self {
         let mut buffer = [0u8; SIZE];
-        CanonicalSerialize::serialize_compressed(&signature.into_affine(), &mut &mut buffer[..])
+        CanonicalSerialize::serialize_compressed(&signature.into_affine(), &mut buffer[..])
             .unwrap();
         CompressedSignature { signature: buffer }
     }

--- a/bls/src/types/public_key.rs
+++ b/bls/src/types/public_key.rs
@@ -60,11 +60,8 @@ impl PublicKey {
     /// and one bit indicating if it is the "point-at-infinity".
     pub fn compress(&self) -> CompressedPublicKey {
         let mut buffer = [0u8; CompressedPublicKey::SIZE];
-        CanonicalSerialize::serialize_compressed(
-            &self.public_key.into_affine(),
-            &mut &mut buffer[..],
-        )
-        .unwrap();
+        CanonicalSerialize::serialize_compressed(&self.public_key.into_affine(), &mut buffer[..])
+            .unwrap();
         CompressedPublicKey { public_key: buffer }
     }
 

--- a/consensus/src/consensus/remote_data_store.rs
+++ b/consensus/src/consensus/remote_data_store.rs
@@ -24,6 +24,7 @@ use crate::messages::RequestTrieProof;
 /// - Validators
 /// - Stakers
 /// - Tombstones
+///
 /// It also serves as an utility function to extract any type from the Accounts Trie
 /// remotely.
 pub(crate) struct RemoteDataStore<N: Network> {

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -133,6 +133,7 @@ const PENDING_SIZE: usize = 5;
 ///   1. Request the latest ZKP from a peer
 ///   2. Request epoch IDs from the peer
 ///   3. Request the last (if any) election or checkpoint blocks
+///
 /// If during the process, a peer is deemed as outdated, then it is emitted
 pub struct LightMacroSync<TNetwork: Network> {
     /// The blockchain

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -111,6 +111,7 @@ pub enum LiveSyncPeerEvent<TPeerId> {
 /// - Macro sync: Synchronizes up to the last macro block
 /// - Live Sync: Synchronizes the blockchain to the blocks being processed/announced
 ///   by the peers.
+///
 /// These two dynamic trait objects are necessary to implement the different types of
 /// synchronization such as: history sync, full sync and light sync.
 /// The Syncer handles the interactions between these trait objects, the blockchain and

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -27,7 +27,6 @@ console-subscriber = { version = "0.4", features = [
 derive_builder = "0.20"
 directories = "5.0"
 hex = "0.4"
-# human-panic = { version = "1.0", optional = true } currently unused, might be used in the future
 log = { workspace = true }
 log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
 parking_lot = "0.12"

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -228,6 +228,7 @@ impl Handler {
     /// Checks if the handler is ready to start the discovery protocol.
     /// This basically checks that:
     /// - Both inbound and outbound are available
+    ///
     /// If these conditions are met, it transitions to sending a handshake and waking
     /// the waker.
     fn check_initialized(&mut self) {

--- a/network-libp2p/src/dispatch/codecs/mod.rs
+++ b/network-libp2p/src/dispatch/codecs/mod.rs
@@ -13,6 +13,7 @@ use libp2p::{request_response, StreamProtocol};
 use nimiq_network_interface::network;
 
 /// Size of a u64
+#[allow(unused_qualifications)] // Remove with a MSVR >= 1.80
 const U64_LENGTH: usize = mem::size_of::<u64>();
 const MAX_REQUEST_SIZE: u64 = network::MIN_SUPPORTED_REQ_SIZE as u64 + U64_LENGTH as u64;
 const MAX_RESPONSE_SIZE: u64 = network::MIN_SUPPORTED_RESP_SIZE as u64 + U64_LENGTH as u64;

--- a/pow-migration/tests/mod.rs
+++ b/pow-migration/tests/mod.rs
@@ -4,7 +4,7 @@
 //! setup code.
 #[cfg(feature = "pow-migration-tests")]
 mod pow_migration_test {
-    use nimiq_database::mdbx::{DatabaseConfig, MdbxDatabase};
+    use nimiq_database::mdbx::MdbxDatabase;
     use nimiq_genesis_builder::config::GenesisConfig;
     use nimiq_keys::Address;
     use nimiq_pow_migration::{migrate, BlockWindows, Error};

--- a/primitives/src/slots_allocation.rs
+++ b/primitives/src/slots_allocation.rs
@@ -232,7 +232,7 @@ impl Hash for Validators {
         let bytes: Vec<u8> = iter
             .flat_map(|pk| {
                 let mut buffer = [0u8; 285];
-                CanonicalSerialize::serialize_compressed(&pk.into_affine(), &mut &mut buffer[..])
+                CanonicalSerialize::serialize_compressed(&pk.into_affine(), &mut buffer[..])
                     .unwrap();
                 buffer.to_vec()
             })

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -7,7 +7,8 @@ use nimiq_serde::{Deserialize, DeserializeError, Serialize, SerializedMaxSize};
 use crate::{SignatureProof, Transaction, TransactionError};
 
 /// We need to distinguish two types of transactions:
-/// 1. Incoming transactions, which include:
+/// 1. Incoming transactions. The type of transaction, parameters and proof are given in the `data` field of this transaction.
+///    Supported incoming transactions are:
 ///     - Validator
 ///         * Create
 ///         * Update
@@ -18,13 +19,13 @@ use crate::{SignatureProof, Transaction, TransactionError};
 ///         * Create
 ///         * Update
 ///         * AddStake
-///     The type of transaction, parameters and proof are given in the data field of the transaction.
-/// 2. Outgoing transactions, which include:
+///
+/// 2. Outgoing transactions. The type of transaction, parameters and proof are given in the `proof` field of this transaction.
+///    Supported outgoing transactions are:
 ///     - Validator
 ///         * Delete
 ///     - Staker
 ///         * RemoveStake
-///     The type of transaction, parameters and proof are given in the proof field of the transaction.
 ///
 /// It is important to note that all `signature` fields contain the signature
 /// over the complete transaction with the `signature` field set to `Default::default()`.

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -1656,7 +1656,7 @@ mod tests {
         let key_3 = "413b397fa".parse().unwrap();
         let key_4 = "cfb986f5a".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -1720,7 +1720,7 @@ mod tests {
         let key_3 = "cfb98e0f6".parse().unwrap();
         let key_4 = "cfb98e0f5".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -1780,7 +1780,7 @@ mod tests {
         let key_6 = "ca".parse().unwrap();
         let key_7 = "b".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -1883,7 +1883,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -1953,7 +1953,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new(&env, TestTrie);
 
         let mut raw_txn = env.write_transaction();
@@ -2060,7 +2060,7 @@ mod tests {
         let key_6 = "413f227fb".parse().unwrap();
         let key_7 = "413f227fa0".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -2097,7 +2097,7 @@ mod tests {
             .put_child(&proof_value_2.key, proof_value_2.hash_assert())
             .unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let trie = MerkleRadixTrie::new_incomplete(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -2174,7 +2174,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5: KeyNibbles = "412324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
         let mut raw_txn = env.write_transaction();
         let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
@@ -2199,7 +2199,7 @@ mod tests {
 
     #[test]
     fn complete_tree_does_not_accept_chunks() {
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
         let trie = MerkleRadixTrie::new(&env, TestTrieCopy);
         let mut raw_txn = env.write_transaction();
@@ -2222,7 +2222,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
         let trie = MerkleRadixTrie::new_incomplete(&env, TestTrieCopy);
         let mut raw_txn = env.write_transaction();
@@ -2290,7 +2290,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
 
         let original = MerkleRadixTrie::new(&env, TestTrie);
         let copy = MerkleRadixTrie::new_incomplete(&env, TestTrieCopy);
@@ -2342,7 +2342,7 @@ mod tests {
         let key_4 = "1c".parse().unwrap();
         let key_5 = "81".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
         let copy = MerkleRadixTrie::new_incomplete(&env, TestTrieCopy);
         let mut raw_txn = env.write_transaction();
@@ -2394,7 +2394,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5 = "412324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
 
         let init_trie = |env: &MdbxDatabase| -> MerkleRadixTrie<TestTrieCopy> {
@@ -2485,7 +2485,7 @@ mod tests {
         let key_3 = "413f227fa".parse().unwrap();
         let key_4 = "413b391".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
 
         let mut raw_txn = env.write_transaction();
@@ -2529,7 +2529,7 @@ mod tests {
         let key_3 = "413f227fa".parse().unwrap();
         let key_4 = "413b391".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
 
         let mut raw_txn = env.write_transaction();
@@ -2564,7 +2564,7 @@ mod tests {
     fn remove_chunk_on_empty_tree() {
         let key_1 = "413f22".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
 
         let mut raw_txn = env.write_transaction();
@@ -2582,7 +2582,7 @@ mod tests {
         let key_4 = "413b391".parse().unwrap();
         let key_5: KeyNibbles = "415324".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
 
         let mut raw_txn = env.write_transaction();
@@ -2618,7 +2618,7 @@ mod tests {
         let key_3 = "413f227fa".parse().unwrap();
         let key_4 = "413b391".parse().unwrap();
 
-        let env = nimiq_database::mdbx::MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let original = MerkleRadixTrie::new(&env, TestTrie);
 
         let mut raw_txn = env.write_transaction();

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -102,6 +102,7 @@ impl<T: SerializedSize> SerializedMaxSize for T {
 }
 
 #[rustfmt::skip]
+#[allow(unused_qualifications)] // Remove with a MSVR >= 1.80
 mod integer_impls {
     use super::SerializedFixedSize;
     use super::SerializedMaxSize;

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -304,7 +304,7 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
     ///
     /// Failing to verify:
     /// * As failing to verify could indicate a malicious validator we might want to introduce punishment here. One
-    /// option to do so is, similar to how we return proposals on the stream, to introduce another `Return` enum variant for that.
+    ///   option to do so is, similar to how we return proposals on the stream, to introduce another `Return` enum variant for that.
     /// * Potentially make a difference between incorrect signatures and incorrect proposals when it comes to punishment.
     fn process_proposal(
         &mut self,
@@ -407,9 +407,9 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
     ///
     /// Returns
     /// * `None` if all messages were successfully dispatched while `level_update_stream` was polled
-    /// until it returned Poll::Pending.
+    ///   until it returned Poll::Pending.
     /// * `Some(tagged_message)` if any message exists for which the sender reports a full channel.
-    /// In this case the stream was not polled until it returned Pending.
+    ///   In this case the stream was not polled until it returned Pending.
     fn dispatch_messages(
         &mut self,
         cx: &mut Context<'_>,

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -223,7 +223,7 @@ where
     /// Checks one buffered proposal after another until a proposal which can be returned is found. Proposals which cannot be returned are either
     ///  * invalid and thus rejected/ignored
     ///  * have an unresolved predecessor and can thus not be verified. These proposals get removed from the buffer and a future to
-    /// resolve their predecessor is created.
+    ///    resolve their predecessor is created.
     pub fn poll_proposal(
         &mut self,
         blockchain_arc: Arc<RwLock<Blockchain>>,

--- a/zkp-primitives/pedersen-generators/src/rand_gen.rs
+++ b/zkp-primitives/pedersen-generators/src/rand_gen.rs
@@ -3,7 +3,7 @@
 //! This file serves two functions:
 //! 1) Hosting a tool that can be used to create a 256 bit random seed.
 //! 2) Documenting in a public way the process so that it can be verified that, in fact,
-//! the seed is random
+//!    the seed is random.
 //!
 //! ## Method
 //! The initial random bytes are going to be the concatenated hashes of 15 Bitcoin block headers

--- a/zkp-primitives/src/pedersen.rs
+++ b/zkp-primitives/src/pedersen.rs
@@ -32,7 +32,7 @@ impl DefaultPedersenParameters95 for MNT4_753 {
 
     fn g1_to_bytes(g1: &Self::G1) -> [u8; 95] {
         let mut buffer = [0u8; 95];
-        CanonicalSerialize::serialize_compressed(&g1.into_affine(), &mut &mut buffer[..]).unwrap();
+        CanonicalSerialize::serialize_compressed(&g1.into_affine(), &mut buffer[..]).unwrap();
         buffer
     }
 }
@@ -44,7 +44,7 @@ impl DefaultPedersenParameters95 for MNT6_753 {
 
     fn g1_to_bytes(g1: &Self::G1) -> [u8; 95] {
         let mut buffer = [0u8; 95];
-        CanonicalSerialize::serialize_compressed(&g1.into_affine(), &mut &mut buffer[..]).unwrap();
+        CanonicalSerialize::serialize_compressed(&g1.into_affine(), &mut buffer[..]).unwrap();
         buffer
     }
 }

--- a/zkp-primitives/src/serialize.rs
+++ b/zkp-primitives/src/serialize.rs
@@ -6,27 +6,27 @@ use ark_serialize::CanonicalSerialize;
 /// Serializes a G1 point in the MNT4-753 curve.
 pub fn serialize_g1_mnt4(point: &MNT4G1Projective) -> [u8; 95] {
     let mut buffer = [0u8; 95];
-    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut &mut buffer[..]).unwrap();
+    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut buffer[..]).unwrap();
     buffer
 }
 
 /// Serializes a G2 point in the MNT4-753 curve.
 pub fn serialize_g2_mnt4(point: &MNT4G2Projective) -> [u8; 190] {
     let mut buffer = [0u8; 190];
-    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut &mut buffer[..]).unwrap();
+    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut buffer[..]).unwrap();
     buffer
 }
 
 /// Serializes a G1 point in the MNT6-753 curve.
 pub fn serialize_g1_mnt6(point: &MNT6G1Projective) -> [u8; 95] {
     let mut buffer = [0u8; 95];
-    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut &mut buffer[..]).unwrap();
+    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut buffer[..]).unwrap();
     buffer
 }
 
 /// Serializes a G2 point in the MNT6-753 curve.
 pub fn serialize_g2_mnt6(point: &MNT6G2Projective) -> [u8; 285] {
     let mut buffer = [0u8; 285];
-    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut &mut buffer[..]).unwrap();
+    CanonicalSerialize::serialize_compressed(&point.into_affine(), &mut buffer[..]).unwrap();
     buffer
 }


### PR DESCRIPTION
Various Clippy fixes with Rust 1.80.

Noticeable changes causing most new Clippy warnings:
- Amongst some others, `size_of` is now part of the prelude https://github.com/rust-lang/rust/pull/123168
- `-Zcheck-cfg` is now enabled by default https://github.com/rust-lang/cargo/pull/13571/

The unexpected `cfg` condition value `parallel` will be addressed in a separate PR.