### PR TITLE
Consensus: return block number from head requests

### DIFF
--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -133,7 +133,7 @@ impl<TNetwork: Network + 'static> Future for HeadRequests<TNetwork> {
             // If we got a result, check it and classify it as known block/unknown block.
             match result {
                 Ok(head) => {
-                    let hash = head.micro;
+                    let hash = head.block_hash;
                     if self.blockchain.read().get_block(&hash, false).is_ok() {
                         self.num_known_blocks += 1;
                     } else {

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -342,9 +342,8 @@ impl<N: Network> Handle<N, BlockchainProxy> for RequestHead {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &BlockchainProxy) -> ResponseHead {
         let blockchain = blockchain.read();
         ResponseHead {
-            micro: blockchain.head_hash(),
-            r#macro: blockchain.macro_head_hash(),
-            election: blockchain.election_head_hash(),
+            block_number: blockchain.block_number(),
+            block_hash: blockchain.head_hash(),
         }
     }
 }

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -479,9 +479,8 @@ pub struct RequestHead {}
 
 #[derive(Clone, Debug, Deserialize, Serialize, SerializedMaxSize)]
 pub struct ResponseHead {
-    pub micro: Blake2bHash,
-    pub r#macro: Blake2bHash,
-    pub election: Blake2bHash,
+    pub block_number: u32,
+    pub block_hash: Blake2bHash,
 }
 
 impl RequestCommon for RequestHead {

--- a/consensus/src/sync/live/block_queue/live_sync.rs
+++ b/consensus/src/sync/live/block_queue/live_sync.rs
@@ -176,4 +176,8 @@ impl<N: Network> LiveSyncQueue<N> for BlockQueue<N> {
     fn resolve_block(&mut self, request: crate::consensus::ResolveBlockRequest<N>) {
         BlockQueue::resolve_block(self, request)
     }
+
+    fn acceptance_window_size(&self) -> u32 {
+        self.config.window_ahead_max
+    }
 }

--- a/consensus/src/sync/live/block_queue/proxy.rs
+++ b/consensus/src/sync/live/block_queue/proxy.rs
@@ -145,6 +145,10 @@ impl<N: Network> LiveSyncQueue<N> for BlockQueueProxy<N> {
     fn resolve_block(&mut self, request: ResolveBlockRequest<N>) {
         self.queue.lock().resolve_block(request)
     }
+
+    fn acceptance_window_size(&self) -> u32 {
+        self.queue.lock().acceptance_window_size()
+    }
 }
 
 impl<N: Network> Stream for BlockQueueProxy<N> {

--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -216,6 +216,10 @@ impl<N: Network> DiffQueue<N> {
     pub(crate) fn resolve_block(&mut self, request: ResolveBlockRequest<N>) {
         self.block_queue.resolve_block(request)
     }
+
+    pub(crate) fn acceptance_window_size(&self) -> u32 {
+        self.block_queue.acceptance_window_size()
+    }
 }
 
 impl<N: Network> Stream for DiffQueue<N> {

--- a/consensus/src/sync/live/mod.rs
+++ b/consensus/src/sync/live/mod.rs
@@ -106,6 +106,10 @@ impl<N: Network, Q: LiveSyncQueue<N>> LiveSync<N> for LiveSyncer<N, Q> {
     fn resolve_block(&mut self, request: ResolveBlockRequest<N>) {
         self.queue.resolve_block(request)
     }
+
+    fn acceptance_window_size(&self) -> u32 {
+        self.queue.acceptance_window_size()
+    }
 }
 
 impl<N: Network, Q: LiveSyncQueue<N>> Stream for LiveSyncer<N, Q> {

--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -114,6 +114,9 @@ pub trait LiveSyncQueue<N: Network>: Stream<Item = Self::QueueResult> + Send + U
 
     /// Initiates an attempt to resolve a ResolveBlockRequest.
     fn resolve_block(&mut self, request: ResolveBlockRequest<N>);
+
+    /// The maximum number of blocks a peer can be ahead before it is considered out-of-sync.
+    fn acceptance_window_size(&self) -> u32;
 }
 
 #[derive(Clone, Debug)]

--- a/consensus/src/sync/live/state_queue/live_sync.rs
+++ b/consensus/src/sync/live/state_queue/live_sync.rs
@@ -270,4 +270,8 @@ impl<N: Network> LiveSyncQueue<N> for StateQueue<N> {
     fn resolve_block(&mut self, request: ResolveBlockRequest<N>) {
         self.diff_queue.resolve_block(request)
     }
+
+    fn acceptance_window_size(&self) -> u32 {
+        self.diff_queue.acceptance_window_size()
+    }
 }


### PR DESCRIPTION
Detect if an incompatible peer is in sync using the returned block number.