### PR TITLE
Allow chunks request retries

### DIFF
--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -656,7 +656,7 @@ impl Default for Policy {
 pub const TEST_POLICY: Policy = Policy {
     blocks_per_batch: 32,
     batches_per_epoch: 4,
-    state_chunks_max_size: 2,
+    state_chunks_max_size: 3,
     transaction_validity_window: 2,
     genesis_block_number: 0,
 };


### PR DESCRIPTION
## What's in this pull request?
Enhances the chunk requests component by having retries in case of failure. This is done by moving the chunks response verification to the sync queue.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
