### PR TITLE
Level up state sync chunk log to INFO

### DIFF
--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -552,7 +552,7 @@ impl<N: Network> Stream for StateQueue<N> {
                         .unwrap_or(0);
 
                     let percentage = (key as f32 / u32::MAX as f32) * 100.0;
-                    log::debug!(
+                    log::info!(
                         ?start_key,
                         "Received state sync chunk, ~{:.2}% complete",
                         percentage,


### PR DESCRIPTION
Set state sync chunk progress log level to `INFO` instead of `DEBUG`.
