### PR TITLE
Add our own versions of `FuturesUnordered` and `FuturesOrdered`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,6 +4773,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-test-utils",
  "parking_lot",
+ "pin-project",
  "rand",
  "rand_core",
  "serde",

--- a/clippy.toml
+++ b/clippy.toml
@@ -9,3 +9,11 @@ reason = "use `nimiq_utils::spawn_local` instead, it is also supported in WASM e
 [[disallowed-methods]]
 path = "wasm_bindgen_futures::spawn_local"
 reason = "use `nimiq_utils::spawn` or `nimq_utils::spawn_local` instead, it is also supported in non-WASM environments"
+
+[[disallowed-types]]
+path = "futures_util::stream::FuturesUnordered"
+reason = "use `nimiq_utils::stream::FuturesUnordered` instead, it does not need manual `Waker`s"
+
+[[disallowed-types]]
+path = "futures_util::stream::FuturesOrdered"
+reason = "use `nimiq_utils::stream::FuturesOrdered` instead, it does not need manual `Waker`s"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -49,7 +49,7 @@ nimiq-primitives = { workspace = true, features = ["policy", "trie"] }
 nimiq-serde = { workspace = true }
 nimiq-time = { workspace = true }
 nimiq-transaction = { workspace = true }
-nimiq-utils = { workspace = true, features = ["merkle", "spawn", "time"] }
+nimiq-utils = { workspace = true, features = ["futures", "merkle", "spawn", "time"] }
 nimiq-zkp-component = { workspace = true }
 
 [dev-dependencies]

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -7,12 +7,13 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
+use futures::{future::BoxFuture, FutureExt, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network, request::RequestError};
+use nimiq_utils::stream::FuturesUnordered;
 
 use crate::messages::{BlockError, RequestBlock, RequestHead, ResponseHead};
 

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -4,11 +4,11 @@ use std::{
     task::Waker,
 };
 
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use nimiq_blockchain::Blockchain;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
-use nimiq_utils::WakerExt as _;
+use nimiq_utils::stream::FuturesUnordered;
 use parking_lot::RwLock;
 
 use crate::{
@@ -117,9 +117,5 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for HistoryMacroSync<TNetwor
         )
         .boxed();
         self.epoch_ids_stream.push(future);
-
-        // Pushing the future to FuturesUnordered above does not wake the task that
-        // polls `epoch_ids_stream`. Therefore, we need to wake the task manually.
-        self.waker.wake();
     }
 }

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -237,8 +237,6 @@ impl<TNetwork: Network> Stream for HistoryMacroSync<TNetwork> {
     type Item = MacroSyncReturn<TNetwork::PeerId>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.waker.store_waker(cx);
-
         if let Poll::Ready(o) = self.poll_network_events(cx) {
             return Poll::Ready(o);
         }
@@ -251,6 +249,7 @@ impl<TNetwork: Network> Stream for HistoryMacroSync<TNetwork> {
 
         self.poll_job_queue(cx);
 
+        self.waker.store_waker(cx);
         Poll::Pending
     }
 }

--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -6,11 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{
-    future::BoxFuture,
-    stream::{FuturesOrdered, FuturesUnordered},
-    Stream, StreamExt, TryStreamExt,
-};
+use futures::{future::BoxFuture, Stream, StreamExt, TryStreamExt};
 use nimiq_block::Block;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{
@@ -19,6 +15,7 @@ use nimiq_network_interface::{
 };
 use nimiq_primitives::trie::trie_diff::TrieDiff;
 use nimiq_serde::{Deserialize, Serialize};
+use nimiq_utils::stream::{FuturesOrdered, FuturesUnordered};
 use parking_lot::RwLock;
 
 use self::diff_request_component::DiffRequestComponent;

--- a/consensus/src/sync/live/state_queue/chunk_request_component.rs
+++ b/consensus/src/sync/live/state_queue/chunk_request_component.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use nimiq_network_interface::{network::Network, request::RequestError};
 use nimiq_primitives::key_nibbles::KeyNibbles;
 use parking_lot::RwLock;
@@ -71,6 +71,14 @@ impl<N: Network> ChunkRequestComponent<N> {
         request: RequestChunk,
     ) -> Result<ResponseChunk, RequestError> {
         network.request::<RequestChunk>(request, peer_id).await
+    }
+
+    /// Returns a future that resolves when the peer list of the chunk request
+    /// component becomes nonempty.
+    ///
+    /// Returns `None` is the chunk request component already has peers.
+    pub fn wait_for_peers(&self) -> Option<BoxFuture<'static, ()>> {
+        self.peers.read().wait_for_peers()
     }
 }
 

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -7,13 +7,14 @@ use std::{
     time::Duration,
 };
 
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent, SubscribeEvents};
 use nimiq_time::{interval, Interval};
