### PR TITLE
Go back to upstream libp2p-websocket-websys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,8 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket-websys"
-version = "0.3.2"
-source = "git+https://github.com/sisou/rust-libp2p?branch=sisou/websocket-websys-drop#1b14ee1a5ae5375a11731328afce361fafa8ad6a"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95cd8a32fcf94ad1e5c2de37c2a05a5a4188d8358b005859a0fc9e63b6953bc"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ opt-level = 2
 ark-ec = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-ff = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-r1cs-std = { git = "https://github.com/paberr/r1cs-std", branch = "pb/fix-pedersen" }
-libp2p-websocket-websys = { git = "https://github.com/sisou/rust-libp2p", branch = "sisou/websocket-websys-drop" }
 
 [workspace.package]
 version = "0.23.0"


### PR DESCRIPTION
As they fixed the issue in v0.3.3: https://github.com/libp2p/rust-libp2p/pull/5521#issuecomment-2265755680

#### This fixes https://github.com/libp2p/rust-libp2p/issues/5490.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
