### PR TITLE
Chore: fix rustfmt errors with new lints

### DIFF
--- a/database/src/mdbx/transaction/mod.rs
+++ b/database/src/mdbx/transaction/mod.rs
@@ -35,9 +35,15 @@ impl<'db, Kind> ReadTransaction<'db> for MdbxTransaction<'db, Kind>
 where
     Kind: TransactionKind,
 {
-    type Cursor<'txn, T: Table> = MdbxCursor<'txn, Kind, T> where 'db: 'txn;
+    type Cursor<'txn, T: Table>
+        = MdbxCursor<'txn, Kind, T>
+    where
+        'db: 'txn;
 
-    type DupCursor<'txn, T: DupTable> = MdbxCursor<'txn, Kind, T> where 'db: 'txn;
+    type DupCursor<'txn, T: DupTable>
+        = MdbxCursor<'txn, Kind, T>
+    where
+        'db: 'txn;
 
     fn get<T: Table>(&self, table: &T, key: &T::Key) -> Option<T::Value> {
         let table = self.open_table(table);
@@ -64,9 +70,15 @@ where
 }
 
 impl<'db> WriteTransaction<'db> for MdbxTransaction<'db, RW> {
-    type WriteCursor<'txn, T: Table> = MdbxWriteCursor<'txn, T> where 'db: 'txn;
+    type WriteCursor<'txn, T: Table>
+        = MdbxWriteCursor<'txn, T>
+    where
+        'db: 'txn;
 
-    type DupWriteCursor<'txn, T: DupTable> = MdbxWriteCursor<'txn, T> where 'db: 'txn;
+    type DupWriteCursor<'txn, T: DupTable>
+        = MdbxWriteCursor<'txn, T>
+    where
+        'db: 'txn;
 
     fn put_reserve<T: Table>(&mut self, table: &T, key: &T::Key, value: &T::Value)
     where

--- a/database/src/mdbx/transaction/proxy.rs
+++ b/database/src/mdbx/transaction/proxy.rs
@@ -20,9 +20,15 @@ impl<'db, 'inner> ReadTransaction<'db> for TransactionProxy<'db, 'inner>
 where
     'db: 'inner,
 {
-    type Cursor<'txn, T: Table> = CursorProxy<'txn, T> where 'inner: 'txn;
+    type Cursor<'txn, T: Table>
+        = CursorProxy<'txn, T>
+    where
+        'inner: 'txn;
 
-    type DupCursor<'txn, T: DupTable> = CursorProxy<'txn, T> where 'inner: 'txn;
+    type DupCursor<'txn, T: DupTable>
+        = CursorProxy<'txn, T>
+    where
+        'inner: 'txn;
 
     fn get<T: Table>(&self, table: &T, key: &T::Key) -> Option<T::Value> {
         match self {

--- a/database/src/mdbx/transaction/wrapper.rs
+++ b/database/src/mdbx/transaction/wrapper.rs
@@ -29,9 +29,15 @@ impl<'db> MdbxReadTransaction<'db> {
 }
 
 impl<'db> ReadTransaction<'db> for MdbxReadTransaction<'db> {
-    type Cursor<'txn, T: Table> = CursorProxy<'txn, T> where Self: 'txn;
+    type Cursor<'txn, T: Table>
+        = CursorProxy<'txn, T>
+    where
+        Self: 'txn;
 
-    type DupCursor<'txn, T: DupTable> = CursorProxy<'txn, T> where  Self: 'txn;
+    type DupCursor<'txn, T: DupTable>
+        = CursorProxy<'txn, T>
+    where
+        Self: 'txn;
 
     fn get<T: Table>(&self, table: &T, key: &T::Key) -> Option<T::Value> {
         match self {
@@ -72,10 +78,15 @@ impl<'db> MdbxWriteTransaction<'db> {
 }
 
 impl<'db> ReadTransaction<'db> for MdbxWriteTransaction<'db> {
-    type Cursor<'txn, T: Table> = CursorProxy<'txn, T> where Self: 'txn;
+    type Cursor<'txn, T: Table>
+        = CursorProxy<'txn, T>
+    where
+        Self: 'txn;
 
-    type DupCursor<'txn, T: DupTable> = CursorProxy<'txn, T>
-    where Self: 'txn;
+    type DupCursor<'txn, T: DupTable>
+        = CursorProxy<'txn, T>
+    where
+        Self: 'txn;
 
     fn get<T: Table>(&self, table: &T, key: &T::Key) -> Option<T::Value> {
         self.txn.get(table, key)
@@ -91,9 +102,15 @@ impl<'db> ReadTransaction<'db> for MdbxWriteTransaction<'db> {
 }
 
 impl<'db> WriteTransaction<'db> for MdbxWriteTransaction<'db> {
-    type WriteCursor<'txn, T: Table> = MdbxCursor<'txn, RW, T>where Self: 'txn;
+    type WriteCursor<'txn, T: Table>
+        = MdbxCursor<'txn, RW, T>
+    where
+        Self: 'txn;
 
-    type DupWriteCursor<'txn, T: DupTable> = MdbxCursor<'txn, RW, T> where Self: 'txn;
+    type DupWriteCursor<'txn, T: DupTable>
+        = MdbxCursor<'txn, RW, T>
+    where
+        Self: 'txn;
 
     fn put_reserve<T: RegularTable>(&mut self, table: &T, key: &T::Key, value: &T::Value)
     where


### PR DESCRIPTION
Rust nightly 1.83 introduced new lints that are breaking the CI

