### PR TITLE
Handel Update

### DIFF
--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -29,7 +29,6 @@ use crate::{
 // TODOS:
 // * protocol.store RwLock.
 // * level.state RwLock
-// * Evaluator::new -> threshold (now covered outside of this crate)
 
 type LevelUpdateStream<P, T> = BoxStream<'static, LevelUpdate<<P as Protocol<T>>::Contribution>>;
 

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -13,6 +13,7 @@ use nimiq_time::{interval, Interval};
 use crate::{
     config::Config,
     contribution::AggregatableContribution,
+    evaluator::Evaluator,
     identity::IdentityRegistry,
     level::Level,
     network::{LevelUpdateSender, Network},
@@ -159,7 +160,7 @@ where
     }
 
     fn is_complete_aggregate(&self, aggregate: &P::Contribution) -> bool {
-        self.num_contributors(aggregate) == self.protocol.partitioner().size()
+        self.protocol.evaluator().is_final(aggregate)
     }
 
     /// Check if a level was completed

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -99,8 +99,8 @@ where
     /// `0` being not useful at all, can be discarded.
     /// `>0` being more useful the bigger the number.
     fn evaluate(&self, contribution: &TProtocol::Contribution, level: usize, id: TId) -> usize {
-        // Special case for final aggregations, full contribution is already checked.
-        if level == self.partitioner.levels() {
+        // Special case for final aggregations.
+        if level == self.partitioner.levels() && self.is_final(contribution) {
             return usize::MAX;
         }
 
@@ -251,12 +251,7 @@ where
 
     fn level_contains_origin(&self, msg: &LevelUpdate<TProtocol::Contribution>) -> bool {
         if msg.level as usize == self.partitioner.levels() {
-            let weight = self
-                .weights
-                .signers_identity(&msg.aggregate.contributors())
-                .len();
-            // Only available to full aggregations
-            return weight == self.partitioner.size();
+            return self.is_final(&msg.aggregate);
         }
         let range = self.partitioner.range(msg.level as usize);
         if let Ok(range) = range {

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -110,11 +110,12 @@ impl Protocol {
             partitioner.clone(),
         )));
 
+        let cloned_registry = Arc::clone(&registry);
         let evaluator = Arc::new(WeightedVote::new(
             store.clone(),
             Arc::clone(&registry),
             partitioner.clone(),
-            threshold,
+            move |c| cloned_registry.signature_weight(c).unwrap_or(0) >= threshold,
         ));
 
         Protocol {
@@ -230,7 +231,7 @@ async fn it_can_aggregate() {
         let net = Arc::new(hub.new_network_with_address(id as u64));
         // Create a protocol with `contributor_num + 1` peers set its id to `id`. Require `contributor_num` contributions
         // meaning all contributions need to be aggregated with the additional node initialized after this for loop.
-        let protocol = Protocol::new(id, contributor_num + 1, contributor_num);
+        let protocol = Protocol::new(id, contributor_num + 1, contributor_num + 1);
         // the sole contributor for soon to be created contribution is this node.
         let mut contributors = BitSet::new();
         contributors.insert(id);

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use futures::{future::BoxFuture, stream::BoxStream};
 use nimiq_collections::BitSet;
 use serde::{Deserialize, Serialize};
@@ -163,4 +165,8 @@ pub trait Protocol: Clone + Send + Sync + Unpin + Sized + 'static {
         step: Step,
         message: Self::AggregationMessage,
     ) -> BoxFuture<'static, Result<(), ()>>;
+
+    /// Compares the two given aggregations. This is used to determine whether or not to overwrite
+    /// a given aggregate with a better one.
+    fn compare_contributions(&self, lhs: &Self::Aggregation, rhs: &Self::Aggregation) -> Ordering;
 }

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -572,14 +572,14 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             self.aggregations.poll_next_unpin(cx)
         {
             // For every update received, first update the best_vote for that aggregation.
-            // If the updated value is better (more votes) make sure, that a state update will be required.
+            // If the updated value is better make sure, that a state update will be required.
             // If this is the first update for the aggregation, create the entry.
             let best_vote = self
                 .state
                 .best_votes
                 .entry(round_and_step)
                 .and_modify(|agg| {
-                    if agg.all_contributors().len() < aggregate.all_contributors().len() {
+                    if self.protocol.compare_contributions(agg, &aggregate).is_lt() {
                         *agg = aggregate.clone();
                         *should_export_state = true;
                     }

--- a/tendermint/tests/common/mod.rs
+++ b/tendermint/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     collections::BTreeMap,
     sync::{Arc, Mutex},
 };
@@ -259,5 +260,15 @@ impl Protocol for Validator {
         self.observe_sender
             .try_send(Observe::Proposal(proposal))
             .expect("Failed to send proposal to observer");
+    }
+
+    fn compare_contributions(&self, lhs: &Self::Aggregation, rhs: &Self::Aggregation) -> Ordering {
+        if lhs.all_contributors().len() < rhs.all_contributors().len() {
+            return Ordering::Less;
+        }
+        if lhs.all_contributors().len() > rhs.all_contributors().len() {
+            return Ordering::Greater;
+        }
+        Ordering::Equal
     }
 }

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -186,12 +186,14 @@ impl SkipBlockAggregationProtocol {
         ))));
 
         let registry = Arc::new(ValidatorRegistry::new(validators));
+        // This will be moved into the closure.
+        let cloned_registry = Arc::clone(&registry);
 
         let evaluator = Arc::new(WeightedVote::new(
             Arc::clone(&store),
             Arc::clone(&registry),
             Arc::clone(&partitioner),
-            threshold,
+            move |message| cloned_registry.signature_weight(message).unwrap_or(0) >= threshold,
         ));
 
         SkipBlockAggregationProtocol {

--- a/validator/src/aggregation/tendermint/protocol.rs
+++ b/validator/src/aggregation/tendermint/protocol.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use nimiq_handel::{
-    evaluator::WeightedVote, partitioner::BinomialPartitioner, protocol::Protocol,
-    store::ReplaceStore,
+    evaluator::WeightedVote, identity::WeightRegistry, partitioner::BinomialPartitioner,
+    protocol::Protocol, store::ReplaceStore,
 };
-use nimiq_primitives::TendermintIdentifier;
+use nimiq_primitives::{policy, TendermintIdentifier};
 use parking_lot::RwLock;
 
 use super::{
@@ -12,7 +12,6 @@ use super::{
     verifier::TendermintVerifier,
 };
 
-#[derive(std::fmt::Debug)]
 pub(crate) struct TendermintAggregationProtocol {
     verifier: Arc<<Self as Protocol<TendermintIdentifier>>::Verifier>,
     partitioner: Arc<<Self as Protocol<TendermintIdentifier>>::Partitioner>,
@@ -28,7 +27,6 @@ impl TendermintAggregationProtocol {
     pub(crate) fn new(
         validators: Arc<ValidatorRegistry>,
         node_id: usize,
-        threshold: usize,
         id: TendermintIdentifier,
     ) -> Self {
         let partitioner = Arc::new(BinomialPartitioner::new(node_id, validators.len()));
@@ -37,14 +35,65 @@ impl TendermintAggregationProtocol {
             ReplaceStore::<TendermintIdentifier, Self>::new(Arc::clone(&partitioner)),
         ));
 
+        // This will be moved into the closure.
+        let cloned_validators = Arc::clone(&validators);
+
         let evaluator = Arc::new(WeightedVote::new(
             Arc::clone(&store),
-            validators.clone(),
+            Arc::clone(&validators),
             Arc::clone(&partitioner),
-            threshold,
+            move |message: &TendermintContribution| {
+                // Conditions for final contributions:
+                // * Any proposal has 2f+1
+                // (* Nil has f+1) would be implicit in the next condition
+                // * The biggest proposal (NOT Nil) combined with the non cast votes is less than 2f+1
+
+                let mut uncast_votes = policy::Policy::SLOTS;
+                let mut biggest_weight = 0;
+
+                // Check every proposal present, including None
+                for (hash, signature) in message.contributions.iter() {
+                    let weight = u16::try_from(
+                        cloned_validators
+                            .signers_weight(&signature.signers)
+                            .unwrap_or(0),
+                    )
+                    // Maybe this should panic as whenever the conversion from usize to u16 is impossible
+                    // due to overflow, this contribution is faulty as a whole and should never have ended up here.
+                    .unwrap_or(0);
+                    // Any option which has at least 2f+1 votes make this contribution final.
+                    if weight >= policy::Policy::TWO_F_PLUS_ONE {
+                        return true;
+                    }
+                    // If the proposal does not have 2f+1 check if it has the new biggest_weight
+                    if hash.is_some() && weight > biggest_weight {
+                        biggest_weight = weight;
+                    }
+                    // The cast votes need to be removed from the uncast votes
+                    uncast_votes = uncast_votes.saturating_sub(weight);
+                }
+
+                let cast_votes = policy::Policy::SLOTS.saturating_sub(uncast_votes);
+                if cast_votes < policy::Policy::TWO_F_PLUS_ONE {
+                    // This should not be here. The criteria that the best vote can be elevated above the threshold
+                    // using the uncast votes is enough. In our case that means that seeing f+1 different proposals
+                    // with 1 vote each is a final aggregate. That is currently not handled that way in tendermint
+                    // as it only looks at contributions above 2f contributors. That behavior is thus maintained
+                    // here, but can be removed in the future if tendermint is changed as well.
+                    return false;
+                }
+
+                // If the uncast votes are not able to put the biggest vote over the threshold
+                // they cannot push any proposal over the threshold and thus the aggregate is final.
+                if uncast_votes + biggest_weight < policy::Policy::TWO_F_PLUS_ONE {
+                    return true;
+                }
+
+                false
+            },
         ));
 
-        let verifier = Arc::new(TendermintVerifier::new(validators.clone(), id.clone()));
+        let verifier = Arc::new(TendermintVerifier::new(Arc::clone(&validators), id.clone()));
 
         Self {
             verifier,

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -404,7 +404,6 @@ where
         let protocol = TendermintAggregationProtocol::new(
             Arc::clone(&self.validator_registry),
             self.validator_slot_band as usize,
-            1, // to be removed
             id,
         );
 
@@ -440,7 +439,6 @@ where
         let protocol = TendermintAggregationProtocol::new(
             Arc::clone(&self.validator_registry),
             self.validator_slot_band as usize,
-            1,
             id,
         );
 


### PR DESCRIPTION
This PR allows Handel to terminate aggregates earlier than once every possible contributor is present. It accepts a closure to check for finality. 
This PR also updates Tendermint, such that it can accept a final contribution with less contributors than the previous, non-final contribution.