### PR TITLE
Use the workspace to specify the package table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "nimiq-macros"
-version = "0.1.1"
+version = "0.24.0"
 dependencies = [
  "hex",
  "nimiq-serde",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "nimiq-primitives"
-version = "0.1.0"
+version = "0.24.0"
 dependencies = [
  "ark-ec",
  "ark-mnt6-753",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-macros"
-version = "0.1.1"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Macros for Nimiq's Rust implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [lints]
 workspace = true

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nimiq-primitives"
-version = "0.1.0"
-authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 description = "Simple primitives to be used in Nimiq's Albatross implementation"
-homepage = "https://nimiq.com"
-repository = "https://github.com/nimiq/core-rs-albatross"
-license = "Apache-2.0"
-categories = ["cryptography::cryptocurrencies"]
-keywords = ["nimiq", "cryptocurrency", "blockchain"]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [badges]
 travis-ci = { repository = "nimiq/core-rs", branch = "master" }


### PR DESCRIPTION
Also use the workspace to specify the package table of the Cargo manifest for the `macros` and `primitives` crates.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
