### PR TITLE
Ignore dtolnay/rust-toolchain Action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,32 +3,34 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   groups:
-    minor-and-patch-updates:
+    minor-and-patch-actions-updates:
       applies-to: version-updates
       update-types:
-      - "minor"
-      - "patch"
+        - "minor"
+        - "patch"
   schedule:
     interval: daily
     timezone: America/Costa_Rica
+  ignore:
+    - dependency-name: "dtolnay/rust-toolchain" # We manually bump the Rust toolchain as we test two versions older than the current Rust stable
   open-pull-requests-limit: 10
   reviewers:
-  - jsdanielh
+    - jsdanielh
   assignees:
-  - jsdanielh
+    - jsdanielh
 - package-ecosystem: cargo
   directory: "/"
   groups:
-    minor-and-patch-updates:
+    minor-and-patch-cargo-updates:
       applies-to: version-updates
       update-types:
-      - "minor"
-      - "patch"
+        - "minor"
+        - "patch"
   schedule:
     interval: daily
     timezone: America/Costa_Rica
   open-pull-requests-limit: 10
   reviewers:
-  - jsdanielh
+    - jsdanielh
   assignees:
-  - jsdanielh
+    - jsdanielh


### PR DESCRIPTION
- Ignore `dtolnay/rust-toolchain` Action updates since we manually bump the version and prevent unnecessary PRs like https://github.com/nimiq/core-rs-albatross/pull/2799
- Better distinction between the Actions and Cargo update group names
- Improved overall indentation
