### PR TITLE
Fix overflow on calculation of available micro body size

### DIFF
--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -63,9 +63,13 @@ impl MicroBlock {
 
     /// Returns the available size, in bytes, in a micro block body for transactions.
     pub fn get_available_bytes(num_equivocation_proofs: usize) -> usize {
-        Policy::MAX_SIZE_MICRO_BODY
-            - (/*equivocation_proofs vector length*/2 + num_equivocation_proofs * EquivocationProof::MAX_SIZE
-            + /*transactions vector length*/ 2)
+        #[allow(clippy::identity_op)]
+        Policy::MAX_SIZE_MICRO_BODY.saturating_sub(
+            0
+            + /* equivocation_proofs vector length */ 2
+            + num_equivocation_proofs * EquivocationProof::MAX_SIZE
+            + /* transactions vector length */ 2,
+        )
     }
 
     pub(crate) fn verify_proposer(&self, signing_key: &Ed25519PublicKey) -> Result<(), BlockError> {

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -62,14 +62,9 @@ impl MicroBlock {
     }
 
     /// Returns the available size, in bytes, in a micro block body for transactions.
-    pub fn get_available_bytes(num_equivocation_proofs: usize) -> usize {
-        #[allow(clippy::identity_op)]
-        Policy::MAX_SIZE_MICRO_BODY.saturating_sub(
-            0
-            + /* equivocation_proofs vector length */ 2
-            + num_equivocation_proofs * EquivocationProof::MAX_SIZE
-            + /* transactions vector length */ 2,
-        )
+    pub fn get_available_bytes(equivocation_proofs: &[EquivocationProof]) -> usize {
+        Policy::MAX_SIZE_MICRO_BODY
+            - (equivocation_proofs.serialized_size() + /*transactions vector length*/ 2)
     }
 
     pub(crate) fn verify_proposer(&self, signing_key: &Ed25519PublicKey) -> Result<(), BlockError> {

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -330,8 +330,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         );
 
         // First we try to fill the block with control transactions
-        let mut block_available_bytes =
-            MicroBlock::get_available_bytes(self.equivocation_proofs.len());
+        let mut block_available_bytes = MicroBlock::get_available_bytes(&self.equivocation_proofs);
 
         let (mut transactions, txn_size) = self
             .mempool


### PR DESCRIPTION
This simply clamps the result at 0. It'd be beneficial to calculate the size more accurately and also to drop equivocation proofs if there are too many to include in a single block. This wasn't done in this commit.

Fixes #2914.