### PR TITLE
spammer: Fix full sync

### DIFF
--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -253,6 +253,9 @@ async fn main_inner() -> Result<(), Error> {
         panic!("Could not start spammer");
     };
 
+    let zkp_component = client.take_zkp_component().unwrap();
+    spawn(zkp_component);
+
     let rolling_window = Policy::blocks_per_batch() as usize;
 
     let mut stat_exerts: VecDeque<StatsExert> = VecDeque::new();


### PR DESCRIPTION
Fix spammer full sync by also spawning the `zkp_component` in the spammer client implementation.

This fixes #2891.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
