### PR TITLE
Remove LevelUpdate origin from serialized representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,7 +3567,6 @@ dependencies = [
  "nimiq-collections",
  "nimiq-database-value",
  "nimiq-database-value-derive",
- "nimiq-handel",
  "nimiq-hash",
  "nimiq-hash_derive",
  "nimiq-keys",

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -20,7 +20,6 @@ log = { workspace = true }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 parking_lot = "0.12"
 rand = "0.8"
-serde = "1.0"
 thiserror = "1.0"
 
 nimiq-bls = { workspace = true }
@@ -31,6 +30,8 @@ nimiq-time = { workspace = true }
 nimiq-utils = { workspace = true, features = ["futures"] }
 
 [dev-dependencies]
+serde = "1.0"
+
 nimiq-network-interface = { workspace = true }
 nimiq-network-mock = { workspace = true }
 nimiq-test-log = { workspace = true }

--- a/handel/src/update.rs
+++ b/handel/src/update.rs
@@ -1,27 +1,22 @@
 use std::fmt::Debug;
 
-use nimiq_serde::fixint;
-use serde::{Deserialize, Serialize};
-
 use crate::contribution::AggregatableContribution;
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound = "C: AggregatableContribution")]
+#[derive(Clone, Debug)]
 pub struct LevelUpdate<C: AggregatableContribution> {
     /// The updated multi-signature for this level
     pub aggregate: C,
 
     /// The individual signature of the sender, or `None`
-    pub(crate) individual: Option<C>,
+    pub individual: Option<C>,
 
     /// The level to which this multi-signature belongs to
-    pub(crate) level: u8,
+    pub level: u8,
 
     /// The validator ID of the sender (a.k.a. `pk_idx`)
     ///
     /// NOTE: It's safe to just send your own validator ID, since everything critical is authenticated
     /// by signatures anyway.
-    #[serde(with = "fixint::be")]
-    pub(crate) origin: u16,
+    pub origin: u16,
 }
 
 impl<C: AggregatableContribution> LevelUpdate<C> {

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -43,6 +43,5 @@ nimiq-utils = { workspace = true, features = ["merkle"] }
 nimiq-vrf = { workspace = true, features = ["serde-derive"] }
 
 [dev-dependencies]
-nimiq-handel = { workspace = true }
 nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -13,7 +13,7 @@ use nimiq_network_interface::{
 
 pub use crate::error::NetworkError;
 
-pub type MessageStream<TMessage> = BoxStream<'static, (TMessage, usize)>;
+pub type MessageStream<TMessage> = BoxStream<'static, (TMessage, u16)>;
 pub type PubsubId<TValidatorNetwork> =
     <<TValidatorNetwork as ValidatorNetwork>::NetworkType as Network>::PubsubId;
 

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -410,7 +410,7 @@ where
                             warn!(%peer_id, ?validator_peer_id, claimed_validator_id = message.validator_id, "dropping validator message");
                             return None;
                         }
-                        Some((message.inner, message.validator_id as usize))
+                        Some((message.inner, message.validator_id))
                     }
                 }),
         )

--- a/validator/src/aggregation/mod.rs
+++ b/validator/src/aggregation/mod.rs
@@ -1,6 +1,7 @@
 pub mod registry;
 pub mod skip_block;
 pub mod tendermint;
+pub mod update;
 /// Implementation of signature aggregation protocols (skip block and pBFT prepare/commit) using
 /// the Handel protocol. The Handel protocol itself is implemented in the nimiq-handel crate.
 mod verifier;

