### PR TITLE
Node 22 built-in Websocket support

### DIFF
--- a/web-client/dist/nodejs/worker.js
+++ b/web-client/dist/nodejs/worker.js
@@ -4,11 +4,15 @@
 const { parentPort } = require('node:worker_threads');
 const Comlink = require('comlink');
 const nodeEndpoint = require('comlink/dist/umd/node-adapter.js');
-const { w3cwebsocket } = require('websocket');
 const { Client } = require('./worker-wasm/index.js');
 
-// Provide a global WebSocket implementation, which is expected by the WASM code built for browsers.
-global.WebSocket = w3cwebsocket;
+// WebSocket was added to Node in v22. Polyfill it for older versions.
+if (!global.WebSocket) {
+    console.debug("Polyfilling WebSocket");
+    // Provide a global WebSocket implementation, which is expected by the WASM code built for browsers.
+    const { w3cwebsocket } = require('websocket');
+    global.WebSocket = w3cwebsocket;
+}
 // Workaround for Node.js as it currently lacks support for Web Workers by pretending there is
 // a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
 global.WorkerGlobalScope = global;

--- a/web-client/dist/nodejs/worker.mjs
+++ b/web-client/dist/nodejs/worker.mjs
@@ -7,8 +7,12 @@ import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import websocket from 'websocket';
 import wasm from './worker-wasm/index.js';
 
-// Provide a global WebSocket implementation, which is expected by the WASM code built for browsers.
-global.WebSocket = websocket.w3cwebsocket;
+// WebSocket was added to Node in v22. Polyfill it for older versions.
+if (!global.WebSocket) {
+    console.debug("Polyfilling WebSocket");
+    // Provide a global WebSocket implementation, which is expected by the WASM code built for browsers.
+    global.WebSocket = websocket.w3cwebsocket;
+}
 // Workaround for Node.js as it currently lacks support for Web Workers by pretending there is
 // a WorkerGlobalScope object available which is checked within the libp2p's websocket-websys transport.
 global.WorkerGlobalScope = global;

--- a/web-client/example/node/index.js
+++ b/web-client/example/node/index.js
@@ -6,9 +6,20 @@ async function main() {
 
     const client = await Nimiq.Client.create(config.build());
 
+    let peerCount = 0;
+    client.addPeerChangedListener((id, reason, count) => {
+        peerCount = count;
+    });
+
+    let blockHeight = 0;
+    client.addHeadChangedListener(async () => {
+        const block = await client.getHeadBlock();
+        blockHeight = block.height;
+    })
+
     setInterval(async () => {
         const consensus = await client.isConsensusEstablished();
-        console.log(`Consensus ${consensus ? 'established' : 'not established'}`);
+        console.log(`Consensus ${consensus ? 'established' : 'not established'} - Peers: ${peerCount}, Block height: ${blockHeight}`);
     }, 1000);
 }
 

--- a/web-client/example/node/index.mjs
+++ b/web-client/example/node/index.mjs
@@ -5,7 +5,18 @@ const config = new Nimiq.ClientConfiguration();
 
 const client = await Nimiq.Client.create(config.build());
 
+let peerCount = 0;
+client.addPeerChangedListener((id, reason, count) => {
+    peerCount = count;
+});
+
+let blockHeight = 0;
+client.addHeadChangedListener(async () => {
+    const block = await client.getHeadBlock();
+    blockHeight = block.height;
+})
+
 setInterval(async () => {
     const consensus = await client.isConsensusEstablished();
-    console.log(`Consensus ${consensus ? 'established' : 'not established'}`);
+    console.log(`Consensus ${consensus ? 'established' : 'not established'} - Peers: ${peerCount}, Block height: ${blockHeight}`);
 }, 1000);


### PR DESCRIPTION
Only set `global.WebSocket` when it doesn't yet exist. [Node v22 added a global `WebSocket` client](https://nodejs.org/en/blog/announcements/v22-release-announce#websocket), which is browser-compatible, so can be used instead. I tested that it indeed works with Node v22.

Additionally adds peer count and block height stats to the Node example applications, to see that the apps are working properly.
