### PR TITLE
Disambiguate VRF seeds across non-competing branches

### DIFF
--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -147,7 +147,7 @@ impl BlockProducer {
             // leader.
             prev_seed
         } else {
-            prev_seed.sign_next_with_rng(&self.signing_key, rng)
+            prev_seed.sign_next_with_rng(&self.signing_key, block_number, rng)
         };
 
         // Create the inherents from the equivocation proofs or skip block info.
@@ -303,10 +303,11 @@ impl BlockProducer {
 
         // Calculate the seed for this block by signing the previous block seed with the validator
         // key.
-        let seed = blockchain
-            .head()
-            .seed()
-            .sign_next_with_rng(&self.signing_key, rng);
+        let seed =
+            blockchain
+                .head()
+                .seed()
+                .sign_next_with_rng(&self.signing_key, block_number, rng);
 
         // If this is an election block, calculate the validator set for the next epoch.
         let validators = match Policy::is_election_block_at(block_number) {

--- a/pow-migration/src/genesis.rs
+++ b/pow-migration/src/genesis.rs
@@ -77,7 +77,11 @@ pub async fn get_pos_genesis(
     let mut parent_hash_bytes = [0u8; 32];
     parent_hash_bytes.copy_from_slice(parent_hash.as_slice());
     let mut rng = StdRng::from_seed(parent_hash_bytes);
-    let vrf_seed = VrfSeed::default().sign_next_with_rng(&KeyPair::generate(&mut rng), &mut rng);
+    let vrf_seed = VrfSeed::default().sign_next_with_rng(
+        &KeyPair::generate(&mut rng),
+        final_block.number,
+        &mut rng,
+    );
 
     log::info!("Getting PoW account state");
 

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -596,7 +596,7 @@ impl Block {
         // Verify VRF seed.
         if !self.is_skip() {
             self.seed()
-                .verify(prev_seed, signing_key)
+                .verify(prev_seed, signing_key, self.block_number())
                 .map_err(|_| BlockError::InvalidSeed)?;
         } else {
             // XXX This is also checked in `verify_immediate_successor`.

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -636,7 +636,7 @@ mod test {
             block_number: Policy::genesis_block_number(),
             timestamp: 1,
             parent_hash: "".hash(),
-            seed: VrfSeed::default().sign_next(&key),
+            seed: VrfSeed::default().sign_next(&key, Policy::genesis_block_number()),
             extra_data: vec![1],
             state_root: "".hash(),
             body_root: "".hash(),
@@ -650,7 +650,9 @@ mod test {
             block_number: Policy::genesis_block_number(),
             timestamp: 2,
             parent_hash: "1".hash(),
-            seed: VrfSeed::default().sign_next(&key).sign_next(&key),
+            seed: VrfSeed::default()
+                .sign_next(&key, Policy::genesis_block_number())
+                .sign_next(&key, Policy::genesis_block_number()),
             extra_data: vec![2],
             state_root: "1".hash(),
             body_root: "1".hash(),
@@ -748,7 +750,7 @@ mod test {
             parent_hash: "".hash(),
             parent_election_hash: "".hash(),
             interlink: Some(vec![]),
-            seed: VrfSeed::default().sign_next(&key),
+            seed: VrfSeed::default().sign_next(&key, Policy::genesis_block_number()),
             extra_data: vec![1],
             state_root: "".hash(),
             body_root: "".hash(),
@@ -767,7 +769,9 @@ mod test {
             parent_hash: "1".hash(),
             parent_election_hash: "1".hash(),
             interlink: Some(vec![Blake2bHash::default()]),
-            seed: VrfSeed::default().sign_next(&key).sign_next(&key),
+            seed: VrfSeed::default()
+                .sign_next(&key, Policy::genesis_block_number())
+                .sign_next(&key, Policy::genesis_block_number()),
             extra_data: vec![2],
             state_root: "1".hash(),
             body_root: "1".hash(),

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -104,7 +104,7 @@ pub fn next_micro_block(
     let seed = config
         .seed
         .clone()
-        .unwrap_or_else(|| prev_seed.sign_next(signing_key));
+        .unwrap_or_else(|| prev_seed.sign_next(signing_key, block_number));
 
     let mut transactions = config.transactions.clone();
     transactions.sort_unstable();
@@ -313,10 +313,12 @@ pub fn next_macro_block_proposal(
         }
     });
 
-    let seed = config
-        .seed
-        .clone()
-        .unwrap_or_else(|| blockchain.head().seed().sign_next(signing_key));
+    let seed = config.seed.clone().unwrap_or_else(|| {
+        blockchain
+            .head()
+            .seed()
+            .sign_next(signing_key, block_number)
+    });
 
     let validators = if Policy::is_election_block_at(blockchain.block_number() + 1) {
         Some(blockchain.next_validators(&seed))


### PR DESCRIPTION
Skip blocks do not change the VRF seed but simply pass it through to the next block, effectively making skip blocks a no-op in terms of VRF seed calculation. This means that before this PR, two non-competing branches (i.e. those that have different skip blocks) will (potentially) get the same VRF seeds for the same block numbers. This breaks some assumptions regarding fork detection and skip block applicability across branches. 

This PR adds the current block number to the VRF seed calculation for regular (non-skip) blocks, effectively encoding the position of skip blocks (because skipped block numbers are **not** part of the VRF), such that non-competing branches get different VRF seeds while competing ones still get the same.
