### PR TITLE
Improve performance of `Mempool::update`

### DIFF
--- a/blockchain-interface/src/abstract_blockchain.rs
+++ b/blockchain-interface/src/abstract_blockchain.rs
@@ -23,7 +23,7 @@ pub trait AbstractBlockchain {
     fn now(&self) -> u64;
 
     /// Returns the head of the main chain.
-    fn head(&self) -> Block;
+    fn head(&self) -> &Block;
 
     /// Returns the last macro block.
     fn macro_head(&self) -> MacroBlock;

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -103,7 +103,7 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         gen_blockchain_match!(self, BlockchainReadProxy, now)
     }
 
-    fn head(&self) -> Block {
+    fn head(&self) -> &Block {
         gen_blockchain_match!(self, BlockchainReadProxy, head)
     }
 

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -115,12 +115,12 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         gen_blockchain_match!(self, BlockchainReadProxy, election_head)
     }
 
-    fn can_enforce_validity_window(&self) -> bool {
-        gen_blockchain_match!(self, BlockchainReadProxy, can_enforce_validity_window)
-    }
-
     fn accounts_complete(&self) -> bool {
         gen_blockchain_match!(self, BlockchainReadProxy, accounts_complete)
+    }
+
+    fn can_enforce_validity_window(&self) -> bool {
+        gen_blockchain_match!(self, BlockchainReadProxy, can_enforce_validity_window)
     }
 
     fn current_validators(&self) -> Option<Validators> {
@@ -145,12 +145,12 @@ impl<'a> AbstractBlockchain for BlockchainReadProxy<'a> {
         )
     }
 
