### PR TITLE
Re-request failed chunks during validity sync

### DIFF
--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -415,6 +415,14 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     }
                     {
                         log::warn!(%err, %peer_id, chunk_index=request.chunk_index,block_number=request.block_number,"The peer could not provide the requested history chunk, we emit it as outdated");
+
+                        // Remove the peer from the syncing process
+                        self.validity_queue.remove_peer(&peer_id);
+                        self.syncing_peers.remove(&peer_id);
+
+                        // Re add the request to the sync queue
+                        self.validity_queue.add_ids(vec![(request, None)]);
+
                         return Poll::Ready(Some(MacroSyncReturn::Outdated(peer_id)));
                     }
                 }


### PR DESCRIPTION
Fixes #2930
If a peer can not provide a history chunk to us, because it is outdated, we properly emit the peer as outdated, however, we also need to re-request the given chunk in order to continue syncing.



...
#### This fixes #2930 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
