### PR TITLE
pow-migration: Do not use `Policy` functions to calculate epoch numbers

### DIFF
--- a/blockchain/src/history/history_store_proxy.rs
+++ b/blockchain/src/history/history_store_proxy.rs
@@ -130,12 +130,8 @@ impl HistoryInterface for HistoryStoreProxy {
         }
     }
 
-    /// Add a list of historic transactions to an existing history tree. It returns the root of the
-    /// resulting tree and the total size of the transactions added.
-    /// This function assumes that:
-    ///     1. The transactions are pushed in increasing block number order.
-    ///     2. All the blocks are consecutive.
-    ///     3. We only push transactions for one epoch at a time.
+    /// Same as `add_to_history_for_epoch` but calculates the `epoch_number` using
+    /// `Policy` functions.
     fn add_to_history(
         &self,
         txn: &mut MdbxWriteTransaction,
@@ -148,6 +144,29 @@ impl HistoryInterface for HistoryStoreProxy {
             }
             HistoryStoreProxy::WithoutIndex(store) => {
                 store.add_to_history(txn, block_number, hist_txs)
+            }
+        }
+    }
+
+    /// Adds a list of historic transactions to an existing history tree. It returns the root of the
+    /// resulting tree and the total size of the transactions added.
+    /// This function assumes that:
+    ///     1. The transactions are pushed in increasing block number order.
+    ///     2. All the blocks are consecutive.
+    ///     3. We only push transactions for one epoch at a time.
+    fn add_to_history_for_epoch(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        epoch_number: u32,
+        block_number: u32,
+        hist_txs: &[HistoricTransaction],
+    ) -> Option<(Blake2bHash, u64)> {
+        match self {
+            HistoryStoreProxy::WithIndex(index) => {
+                index.add_to_history_for_epoch(txn, epoch_number, block_number, hist_txs)
+            }
+            HistoryStoreProxy::WithoutIndex(store) => {
+                store.add_to_history_for_epoch(txn, epoch_number, block_number, hist_txs)
             }
         }
     }

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -63,15 +63,26 @@ pub trait HistoryInterface {
     /// Returns the first and last block number stored in the history store
     fn history_store_range(&self, txn_option: Option<&MdbxReadTransaction>) -> (u32, u32);
 
+    /// Same as `add_to_history_for_epoch` but calculates the `epoch_number` using
+    /// `Policy` functions.
+    fn add_to_history(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        block_number: u32,
+        hist_txs: &[HistoricTransaction],
+    ) -> Option<(Blake2bHash, u64)>;
+
     /// Add a list of historic transactions to an existing history tree. It returns the root of the
     /// resulting tree and the total size of the transactions added.
     /// This function assumes that:
     ///     1. The transactions are pushed in increasing block number order.
     ///     2. All the blocks are consecutive.
     ///     3. We only push transactions for one epoch at a time.
-    fn add_to_history(
+    /// This method will fail if we try to push transactions from previous epochs.
+    fn add_to_history_for_epoch(
         &self,
         txn: &mut MdbxWriteTransaction,
+        epoch_number: u32,
         block_number: u32,
         hist_txs: &[HistoricTransaction],
     ) -> Option<(Blake2bHash, u64)>;

--- a/pow-migration/src/history/mod.rs
+++ b/pow-migration/src/history/mod.rs
@@ -194,8 +194,9 @@ pub async fn migrate_history(
 
             // Add transactions to the history store
             let mut txn = env.write_transaction();
-            history_store.add_to_history(
+            history_store.add_to_history_for_epoch(
                 &mut txn,
+                0,
                 block_height,
                 &HistoricTransaction::from(
                     network_id,


### PR DESCRIPTION
Change the blockchain history store interface to add a function (`add_to_history_for_epoch`) that receives the epoch number instead of relying on `Policy` to calculate it. This is useful in the history migration for `PoW` since the genesis block number wouldn't be known until the migration is over.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
