### PR TITLE
Log the actual error when the head request to a peer fails

### DIFF
--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -149,8 +149,8 @@ impl<TNetwork: Network + 'static> Future for HeadRequests<TNetwork> {
                         }
                     }
                 }
-                Err(_) => {
-                    trace!("Failed head hash request");
+                Err(error) => {
+                    trace!(%error, "Failed head hash request");
                 } // We don't count failed requests.
             }
         }


### PR DESCRIPTION
## What's in this pull request?
In the CI runs I noticed an increase of the `Failed head hash request` line. However we ignore the actual `RequestError` and don't let it be part of the log so I added that.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
