### PR TITLE
Test that we don't require the latest stable Rust version

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@1.78.0 # Also test our Rust MSRV here.
     - uses: Swatinem/rust-cache@v2
     - run: cargo check --all-features --tests --benches
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ the following packages are required to be able to compile the source code:
 - `libssl-dev` (in Debian/Ubuntu) or `openssl-devel` (in Fedora/Red Hat)
 - `pkg-config`
 
+We currently do not make any guarantees about the minimum supported Rust version to consumers, but we currently test two versions older than the current Rust stable.
+
 After installing the previous packages, compiling the project is achieved through [`cargo`](https://doc.rust-lang.org/cargo/):
 
 ```bash


### PR DESCRIPTION
I chose 1.78.0 because it's two versions behind the latest Rust version and I've seen other Rust projects choose that.

We can bump that any time, I'd like to ensure that bumps in our MSRV are visible in PRs.