### PR TITLE
Handel update

### DIFF
--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -13,6 +13,7 @@ use nimiq_time::{interval, Interval};
 use crate::{
     config::Config,
     contribution::AggregatableContribution,
+    evaluator::Evaluator,
     identity::IdentityRegistry,
     level::Level,
     network::{LevelUpdateSender, Network},
@@ -159,7 +160,7 @@ where
     }
 
     fn is_complete_aggregate(&self, aggregate: &P::Contribution) -> bool {
-        self.num_contributors(aggregate) == self.protocol.partitioner().size()
+        self.protocol.evaluator().is_final(aggregate)
     }
 
     /// Check if a level was completed

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -99,8 +99,8 @@ where
     /// `0` being not useful at all, can be discarded.
     /// `>0` being more useful the bigger the number.
     fn evaluate(&self, contribution: &TProtocol::Contribution, level: usize, id: TId) -> usize {
-        // Special case for final aggregations, full contribution is already checked.
-        if level == self.partitioner.levels() {
+        // Special case for final aggregations.
+        if level == self.partitioner.levels() && self.is_final(contribution) {
             return usize::MAX;
         }
 
@@ -251,12 +251,7 @@ where
 
     fn level_contains_origin(&self, msg: &LevelUpdate<TProtocol::Contribution>) -> bool {
         if msg.level as usize == self.partitioner.levels() {
-            let weight = self
-                .weights
-                .signers_identity(&msg.aggregate.contributors())
-                .len();
-            // Only available to full aggregations
-            return weight == self.partitioner.size();
+            return self.is_final(&msg.aggregate);
         }
         let range = self.partitioner.range(msg.level as usize);
         if let Ok(range) = range {

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -110,11 +110,12 @@ impl Protocol {
             partitioner.clone(),
         )));
 
+        let cloned_registry = Arc::clone(&registry);
         let evaluator = Arc::new(WeightedVote::new(
             store.clone(),
             Arc::clone(&registry),
             partitioner.clone(),
-            threshold,
+            move |c| cloned_registry.signature_weight(c).unwrap_or(0) >= threshold,
         ));
 
         Protocol {
@@ -230,7 +231,7 @@ async fn it_can_aggregate() {
         let net = Arc::new(hub.new_network_with_address(id as u64));
         // Create a protocol with `contributor_num + 1` peers set its id to `id`. Require `contributor_num` contributions
         // meaning all contributions need to be aggregated with the additional node initialized after this for loop.
-        let protocol = Protocol::new(id, contributor_num + 1, contributor_num);
+        let protocol = Protocol::new(id, contributor_num + 1, contributor_num + 1);
         // the sole contributor for soon to be created contribution is this node.
         let mut contributors = BitSet::new();
         contributors.insert(id);

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -186,12 +186,14 @@ impl SkipBlockAggregationProtocol {
         ))));
 
         let registry = Arc::new(ValidatorRegistry::new(validators));
+        // This will be moved into the closure.
+        let cloned_registry = Arc::clone(&registry);
 
         let evaluator = Arc::new(WeightedVote::new(
             Arc::clone(&store),
             Arc::clone(&registry),
             Arc::clone(&partitioner),
-            threshold,
+            move |message| cloned_registry.signature_weight(message).unwrap_or(0) >= threshold,
         ));
 
         SkipBlockAggregationProtocol {

--- a/validator/src/aggregation/tendermint/protocol.rs
+++ b/validator/src/aggregation/tendermint/protocol.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use nimiq_handel::{
-    evaluator::WeightedVote, partitioner::BinomialPartitioner, protocol::Protocol,
-    store::ReplaceStore,
+    evaluator::WeightedVote, identity::WeightRegistry, partitioner::BinomialPartitioner,
+    protocol::Protocol, store::ReplaceStore,
 };
-use nimiq_primitives::TendermintIdentifier;
+use nimiq_primitives::{policy, TendermintIdentifier};
 use parking_lot::RwLock;
 
 use super::{
@@ -12,7 +12,6 @@ use super::{
     verifier::TendermintVerifier,
 };
 
-#[derive(std::fmt::Debug)]
 pub(crate) struct TendermintAggregationProtocol {
     verifier: Arc<<Self as Protocol<TendermintIdentifier>>::Verifier>,
     partitioner: Arc<<Self as Protocol<TendermintIdentifier>>::Partitioner>,
@@ -28,7 +27,6 @@ impl TendermintAggregationProtocol {
     pub(crate) fn new(
         validators: Arc<ValidatorRegistry>,
         node_id: usize,
-        threshold: usize,
         id: TendermintIdentifier,
     ) -> Self {
         let partitioner = Arc::new(BinomialPartitioner::new(node_id, validators.len()));
@@ -37,14 +35,60 @@ impl TendermintAggregationProtocol {
             ReplaceStore::<TendermintIdentifier, Self>::new(Arc::clone(&partitioner)),
         ));
 
+        // This will be moved into the closure.
+        let cloned_validators = Arc::clone(&validators);
+
         let evaluator = Arc::new(WeightedVote::new(
             Arc::clone(&store),
-            validators.clone(),
+            Arc::clone(&validators),
             Arc::clone(&partitioner),
-            threshold,
+            move |message: &TendermintContribution| {
+                // Conditions for final contributions:
+                // * Any proposal has 2f+1
+                // (* Nil has f+1) would be implicit in the next condition
+                // * The biggest proposal (NOT Nil) combined with the non cast votes is less than 2f+1
+
+                let mut uncast_votes = policy::Policy::SLOTS as usize;
+                let mut biggest_weight = 0;
+
+                // Check every proposal present, including None
+                for (hash, signature) in message.contributions.iter() {
+                    let weight = cloned_validators
+                        .signers_weight(&signature.signers)
+                        .unwrap_or(0);
+                    // Any option which has at least 2f+1 votes make this contribution final.
+                    if weight >= policy::Policy::TWO_F_PLUS_ONE as usize {
+                        return true;
+                    }
+                    // If the proposal does not have 2f+1 check if it has the new biggest_weight
+                    if hash.is_some() && weight > biggest_weight {
+                        biggest_weight = weight;
+                    }
+                    // The cast votes need to be removed from the uncast votes
+                    uncast_votes = uncast_votes.saturating_sub(weight);
+                }
+
+                let cast_votes = (policy::Policy::SLOTS as usize).saturating_sub(uncast_votes);
+                if cast_votes < policy::Policy::TWO_F_PLUS_ONE as usize {
+                    // This should not be here. The criteria that the best vote can be elevated above the threshold
+                    // using the uncast votes is enough. In our case that means that seeing f+1 different proposals
+                    // with 1 vote each is a final aggregate. That is currently not handled that way in tendermint
+                    // as it only looks at contributions above 2f contributors. That behavior is thus maintained
+                    // here, but can be removed in the future if tendermint is changed as well.
+                    return false;
+                }
+
+                // If the uncast votes are not able to put the biggest vote over the threshold
+                // they cannot push any proposal over the threshold and thus the aggregate is final.
+                if uncast_votes + biggest_weight < policy::Policy::TWO_F_PLUS_ONE as usize {
+                    return true;
+                }
+
+                false
+            },
         ));
 
-        let verifier = Arc::new(TendermintVerifier::new(validators.clone(), id.clone()));
+        let verifier = Arc::new(TendermintVerifier::new(Arc::clone(&validators), id.clone()));
 
         Self {
             verifier,

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -403,7 +403,6 @@ where
         let protocol = TendermintAggregationProtocol::new(
             Arc::clone(&self.validator_registry),
             self.validator_slot_band as usize,
-            1, // to be removed
             id,
         );
 
@@ -439,7 +438,6 @@ where
         let protocol = TendermintAggregationProtocol::new(
             Arc::clone(&self.validator_registry),
             self.validator_slot_band as usize,
-            1,
             id,
         );
 


### PR DESCRIPTION
Allows Handel to to switch to response only mode before all signatures are accumulated. A Closure is used to determine if continuing the aggregation can lead to a different result and if it cannot, it switches to respond only. This produces less or even zero network activity for finished aggregations, while still allowing people to catch up as the aggregations do not fully terminate.

Might be related to #2623.