### PR TITLE
Move more imports, methods and properties behind features

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -13,7 +13,9 @@ use futures::{FutureExt, StreamExt};
 use instant::Instant;
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
-use nimiq_blockchain_proxy::{BlockchainProxy, BlockchainReadProxy};
+use nimiq_blockchain_proxy::BlockchainProxy;
+#[cfg(feature = "full")]
+use nimiq_blockchain_proxy::BlockchainReadProxy;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network, request::request_handler};
 use nimiq_utils::spawn;
@@ -129,6 +131,7 @@ pub struct Consensus<N: Network> {
 
     events: BroadcastSender<ConsensusEvent>,
     established_flag: Arc<AtomicBool>,
+    #[cfg(feature = "full")]
     last_batch_number: u32,
     synced_validity_window_flag: Arc<AtomicBool>,
     head_requests: Option<HeadRequests<N>>,
@@ -210,6 +213,7 @@ impl<N: Network> Consensus<N> {
             sync: syncer,
             events: tx,
             established_flag,
+            #[cfg(feature = "full")]
             last_batch_number: 0,
             synced_validity_window_flag,
             head_requests: None,
@@ -221,11 +225,11 @@ impl<N: Network> Consensus<N> {
         }
     }
 
+    #[cfg(feature = "full")]
     fn init_remote_event_dispatcher(network: &Arc<N>, blockchain: &BlockchainProxy) {
         // We spawn the Remote Event Dispatcher into its own task (this is only available for full nodes and history nodes)
 
         match blockchain {
-            #[cfg(feature = "full")]
             BlockchainProxy::Full(blockchain) => {
                 let network = Arc::clone(network);
                 let blockchain = Arc::clone(blockchain);

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -9,7 +9,9 @@ use nimiq_block::BlockInclusionProof;
 use nimiq_blockchain::interface::{HistoryIndexInterface, HistoryInterface};
 #[cfg(feature = "full")]
 use nimiq_blockchain::{Blockchain, CHUNK_SIZE};
-use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainError, Direction};
+#[cfg(feature = "full")]
+use nimiq_blockchain_interface::BlockchainError;
+use nimiq_blockchain_interface::{AbstractBlockchain, Direction};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_network_interface::{network::Network, request::Handle};
 use nimiq_primitives::policy::Policy;

--- a/consensus/src/sync/light/mod.rs
+++ b/consensus/src/sync/light/mod.rs
@@ -1,6 +1,7 @@
 mod sync;
 mod sync_requests;
 mod sync_stream;
+#[cfg(feature = "full")]
 mod validity_window;
 
 pub use sync::LightMacroSync;

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "full")]
+use std::collections::HashSet;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     sync::Arc,
 };
 
@@ -16,13 +18,17 @@ use nimiq_zkp_component::{
     types::{Error, ZKPRequestEvent},
     zkp_component::ZKPComponentProxy,
 };
+#[cfg(feature = "full")]
 use parking_lot::RwLock;
 
-#[cfg(feature = "full")]
-use crate::messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk};
 use crate::{
     messages::{BlockError, Checkpoint},
-    sync::{peer_list::PeerList, sync_queue::SyncQueue, syncer::MacroSync},
+    sync::syncer::MacroSync,
+};
+#[cfg(feature = "full")]
+use crate::{
+    messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk},
+    sync::{peer_list::PeerList, sync_queue::SyncQueue},
 };
 
 #[derive(Clone)]
@@ -53,6 +59,7 @@ impl<T> EpochIds<T> {
     }
 }
 
+#[cfg(feature = "full")]
 /// Struct used to track the progress of the validity window chunk process.
 pub struct ValidityChunkRequest {
     /// This corresponds to the block that should be used to verify the proof.
@@ -123,6 +130,7 @@ impl PeerMacroRequests {
     }
 }
 
+#[cfg(feature = "full")]
 /// Validity sync queue pending size
 const PENDING_SIZE: usize = 5;
 
@@ -176,12 +184,16 @@ pub struct LightMacroSync<TNetwork: Network> {
         (),
     >,
 
+    #[cfg(feature = "full")]
     /// Used to track the validity chunks we are requesting
     pub(crate) validity_requests: Option<ValidityChunkRequest>,
+    #[cfg(feature = "full")]
     /// The peers we are currently syncing with
     pub(crate) syncing_peers: HashSet<TNetwork::PeerId>,
+    #[cfg(feature = "full")]
     /// A vec of all the peers that we successfully synced with
     pub(crate) synced_validity_peers: Vec<TNetwork::PeerId>,
+    #[cfg(feature = "full")]
     /// Minimum distance to light sync in #blocks from the peers head.
     pub(crate) full_sync_threshold: u32,
 }
