### PR TITLE
Limit genesis-builder volatile database to 100GB

### DIFF
--- a/database/src/mdbx/database.rs
+++ b/database/src/mdbx/database.rs
@@ -10,8 +10,8 @@ use crate::{
     Error,
 };
 
-const GIGABYTE: usize = 1024 * 1024 * 1024;
-const TERABYTE: usize = GIGABYTE * 1024;
+pub const GIGABYTE: usize = 1024 * 1024 * 1024;
+pub const TERABYTE: usize = GIGABYTE * 1024;
 
 /// Database config options.
 pub struct DatabaseConfig {

--- a/genesis-builder/src/main.rs
+++ b/genesis-builder/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, process::exit};
 
-use nimiq_database::mdbx::MdbxDatabase;
+use nimiq_database::mdbx::{DatabaseConfig, MdbxDatabase, GIGABYTE};
 use nimiq_genesis_builder::{GenesisBuilder, GenesisInfo};
 
 fn usage(args: Vec<String>) -> ! {
@@ -16,8 +16,12 @@ fn main() {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let db =
-        MdbxDatabase::new_volatile(Default::default()).expect("Could not open a volatile database");
+    let db = MdbxDatabase::new_volatile(DatabaseConfig {
+        // Limit the database to 100GB to support platforms with a lower allowed maximum
+        size: Some(0..(100 * GIGABYTE as isize)),
+        ..Default::default()
+    })
+    .expect("Could not open a volatile database");
     let args = env::args().collect::<Vec<String>>();
 
     if let Some(file) = args.get(1) {


### PR DESCRIPTION
This is to support platforms that don't support 1TB mapped databases, such as RISC-V in testing. At runtime, the database size can be limited via a config option, but for compilation, no such configuration is possible.

100GB should be more than enough for genesis generation.

#### This fixes #2840.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
