### PR TITLE
Fix prove_num_leaves

### DIFF
--- a/blockchain/src/history/history_store_index.rs
+++ b/blockchain/src/history/history_store_index.rs
@@ -635,12 +635,19 @@ mod tests {
         let history_store = HistoryStoreIndex::new(env.clone(), NetworkId::UnitAlbatross);
 
         let mut txn = env.write_transaction();
+        let history_root_initial = history_store.get_history_tree_root(0, Some(&txn)).unwrap();
 
-        let size_proof = history_store.prove_num_leaves(0, Some(&txn));
-        assert!(size_proof.is_err());
+        let size_proof = history_store
+            .prove_num_leaves(0, Some(&txn))
+            .expect("Should be able to prove number of leaves");
+        assert!(size_proof.verify(&history_root_initial));
+        assert_eq!(size_proof.size(), 0);
 
-        let size_proof = history_store.prove_num_leaves(100, Some(&txn));
-        assert!(size_proof.is_err());
+        let size_proof = history_store
+            .prove_num_leaves(100, Some(&txn))
+            .expect("Should be able to prove number of leaves");
+        assert!(size_proof.verify(&history_root_initial));
+        assert_eq!(size_proof.size(), 0);
 
         // Create historic transactions.
         let ext_0 = create_transaction(3, 0);
@@ -651,9 +658,11 @@ mod tests {
         // Add first historic transaction to History Store.
         let (history_root0, _) = history_store.add_to_history(&mut txn, 3, &[ext_0]).unwrap();
 
-        let size_proof = history_store.prove_num_leaves(0, Some(&txn));
-        // This fails because we added block number 3, so block 0 does not exist.
-        assert!(size_proof.is_err());
+        let size_proof = history_store
+            .prove_num_leaves(0, Some(&txn))
+            .expect("Should be able to prove number of leaves");
+        assert!(size_proof.verify(&history_root_initial));
+        assert_eq!(size_proof.size(), 0);
 
         let size_proof = history_store
             .prove_num_leaves(100, Some(&txn))
@@ -667,9 +676,11 @@ mod tests {
         let (history_root3, _) = history_store.add_to_history(&mut txn, 8, &[ext_3]).unwrap();
 
         // Prove number of leaves.
-        let size_proof = history_store.prove_num_leaves(2, Some(&txn));
-        // This fails because the first block number is 3, so block 2 does not exist.
-        assert!(size_proof.is_err());
+        let size_proof = history_store
+            .prove_num_leaves(2, Some(&txn))
+            .expect("Should be able to prove number of leaves");
+        assert!(size_proof.verify(&history_root_initial));
+        assert_eq!(size_proof.size(), 0);
 
         let size_proof = history_store
             .prove_num_leaves(3, Some(&txn))


### PR DESCRIPTION
- If we do not know a block, then prove_num_leaves returns an empty proof (same as before the fix for #2893 was introduced)
- However, if we try to prove a history chunk for a block that we don't know, then we still return None (i.e the fix for #2893 is still in place)
- This fixes #2908

## What's in this pull request?

...
#### This fixes #2908 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
