### PR TITLE
network-libp2p: Only use secure WS dial attempts when requested

### DIFF
--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -17,6 +17,8 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::utils;
+
 #[derive(Debug, Error)]
 pub enum PeerContactError {
     #[error("Exceeded number of advertised addresses")]
@@ -382,7 +384,7 @@ impl PeerContactBook {
             let has_secure_ws_connections = peer_contact
                 .addresses
                 .iter()
-                .any(Self::is_address_ws_secure);
+                .any(utils::is_address_ws_secure);
             if !has_secure_ws_connections {
                 return;
             }
@@ -566,12 +568,6 @@ impl PeerContactBook {
                 self.peer_contacts.remove(&peer_id);
             }
         }
-    }
-
-    /// Returns true if an address is a secure websocket connection.
-    /// If address doesn't have the websocket protocol, it will return `false`.
-    fn is_address_ws_secure(address: &Multiaddr) -> bool {
-        address.into_iter().any(|p| matches!(p, Protocol::Wss(_)))
     }
 
     /// Returns true if an address is valid for dialing.

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -11,8 +11,10 @@ mod network;
 #[cfg(feature = "metrics")]
 mod network_metrics;
 mod network_types;
+mod only_secure_ws_transport;
 mod rate_limiting;
 mod swarm;
+mod utils;
 
 pub const DISCOVERY_PROTOCOL: &str = "/nimiq/discovery/0.0.1";
 pub const DHT_PROTOCOL: &str = "/nimiq/kad/0.0.1";

--- a/network-libp2p/src/only_secure_ws_transport.rs
+++ b/network-libp2p/src/only_secure_ws_transport.rs
@@ -1,0 +1,62 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use libp2p::{
+    core::transport::{DialOpts, ListenerId, TransportError, TransportEvent},
+    multiaddr::Multiaddr,
+};
+
+use crate::utils;
+
+/// Drops all dial requests to non-secure Web Socket multiaddresses.
+/// Inspired on the global-only transport from libp2p: https://github.com/libp2p/rust-libp2p/blob/master/core/src/transport/global_only.rs
+#[derive(Debug, Clone, Default)]
+pub struct Transport<T> {
+    inner: T,
+}
+
+impl<T> Transport<T> {
+    pub(crate) fn new(transport: T) -> Self {
+        Transport { inner: transport }
+    }
+}
+
+impl<T: libp2p::Transport + Unpin> libp2p::Transport for Transport<T> {
+    type Output = <T as libp2p::Transport>::Output;
+    type Error = <T as libp2p::Transport>::Error;
+    type ListenerUpgrade = <T as libp2p::Transport>::ListenerUpgrade;
+    type Dial = <T as libp2p::Transport>::Dial;
+
+    fn listen_on(
+        &mut self,
+        id: ListenerId,
+        addr: Multiaddr,
+    ) -> Result<(), TransportError<Self::Error>> {
+        self.inner.listen_on(id, addr)
+    }
+
+    fn remove_listener(&mut self, id: ListenerId) -> bool {
+        self.inner.remove_listener(id)
+    }
+
+    fn dial(
+        &mut self,
+        addr: Multiaddr,
+        opts: DialOpts,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        if utils::is_address_ws_secure(&addr) {
+            return self.inner.dial(addr, opts);
+        }
+        debug!(%addr, "Not dialing non secure address");
+        Err(TransportError::MultiaddrNotSupported(addr))
+    }
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<TransportEvent<Self::ListenerUpgrade, Self::Error>> {
+        Pin::new(&mut self.inner).poll(cx)
+    }
+}

--- a/network-libp2p/src/utils.rs
+++ b/network-libp2p/src/utils.rs
@@ -1,0 +1,7 @@
+use libp2p::{multiaddr::Protocol, Multiaddr};
+
+/// Returns true if an address is a secure websocket connection.
+/// If address doesn't have the websocket protocol, it will return `false`.
+pub fn is_address_ws_secure(address: &Multiaddr) -> bool {
+    address.into_iter().any(|p| matches!(p, Protocol::Wss(_)))
+}


### PR DESCRIPTION
Introduce a new transport wrapper (only_secure_ws_transport) that filters out any address that is not a web socket secure address. The transport is inspired on the [global_only transport from libp2p](https://github.com/libp2p/rust-libp2p/blob/master/core/src/transport/global_only.rs). The transport is only enabled when the configuration option `only_secure_ws_connections` is enabled.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