@@ -227,12 +239,16 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             epoch_ids_stream: FuturesUnordered::new(),
             zkp_component_proxy,
             zkp_requests: FuturesUnordered::new(),
+            #[cfg(feature = "full")]
             full_sync_threshold,
             block_headers: Default::default(),
+            #[cfg(feature = "full")]
             validity_requests: None,
+            #[cfg(feature = "full")]
             syncing_peers: HashSet::new(),
             #[cfg(feature = "full")]
             validity_queue,
+            #[cfg(feature = "full")]
             synced_validity_peers: Vec::new(),
         }
     }

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -153,6 +153,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         }
     }
 
+    #[cfg(feature = "full")]
     pub(crate) fn request_single_macro_block(
         &mut self,
         peer_id: TNetwork::PeerId,

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -12,6 +12,7 @@ use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent};
+#[cfg(feature = "full")]
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_component::types::ZKPRequestEvent::{OutdatedProof, Proof};
 

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -4,10 +4,7 @@ use std::{
 };
 
 use futures::StreamExt;
-#[cfg(feature = "full")]
-use nimiq_blockchain::interface::HistoryInterface;
-#[cfg(feature = "full")]
-use nimiq_blockchain::{Blockchain, CHUNK_SIZE};
+use nimiq_blockchain::{interface::HistoryInterface, Blockchain, CHUNK_SIZE};
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_hash::Blake2bHash;
@@ -18,11 +15,11 @@ use nimiq_network_interface::{
 use nimiq_primitives::policy::Policy;
 
 use super::LightMacroSync;
-#[cfg(feature = "full")]
-use crate::messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk};
-use crate::sync::{light::sync::ValidityChunkRequest, syncer::MacroSyncReturn};
+use crate::{
+    messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk},
+    sync::{light::sync::ValidityChunkRequest, syncer::MacroSyncReturn},
+};
 
-#[cfg(feature = "full")]
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
     pub async fn request_validity_window_chunk(
         network: Arc<TNetwork>,

--- a/consensus/src/sync/live/block_queue/proxy.rs
+++ b/consensus/src/sync/live/block_queue/proxy.rs
@@ -13,9 +13,13 @@ use nimiq_bls::cache::PublicKeyCache;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::Network;
 use nimiq_utils::spawn;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
+#[cfg(feature = "full")]
+use parking_lot::RwLock;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
+#[cfg(feature = "full")]
+use crate::sync::peer_list::PeerList;
 use crate::{
     consensus::ResolveBlockRequest,
     sync::{
@@ -26,7 +30,6 @@ use crate::{
             },
             queue::{LiveSyncQueue, QueueConfig},
         },
-        peer_list::PeerList,
         syncer::LiveSyncEvent,
     },
 };
@@ -93,6 +96,7 @@ impl<N: Network> BlockQueueProxy<N> {
         self.queue.lock().num_buffered_blocks()
     }
 
+    #[cfg(feature = "full")]
     pub(crate) fn peer_list(&self) -> Arc<RwLock<PeerList<N>>> {
         self.queue.lock().peer_list()
     }

--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -8,9 +8,9 @@ use futures::{future::BoxFuture, FutureExt, Stream};
 use nimiq_block::Block;
 #[cfg(feature = "full")]
 use nimiq_blockchain::Blockchain;
-use nimiq_blockchain_interface::{
-    AbstractBlockchain, ChunksPushError, ChunksPushResult, PushError, PushResult,
-};
+#[cfg(feature = "full")]
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_interface::{ChunksPushError, ChunksPushResult, PushError, PushResult};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_hash::Blake2bHash;
@@ -163,6 +163,7 @@ impl<N: Network> BlockchainPushResult<N> {
         }
     }
 
+    #[cfg(feature = "full")]
     fn with_block_result(
         push_result: Result<(PushResult, Result<ChunksPushResult, ChunksPushError>), PushError>,
         block_hash: Blake2bHash,
@@ -187,6 +188,7 @@ impl<N: Network> BlockchainPushResult<N> {
         }
     }
 