--- a/validator/src/aggregation/tendermint/contribution.rs
+++ b/validator/src/aggregation/tendermint/contribution.rs
@@ -68,7 +68,7 @@ impl AggregatableContribution for TendermintContribution {
                     .entry(hash.clone())
                     // and update it
                     .and_modify(|sig|
-                        // by combining both Multisigs
+                        // by combining both Multisignatures
                         sig
                             .combine(other_sig)
                             .expect("Non Overlapping TendermintContribution encountered overlapping MultiSignatures"))
@@ -114,7 +114,8 @@ impl Aggregation<Blake2sHash> for TendermintContribution {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Utility structure to implement traits for LevelUpdate.
+#[derive(Clone, Debug)]
 pub struct AggregateMessage(pub(crate) LevelUpdate<TendermintContribution>);
 
 impl Aggregation<Blake2sHash> for AggregateMessage {
@@ -131,6 +132,6 @@ impl Aggregation<Blake2sHash> for AggregateMessage {
 
 impl AggregationMessage<Blake2sHash> for AggregateMessage {
     fn sender(&self) -> u16 {
-        self.0.origin().try_into().expect("validator ID")
+        self.0.origin
     }
 }

--- a/validator/src/aggregation/tendermint/update_message.rs
+++ b/validator/src/aggregation/tendermint/update_message.rs
@@ -4,11 +4,17 @@ use nimiq_network_interface::request::{MessageMarker, RequestCommon};
 use nimiq_tendermint::TaggedAggregationMessage;
 use serde::{Deserialize, Serialize};
 
-use super::contribution::AggregateMessage;
+use crate::aggregation::{
+    tendermint::contribution::TendermintContribution, update::SerializableLevelUpdate,
+};
 
+/// The message tendermint will use to send a LevelUpdate.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct TendermintUpdate {
-    pub message: TaggedAggregationMessage<AggregateMessage>,
+    /// The TaggedAggregationMessage over a SerializableLevelUpdate. The origin is of no concern, as
+    /// this will be an outgoing message and the origin will be set by the ValidatorNetwork in its own structure.
+    pub message: TaggedAggregationMessage<SerializableLevelUpdate<TendermintContribution>>,
+    /// The height this aggregation runs over.
     pub height: u32,
 }
 

--- a/validator/src/aggregation/update.rs
+++ b/validator/src/aggregation/update.rs
@@ -1,0 +1,43 @@
+use nimiq_handel::{contribution::AggregatableContribution, update::LevelUpdate};
+use serde::{Deserialize, Serialize};
+
+/// The serializable/deserializable representation of a LevelUpdate. It does omit the origin of the
+/// LevelUpdate itself, as the ValidatorNetwork's ValidatorMessage already includes it.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "C: AggregatableContribution")]
+pub struct SerializableLevelUpdate<C>
+where
+    C: AggregatableContribution,
+{
+    pub aggregate: C,
+    pub individual: Option<C>,
+    pub level: u8,
+}
+
+impl<C> SerializableLevelUpdate<C>
+where
+    C: AggregatableContribution,
+{
+    /// Given an origin, transforms this SerializableLevelUpdate into a LevelUpdate.
+    pub fn into_level_update(self, origin: u16) -> LevelUpdate<C> {
+        LevelUpdate {
+            aggregate: self.aggregate,
+            individual: self.individual,
+            level: self.level,
+            origin,
+        }
+    }
+}
+
+impl<C> From<LevelUpdate<C>> for SerializableLevelUpdate<C>
+where
+    C: AggregatableContribution,
+{
+    fn from(value: LevelUpdate<C>) -> Self {
+        Self {
+            aggregate: value.aggregate,
+            individual: value.individual,
+            level: value.level,
+        }
+    }
+}

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -75,12 +75,11 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
         &self,
         (msg, recipient): (nimiq_handel::update::LevelUpdate<Self::Contribution>, u16),
     ) -> BoxFuture<'static, ()> {
-        // wrap the level update in the AggregateMessage
-        let aggregation = AggregateMessage(msg);
-        // tag it
+        // Tag the LevelUpdate, while also converting it to the serializable representation.
+        // The origin gets lost here, but will get re-set by the ValidatorNetwork in its sent_to call.
         let tagged_aggregation_message = TaggedAggregationMessage {
             tag: self.tag,
-            aggregation,
+            aggregation: msg.into(),
         };
         // and create the update.
         let update_message = TendermintUpdate {

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -25,11 +25,13 @@ use nimiq_test_utils::{
 };
 use nimiq_time::{sleep, timeout};
 use nimiq_utils::spawn;
-use nimiq_validator::aggregation::skip_block::SignedSkipBlockMessage;
+use nimiq_validator::aggregation::{
+    skip_block::SignedSkipBlockMessage, update::SerializableLevelUpdate,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
-struct SkipBlockMessage(LevelUpdate<SignedSkipBlockMessage>);
+struct SkipBlockMessage(SerializableLevelUpdate<SignedSkipBlockMessage>);
 
 impl RequestCommon for SkipBlockMessage {
     type Kind = MessageMarker;
@@ -310,7 +312,7 @@ async fn validator_can_catch_up() {
     for network in &networks {
         for peer_id in network.get_peers() {
             network
-                .message::<SkipBlockMessage>(SkipBlockMessage(vc.clone()), peer_id)
+                .message::<SkipBlockMessage>(SkipBlockMessage(vc.clone().into()), peer_id)
                 .await
                 .unwrap();
         }

--- a/validator/tests/updates.rs
+++ b/validator/tests/updates.rs
@@ -1,0 +1,60 @@
+use nimiq_block::MultiSignature;
+use nimiq_bls::{AggregateSignature, KeyPair};
+use nimiq_collections::BitSet;
+use nimiq_handel::{
+    contribution::{AggregatableContribution, ContributionError},
+    update::LevelUpdate,
+};
+use nimiq_serde::{Deserialize, Serialize};
+use nimiq_validator::aggregation::update::SerializableLevelUpdate;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct WrappedMultiSignature(pub MultiSignature);
+
+impl AggregatableContribution for WrappedMultiSignature {
+    fn contributors(&self) -> BitSet {
+        self.0.contributors()
+    }
+
+    fn combine(&mut self, other_contribution: &Self) -> Result<(), ContributionError> {
+        self.0
+            .combine(&other_contribution.0)
+            .map_err(ContributionError::Overlapping)
+    }
+}
+
+fn create_multisig() -> WrappedMultiSignature {
+    let raw_key = hex::decode(
+        "1b9e470e0deb06fe55774bb2cf499b411f55265c10d8d78742078381803451e058c88\
+        391431799462edde4c7872649964137d8e03cd618dd4a25690c56ffd7f42fb7ae8049d29f38d569598b38d4\
+        39f69107cc0b6f4ecd00a250c74409510100",
+    )
+    .unwrap();
+    let key_pair = KeyPair::deserialize_from_vec(&raw_key).unwrap();
+    let signature = key_pair.sign(&"foobar");
+    let signature = AggregateSignature::from_signatures(&[signature]);
+    let mut signers = BitSet::default();
+    signers.insert(1);
+    WrappedMultiSignature(MultiSignature { signature, signers })
+}
+
+#[test]
+fn test_serialize_deserialize_level_update() {
+    let update: SerializableLevelUpdate<WrappedMultiSignature> =
+        LevelUpdate::new(create_multisig(), None, 2, 3).into();
+    let data = update.serialize_to_vec();
+    let update_2: SerializableLevelUpdate<WrappedMultiSignature> =
+        Deserialize::deserialize_from_vec(&data).unwrap();
+
+    assert_eq!(data.len(), update.serialized_size());
+    assert_eq!(update.serialized_size(), 99);
+    assert!(update_2.individual.is_none());
+    assert_eq!(update_2.level, 2);
+}
+
+#[test]
+fn test_serialize_deserialize_with_message() {
+    let update: SerializableLevelUpdate<WrappedMultiSignature> =
+        LevelUpdate::new(create_multisig(), None, 2, 3).into();
+    assert_eq!(update.serialized_size(), 99);
+}


### PR DESCRIPTION
This PR removes the origin from Handel's `LevelUpdates` for the network traffic generated. `LevelUpdate` therefore no longer implements `Serialize` and `Deserialize` such that it cannot be accidentally send again in a future update.

A new utility structure is added, `SerializableLevelUpdate`, which implements `Serialize` and `Deserialize` again while removing the origin. Before sending a `LevelUpdate` is converted into a `SerializableLevelUpdate` and when receiving it uses the `ValidatorMessage`'s `validator_id` to recreate the `LevelUpdate`. This is necessary as in a different PR this origin will be used to ban misbehaving validators.

Minor cleanup to dependencies. I also moved some tests around as they make way more sense there than where they were previously.