### PR TITLE
network-libp2p: Increase the req-res max concurrent streams

### DIFF
--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -90,7 +90,7 @@ impl Behaviour {
 
         // Request Response behaviour
         let protocol = StreamProtocol::new("/nimiq/reqres/0.0.1");
-        let req_res_config = request_response::Config::default();
+        let req_res_config = request_response::Config::default().with_max_concurrent_streams(1000);
         let request_response = request_response::Behaviour::new(
             iter::once((protocol, request_response::ProtocolSupport::Full)),
             req_res_config,


### PR DESCRIPTION
Increase the maximum number of request-response concurrent streams from 100 (default value) to 1000.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
