### PR TITLE
Migration: introduce `async_retryer` helper function to allow multiple attempts for Futures that return a `Result`

### DIFF
--- a/pow-migration/src/history.rs
+++ b/pow-migration/src/history.rs
@@ -113,7 +113,7 @@ pub async fn migrate_history(
             // If this is true, we may need to take some extra time in order to make sure
             // that blocks leading up to the head block are confirmed before we
             // can safely add them to the PoS history store.
-            if pow_head_height - block_height <= block_confirmations {
+            if pow_head_height - block_height < block_confirmations {
                 loop {
                     log::info!(
                         block = block_height,
@@ -123,7 +123,7 @@ pub async fn migrate_history(
                     sleep(Duration::from_secs(60)).await;
                     pow_head_height = async_retryer(|| pow_client.block_number()).await.unwrap();
                     // Check if the block has been confirmed.
-                    if pow_head_height > block_height + block_confirmations {
+                    if pow_head_height >= block_height + block_confirmations {
                         break;
                     }
                 }

--- a/pow-migration/src/history.rs
+++ b/pow-migration/src/history.rs
@@ -133,6 +133,10 @@ pub async fn migrate_history(
                 .await
                 .unwrap();
 
+            if block_height % 100 == 0 {
+                log::info!(block_number = %block.number, target = %candidate_block, "Migrated new PoW history chunk");
+            }
+
             // Get all transactions for this block height
             let mut transactions = vec![];
             let mut network_id = NetworkId::Main;


### PR DESCRIPTION
## What's in this pull request?
- Introduce `async_retryer` helper function to allow multiple attempts for Futures that return a `Result`. This is helpful since RPC calls to the PoW node can fail at any point in time.
- Add log message to inform about the PoW history migration progress.
- Fix "off by one" to migrate the PoW history when the amount of block confirmations is reached instead of block confirmations + 1

#### This fixes #2921 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
