### PR TITLE
Implement pagination by tx hash for requesting of transaction history

### DIFF
--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -195,11 +195,13 @@ pub trait HistoryIndexInterface {
 
     /// Returns a vector containing all transaction (and reward inherents) hashes corresponding to the given
     /// address. It fetches the transactions from most recent to least recent up to the maximum
-    /// number given.
+    /// number given. It allows to give a starting point to fetch the transactions from (exclusive). If this hash is given
+    /// but not found, the function will return an empty vector.
     fn get_tx_hashes_by_address(
         &self,
         address: &Address,
         max: u16,
+        start_at: Option<Blake2bHash>,
         txn_option: Option<&MdbxReadTransaction>,
     ) -> Vec<Blake2bHash>;
 

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -107,6 +107,7 @@ impl<N: Network> ConsensusProxy<N> {
         address: Address,
         min_peers: usize,
         max: Option<u16>,
+        start_at: Option<Blake2bHash>,
     ) -> Result<Vec<(Blake2bHash, u32)>, RequestError> {
         let mut obtained_receipts = HashSet::new();
 
@@ -125,6 +126,7 @@ impl<N: Network> ConsensusProxy<N> {
                     RequestTransactionReceiptsByAddress {
                         address: address.clone(),
                         max,
+                        start_at: start_at.clone(),
                     },
                     peer_id,
                 )

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -620,7 +620,12 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTransactionReceip
             .history_store
             .history_index()
             .unwrap()
-            .get_tx_hashes_by_address(&self.address, self.max.unwrap_or(500).min(500), None);
+            .get_tx_hashes_by_address(
+                &self.address,
+                self.max.unwrap_or(500).min(500),
+                self.start_at.clone(),
+                None,
+            );
 
         let mut receipts = vec![];
 

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -532,10 +532,17 @@ impl RequestCommon for RequestTransactionsProof {
     const MAX_REQUESTS: u32 = MAX_REQUEST_TRANSACTIONS_PROOF;
 }
 
+/// Returns the latest transactions for a given address. All the transactions
+/// where the given address is listed as a recipient or as a sender are considered. Reward
+/// transactions are also returned. It has an option to specify the maximum number of transactions
+/// to fetch. It has also an option to retrieve transactions before a given transaction hash.
+/// If this hash is not found or does not belong to this address, it will return an empty list.
+/// The transactions are returned in descending order, meaning the latest transaction is the first.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestTransactionReceiptsByAddress {
     pub address: Address,
     pub max: Option<u16>,
+    pub start_at: Option<Blake2bHash>,
 }
 
 impl RequestCommon for RequestTransactionReceiptsByAddress {

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -92,7 +92,7 @@ async fn test_request_transactions_by_address() {
     let key_pair = KeyPair::from(PrivateKey::from_str(REWARD_KEY).unwrap());
 
     let receipts = consensus_proxy
-        .request_transaction_receipts_by_address(Address::from(&key_pair.public), 1, None)
+        .request_transaction_receipts_by_address(Address::from(&key_pair.public), 1, None, None)
         .await;
     assert!(receipts.is_ok());
     let res = consensus_proxy

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -83,7 +83,9 @@ pub enum BlockchainCommand {
     /// Returns the latests transactions or their hashes for a given address. All the transactions
     /// where the given address is listed as a recipient or as a sender are considered. Reward
     /// transactions are also returned. It has an option to specify the maximum number of transactions/hashes to
-    /// fetch, it defaults to 500.
+    /// fetch, it defaults to 500. It has also an option to retrieve transactions before a given
+    /// transaction hash. If this hash is not found or does not belong to this address, it will return an empty list.
+    /// The transactions are returned in descending order, meaning the latest transaction is the first.
     TransactionsByAddress {
         /// The address to query by.
         address: Address,
@@ -91,6 +93,10 @@ pub enum BlockchainCommand {
         /// Max number of transactions to fetch. If absent it defaults to 500.
         #[clap(long)]
         max: Option<u16>,
+
+        /// A transaction to start at.
+        #[clap(long)]
+        start_at: Option<Blake2bHash>,
 
         /// If set true only the hash of the transactions will be fetched. Otherwise the full transactions will be retrieved.
         #[clap(short = 'h')]
@@ -265,6 +271,7 @@ impl HandleSubcommand for BlockchainCommand {
             BlockchainCommand::TransactionsByAddress {
                 address,
                 max,
+                start_at,
                 just_hash,
             } => {
                 if just_hash {
@@ -272,7 +279,7 @@ impl HandleSubcommand for BlockchainCommand {
                         "{:#?}",
                         client
                             .blockchain
-                            .get_transaction_hashes_by_address(address, max)
+                            .get_transaction_hashes_by_address(address, max, start_at)
                             .await?
                     )
                 } else {
@@ -280,7 +287,7 @@ impl HandleSubcommand for BlockchainCommand {
                         "{:#?}",
                         client
                             .blockchain
-                            .get_transactions_by_address(address, max)
+                            .get_transactions_by_address(address, max, start_at)
                             .await?
                     )
                 }

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -84,7 +84,7 @@ pub trait BlockchainInterface {
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     /// Returns all the inherents (including reward inherents) for the given batch number. Note
-    /// that this only considers blocks in the main chain.  
+    /// that this only considers blocks in the main chain.
     async fn get_inherents_by_batch_number(
         &mut self,
         batch_number: u32,
@@ -93,21 +93,27 @@ pub trait BlockchainInterface {
     /// Returns the hashes for the latest transactions for a given address. All the transactions
     /// where the given address is listed as a recipient or as a sender are considered. Reward
     /// transactions are also returned. It has an option to specify the maximum number of hashes to
-    /// fetch, it defaults to 500.
+    /// fetch, it defaults to 500. It has also an option to retrieve transactions before a given
+    /// transaction hash (exclusive). If this hash is not found or does not belong to this address, it will return an empty list.
+    /// The transaction hashes are returned in descending order, meaning the latest transaction is the first.
     async fn get_transaction_hashes_by_address(
         &mut self,
         address: Address,
         max: Option<u16>,
+        start_at: Option<Blake2bHash>,
     ) -> RPCResult<Vec<Blake2bHash>, (), Self::Error>;
 
     /// Returns the latest transactions for a given address. All the transactions
     /// where the given address is listed as a recipient or as a sender are considered. Reward
     /// transactions are also returned. It has an option to specify the maximum number of transactions
-    /// to fetch, it defaults to 500.
+    /// to fetch, it defaults to 500. It has also an option to retrieve transactions before a given
+    /// transaction hash (exclusive). If this hash is not found or does not belong to this address, it will return an empty list.
+    /// The transactions are returned in descending order, meaning the latest transaction is the first.
     async fn get_transactions_by_address(
         &mut self,
         address: Address,
         max: Option<u16>,
+        start_at: Option<Blake2bHash>,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     /// Tries to fetch the account at the given address.

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -307,6 +307,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         address: Address,
         max: Option<u16>,
+        start_at: Option<Blake2bHash>,
     ) -> RPCResult<Vec<Blake2bHash>, (), Self::Error> {
         if let BlockchainProxy::Full(blockchain) = &self.blockchain {
             Ok(blockchain
@@ -314,7 +315,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                 .history_store
                 .history_index()
                 .ok_or(Error::RequiresHistoryIndex)?
-                .get_tx_hashes_by_address(&address, max.unwrap_or(500), None)
+                .get_tx_hashes_by_address(&address, max.unwrap_or(500), start_at, None)
                 .into())
         } else {
             Err(Error::NotSupportedForLightBlockchain)
@@ -325,6 +326,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         &mut self,
         address: Address,
         max: Option<u16>,
+        start_at: Option<Blake2bHash>,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
             // Get the transaction hashes for this address.
@@ -332,7 +334,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                 .history_store
                 .history_index()
                 .ok_or(Error::RequiresHistoryIndex)?
-                .get_tx_hashes_by_address(&address, max.unwrap_or(500), None);
+                .get_tx_hashes_by_address(&address, max.unwrap_or(500), start_at, None);
 
             let mut txs = vec![];
 


### PR DESCRIPTION
## What's in this pull request?
This PR adds a `start_at` parameter to various functions used to request the transaction history.
This efficiently adds pagination of results from a known transaction hash (which will not be included in subsequent queries).

@sisou This changes the interface slightly, adding a new parameter. It would be good to have your input on this.

#### This fixes #2697, #2733, #2247.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
