### PR TITLE
Optimize the chain store block table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,6 +3627,7 @@ dependencies = [
  "nimiq-collections",
  "nimiq-database",
  "nimiq-database-value",
+ "nimiq-database-value-derive",
  "nimiq-genesis",
  "nimiq-hash",
  "nimiq-keys",

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -38,6 +38,7 @@ nimiq-bls = { workspace = true, features = ["serde-derive"] }
 nimiq-collections = { workspace = true }
 nimiq-database = { workspace = true }
 nimiq-database-value = { workspace = true }
+nimiq-database-value-derive = { workspace = true }
 nimiq-genesis = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -378,7 +378,7 @@ impl Blockchain {
         );
 
         this.chain_store
-            .put_chain_info(&mut txn, &block_hash, &chain_info, true);
+            .put_chain_info(&mut txn, &block_hash, &chain_info, false);
 
         let wanted_history_root = this
             .history_store

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -319,6 +319,10 @@ impl Blockchain {
             .put_chain_info(&mut txn, chain_info.head.parent_hash(), &prev_info, false);
         this.chain_store.set_head(&mut txn, &block_hash);
 
+        if is_macro_block {
+            this.chain_store.finalize_batch(&mut txn);
+        }
+
         if is_election_block {
             let max_epochs_stored =
                 cmp::max(this.config.max_epochs_stored, Policy::MIN_EPOCHS_STORED);

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -48,6 +48,7 @@ declare_table!(LastLeafTable, "LastLeafIndexesByBlock", u32 => u32);
 /// are representations of transactions).
 /// The history trees allow a node in possession of a transaction to prove to another node (that
 /// only has macro block headers) that that given transaction happened.
+#[derive(Debug)]
 pub struct HistoryStore {
     /// Database handle.
     db: MdbxDatabase,

--- a/blockchain/src/history/history_store_index.rs
+++ b/blockchain/src/history/history_store_index.rs
@@ -32,6 +32,7 @@ declare_table!(TxHashTable, "LeafIndexByTxHash", RawTransactionHash => EpochBase
 // `Address` -> `EpochBasedIndex` -> `Blake2bHash`
 declare_table!(AddressTable, "TxHashesByAddress", Address => EpochBasedIndex => Blake2bHash);
 
+#[derive(Debug)]
 /// A struct that contains databases to store history indices.
 pub struct HistoryStoreIndex {
     /// Database handle.

--- a/blockchain/src/history/history_store_proxy.rs
+++ b/blockchain/src/history/history_store_proxy.rs
@@ -130,12 +130,8 @@ impl HistoryInterface for HistoryStoreProxy {
         }
     }
 
-    /// Add a list of historic transactions to an existing history tree. It returns the root of the
-    /// resulting tree and the total size of the transactions added.
-    /// This function assumes that:
-    ///     1. The transactions are pushed in increasing block number order.
-    ///     2. All the blocks are consecutive.
-    ///     3. We only push transactions for one epoch at a time.
+    /// Same as `add_to_history_for_epoch` but calculates the `epoch_number` using
+    /// `Policy` functions.
     fn add_to_history(
         &self,
         txn: &mut MdbxWriteTransaction,
@@ -148,6 +144,29 @@ impl HistoryInterface for HistoryStoreProxy {
             }
             HistoryStoreProxy::WithoutIndex(store) => {
                 store.add_to_history(txn, block_number, hist_txs)
+            }
+        }
+    }
+
+    /// Adds a list of historic transactions to an existing history tree. It returns the root of the
+    /// resulting tree and the total size of the transactions added.
+    /// This function assumes that:
+    ///     1. The transactions are pushed in increasing block number order.
+    ///     2. All the blocks are consecutive.
+    ///     3. We only push transactions for one epoch at a time.
+    fn add_to_history_for_epoch(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        epoch_number: u32,
+        block_number: u32,
+        hist_txs: &[HistoricTransaction],
+    ) -> Option<(Blake2bHash, u64)> {
+        match self {
+            HistoryStoreProxy::WithIndex(index) => {
+                index.add_to_history_for_epoch(txn, epoch_number, block_number, hist_txs)
+            }
+            HistoryStoreProxy::WithoutIndex(store) => {
+                store.add_to_history_for_epoch(txn, epoch_number, block_number, hist_txs)
             }
         }
     }

--- a/blockchain/src/history/history_store_proxy.rs
+++ b/blockchain/src/history/history_store_proxy.rs
@@ -14,6 +14,7 @@ use nimiq_transaction::{
 use super::history_store_index::HistoryStoreIndex;
 use crate::{interface::HistoryInterface, HistoryTreeChunk};
 
+#[derive(Debug)]
 pub enum HistoryStoreProxy {
     WithIndex(HistoryStoreIndex),
     WithoutIndex(Box<dyn HistoryInterface + Send + Sync>),

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -16,7 +16,7 @@ use nimiq_transaction::{
 use crate::HistoryTreeChunk;
 
 /// Defines several methods to interact with a history store.
-pub trait HistoryInterface {
+pub trait HistoryInterface: std::fmt::Debug {
     /// Adds all the transactions included in a given block into the history store.
     fn add_block(
         &self,

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -63,15 +63,26 @@ pub trait HistoryInterface {
     /// Returns the first and last block number stored in the history store
     fn history_store_range(&self, txn_option: Option<&MdbxReadTransaction>) -> (u32, u32);
 
+    /// Same as `add_to_history_for_epoch` but calculates the `epoch_number` using
+    /// `Policy` functions.
+    fn add_to_history(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        block_number: u32,
+        hist_txs: &[HistoricTransaction],
+    ) -> Option<(Blake2bHash, u64)>;
+
     /// Add a list of historic transactions to an existing history tree. It returns the root of the
     /// resulting tree and the total size of the transactions added.
     /// This function assumes that:
     ///     1. The transactions are pushed in increasing block number order.
     ///     2. All the blocks are consecutive.
     ///     3. We only push transactions for one epoch at a time.
-    fn add_to_history(
+    /// This method will fail if we try to push transactions from previous epochs.
+    fn add_to_history_for_epoch(
         &self,
         txn: &mut MdbxWriteTransaction,
+        epoch_number: u32,
         block_number: u32,
         hist_txs: &[HistoricTransaction],
     ) -> Option<(Blake2bHash, u64)>;

--- a/pow-migration/src/history/mod.rs
+++ b/pow-migration/src/history/mod.rs
@@ -194,8 +194,9 @@ pub async fn migrate_history(
 
             // Add transactions to the history store
             let mut txn = env.write_transaction();
-            history_store.add_to_history(
+            history_store.add_to_history_for_epoch(
                 &mut txn,
+                0,
                 block_height,
                 &HistoricTransaction::from(
                     network_id,


### PR DESCRIPTION
Optimize the chain store block table by differentiating pushed vs stored blocks in the chain store.
Pushed blocks are partially restored and are rebuilt by using the chain info DB and the history store. Stored blocks are fully stored since there is no associated history.
The `chain_info.on_main_chain` flag is used to differentiate where to store the block and how to rebuild it (if needed).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
