### PR TITLE
Fix production of invalid history chunks

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -118,9 +118,9 @@ impl Blockchain {
                 .0;
 
             debug!(
-                num_transactions = hist_txs.len(),
+                transactions = hist_txs.len(),
                 block = bn,
-                "Pushed txns to the history store during validity sync"
+                "Pushed txns to the history store"
             );
         }
 

--- a/blockchain/src/history/history_store_proxy.rs
+++ b/blockchain/src/history/history_store_proxy.rs
@@ -98,7 +98,11 @@ impl HistoryInterface for HistoryStoreProxy {
     /// Returns the length (i.e. the number of leaves) of the History Tree at a given block height.
     /// Note that this returns the number of leaves for only the epoch of the given block height,
     /// this is because we have separate History Trees for separate epochs.
-    fn length_at(&self, block_number: u32, txn_option: Option<&MdbxReadTransaction>) -> u32 {
+    fn length_at(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Option<u32> {
         match self {
             HistoryStoreProxy::WithIndex(index) => index.length_at(block_number, txn_option),
             HistoryStoreProxy::WithoutIndex(store) => store.length_at(block_number, txn_option),

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -49,7 +49,9 @@ pub trait HistoryInterface: std::fmt::Debug {
     /// Returns the length (i.e. the number of leaves) of the History Tree at a given block height.
     /// Note that this returns the number of leaves for only the epoch of the given block height,
     /// this is because we have separate History Trees for separate epochs.
-    fn length_at(&self, block_number: u32, txn_option: Option<&MdbxReadTransaction>) -> u32;
+    /// If we dont have a block number at the given block height, we return None.
+    fn length_at(&self, block_number: u32, txn_option: Option<&MdbxReadTransaction>)
+        -> Option<u32>;
 
     /// Returns the total length of the History Tree at a given epoch number.
     /// The size of the history length is useful for getting a proof for a previous state

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -49,105 +49,114 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         validity_window_start: u32,
         mut election_in_window: bool,
     ) {
-        if self.validity_requests.is_none() {
-            // By default we set the parameters assuming we are starting from the beginning of the epoch.
-            let mut epoch_number = Policy::epoch_at(verifier_block_number);
-            let mut chunk_index = 0;
-            let mut root_hash = expected_root.clone();
-            let mut last_chunk_items: Option<usize> = None;
+        // By default we set the parameters assuming we are starting from the beginning of the epoch.
+        let mut epoch_number = Policy::epoch_at(verifier_block_number);
+        let mut chunk_index = 0;
+        let mut root_hash = expected_root.clone();
+        let mut last_chunk_items: Option<usize> = None;
 
-            // First we need to check if we already have items in the history store, and request only the remaining portion (if any)
-            match &self.blockchain {
-                BlockchainProxy::Full(blockchain) => {
-                    let blockchain_wr = blockchain.read();
+        let blockchain = match &self.blockchain {
+            BlockchainProxy::Full(blockchain) => blockchain,
+            BlockchainProxy::Light(_) => unreachable!(),
+        };
 
-                    let (first_bn, last_bn) = blockchain_wr.history_store.history_store_range(None);
+        let blockchain_wr = blockchain.read();
 
-                    // This means we already have items for the first epoch of the validity window we are interested in
-                    // so we need to move to the next epoch to request the missing items.
-                    if last_bn >= verifier_block_number {
-                        epoch_number = Policy::epoch_at(last_bn);
+        // First we need to check if we already have items in the history store, and request only the remaining portion (if any)
+        let (first_bn, last_bn) = blockchain_wr.history_store.history_store_range(None);
 
-                        // This length is based on number of leaves in the tree
-                        let current_length =
-                            blockchain_wr.history_store.length_at(last_bn, None) as usize;
+        // This means we already have items for the first epoch of the validity window we are interested in
+        // so we need to move to the next epoch to request the missing items.
+        if last_bn >= verifier_block_number {
+            epoch_number = Policy::epoch_at(last_bn);
 
-                        log::debug!(
-                            first_bn = first_bn,
-                            last_bn = last_bn,
-                            current_items = current_length,
-                            "We already have items in our history store, moving to the current epoch",
-                        );
+            // This length is based on number of leaves in the tree
+            let current_length = blockchain_wr
+                .history_store
+                .length_at(last_bn, None)
+                .expect("We must have items in the history store at this height")
+                as usize;
 
-                        chunk_index = (current_length / CHUNK_SIZE) as u32;
-                        last_chunk_items = Some(current_length % CHUNK_SIZE);
-                        root_hash = blockchain_wr.macro_head().header.history_root.clone();
-                        verifier_block_number = blockchain_wr.macro_head().block_number();
-                        election_in_window = false;
-                    } else if last_bn >= validity_window_start {
-                        // This is the case where we already have items in the start of the validity window
-                        // We need to request the missing items
-                        epoch_number = Policy::epoch_at(last_bn);
-
-                        // This length is based on number of leaves in the tree
-                        let current_length =
-                            blockchain_wr.history_store.length_at(last_bn, None) as usize;
-
-                        log::debug!(
-                            first_bn = first_bn,
-                            last_bn = last_bn,
-                            current_items = current_length,
-                            "We already have items in our history store",
-                        );
-
-                        chunk_index = (current_length / CHUNK_SIZE) as u32;
-                        last_chunk_items = Some(current_length % CHUNK_SIZE);
-                    }
-                }
-                BlockchainProxy::Light(_) => {
-                    unreachable!()
-                }
-            };
-
-            self.validity_requests = Some(ValidityChunkRequest {
-                verifier_block_number,
-                root_hash,
-                chunk_index,
-                election_in_window,
-                last_chunk_items,
-            });
-
-            // Add the peer
-            self.validity_queue.add_peer(peer_id);
-            self.syncing_peers.insert(peer_id);
-
-            let request = RequestHistoryChunk {
-                epoch_number,
-                block_number: verifier_block_number,
-                chunk_index: chunk_index as u64,
-            };
-
-            log::info!(
-                target_macro = verifier_block_number,
-                chunk_index = chunk_index,
-                last_chunk_items = last_chunk_items,
-                epoch = epoch_number,
-                validity_start = validity_window_start,
-                election_in_between = election_in_window,
-                expected_root = %expected_root,
-                "Starting validity window synchronization process"
+            log::debug!(
+                first_bn = first_bn,
+                last_bn = last_bn,
+                current_items = current_length,
+                "We already have items in our history store, moving to the current epoch",
             );
 
-            // Request the chunk
-            self.validity_queue.add_ids(vec![(request, None)]);
-        } else {
-            // If we are already requesting chunks, then we only add the peer
-            self.validity_queue.add_peer(peer_id);
-            self.syncing_peers.insert(peer_id);
+            chunk_index = (current_length / CHUNK_SIZE) as u32;
+            last_chunk_items = Some(current_length % CHUNK_SIZE);
+            root_hash = blockchain_wr.macro_head().header.history_root.clone();
+            verifier_block_number = blockchain_wr.macro_head().block_number();
+            election_in_window = false;
+        } else if last_bn >= validity_window_start {
+            // This is the case where we already have items in the start of the validity window
+            // We need to request the missing items
+            epoch_number = Policy::epoch_at(last_bn);
+
+            // This length is based on number of leaves in the tree
+            let current_length = blockchain_wr
+                .history_store
+                .length_at(last_bn, None)
+                .expect("We must have items in the history store at this height")
+                as usize;
+
+            log::debug!(
+                first_bn = first_bn,
+                last_bn = last_bn,
+                current_items = current_length,
+                "We already have items in our history store",
+            );
+
+            chunk_index = (current_length / CHUNK_SIZE) as u32;
+            last_chunk_items = Some(current_length % CHUNK_SIZE);
         }
+
+        // Request the macro chain at this height to know the history tree length at this height
+
+        self.validity_requests = Some(ValidityChunkRequest {
+            verifier_block_number,
+            root_hash,
+            chunk_index,
+            election_in_window,
+            last_chunk_items,
+        });
+
+        // Add the peer
+        self.validity_queue.add_peer(peer_id);
+        self.syncing_peers.insert(peer_id);
+
+        let request = RequestHistoryChunk {
+            epoch_number,
+            block_number: verifier_block_number,
+            chunk_index: chunk_index as u64,
+        };
+
+        log::info!(
+            target_macro = verifier_block_number,
+            chunk_index = chunk_index,
+            last_chunk_items = last_chunk_items,
+            epoch = epoch_number,
+            validity_start = validity_window_start,
+            election_in_between = election_in_window,
+            expected_root = %expected_root,
+            "Starting validity window synchronization process"
+        );
+
+        // Request the chunk
+        self.validity_queue.add_ids(vec![(request, None)]);
     }
 
     pub fn start_validity_synchronization(&mut self, peer_id: TNetwork::PeerId) {
+        if self.validity_requests.is_some() {
+            // We already have a synchoronization in progress, so we just add the peer
+            let current_chunk = self.validity_requests.as_ref().unwrap().chunk_index;
+            log::debug!(%peer_id,current_chunk,"Adding peer to existing validity synchronization process");
+            self.validity_queue.add_peer(peer_id);
+            self.syncing_peers.insert(peer_id);
+            return;
+        }
+
         let macro_head = self.blockchain.read().macro_head().header.clone();
 
         let validity_start = macro_head
@@ -219,7 +228,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         while let Poll::Ready(Some(Ok((request, result, peer_id)))) =
             self.validity_queue.poll_next_unpin(cx)
         {
-            log::trace!(peer=%peer_id, chunk_index=request.chunk_index, block_number=request.block_number,  "Processing response from validity queue");
+            log::trace!(%peer_id, chunk_index=request.chunk_index, block_number=request.block_number,  "Processing response from validity queue");
 
             match result {
                 Ok(chunk) => {
@@ -230,165 +239,25 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     let leaf_index = peer_request.chunk_index * (CHUNK_SIZE as u32);
                     let chunk = chunk.chunk;
 
-                    log::trace!(
+                    log::info!(
                         chunk_index = peer_request.chunk_index,
                         chunk_size = chunk.history.len(),
                         target_macro = verifier_block_number,
-                        "Applying a new validity chunk"
+                        "Applying a new history chunk"
                     );
 
                     // Verify the history chunk
-                    let verification_result = chunk
+                    let valid_chunk = chunk
                         .verify(&expected_root, leaf_index as usize)
                         .map_or(false, |result| result);
 
-                    if verification_result {
-                        let mut epoch_complete = match &self.blockchain {
-                            BlockchainProxy::Full(blockchain) => {
-                                // First we calculate the beginning of the chunk that we want to apply
-                                let starting_index = if let Some(prev_items) =
-                                    peer_request.last_chunk_items.take()
-                                {
-                                    // This is the case where we re-requested a chunk due to a new target
-
-                                    match prev_items.cmp(&chunk.history.len()) {
-                                        std::cmp::Ordering::Less => {
-                                            // If the chunk has new history items, we need to apply the delta
-                                            prev_items
-                                        }
-                                        std::cmp::Ordering::Equal => {
-                                            // If we recieved the same chunk (i.e nothing changed) we don't need to re-apply it
-                                            // So we set the start as the chunk length to apply an empty slice.
-                                            chunk.history.len()
-                                        }
-                                        std::cmp::Ordering::Greater => 0,
-                                    }
-                                } else {
-                                    // This is the regular case, where we just apply the whole chunk
-                                    0
-                                };
-
-                                let history_root = Blockchain::extend_validity_sync(
-                                    blockchain.upgradable_read(),
-                                    &chunk.history[starting_index..],
-                                );
-
-                                history_root == expected_root
-                            }
-                            BlockchainProxy::Light(_) => unreachable!(),
-                        };
-
-                        // Get ready for requesting the next chunk
-                        let mut chunk_index = peer_request.chunk_index + 1;
-
-                        // We need to check the latest macro head.
-                        let (latest_macro_head_number, latest_history_root) = {
-                            let blockchain = self.blockchain.read();
-                            let macro_head = blockchain.macro_head();
-                            (
-                                macro_head.block_number(),
-                                macro_head.header.history_root.clone(),
-                            )
-                        };
-
-                        if latest_macro_head_number > verifier_block_number {
-                            // A new macro head was adopted.
-                            // TODO: We could keep track of the latest macro heads on a per peer basis
-                            //  because not all peers have the latest state.
-                            if Policy::epoch_at(verifier_block_number)
-                                < Policy::epoch_at(latest_macro_head_number)
-                            {
-                                if !peer_request.election_in_window {
-                                    // If the new macro head belongs to the next epoch, we still need to finish syncing the current epoch.
-                                    log::debug!(
-                                        new_macro_head = latest_macro_head_number,
-                                        new_epoch = Policy::epoch_at(latest_macro_head_number),
-                                        "We have a new macro head that belongs to the next epoch"
-                                    );
-                                    peer_request.election_in_window = true;
-                                }
-                            } else {
-                                log::debug!(new_macro_head=latest_macro_head_number, new_history_root=%latest_history_root, current_epoch = Policy::epoch_at(latest_macro_head_number), "We have a new macro head, updating the validity sync target for our current epoch");
-                                verifier_block_number = latest_macro_head_number;
-                                peer_request.root_hash = latest_history_root.clone();
-                                peer_request.verifier_block_number = latest_macro_head_number;
-
-                                // We re-request the same chunk because applying a new macro head could potentially change the number of chunk items.
-                                chunk_index = peer_request.chunk_index;
-                                peer_request.last_chunk_items = Some(chunk.history.len());
-
-                                // We are no longer complete
-                                epoch_complete = false;
-                            }
-                        }
-
-                        if epoch_complete {
-                            // We need to check if there was an election in between, if so, we need to proceed to the next epoch
-                            if peer_request.election_in_window {
-                                log::trace!(
-                                    current_epoch = Policy::epoch_at(verifier_block_number),
-                                    new_verifier_bn = latest_macro_head_number,
-                                    new_expected_root = %latest_history_root,
-                                    next_epoch = Policy::epoch_at(latest_macro_head_number),
-                                    "Moving to the next epoch to continue validity syncing",
-                                );
-
-                                // Move to the next epoch:
-                                // Note, when we move to the next epoch, we always select the latest macro head as our target
-                                verifier_block_number = latest_macro_head_number;
-                                chunk_index = 0;
-                                peer_request.election_in_window = false;
-                                peer_request.root_hash = latest_history_root.clone();
-                                peer_request.verifier_block_number = latest_macro_head_number;
-                            } else {
-                                // We are done
-                                log::info!(
-                                    synced_root = %expected_root,
-                                    synced_macro_head = verifier_block_number,
-                                    "Validity window syncing is complete"
-                                );
-
-                                self.synced_validity_peers.push(peer_id);
-                                self.validity_queue.remove_peer(&peer_id);
-                                self.syncing_peers.remove(&peer_id);
-
-                                // We move all the peers from the sync queue to the synced peers.
-                                for peer_id in self.syncing_peers.iter() {
-                                    self.synced_validity_peers.push(*peer_id);
-                                    self.validity_queue.remove_peer(peer_id);
-                                }
-
-                                // We are complete so we emit the peer
-                                self.validity_requests = None;
-                                self.syncing_peers.clear();
-                                break;
-                            }
-                        }
-
-                        // Update the peer tracker structure
-                        peer_request.chunk_index = chunk_index;
-
-                        let request = RequestHistoryChunk {
-                            epoch_number: Policy::epoch_at(verifier_block_number),
-                            block_number: verifier_block_number,
-                            chunk_index: chunk_index as u64,
-                        };
-
-                        log::trace!(
-                            verifier_bn = verifier_block_number,
-                            epoch_number = Policy::epoch_at(verifier_block_number),
-                            chunk_index = chunk_index,
-                            "Adding a new validity window chunk request"
-                        );
-
-                        self.validity_queue.add_ids(vec![(request, None)]);
-                    } else {
+                    if !valid_chunk {
                         // If the chunk doesn't verify we disconnect from the peer
                         log::warn!(%peer_id,
-                                    chunk=request.chunk_index,
-                                    verifier_block=request.block_number,
-                                    epoch=request.epoch_number,
-                                    "Banning peer because the validity history chunk didn't verify");
+                            chunk=request.chunk_index,
+                            verifier_block=request.block_number,
+                            epoch=request.epoch_number,
+                            "Banning peer because the history chunk didn't verify");
 
                         // Remove the peer from the syncing process
                         self.validity_queue.remove_peer(&peer_id);
@@ -399,13 +268,153 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 
                         // Re add the request to the sync queue
                         self.validity_queue.add_ids(vec![(request, None)]);
+
+                        break;
                     }
+
+                    let blockchain = match &self.blockchain {
+                        BlockchainProxy::Full(blockchain) => blockchain,
+                        BlockchainProxy::Light(_) => unreachable!(),
+                    };
+
+                    let mut epoch_complete = {
+                        // We need to check if there were previous items that belong to this chunk
+                        let prev_items = peer_request.last_chunk_items.take().unwrap_or(0);
+
+                        // First we calculate the beginning of the chunk that we want to apply
+                        let starting_index = match prev_items.cmp(&chunk.history.len()) {
+                            std::cmp::Ordering::Less => {
+                                // If the chunk has new history items, we need to apply the delta
+                                prev_items
+                            }
+                            std::cmp::Ordering::Equal => {
+                                // If we recieved the same chunk (i.e nothing changed) we don't need to re-apply it
+                                // So we set the start as the chunk length to apply an empty slice.
+                                chunk.history.len()
+                            }
+                            std::cmp::Ordering::Greater => 0,
+                        };
+
+                        let history_root = Blockchain::extend_validity_sync(
+                            blockchain.upgradable_read(),
+                            &chunk.history[starting_index..],
+                        );
+
+                        history_root == expected_root
+                    };
+
+                    // Get ready for requesting the next chunk
+                    let mut chunk_index = peer_request.chunk_index + 1;
+
+                    // We need to check the latest macro head.
+                    let (latest_macro_head_number, latest_history_root) = {
+                        let blockchain = self.blockchain.read();
+                        let macro_head = blockchain.macro_head();
+                        (
+                            macro_head.block_number(),
+                            macro_head.header.history_root.clone(),
+                        )
+                    };
+
+                    if latest_macro_head_number > verifier_block_number {
+                        // A new macro head was adopted.
+                        // TODO: We could keep track of the latest macro heads on a per peer basis
+                        //  because not all peers have the latest state.
+                        if Policy::epoch_at(verifier_block_number)
+                            < Policy::epoch_at(latest_macro_head_number)
+                        {
+                            if !peer_request.election_in_window {
+                                // If the new macro head belongs to the next epoch, we still need to finish syncing the current epoch.
+                                log::debug!(
+                                    new_macro_head = latest_macro_head_number,
+                                    new_epoch = Policy::epoch_at(latest_macro_head_number),
+                                    "We have a new macro head that belongs to the next epoch"
+                                );
+                                peer_request.election_in_window = true;
+                            }
+                        } else {
+                            log::debug!(new_macro_head=latest_macro_head_number, new_history_root=%latest_history_root, current_epoch = Policy::epoch_at(latest_macro_head_number), "We have a new macro head, updating the validity sync target for our current epoch");
+                            verifier_block_number = latest_macro_head_number;
+                            peer_request.root_hash = latest_history_root.clone();
+                            peer_request.verifier_block_number = latest_macro_head_number;
+
+                            // We re-request the same chunk because applying a new macro head could potentially change the number of chunk items.
+                            chunk_index = peer_request.chunk_index;
+                            peer_request.last_chunk_items = Some(chunk.history.len());
+
+                            // We are no longer complete
+                            epoch_complete = false;
+                        }
+                    }
+
+                    if epoch_complete {
+                        // We need to check if there was an election in between, if so, we need to proceed to the next epoch
+                        if peer_request.election_in_window {
+                            log::trace!(
+                                current_epoch = Policy::epoch_at(verifier_block_number),
+                                new_verifier_bn = latest_macro_head_number,
+                                new_expected_root = %latest_history_root,
+                                next_epoch = Policy::epoch_at(latest_macro_head_number),
+                                "Moving to the next epoch to continue validity syncing",
+                            );
+
+                            // Move to the next epoch:
+                            // Note, when we move to the next epoch, we always select the latest macro head as our target
+                            verifier_block_number = latest_macro_head_number;
+                            chunk_index = 0;
+                            peer_request.election_in_window = false;
+                            peer_request.root_hash = latest_history_root.clone();
+                            peer_request.verifier_block_number = latest_macro_head_number;
+                        } else {
+                            // We are done
+                            log::info!(
+                                synced_root = %expected_root,
+                                synced_macro_head = verifier_block_number,
+                                "Validity window syncing is complete"
+                            );
+
+                            self.synced_validity_peers.push(peer_id);
+                            self.validity_queue.remove_peer(&peer_id);
+                            self.syncing_peers.remove(&peer_id);
+
+                            // We move all the peers from the sync queue to the synced peers.
+                            for peer_id in self.syncing_peers.iter() {
+                                self.synced_validity_peers.push(*peer_id);
+                                self.validity_queue.remove_peer(peer_id);
+                            }
+
+                            // We are complete so we emit the peer
+                            self.validity_requests = None;
+                            self.syncing_peers.clear();
+                            break;
+                        }
+                    }
+
+                    // Update the peer tracker structure
+                    peer_request.chunk_index = chunk_index;
+
+                    let request = RequestHistoryChunk {
+                        epoch_number: Policy::epoch_at(verifier_block_number),
+                        block_number: verifier_block_number,
+                        chunk_index: chunk_index as u64,
+                    };
+
+                    log::trace!(
+                        verifier_bn = verifier_block_number,
+                        epoch_number = Policy::epoch_at(verifier_block_number),
+                        chunk_index = chunk_index,
+                        "Adding a new validity window chunk request"
+                    );
+
+                    self.validity_queue.add_ids(vec![(request, None)]);
                 }
-                Err(_err) => {
+                Err(err) => {
                     if request.epoch_number == 0 {
+                        // A proof cannot be produced for epoch 0, so we emit the peer
                         return Poll::Ready(Some(MacroSyncReturn::Good(peer_id)));
                     }
                     {
+                        log::warn!(%err, %peer_id, chunk_index=request.chunk_index,block_number=request.block_number,"The peer could not provide the requested history chunk, we emit it as outdated");
                         return Poll::Ready(Some(MacroSyncReturn::Outdated(peer_id)));
                     }
                 }


### PR DESCRIPTION
- Do not produce invalid history chunks if the verifier block number is ahead of our state
- Improve the validity window sync (log & process)

#### This fixes #2890 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