+    #[cfg(feature = "full")]
     fn with_chunks_result(
         push_chunks_result: Result<ChunksPushResult, ChunksPushError>,
         block_hash: Blake2bHash,

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -114,6 +114,7 @@ where
     TError: Debug + Display + Send,
     TNetwork: Network,
 {
+    #[cfg(feature = "full")]
     pub fn new(
         network: Arc<TNetwork>,
         ids: Vec<(TId, Option<TNetwork::PeerId>)>,
@@ -309,10 +310,12 @@ where
         true
     }
 
+    #[cfg(feature = "full")]
     pub fn add_peer(&mut self, peer_id: TNetwork::PeerId) -> bool {
         self.peers.write().add_peer(peer_id)
     }
 
+    #[cfg(feature = "full")]
     pub fn remove_peer(&mut self, peer_id: &TNetwork::PeerId) {
         self.peers.write().remove_peer(peer_id);
     }
@@ -326,6 +329,7 @@ where
         self.waker.wake();
     }
 
+    #[cfg(feature = "full")]
     /// Truncates the stored ids, retaining only the first `len` elements.
     /// The elements are counted from the *original* start of the ids vector.
     pub fn truncate_ids(&mut self, len: usize) {
@@ -333,6 +337,7 @@ where
             .truncate(len.saturating_sub(self.next_incoming_index));
     }
 
+    #[cfg(feature = "full")]
     pub fn num_peers(&self) -> usize {
         self.peers.read().len()
     }
@@ -341,10 +346,12 @@ where
         self.ids_to_request.len() + self.pending_futures.len() + self.queued_outputs.len()
     }
 
+    #[cfg(feature = "full")]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    #[cfg(feature = "full")]
     pub fn set_verify_state(&mut self, verify_state: TVerifyState) {
         self.verify_state = verify_state;
     }

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -11,6 +11,7 @@ use nimiq_block::Block;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
+#[cfg(feature = "full")]
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 use parking_lot::Mutex;

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -6,9 +6,11 @@ use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
+#[cfg(feature = "full-consensus")]
+use nimiq_consensus::Error::BlockchainError;
 use nimiq_consensus::{
     sync::syncer_proxy::SyncerProxy, Consensus as AbstractConsensus,
-    ConsensusProxy as AbstractConsensusProxy, Error::BlockchainError,
+    ConsensusProxy as AbstractConsensusProxy,
 };
 #[cfg(feature = "zkp-prover")]
 use nimiq_genesis::NetworkId;
@@ -28,6 +30,7 @@ use nimiq_network_libp2p::{
     TlsConfig as NetworkTls,
 };
 use nimiq_primitives::policy::Policy;
+#[cfg(feature = "full-consensus")]
 use nimiq_utils::time::OffsetTime;
 #[cfg(feature = "validator")]
 use nimiq_validator::validator::Validator as AbstractValidator;
@@ -210,6 +213,7 @@ impl ClientInner {
             )));
         }
 
+        #[cfg(feature = "full-consensus")]
         // Initialize clock
         let time = Arc::new(OffsetTime::new());
 

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -9,8 +9,6 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{future::BoxFuture, ready, stream::BoxStream, Stream, StreamExt};
-#[cfg(all(target_family = "wasm", not(feature = "tokio-websocket")))]
-use libp2p::websocket_websys;
 use libp2p::{
     gossipsub, request_response::InboundRequestId, swarm::NetworkInfo, Multiaddr, PeerId, Swarm,
 };

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
+#[cfg(feature = "metrics")]
 use instant::Instant;
 use libp2p::{
     gossipsub,

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, num::NonZeroU8, sync::Arc};
 
 use base64::Engine;
 use futures::StreamExt;
+#[cfg(feature = "metrics")]
 use instant::Instant;
 #[cfg(all(target_family = "wasm", not(feature = "tokio-websocket")))]
 use libp2p::websocket_websys;

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -1,5 +1,7 @@
 use nimiq_keys::Address;
-use nimiq_primitives::{account::AccountError, key_nibbles::KeyNibbles};
+#[cfg(feature = "interaction-traits")]
+use nimiq_primitives::account::AccountError;
+use nimiq_primitives::key_nibbles::KeyNibbles;
 
 #[cfg(feature = "interaction-traits")]
 use crate::data_store::DataStoreWrite;
@@ -142,12 +144,14 @@ impl<'write, 'store, 'tree, 'txn, 'txni, 'env> StakingContractStoreReadOps
     }
 }
 
+#[cfg(feature = "interaction-traits")]
 pub trait StakingContractStoreReadOpsExt {
     fn expect_validator(&self, address: &Address) -> Result<Validator, AccountError>;
 
     fn expect_staker(&self, address: &Address) -> Result<Staker, AccountError>;
 }
 
+#[cfg(feature = "interaction-traits")]
 impl<T: StakingContractStoreReadOps> StakingContractStoreReadOpsExt for T {
     fn expect_validator(&self, address: &Address) -> Result<Validator, AccountError> {
         self.get_validator(address)

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -422,6 +422,7 @@ impl<'a> InherentLogger<'a> {
         }
     }
 
+    #[cfg(feature = "interaction-traits")]
     pub(crate) fn push_tx_logger(&mut self, mut tx_logger: TransactionLog) {
         if let Some(ref mut inherents) = self.inherents {
             inherents.append(&mut tx_logger.logs)


### PR DESCRIPTION
Compiling the web-client was outputting lots of warning about this. Now much less. Only unused arguments or unnecessary `mut` arguments in method signatures remaining, which cannot be easily fixed.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