-    fn get_block(&self, hash: &Blake2bHash, include_body: bool) -> Result<Block, BlockchainError> {
-        gen_blockchain_match!(self, BlockchainReadProxy, get_block, hash, include_body)
-    }
-
     fn get_genesis_hash(&self) -> Blake2bHash {
         gen_blockchain_match!(self, BlockchainReadProxy, get_genesis_hash)
+    }
+
+    fn get_block(&self, hash: &Blake2bHash, include_body: bool) -> Result<Block, BlockchainError> {
+        gen_blockchain_match!(self, BlockchainReadProxy, get_block, hash, include_body)
     }
 
     fn get_blocks(

--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -90,7 +90,7 @@ impl BlockProducer {
 
         // Calculate the timestamp. It must be greater than or equal to the previous block
         // timestamp (i.e. time must not go back).
-        let timestamp = u64::max(timestamp, blockchain.head().timestamp());
+        let timestamp = u64::max(timestamp, blockchain.timestamp());
 
         // Get the hash of the latest block. It can be any block type.
         let parent_hash = blockchain.head_hash();
@@ -245,7 +245,7 @@ impl BlockProducer {
 
         // Calculate the timestamp. It must be greater than or equal to the previous block
         // timestamp (i.e. time must not go back).
-        let timestamp = u64::max(timestamp, blockchain.head().timestamp());
+        let timestamp = u64::max(timestamp, blockchain.timestamp());
 
         // Get the hash of the latest block (it is by definition a micro block).
         let parent_hash = blockchain.head_hash();

--- a/blockchain/src/blockchain/abstract_blockchain.rs
+++ b/blockchain/src/blockchain/abstract_blockchain.rs
@@ -46,6 +46,10 @@ impl AbstractBlockchain for Blockchain {
         self.state.main_chain.head.epoch_number()
     }
 
+    fn accounts_complete(&self) -> bool {
+        self.state.accounts.is_complete(None)
+    }
+
     fn can_enforce_validity_window(&self) -> bool {
         // If we are at the genesis block, we can enforce the validity window
         if self.block_number() == Policy::genesis_block_number() {
@@ -58,10 +62,6 @@ impl AbstractBlockchain for Blockchain {
                     .get_history_tree_root(self.block_number(), None)
                     .unwrap()
         }
-    }
-
-    fn accounts_complete(&self) -> bool {
-        self.state.accounts.is_complete(None)
     }
 
     fn current_validators(&self) -> Option<Validators> {
@@ -83,12 +83,12 @@ impl AbstractBlockchain for Blockchain {
         self.get_block_at(height, include_body, None)
     }
 
-    fn get_block(&self, hash: &Blake2bHash, include_body: bool) -> Result<Block, BlockchainError> {
-        self.get_block(hash, include_body, None)
-    }
-
     fn get_genesis_hash(&self) -> Blake2bHash {
         self.genesis_hash.clone()
+    }
+
+    fn get_block(&self, hash: &Blake2bHash, include_body: bool) -> Result<Block, BlockchainError> {
+        self.get_block(hash, include_body, None)
     }
 
     fn get_blocks(

--- a/blockchain/src/blockchain/abstract_blockchain.rs
+++ b/blockchain/src/blockchain/abstract_blockchain.rs
@@ -22,8 +22,8 @@ impl AbstractBlockchain for Blockchain {
         self.time.now()
     }
 
-    fn head(&self) -> Block {
-        self.state.main_chain.head.clone()
+    fn head(&self) -> &Block {
+        &self.state.main_chain.head
     }
 
     fn macro_head(&self) -> MacroBlock {

--- a/blockchain/tests/block_production.rs
+++ b/blockchain/tests/block_production.rs
@@ -57,7 +57,7 @@ fn it_can_produce_micro_blocks() {
     // #1.0: Empty standard micro block
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -100,7 +100,7 @@ fn it_can_produce_micro_blocks() {
     // #2.0: Empty micro block with fork proof
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![fork_proof.into()],
         vec![],
         vec![0x41],
@@ -120,7 +120,7 @@ fn it_can_produce_micro_blocks() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -141,7 +141,7 @@ fn it_can_produce_micro_blocks() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -178,7 +178,7 @@ fn it_can_produce_macro_blocks() {
     let macro_block = {
         producer.next_macro_block_proposal(
             &bc,
-            bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0u32,
             vec![],
         )
@@ -205,7 +205,7 @@ fn it_can_produce_macro_block_after_punishment() {
     let macro_block = {
         producer.producer.next_macro_block_proposal(
             &bc,
-            bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0u32,
             vec![],
         )
@@ -254,7 +254,7 @@ fn it_can_produce_macro_block_after_punishment() {
     let macro_block = {
         producer.producer.next_macro_block_proposal(
             &bc,
-            bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0u32,
             vec![],
         )
@@ -308,7 +308,7 @@ fn it_can_produce_election_blocks() {
         let macro_block = {
             producer.next_macro_block_proposal(
                 &bc,
-                bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+                bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
                 0u32,
                 vec![0x42],
             )
@@ -353,7 +353,7 @@ fn it_can_produce_a_chain_with_txns() {
 
         let macro_block_proposal = producer.next_macro_block_proposal(
             &blockchain,
-            blockchain.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0u32,
             vec![],
         );
@@ -391,7 +391,7 @@ fn it_can_revert_create_staker_transaction() {
 
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -411,7 +411,7 @@ fn it_can_revert_create_staker_transaction() {
     // One empty block
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -452,7 +452,7 @@ fn it_can_revert_create_staker_transaction() {
     // Block with staking transactions
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],
@@ -503,7 +503,7 @@ fn it_can_revert_failed_transactions() {
 
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -523,7 +523,7 @@ fn it_can_revert_failed_transactions() {
     // One empty block
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![],
         vec![0x41],
@@ -578,7 +578,7 @@ fn it_can_revert_failed_transactions() {
     // Block with staking transactions
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],
@@ -665,7 +665,7 @@ fn it_can_revert_failed_vesting_contract_transaction() {
 
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],
@@ -727,7 +727,7 @@ fn it_can_revert_failed_vesting_contract_transaction() {
     // Block with redeem funds transaction
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],
@@ -830,7 +830,7 @@ fn it_can_revert_reactivate_transaction() {
     // Block with staking transactions
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],
@@ -870,7 +870,7 @@ fn it_can_revert_reactivate_transaction() {
     // Block with staking transactions
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],
@@ -955,7 +955,7 @@ fn it_can_consume_all_validator_deposit() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![create_tx, retire_tx, vesting_tx.clone()],
         vec![],
@@ -994,7 +994,7 @@ fn it_can_consume_all_validator_deposit() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![invalid_tx.clone()],
         vec![],
@@ -1051,7 +1051,7 @@ fn it_can_consume_all_validator_deposit() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![invalid_tx.clone()],
         vec![],
@@ -1167,7 +1167,7 @@ fn it_can_revert_failed_delete_validator() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![create_tx, retire_tx, vesting_tx.clone()],
         vec![],
@@ -1206,7 +1206,7 @@ fn it_can_revert_failed_delete_validator() {
     let bc = blockchain.upgradable_read();
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![invalid_tx.clone()],
         vec![],
@@ -1351,7 +1351,7 @@ fn it_can_revert_basic_and_create_contracts_txns() {
     // Block with txns
     let block = producer.next_micro_block(
         &bc,
-        bc.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         transactions,
         vec![0x41],

--- a/blockchain/tests/history_store.rs
+++ b/blockchain/tests/history_store.rs
@@ -60,7 +60,7 @@ fn setup_blockchain_with_history() -> (TemporaryBlockProducer, TemporaryBlockPro
 
     add_block_assert_history_store(&temp_producer1, vec![], vec![], true);
 
-    let block = temp_producer1.blockchain.read().head();
+    let block = temp_producer1.blockchain.read().head().clone();
 
     assert_eq!(&temp_producer2.push(block), &Ok(PushResult::Extended));
 
@@ -125,12 +125,14 @@ fn do_double_proposal(
         .blockchain
         .read()
         .head()
+        .clone()
         .unwrap_macro()
         .header;
     let header2 = temp_producer2
         .blockchain
         .read()
         .head()
+        .clone()
         .unwrap_macro()
         .header;
     let justification1 = signing_key.sign(MacroHeader::hash::<Blake2bHash>(&header1).as_bytes());
@@ -155,6 +157,7 @@ fn do_double_vote(temp_producer1: &TemporaryBlockProducer) -> EquivocationProof 
         .blockchain
         .read()
         .head()
+        .clone()
         .unwrap_macro()
         .header;
 
@@ -398,7 +401,12 @@ fn it_pushes_macro_block_with_rewards() {
 
     // Simple case. 1x Reward to validator.
     let reward_txs = {
-        let macro_block = temp_producer1.blockchain.read().head().unwrap_macro();
+        let macro_block = temp_producer1
+            .blockchain
+            .read()
+            .head()
+            .clone()
+            .unwrap_macro();
         macro_block.body.unwrap().transactions
     };
     assert_eq!(reward_txs.len(), 1);

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -215,8 +215,8 @@ impl<N: Network> ConsensusProxy<N> {
         let blockchain = self.blockchain.read();
         let election_head = blockchain.election_head();
         let checkpoint_head = blockchain.macro_head();
-        let current_head = blockchain.head();
-        let current_block_number = current_head.block_number();
+        let current_head_hash = blockchain.head_hash();
+        let current_block_number = blockchain.block_number();
 
         // We drop the blockchain lock because it's no longer needed while we request proofs
         drop(blockchain);
@@ -282,7 +282,7 @@ impl<N: Network> ConsensusProxy<N> {
                     } else {
                         // Third Case: Transactions from the current batch
                         hashes_by_block
-                            .entry(Some(current_head.block_number()))
+                            .entry(Some(current_block_number))
                             .or_insert(vec![])
                             .push(hash.clone());
                     }
@@ -398,7 +398,7 @@ impl<N: Network> ConsensusProxy<N> {
                                 log::debug!(peer = %peer_id, "BlockProof does not correspond to expected checkpoint block");
                                 continue;
                             }
-                        } else if response.block.hash() != current_head.hash() {
+                        } else if response.block.hash() != current_head_hash {
                             log::debug!(block_number = %response.block.block_number(), peer=%peer_id, "BlockProof does not correspond to expected block");
                             continue;
                         }

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -691,7 +691,7 @@ async fn can_reset_chain_of_chunks() {
                 .set(|_, _, _| ResponseTrieDiff::PartialDiff(TrieDiff::default()));
         },
         |mock_id, block_tx, blockchain| async move {
-            let mut block = blockchain.read().head();
+            let mut block = blockchain.read().head().clone();
             match block {
                 Block::Micro(ref mut micro_block) => {
                     micro_block.header.body_root = Blake2sHash::default();

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -638,7 +638,7 @@ impl Client {
 
     /// Returns the blockchain head
     pub fn blockchain_head(&self) -> Block {
-        self.inner.blockchain.read().head()
+        self.inner.blockchain.read().head().clone()
     }
 
     #[cfg(feature = "wallet")]

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -20,8 +20,8 @@ impl AbstractBlockchain for LightBlockchain {
         self.time.now()
     }
 
-    fn head(&self) -> Block {
-        self.head.clone()
+    fn head(&self) -> &Block {
+        &self.head
     }
 
     fn macro_head(&self) -> MacroBlock {

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -120,7 +120,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error> {
         let blockchain = self.blockchain.read();
-        let block = blockchain.head();
+        let block = blockchain.head().clone();
 
         Ok(
             Block::from_block(&blockchain, block, include_body.unwrap_or(false))

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -158,7 +158,7 @@ impl TemporaryBlockProducer {
         let block = if Policy::is_macro_block_at(height) {
             let macro_block_proposal = self.producer.next_macro_block_proposal(
                 &blockchain,
-                blockchain.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+                blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
                 0,
                 extra_data,
             );
@@ -189,7 +189,7 @@ impl TemporaryBlockProducer {
         } else if skip_block {
             Block::Micro(self.producer.next_micro_block(
                 &blockchain,
-                blockchain.head().timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT,
+                blockchain.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT,
                 vec![],
                 vec![],
                 extra_data,
@@ -198,7 +198,7 @@ impl TemporaryBlockProducer {
         } else {
             Block::Micro(self.producer.next_micro_block(
                 &blockchain,
-                blockchain.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+                blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
                 vec![],
                 transactions,
                 extra_data,

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -83,7 +83,7 @@ pub fn produce_macro_blocks_with_txns(
 
         let macro_block_proposal = producer.next_macro_block_proposal(
             &blockchain,
-            blockchain.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0u32,
             vec![],
         );
@@ -142,7 +142,7 @@ pub fn fill_micro_blocks_with_txns(
         let block_production_start = Instant::now();
         let last_micro_block = producer.next_micro_block(
             &blockchain,
-            blockchain.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             vec![],
             txns,
             vec![0x42],

--- a/test-utils/src/blockchain_with_rng.rs
+++ b/test-utils/src/blockchain_with_rng.rs
@@ -24,7 +24,7 @@ pub fn produce_macro_blocks_with_rng<R: Rng + CryptoRng>(
 
         let macro_block_proposal = producer.next_macro_block_proposal_with_rng(
             &blockchain,
-            blockchain.head().timestamp() + next_block_height * 1000,
+            blockchain.timestamp() + next_block_height * 1000,
             0u32,
             vec![],
             rng,
@@ -52,7 +52,7 @@ pub fn next_micro_block_with_rng<R: Rng + CryptoRng>(
     let blockchain = blockchain.upgradable_read();
     let block = producer.next_micro_block_with_rng(
         &blockchain,
-        blockchain.head().timestamp() + 500,
+        blockchain.timestamp() + 500,
         vec![],
         vec![],
         vec![0x42],

--- a/test-utils/src/performance/blockchain-push/main.rs
+++ b/test-utils/src/performance/blockchain-push/main.rs
@@ -85,7 +85,7 @@ fn main() {
 
         let macro_block_proposal = producer.next_macro_block_proposal(
             &blockchain,
-            blockchain.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0u32,
             vec![],
         );

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -93,7 +93,7 @@ pub fn next_micro_block(
 
     let block_number = (blockchain.block_number() as i32 + 1 + config.block_number_offset) as u32;
 
-    let timestamp = (blockchain.head().timestamp() as i64 + 1 + config.timestamp_offset) as u64;
+    let timestamp = (blockchain.timestamp() as i64 + 1 + config.timestamp_offset) as u64;
 
     let parent_hash = config
         .parent_hash
@@ -195,9 +195,9 @@ pub fn next_skip_block(
     let block_number = (blockchain.block_number() as i32 + 1 + config.block_number_offset) as u32;
 
     let timestamp = if config.timestamp_offset != 0 {
-        (blockchain.head().timestamp() as i64 + config.timestamp_offset) as u64
+        (blockchain.timestamp() as i64 + config.timestamp_offset) as u64
     } else {
-        blockchain.head().timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT
+        blockchain.timestamp() + Policy::BLOCK_PRODUCER_TIMEOUT
     };
 
     let parent_hash = config
@@ -291,7 +291,7 @@ pub fn next_macro_block_proposal(
 
     let block_number = (blockchain.block_number() as i32 + 1 + config.block_number_offset) as u32;
 
-    let timestamp = (blockchain.head().timestamp() as i64 + config.timestamp_offset) as u64;
+    let timestamp = (blockchain.timestamp() as i64 + config.timestamp_offset) as u64;
 
     let parent_hash = config
         .parent_hash

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -92,7 +92,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
                 // Calculate the expected block time as expected by the reward function.
                 expected_next_ts = self.expected_next_timestamp(&blockchain);
 
-                if !in_current_state(&blockchain.head()) {
+                if !in_current_state(blockchain.head()) {
                     break Some(None);
                 } else if self.is_our_turn(&blockchain) {
                     // We want to produce a block at the expected timestamp for this block in this batch
@@ -183,7 +183,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         // Acquire a blockchain read lock and check if the state still matches to fetch active validators.
         let active_validators = {
             let blockchain = self.blockchain.read();
-            if in_current_state(&blockchain.head()) {
+            if in_current_state(blockchain.head()) {
                 Some(blockchain.current_validators().unwrap())
             } else {
                 None
@@ -213,7 +213,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             let blockchain = self.blockchain.upgradable_read();
             let head = blockchain.head();
 
-            if !in_current_state(&head) {
+            if !in_current_state(head) {
                 None
             } else {
                 let timestamp = head.timestamp() + self.producer_timeout.as_millis() as u64;

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -53,7 +53,7 @@ async fn validator_update() {
     );
     let new_micro_block = producer1.next_micro_block(
         &blockchain.read(),
-        blockchain.read().head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        blockchain.read().timestamp() + Policy::BLOCK_SEPARATION_TIME,
         vec![],
         vec![tx],
         vec![0x42],

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -44,7 +44,7 @@ async fn it_verifies_inferior_chain_proposals() {
         let b = blockchain1.read();
         temp_producer1.producer.next_macro_block_proposal(
             &b,
-            b.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            b.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0,
             vec![],
         )
@@ -76,7 +76,7 @@ async fn it_verifies_inferior_chain_proposals() {
         let b = blockchain1.read();
         temp_producer1.producer.next_macro_block_proposal(
             &b,
-            b.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            b.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0,
             vec![],
         )
@@ -104,7 +104,7 @@ async fn it_verifies_inferior_chain_proposals() {
         let b = blockchain1.read();
         temp_producer1.producer.next_macro_block_proposal(
             &b,
-            b.head().timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            b.timestamp() + Policy::BLOCK_SEPARATION_TIME,
             0,
             vec![],
         )


### PR DESCRIPTION
Eliminate unnecessary cloning of the blockchain's head block by returning a reference from `AbstractBlockchain::head`.

Closes #2855 