### PR TITLE
RPC: Always include all fields for staker/validator

### DIFF
--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -901,7 +901,6 @@ impl Account {
 pub struct Staker {
     pub address: Address,
     pub balance: Coin,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation: Option<Address>,
     pub inactive_balance: Coin,
     pub inactive_from: Option<u32>,
@@ -928,14 +927,11 @@ pub struct Validator {
     pub signing_key: Ed25519PublicKey,
     pub voting_key: CompressedPublicKey,
     pub reward_address: Address,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub signal_data: Option<Blake2bHash>,
     pub balance: Coin,
     pub num_stakers: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inactivity_flag: Option<u32>,
     pub retired: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub jailed_from: Option<u32>,
 }
 

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -166,6 +166,10 @@ impl Block {
         macro_block: nimiq_block::MacroBlock,
         include_body: bool,
     ) -> Result<Self, BlockchainError> {
+        if include_body && macro_block.body.is_none() {
+            return Err(BlockchainError::BlockBodyNotFound);
+        }
+
         let block_number = macro_block.block_number();
 
         let slots = macro_block.get_validators().map(Slots::from_slots);
@@ -238,6 +242,10 @@ impl Block {
         micro_block: nimiq_block::MicroBlock,
         include_body: bool,
     ) -> Result<Self, BlockchainError> {
+        if include_body && micro_block.body.is_none() {
+            return Err(BlockchainError::BlockBodyNotFound);
+        }
+
         let block_number = micro_block.block_number();
 
         let (equivocation_proofs, transactions) = match micro_block.body {


### PR DESCRIPTION
- **Do not omit unset fields in Staker and Validator structs when returned from the RPC API**
  This is so users of these structs learn about these potentially set fields even while their staker/validator is running smoothly, so that they won't be surprised by unknown fields once they become set.
- **Return an error when requesting data from a block body, but the node doesn't have the block body**
  Previously this silently omitted the body data, which made the `include_body` flag seem broken.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
