### PR TITLE
Allow multiple rounds of validity sync

### DIFF
--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -437,7 +437,9 @@ impl<TNetwork: Network> Stream for LightMacroSync<TNetwork> {
             }
 
             if let Some(peer_id) = self.synced_validity_peers.pop() {
-                return Poll::Ready(Some(MacroSyncReturn::Good(peer_id)));
+                // We move the validity synced peer to another round of macro sync,
+                // to re-check if there is new state that we need to sync with.
+                self.add_peer(peer_id);
             }
         }
 

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -348,6 +348,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                     "Validity window syncing is complete"
                                 );
 
+                                self.synced_validity_peers.push(peer_id);
                                 self.validity_queue.remove_peer(&peer_id);
                                 self.syncing_peers.remove(&peer_id);
 
@@ -360,8 +361,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                 // We are complete so we emit the peer
                                 self.validity_requests = None;
                                 self.syncing_peers.clear();
-
-                                return Poll::Ready(Some(MacroSyncReturn::Good(peer_id)));
+                                break;
                             }
                         }
 


### PR DESCRIPTION
When we are done with the validity sync, move the peers back to macro sync to re-check if there is a more recent state that we need to sync with.
The exit condition is:
 - No more new macro state
 - We can verify the history root



...
#### This fixes #2881 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