+use nimiq_utils::stream::FuturesUnordered;
 
 use crate::{consensus::ResolveBlockRequest, messages::RequestHead};
 

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -28,7 +28,7 @@ nimiq-collections = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-serde = { workspace = true }
 nimiq-time = { workspace = true }
-nimiq-utils = { workspace = true }
+nimiq-utils = { workspace = true, features = ["futures"] }
 
 [dev-dependencies]
 nimiq-network-interface = { workspace = true }

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -5,10 +5,10 @@ use std::{
 
 use futures::{
     future::{BoxFuture, FutureExt},
-    stream::{FuturesUnordered, StreamExt},
+    stream::StreamExt,
     Future,
 };
-use nimiq_utils::WakerExt as _;
+use nimiq_utils::{stream::FuturesUnordered, WakerExt as _};
 
 use crate::{contribution::AggregatableContribution, update::LevelUpdate};
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.39", features = [
 tokio-stream = "0.1"
 
 nimiq-collections = { workspace = true }
-nimiq-utils = { workspace = true }
+nimiq-utils = { workspace = true, features = ["futures"] }
 nimiq-time = { workspace = true }
 
 [dev-dependencies]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -62,17 +62,3 @@ otp = ["clear_on_drop", "nimiq-hash", "rand"]
 spawn = ["tokio", "tokio/rt", "wasm-bindgen-futures"]
 tagged-signing = ["hex"]
 time = []
-
-# Compiles this package with all features.
-all = [
-    "key-store",
-    "merkle",
-    "otp",
-    "time",
-]
-# Compiles this package with the features needed for the nimiq client.
-full-nimiq = [
-    "key-store",
-    "merkle",
-    "time",
-]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -26,6 +26,7 @@ hex = { version = "0.4", optional = true }
 libp2p-identity = { version = "0.2", optional = true }
 log = { workspace = true, optional = true }
 parking_lot = "0.12"
+pin-project = "1.1"
 rand = { version = "0.8", optional = true }
 rand_core = { version = "0.6", optional = true }
 serde = "1.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 clear_on_drop = { version = "0.2", optional = true }
-futures = { workspace = true }
+futures = { workspace = true, optional = true }
 hex = { version = "0.4", optional = true }
 libp2p-identity = { version = "0.2", optional = true }
 log = { workspace = true, optional = true }
@@ -51,6 +51,7 @@ nimiq-test-utils = { workspace = true }
 
 [features]
 crc = []
+futures = ["dep:futures"]
 key-rng = ["rand", "rand_core"]
 key-store = ["log", "thiserror"]
 libp2p = ["libp2p-identity"]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -18,6 +18,8 @@ pub mod tagged_signing;
 #[cfg(feature = "time")]
 pub mod time;
 
+pub mod stream;
+
 mod sensitive;
 mod waker;
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -18,6 +18,7 @@ pub mod tagged_signing;
 #[cfg(feature = "time")]
 pub mod time;
 
+#[cfg(feature = "futures")]
 pub mod stream;
 
 mod sensitive;

--- a/utils/src/stream.rs
+++ b/utils/src/stream.rs
@@ -1,0 +1,144 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+use futures::{stream as inner, Stream};
+use pin_project::pin_project;
+
+use crate::WakerExt as _;
+
+/// An unbounded queue of futures.
+///
+/// This is a wrapper around [`futures::stream::FuturesOrdered`] that takes
+/// care of waking when a future is pushed. See its documentation for more
+/// details.
+#[pin_project]
+pub struct FuturesOrdered<F: Future> {
+    #[pin]
+    inner: inner::FuturesOrdered<F>,
+    waker: Option<Waker>,
+}
+
+impl<F: Future> Default for FuturesOrdered<F> {
+    fn default() -> FuturesOrdered<F> {
+        FuturesOrdered {
+            inner: Default::default(),
+            waker: None,
+        }
+    }
+}
+
+impl<F: Future> FuturesOrdered<F> {
+    /// Constructs an empty queue of futures.
+    ///
+    /// See also [`futures::stream::FuturesOrdered::new`].
+    pub fn new() -> FuturesOrdered<F> {
+        Default::default()
+    }
+    /// Returns `true` if the queue contains no futures.
+    ///
+    /// See also [`futures::stream::FuturesOrdered::is_empty`].
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+    /// Returns the number of futures in the queue.
+    ///
+    /// See also [`futures::stream::FuturesOrdered::is_empty`].
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+    /// Push a future into the back of the queue.
+    ///
+    /// See also [`futures::stream::FuturesOrdered::push`].
+    pub fn push_back(&mut self, future: F) {
+        self.inner.push_back(future);
+        self.waker.wake();
+    }
+}
+
+impl<F: Future> FromIterator<F> for FuturesOrdered<F> {
+    fn from_iter<I: IntoIterator<Item = F>>(iter: I) -> FuturesOrdered<F> {
+        FuturesOrdered {
+            inner: inner::FuturesOrdered::from_iter(iter),
+            waker: None,
+        }
+    }
+}
+
+impl<F: Future> Stream for FuturesOrdered<F> {
+    type Item = F::Output;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<F::Output>> {
+        let this = self.project();
+        this.waker.store_waker(cx);
+        this.inner.poll_next(cx)
+    }
+}
+
+/// An unbounded set of futures which may complete in any order.
+///
+/// This is a wrapper around [`futures::stream::FuturesUnordered`] that takes
+/// care of waking when a future is pushed. See its documentation for more
+/// details.
+#[pin_project]
+pub struct FuturesUnordered<F: Future> {
+    #[pin]
+    inner: inner::FuturesUnordered<F>,
+    waker: Option<Waker>,
+}
+
+impl<F: Future> Default for FuturesUnordered<F> {
+    fn default() -> FuturesUnordered<F> {
+        FuturesUnordered {
+            inner: Default::default(),
+            waker: None,
+        }
+    }
+}
+
+impl<F: Future> FuturesUnordered<F> {
+    /// Constructs an empty set of futures.
+    ///
+    /// See also [`futures::stream::FuturesUnordered::new`].
+    pub fn new() -> FuturesUnordered<F> {
+        Default::default()
+    }
+    /// Returns `true` if the set contains no futures.
+    ///
+    /// See also [`futures::stream::FuturesUnordered::is_empty`].
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+    /// Returns the number of futures in the set.
+    ///
+    /// See also [`futures::stream::FuturesUnordered::is_empty`].
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+    /// Push a future into the set.
+    ///
+    /// See also [`futures::stream::FuturesUnordered::push`].
+    pub fn push(&mut self, future: F) {
+        self.inner.push(future);
+        self.waker.wake();
+    }
+}
+
+impl<F: Future> FromIterator<F> for FuturesUnordered<F> {
+    fn from_iter<I: IntoIterator<Item = F>>(iter: I) -> FuturesUnordered<F> {
+        FuturesUnordered {
+            inner: inner::FuturesUnordered::from_iter(iter),
+            waker: None,
+        }
+    }
+}
+
+impl<F: Future> Stream for FuturesUnordered<F> {
+    type Item = F::Output;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<F::Output>> {
+        let this = self.project();
+        this.waker.store_waker(cx);
+        this.inner.poll_next(cx)
+    }
+}

--- a/utils/src/stream.rs
+++ b/utils/src/stream.rs
@@ -1,3 +1,7 @@
+// We need to silence this lint because we're using the original
+// `FuturesOrdered` and `FuturesUnordered` in this module to reimplement them.
+#![allow(clippy::disallowed_types)]
+
 use std::{
     future::Future,
     pin::Pin,

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -32,4 +32,4 @@ tokio = { version = "1.39", features = ["rt"] }
 nimiq-bls = { workspace = true, features = ["lazy", "serde-derive"] }
 nimiq-network-interface = { workspace = true }
 nimiq-serde = { workspace = true }
-nimiq-utils = { workspace = true, features = ["spawn", "tagged-signing"] }
+nimiq-utils = { workspace = true, features = ["futures", "spawn", "tagged-signing"] }

--- a/validator-network/src/single_response_requester.rs
+++ b/validator-network/src/single_response_requester.rs
@@ -6,10 +6,10 @@ use std::{
 
 use futures::{
     future::{BoxFuture, Future, FutureExt},
-    stream::FuturesUnordered,
     StreamExt,
 };
 use nimiq_network_interface::request::{Request, RequestCommon};
+use nimiq_utils::stream::FuturesUnordered;
 
 use crate::ValidatorNetwork;
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -54,7 +54,7 @@ nimiq-serde = { workspace = true }
 nimiq-tendermint = { workspace = true }
 nimiq-time = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
-nimiq-utils = { workspace = true, features = ["time"] }
+nimiq-utils = { workspace = true, features = ["futures", "time"] }
 nimiq-validator-network = { workspace = true }
 nimiq-vrf = { workspace = true }
 

--- a/zkp-component/Cargo.toml
+++ b/zkp-component/Cargo.toml
@@ -55,7 +55,7 @@ nimiq-network-interface = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["policy"] }
 nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true }
-nimiq-utils = { workspace = true, features = ["merkle", "spawn", "time"] }
+nimiq-utils = { workspace = true, features = ["futures", "merkle", "spawn", "time"] }
 nimiq-zkp = { workspace = true }
 nimiq-zkp-circuits = { workspace = true }
 nimiq-zkp-primitives = { workspace = true }


### PR DESCRIPTION
Unlike their `futures_util::stream::*` counterparts, they wake themselves when some future is pushed.

This gets rid of a couple of manual waker instances.

It also fixes some waking-related bugs (CC #2550).

Use clippy to warn for usages of the old types.