### PR TITLE
Add native `spawn` methods to `clippy.toml`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,11 @@
+[[disallowed-methods]]
+path = "tokio::task::spawn"
+reason = "use `nimiq_utils::spawn` instead, it is also supported in WASM environments"
+
+[[disallowed-methods]]
+path = "tokio::task::spawn_local"
+reason = "use `nimiq_utils::spawn_local` instead, it is also supported in WASM environments"
+
+[[disallowed-methods]]
+path = "wasm_bindgen_futures::spawn_local"
+reason = "use `nimiq_utils::spawn` or `nimq_utils::spawn_local` instead, it is also supported in non-WASM environments"


### PR DESCRIPTION
Forgot to add them in #2801.