### PR TITLE
Handel refactor and update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,6 +3872,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "instant",
+ "linked-hash-map",
  "nimiq-bls",
  "nimiq-collections",
  "nimiq-hash",

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -23,13 +23,7 @@ pub struct BitSet {
 }
 
 impl BitSet {
-    /// An empty BitSet.
-    pub const EMPTY: Self = Self {
-        store: vec![],
-        count: 0,
-    };
-
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         BitSet {
             store: Vec::new(),
             count: 0,

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -23,6 +23,12 @@ pub struct BitSet {
 }
 
 impl BitSet {
+    /// An empty BitSet.
+    pub const EMPTY: Self = Self {
+        store: vec![],
+        count: 0,
+    };
+
     pub fn new() -> Self {
         BitSet {
             store: Vec::new(),

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -19,7 +19,6 @@ futures = { workspace = true }
 log = { workspace = true }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 parking_lot = "0.12"
-rand = "0.8"
 thiserror = "1.0"
 
 nimiq-bls = { workspace = true }
@@ -30,11 +29,11 @@ nimiq-time = { workspace = true }
 nimiq-utils = { workspace = true, features = ["futures"] }
 
 [dev-dependencies]
+rand = "0.8"
 serde = "1.0"
+tokio = { version = "1.40", features = ["rt", "time", "macros"] }
 
 nimiq-network-interface = { workspace = true }
 nimiq-network-mock = { workspace = true }
 nimiq-test-log = { workspace = true }
-
-tokio = { version = "1.40", features = ["rt", "time", "macros"] }
 nimiq-utils = { workspace = true, features = ["spawn"] }

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 futures = { workspace = true }
+linked-hash-map = "0.5.6"
 log = { workspace = true }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 parking_lot = "0.12"

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -151,7 +151,7 @@ where
             level.start();
 
             debug!(
-                id = ?self.protocol.identify(),
+                id = %self.protocol.identify(),
                 level = level.id,
                 activated_by,
                 "Starting level"
@@ -210,7 +210,7 @@ where
         }
 
         trace!(
-            id = ?self.protocol.identify(),
+            id = %self.protocol.identify(),
             level_id,
             num_peers,
             "Level complete",
@@ -431,9 +431,10 @@ where
         let evaluator = self.protocol.evaluator();
         while let Poll::Ready(Some(update)) = self.input_stream.poll_next_unpin(cx) {
             // Verify the level update.
-            if !evaluator.verify(&update) {
-                trace!(
-                    id = ?self.protocol.identify(),
+            if let Err(error) = evaluator.verify(&update) {
+                warn!(
+                    id = %self.protocol.identify(),
+                    ?error,
                     ?update,
                     "Rejecting invalid level update",
                 );
@@ -538,7 +539,7 @@ where
         // If the best aggregate is a full aggregation, this aggregation is finished.
         if self.is_complete_aggregate(&best_aggregate) {
             debug!(
-                id = ?self.protocol.identify(),
+                id = %self.protocol.identify(),
                 "Aggregation complete"
             );
 

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -97,6 +97,7 @@ where
         let levels = Arc::new(Level::create_levels(
             protocol.partitioner(),
             protocol.identify(),
+            protocol.node_id(),
         ));
 
         // Create an empty list which can later be polled for the best available pending contribution.

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -1,6 +1,5 @@
 use std::{
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -44,7 +43,7 @@ where
     config: Config,
 
     /// Levels
-    levels: Arc<Vec<Level>>,
+    levels: Vec<Level>,
 
     /// Stream of level updates received from other peers.
     input_stream: LevelUpdateStream<P::Contribution>,
@@ -94,11 +93,11 @@ where
         let sender = NetworkHelper::new(protocol.partitioner().size(), network);
 
         // Invoke the partitioner to create the level structure of peers.
-        let levels = Arc::new(Level::create_levels(
+        let levels = Level::create_levels(
             protocol.partitioner(),
             protocol.identify(),
             protocol.node_id(),
-        ));
+        );
 
         // Create an empty list which can later be polled for the best available pending contribution.
         let mut pending_contributions =

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -1,11 +1,11 @@
 use std::{
-    mem,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use futures::{
-    future::{BoxFuture, Future, FutureExt},
+    future::{BoxFuture, FutureExt},
     stream::{BoxStream, Stream, StreamExt},
 };
 use nimiq_time::{interval, Interval};
@@ -13,6 +13,7 @@ use nimiq_time::{interval, Interval};
 use crate::{
     config::Config,
     contribution::AggregatableContribution,
+    evaluator::Evaluator,
     identity::IdentityRegistry,
     level::Level,
     network::{LevelUpdateSender, Network},
@@ -30,10 +31,10 @@ use crate::{
 // * level.state RwLock
 // * Evaluator::new -> threshold (now covered outside of this crate)
 
-type LevelUpdateStream<P, T> = BoxStream<'static, LevelUpdate<<P as Protocol<T>>::Contribution>>;
+type LevelUpdateStream<C> = BoxStream<'static, LevelUpdate<C>>;
 
 /// Future implementation for the next aggregation event
-pub struct OngoingAggregation<TId, P, N>
+pub struct Aggregation<TId, P, N>
 where
     TId: Identifier,
     P: Protocol<TId>,
@@ -43,7 +44,10 @@ where
     config: Config,
 
     /// Levels
-    levels: Vec<Level>,
+    levels: Arc<Vec<Level>>,
+
+    /// Stream of level updates received from other peers.
+    input_stream: LevelUpdateStream<P::Contribution>,
 
     /// List of remaining pending contributions
     pending_contributions: PendingContributionList<TId, P>,
@@ -57,22 +61,23 @@ where
     /// Sink used to relay messages
     sender: LevelUpdateSender<N>,
 
-    /// Interval for starting the next level regardless of previous levels completion
+    /// Timeout for starting the next level regardless of previous level's completion.
     start_level_interval: Interval,
 
-    /// Interval for sending level updates to the corresponding peers regardless of progression
+    /// Interval for sending level updates to the corresponding peers regardless of progression.
     periodic_update_interval: Interval,
-
-    /// the level which needs activation next
-    next_level_timeout: usize,
 
     /// Future of the currently verified pending contribution.
     /// There is only ever one contribution being verified at a time.
     current_verification:
         Option<BoxFuture<'static, (VerificationResult, PendingContribution<P::Contribution>)>>,
+
+    /// The final result of the aggregation once it has been produced.
+    /// A Some(_) value here indicates that the aggregation has finished.
+    final_result: Option<P::Contribution>,
 }
 
-impl<TId, P, N> OngoingAggregation<TId, P, N>
+impl<TId, P, N> Aggregation<TId, P, N>
 where
     TId: Identifier,
     P: Protocol<TId>,
@@ -82,73 +87,89 @@ where
         protocol: P,
         config: Config,
         own_contribution: P::Contribution,
-        input_stream: LevelUpdateStream<P, TId>,
-        sender: LevelUpdateSender<N>,
+        input_stream: LevelUpdateStream<P::Contribution>,
+        network: N,
     ) -> Self {
+        // Create the Sender, buffering a single message per recipient.
+        let sender = LevelUpdateSender::new(protocol.partitioner().size(), network);
+
         // Invoke the partitioner to create the level structure of peers.
-        let levels: Vec<Level> = Level::create_levels(protocol.partitioner(), protocol.identify());
+        let levels = Arc::new(Level::create_levels(
+            protocol.partitioner(),
+            protocol.identify(),
+        ));
 
         // Create an empty list which can later be polled for the best available pending contribution.
         let mut pending_contributions =
-            PendingContributionList::new(protocol.identify(), protocol.evaluator(), input_stream);
+            PendingContributionList::new(protocol.identify(), protocol.evaluator());
 
         // Add our own contribution to the list.
         pending_contributions.add_contribution(own_contribution.clone(), 0);
 
-        // Regardless of level completion consecutive levels need to be activated at some point. Activate Levels every time this interval ticks,
-        // if the level has not already been activated due to level completion
-        let start_level_interval = interval(config.timeout);
+        // Regardless of level completion consecutive levels need to be activated at some point.
+        // Activate levels every time this interval ticks, if the level has not already been
+        // activated due to level completion.
+        let start_level_interval = interval(config.level_timeout);
 
-        // Every `config.update_interval` send Level updates to corresponding peers no matter the aggregations progression
-        // (makes sure other peers can catch up).
+        // Every `config.update_interval` send level updates to corresponding peers no matter the
+        // aggregation's progression (makes sure other peers can catch up).
         let periodic_update_interval = interval(config.update_interval);
 
-        // Create the NextAggregation struct
         Self {
             protocol,
             config,
             pending_contributions,
             levels,
+            input_stream,
             contribution: own_contribution,
             sender,
             start_level_interval,
             periodic_update_interval,
-            next_level_timeout: 0,
             current_verification: None,
+            final_result: None,
         }
     }
 
     /// Starts level `level`
-    fn start_level(&mut self, level: usize, store: &<P as Protocol<TId>>::Store) {
-        let level = self
-            .levels
-            .get(level)
-            .unwrap_or_else(|| panic!("Attempted to start invalid level {level}"));
-        trace!(
+    fn start_level(
+        &mut self,
+        level: usize,
+        store: &<P as Protocol<TId>>::Store,
+        activated_by: &'static str,
+    ) {
+        // Try to start the level. `level.start()` returns false if the level was already started.
+        let level = &self.levels[level];
+        if !level.start() {
+            return;
+        }
+
+        debug!(
             id = ?self.protocol.identify(),
-            ?level,
-            "Starting level",
+            level = level.id,
+            activated_by,
+            "Starting level"
         );
 
-        // Try to Start the level
-        if level.start() {
-            // In case the level was not started previously send the best contribution to peers on the level
+        // Reset the level timeout.
+        self.start_level_interval = interval(self.config.level_timeout);
 
-            // Don't do anything for level 0 as it only contains this node
-            if level.id > 0 {
-                // Get the current best for the level. Freeing the lock as soon as possible to continue working on contributions
-                let best = store.combined(level.id - 1);
-
-                if let Some(best) = best {
-                    self.send_update(
-                        best,
-                        level.id,
-                        !level.receive_complete(),
-                        level.select_next_peers(self.config.peer_count),
-                    );
-                }
-            }
+        // Nothing else to do for level 0 as it only contains this node.
+        if level.id == 0 {
+            return;
         }
+
+        // Get the current best aggregate for the level.
+        let Some(best) = store.combined(level.id - 1) else {
+            return;
+        };
+
+        // Send the best aggregate to the peers on the level.
+        self.send_update(
+            best,
+            level.id,
+            !level.is_complete(),
+            level.select_next_peers(self.config.peer_count),
+        );
     }
 
     fn num_contributors(&self, aggregate: &P::Contribution) -> usize {
@@ -162,76 +183,67 @@ where
         self.num_contributors(aggregate) == self.protocol.partitioner().size()
     }
 
-    /// Check if a level was completed
+    /// Check if the given level was completed.
     fn check_completed_level(&mut self, level_id: usize, store: &<P as Protocol<TId>>::Store) {
-        let num_peers = {
-            let level = self
-                .levels
-                .get(level_id)
-                .expect("Attempted to check completeness of invalid level");
-
-            // check if level already is completed
-            if level.state.read().receive_completed {
-                // The level was completed before so nothing more to do.
-                return;
-            }
-
-            level.num_peers()
-        };
-
-        if num_peers == 0 {
-            trace!("Level {} is empty and thus complete", level_id);
+        // Nothing to do if the level is already complete.
+        let level = &self.levels[level_id];
+        if level.is_complete() {
             return;
         }
 
-        // first get the current contributor count for this level. Release the lock as soon as possible
-        // to continue working on contributions.
-        let best = store
-            .best(level_id)
-            .unwrap_or_else(|| panic!("Expected a best signature for level {}", level_id));
-        let num_contributors = self.num_contributors(best);
+        // Check if the level is complete.
+        let num_peers = level.num_peers();
+        let level_complete = if num_peers == 0 {
+            // If there are no peers on this level, it is always complete.
+            trace!("Level {} is empty and thus complete", level_id);
+            true
+        } else {
+            // Get the number of contributors that we have stored for this level.
+            let best = store
+                .best(level_id)
+                .unwrap_or_else(|| panic!("Expected a best signature for level {}", level_id));
+            let num_contributors = self.num_contributors(best);
 
-        // If the number of contributors on this level is equal to the number of peers on this level it is completed.
-        if num_contributors == num_peers {
+            // The level is complete if the number of contributors equals the number of peers.
+            num_contributors == num_peers
+        };
+
+        if level_complete {
             trace!(
                 id = ?self.protocol.identify(),
                 level_id,
+                num_peers,
                 "Level complete",
             );
-            {
-                // Acquire write lock and set the level state for this level to completed.
-                self.levels
-                    .get(level_id)
-                    .unwrap() // would have panicked earlier.
-                    .state
-                    .write()
-                    .receive_completed = true;
-            }
-            // if there is a level with a higher id than the completed one it needs to be activated.
+
+            // Mark the level as complete.
+            self.levels[level_id].state.write().complete = true;
+
+            // If there is a level above the completed one, it needs to be activated.
             if level_id + 1 < self.levels.len() {
-                // activate next level
-                self.start_level(level_id + 1, store);
+                self.start_level(level_id + 1, store, "LevelComplete");
             }
         }
 
         // In order to send updated messages iterate all levels higher than the given level.
-        let level_count = self.levels.len();
-        for i in level_id + 1..level_count {
-            let combined = store.combined(i - 1);
-
-            // if there is an aggregate contribution for given level i send it out to the peers of that level.
-            if let Some(multisig) = combined {
-                let level = self.levels.get(i).unwrap_or_else(|| panic!("No level {i}"));
-                if level.update_signature_to_send(&multisig.clone()) {
-                    self.send_update(
-                        multisig,
-                        level.id,
-                        !level.receive_complete(),
-                        level.select_next_peers(self.config.peer_count),
-                    );
-                }
-            }
-        }
+        // TODO Why do we need this?
+        // let num_levels = self.levels.len();
+        // for i in level_id + 1..num_levels {
+        //     let combined = store.combined(i - 1);
+        //
+        //     // if there is an aggregate contribution for given level i send it out to the peers of that level.
+        //     if let Some(multisig) = combined {
+        //         let level = &self.levels[i];
+        //         if level.update_signature(&multisig.clone()) {
+        //             self.send_update(
+        //                 multisig,
+        //                 level.id,
+        //                 !level.is_complete(),
+        //                 level.select_next_peers(self.config.peer_count),
+        //             );
+        //         }
+        //     }
+        // }
     }
 
     /// Send updated `contribution` for `level` to `count` peers
@@ -243,139 +255,143 @@ where
         contribution: P::Contribution,
         level_id: usize,
         send_individual: bool,
-        peer_ids: Vec<usize>,
+        node_ids: Vec<usize>,
     ) {
-        // If there are peers to send the update to send them
-        if !peer_ids.is_empty() {
-            // If the send_individual flag is set the individual contribution is sent alongside the aggregate.
-            let individual = if send_individual {
-                Some(self.contribution.clone())
-            } else {
-                None
-            };
+        // Nothing to do if there are no recipients.
+        if node_ids.is_empty() {
+            return;
+        }
 
-            // Create the LevelUpdate
-            let update = LevelUpdate::<P::Contribution>::new(
-                contribution,
-                individual,
-                level_id,
-                self.protocol.node_id(),
+        // If the send_individual flag is set, the individual contribution is sent alongside the aggregate.
+        let individual = if send_individual {
+            Some(self.contribution.clone())
+        } else {
+            None
+        };
+
+        // Create the LevelUpdate
+        let update = LevelUpdate::<P::Contribution>::new(
+            contribution,
+            individual,
+            level_id,
+            self.protocol.node_id(),
+        );
+
+        // Send the level update to every node_id in node_ids.
+        for node_id in node_ids {
+            self.sender.send(node_id, update.clone());
+            debug!(
+                from = self.protocol.node_id(),
+                to = node_id,
+                level = level_id,
+                signers = %update.aggregate.contributors(),
+                "Sending level update",
             );
-
-            // Send the level update to every peer_id in peer_ids
-            for peer_id in peer_ids {
-                // This should always be the case
-                if peer_id < self.protocol.partitioner().size() {
-                    self.sender
-                        // `send` is not a future and thus will not block execution.
-                        .send((update.clone(), peer_id));
-                }
-            }
         }
     }
 
     /// Send updates for every level to every peer accordingly.
     fn automatic_update(&mut self) {
-        // Skip level 0 since it only contains this node
+        // Skip level 0 since it only contains this node.
         for level_id in 1..self.levels.len() {
-            let (receive_complete, next_peers) = {
-                let level = self.levels.get(level_id).unwrap();
-                (
-                    level.receive_complete(),
-                    level.select_next_peers(self.config.peer_count),
-                )
-            };
+            // Skip levels that are complete or that haven't started yet.
+            let level = &self.levels[level_id];
+            if level.is_complete() || !level.is_started() {
+                continue;
+            }
 
-            // Get the current best aggregate from store (no clone() needed as that already happens within the store)
-            // freeing the lock as soon as possible for the aggregation to continue.
+            // Get the current best aggregate for this level from the store.
             let aggregate = {
                 let store = self.protocol.store();
                 let store = store.read();
-                store.combined(level_id - 1)
+                let Some(aggregate) = store.combined(level_id - 1) else {
+                    continue;
+                };
+                aggregate
             };
 
-            // For an existing aggregate for this level send it around to the respective peers.
-            if let Some(aggregate) = aggregate {
-                self.send_update(aggregate, level_id, !receive_complete, next_peers);
-            }
+            // Send the aggregate to the next peers on this level.
+            let next_peers = level.select_next_peers(self.config.peer_count);
+            self.send_update(aggregate, level_id, true, next_peers);
         }
     }
 
-    /// activate the next level which needs to be activated.
+    /// Activate the next level that has not started yet.
     fn activate_next_level(&mut self) {
-        // the next level which needs activating on timeout.
-        let level = self.next_level_timeout;
-        // make sure such level exists
-        if level < self.levels.len() {
-            trace!(
-                id = ?self.protocol.identify(),
-                ?level,
-                "Timeout at level",
-            );
+        // Find the best completed level.
+        let best_complete = self
+            .levels
+            .iter()
+            .rposition(|level| level.is_complete())
+            .unwrap_or(0);
 
-            // next time the timeout triggers the next level needs activating
-            self.next_level_timeout += 1;
-
-            let store_rw = self.protocol.store();
-            let store = store_rw.read();
-
-            // finally start the level.
-            self.start_level(level, &store);
+        // If the best completed level is the last level, we're done.
+        if best_complete == self.levels.len() - 1 {
+            return;
         }
+
+        // Now find the first level above the best completed level that has not been started yet.
+        let to_start = self.levels[best_complete + 1..]
+            .iter()
+            .position(|level| !level.is_started());
+
+        // If there are no levels to start, we're done.
+        let Some(to_start) = to_start else {
+            return;
+        };
+
+        // Start the level.
+        let store = self.protocol.store();
+        self.start_level(to_start, &store.read(), "Timeout");
     }
 
-    fn into_inner(self) -> (LevelUpdateStream<P, TId>, LevelUpdateSender<N>) {
-        (self.pending_contributions.into_stream(), self.sender)
-    }
-
-    /// Applies the given pending contribution. It will either be immediately emitted as the new best aggregate if it is completed
-    /// or it will be added to the store and the new best aggregate will be emitted.
-    fn apply_pending_contribution(
+    /// Applies the given pending contribution. It will either be immediately emitted as the new
+    /// best aggregate if it is completed, or it will be added to the store and the new best
+    /// aggregate will be emitted.
+    fn apply_contribution(
         &mut self,
-        pending_contribution: PendingContribution<P::Contribution>,
+        contribution: PendingContribution<P::Contribution>,
     ) -> P::Contribution {
-        // special case of full contributions
-        if pending_contribution.level == self.protocol.partitioner().levels()
-            && self.is_complete_aggregate(&pending_contribution.contribution)
-        {
-            return pending_contribution.contribution;
+        // Special case for full aggregations, which are sent at level `num_levels`.
+        if contribution.level == self.levels.len() {
+            return contribution.contribution;
         }
 
-        let store_rw = self.protocol.store();
-        let mut store = store_rw.write();
+        let store = self.protocol.store();
+        let mut store = store.write();
 
         // if the contribution is valid push it to the store, creating a new aggregate
         store.put(
-            pending_contribution.contribution.clone(),
-            pending_contribution.level,
+            contribution.contribution.clone(),
+            contribution.level,
             self.protocol.registry(),
             self.protocol.identify(),
         );
 
-        // in case the level of this pending contribution has not started, start it now as we have already contributions on it.
-        self.start_level(pending_contribution.level, &store);
-        // check if a level was completed by the addition of the contribution
-        self.check_completed_level(pending_contribution.level, &store);
+        // If the level of this pending contribution has not started, start it now as we already
+        // have contributions for it.
+        self.start_level(contribution.level, &store, "ApplyContribution");
 
-        // get the best aggregate
-        let last_level = self.levels.last().expect("No levels");
+        // Check if a level was completed by the addition of the contribution.
+        self.check_completed_level(contribution.level, &store);
 
-        let best = store.combined(last_level.id);
-
-        best.expect("A best signature must exist after applying a contribution.")
+        // Return the best aggregate.
+        store
+            .combined(self.levels.len() - 1)
+            .expect("A best signature must exist after applying a contribution")
     }
 
-    /// Verifies a given signature.
+    /// Verifies a given contribution.
     ///
-    /// As signature verification can be costly it creates a future which will be polled directly after creation.
-    /// The created future may return immediately.
+    /// As signature verification can be costly it, creates a future which will be polled directly
+    /// after creation. The created future may return immediately.
     ///
-    /// This function will override `self.current_verification` if the created future does not immediately produce a value.
+    /// This function will override `self.current_verification` if the created future does not
+    /// immediately produce a value.
     ///
-    /// ## Returns
-    /// Returns the [VerificationResult] and the [PendingContribution] in question iff the verification resolves immediately.
-    /// None otherwise
-    fn start_pending_contribution_verification(
+    /// Returns the [VerificationResult] and the [PendingContribution] in question if the
+    /// verification resolves immediately, None otherwise.
+    fn start_verification(
         &mut self,
         pending_contribution: PendingContribution<P::Contribution>,
         cx: &mut Context<'_>,
@@ -395,215 +411,40 @@ where
         self.current_verification = Some(fut);
         None
     }
-}
 
-impl<TId, P, N> Stream for OngoingAggregation<TId, P, N>
-where
-    TId: Identifier,
-    P: Protocol<TId>,
-    N: Network<Contribution = P::Contribution>,
-{
-    type Item = P::Contribution;
+    fn respond_to_update(&mut self, node_id: usize, level_id: usize) {
+        // TODO Only respond if our aggregate is better than the peer's or complements it.
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // Poll the verification future if there is one.
-        let mut best_aggregate = if let Some(verification_future) = &mut self.current_verification {
-            if let Poll::Ready((result, pending_contribution)) = verification_future.poll_unpin(cx)
-            {
-                // If a result is produced, unset the future such that a new one can take its place.
-                self.current_verification = None;
-                if result.is_ok() {
-                    // If the contribution was successfully verified, apply it and return the new best aggregate
-                    Some(self.apply_pending_contribution(pending_contribution))
-                } else {
-                    // If the contribution failed to verify there is nothing to be done, and also no new best aggregate.
-                    log::debug!(
-                        ?result,
-                        ?pending_contribution,
-                        "Verification of PendingContribution failed."
-                    );
-                    None
-                }
-            } else {
-                // The future has not yet resolved. There is no new best aggregate.
-                None
-            }
-        } else {
-            // There is no future to poll and thus no new pending contribution to process. There is no new best aggregate.
-            None
+        // Don't access `self.levels[level_id]` directly as it could point to `num_levels`, which
+        // is the case for full aggregations. It's fine to just return, as the peer has already
+        // finished aggregating and doesn't need our response anymore.
+        let Some(level) = self.levels.get(level_id) else {
+            return;
         };
 
-        // Check if the automatic update interval triggers, if so perform the update.
-        while let Poll::Ready(_instant) = self.periodic_update_interval.as_mut().poll_tick(cx) {
-            // This creates new messages in the sender.
-            self.automatic_update();
-        }
+        // If we already have a final result for this aggregation, return it.
+        // Otherwise, return our current best aggregate for the peer's level.
+        if let Some(final_result) = &self.final_result {
+            self.send_update(
+                final_result.clone(),
+                self.levels.len(),
+                false,
+                vec![node_id],
+            );
+        } else {
+            let store = self.protocol.store();
+            let store = store.read();
+            let Some(best_aggregate) = store.combined(level_id - 1) else {
+                return;
+            };
 
-        while let Poll::Ready(_instant) = self.start_level_interval.as_mut().poll_tick(cx) {
-            // Activates the next level if there is a next level.
-            // This potentially creates new messages in the sender.
-            self.activate_next_level();
-        }
-
-        // Check and see if a new pending contribution should be verified.
-        // Only start a new verification task if there is not already one and also only if the poll does not have produced a value yet.
-        // This is necessary as the verification future could resolve immediately producing a second item for the stream.
-        // As the new best aggregate will be returned this stream will be polled again creating the future in the next poll
-        if self.current_verification.is_none() && best_aggregate.is_none() {
-            // Get the next best pending contribution.
-            while let Poll::Ready(Some(pending_contribution)) =
-                self.pending_contributions.poll_next_unpin(cx)
-            {
-                // Start the verification. This will also poll and thus may immediately return a result.
-                if let Some((result, pending_contribution)) =
-                    self.start_pending_contribution_verification(pending_contribution, cx)
-                {
-                    // If the future returned immediately it needs to be handled.
-                    if result.is_ok() {
-                        // If the contribution verified, apply it and return the new best aggregate
-                        let new_aggregate = self.apply_pending_contribution(pending_contribution);
-
-                        best_aggregate = Some(new_aggregate);
-                        break;
-                    } else {
-                        log::debug!(
-                            ?result,
-                            ?pending_contribution,
-                            "Verification of PendingContribution failed."
-                        );
-                    }
-                } else {
-                    break;
-                }
-            }
-        }
-
-        // Poll the sender, sending as many messages as possible.
-        assert!(self.sender.poll_unpin(cx).is_pending());
-
-        // Return the aggregate if available.
-        if let Some(contribution) = best_aggregate {
-            return Poll::Ready(Some(contribution));
-        }
-
-        // Return Pending otherwise.
-        Poll::Pending
-    }
-}
-
-pub struct FinishedAggregation<TId, P, N>
-where
-    TId: Identifier,
-    P: Protocol<TId>,
-    N: Network<Contribution = P::Contribution>,
-{
-    level_update: LevelUpdate<P::Contribution>,
-    input_stream: LevelUpdateStream<P, TId>,
-    sender: LevelUpdateSender<N>,
-}
-
-impl<TId, P, N> FinishedAggregation<TId, P, N>
-where
-    TId: Identifier,
-    P: Protocol<TId>,
-    N: Network<Contribution = P::Contribution>,
-{
-    fn from(aggregation: OngoingAggregation<TId, P, N>, aggregate: P::Contribution) -> Self {
-        // create a level update from the final aggregation
-        let level_update = LevelUpdate::<P::Contribution>::new(
-            aggregate,
-            None,
-            aggregation.protocol.partitioner().levels(),
-            aggregation.protocol.node_id(),
-        );
-
-        // Get rid of the aggregation retaining the input stream of level updates and the sender.
-        let (input_stream, sender) = aggregation.into_inner();
-
-        Self {
-            level_update,
-            input_stream,
-            sender,
-        }
-    }
-}
-
-impl<TId, P, N> Future for FinishedAggregation<TId, P, N>
-where
-    TId: Identifier,
-    P: Protocol<TId>,
-    N: Network<Contribution = P::Contribution>,
-{
-    /// The type could just be `()` as it will only ever return `Poll::Pending`, but for compatibility with the
-    /// `OngoingAggregation` it is kept. As it is a Future the Option is added.
-    type Output = Option<P::Contribution>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        while let Poll::Ready(msg) = self.input_stream.poll_next_unpin(cx) {
-            if let Some(msg) = msg {
-                // Don't respond to final level updates.
-                if msg.level == self.level_update.level {
-                    continue;
-                }
-
-                let response = (self.level_update.clone(), msg.origin());
-                self.sender.send(response);
-            } else {
-                log::error!("Failed to poll input stream; None returned")
-            }
-        }
-
-        // Send as many messages as possible.
-        assert!(self.sender.poll_unpin(cx).is_pending());
-
-        // Do never produce an item as it has been produced earlier already.
-        // This future will never produce an item.
-        Poll::Pending
-    }
-}
-
-/// Abstraction for both kinds of aggregations.
-/// There is an additional variant used to transition from ongoing to finished.
-pub enum Aggregation<TId, P, N>
-where
-    TId: Identifier,
-    P: Protocol<TId>,
-    N: Network<Contribution = P::Contribution>,
-{
-    /// The aggregation is currently ongoing and it is going to produce stream items as well as network traffic.
-    Ongoing(OngoingAggregation<TId, P, N>),
-    /// The aggregation is finished and it will no longer produce stream items and it will reduce network traffic
-    /// to answering messages with an unfinished aggregate within them.
-    Finished(FinishedAggregation<TId, P, N>),
-    /// The aggregation has just finished and is transitioning from ongoing to finished.
-    /// Used to deconstruct the OngoingAggregation and should be `unreachable!()` everywhere but in that location.
-    Transitioning,
-}
-
-impl<TId, P, N> Aggregation<TId, P, N>
-where
-    TId: Identifier,
-    P: Protocol<TId>,
-    N: Network<Contribution = P::Contribution>,
-{
-    pub fn new(
-        protocol: P,
-        config: Config,
-        own_contribution: P::Contribution,
-        input_stream: LevelUpdateStream<P, TId>,
-        network: N,
-    ) -> Self {
-        // Create the Sender, buffering a single message per recipient.
-        let sender = LevelUpdateSender::new(protocol.partitioner().size(), network);
-
-        // Aggregations start out as Ongoing
-        Self::Ongoing(OngoingAggregation::new(
-            protocol,
-            config,
-            own_contribution,
-            input_stream,
-            sender,
-        ))
+            self.send_update(
+                best_aggregate,
+                level_id,
+                !level.is_complete(),
+                vec![node_id],
+            );
+        };
     }
 }
 
@@ -616,45 +457,132 @@ where
     type Item = P::Contribution;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // Poll either the ongoing or the finished aggregation
-        let result = match &mut *self {
-            Self::Transitioning => {
-                unreachable!("Aggregation should never be transitioning when polled.")
+        let mut best_aggregate = None;
+
+        // Poll the input stream for new level updates.
+        let evaluator = self.protocol.evaluator();
+        while let Poll::Ready(Some(update)) = self.input_stream.poll_next_unpin(cx) {
+            // Verify that the sender of this update is on the correct level.
+            if !evaluator.verify(&update) {
+                trace!(
+                    id = ?self.protocol.identify(),
+                    ?update,
+                    "Rejecting invalid level update",
+                );
+                continue;
             }
-            Self::Finished(finished_aggregation) => {
-                // Finished aggregations are simply polled as the future will never produce a value.
-                assert!(finished_aggregation.poll_unpin(cx).is_pending());
-                return Poll::Pending;
+
+            // Respond with our own update.
+            self.respond_to_update(update.origin(), update.level());
+
+            // Store the aggregate (and individual if present) contributions in `pending_contributions`.
+            let level = update.level();
+            self.pending_contributions
+                .add_contribution(update.aggregate, level);
+            if let Some(individual) = update.individual {
+                self.pending_contributions
+                    .add_contribution(individual, level);
             }
-            Self::Ongoing(ongoing_aggregation) => {
-                let result = ongoing_aggregation.poll_next_unpin(cx);
-                // For produced stream items of the ongoing aggregations it needs to be checked if the transition into a
-                // finished aggregation is required.
-                if let Poll::Ready(Some(aggregate)) = &result {
-                    // Only completely full aggregates trigger the transition.
-                    if ongoing_aggregation.is_complete_aggregate(aggregate) {
-                        // Take the ongoing aggregation out of *self, replacing it with the Transitioning variant.
-                        let ongoing_aggregation = mem::replace(&mut *self, Self::Transitioning);
-                        let ongoing_aggregation = match ongoing_aggregation {
-                            Self::Ongoing(aggregation) => aggregation,
-                            _ => panic!("Was ongoing before, should still be ongoing."),
-                        };
-                        // Create the FinishedAggregation and replace the Transitioning variant with it again.
-                        *self = Self::Finished(FinishedAggregation::from(
-                            ongoing_aggregation,
-                            aggregate.clone(),
-                        ));
-                    }
+        }
+
+        // Poll the verification future if there is one.
+        if let Some(future) = &mut self.current_verification {
+            if let Poll::Ready((result, pending_contribution)) = future.poll_unpin(cx) {
+                // If a result is produced, unset the future such that a new one can take its place.
+                self.current_verification = None;
+
+                if result.is_ok() {
+                    // If the contribution was successfully verified, apply it and return the new
+                    // best aggregate.
+                    best_aggregate = Some(self.apply_contribution(pending_contribution))
+                } else {
+                    // TODO Ban peer who sent the failed contribution?
+                    //  Or penalize it when scoring contributions?
+                    debug!(
+                        ?result,
+                        ?pending_contribution,
+                        "Verification of PendingContribution failed"
+                    );
                 }
-                result
             }
         };
 
-        // In case there is now a FinishedAggregation where before there wasn't poll it, to register the waker.
-        if let Self::Finished(finished_aggregation) = &mut *self {
-            assert!(finished_aggregation.poll_unpin(cx).is_pending());
+        // Check if the automatic update interval triggers, if so perform the update.
+        while let Poll::Ready(_instant) = self.periodic_update_interval.poll_next_unpin(cx) {
+            // This creates new messages in the sender.
+            self.automatic_update();
         }
 
-        result
+        while let Poll::Ready(_instant) = self.start_level_interval.poll_next_unpin(cx) {
+            // Activates the next level if there is a next level.
+            // This potentially creates new messages in the sender.
+            self.activate_next_level();
+        }
+
+        // Check and see if a new pending contribution should be verified.
+        // Only start a new verification task if there is not already one and also only if the poll
+        // does not have produced a value yet. This is necessary as the verification future could
+        // resolve immediately producing a second item for the stream. As the new best aggregate
+        // will be returned, this stream will be polled again creating the future in the next poll.
+        if self.current_verification.is_none() && best_aggregate.is_none() {
+            // Get the next best pending contribution.
+            while let Poll::Ready(Some(contribution)) =
+                self.pending_contributions.poll_next_unpin(cx)
+            {
+                // Start the verification. This will also poll and thus may immediately return a result.
+                let Some((result, contribution)) = self.start_verification(contribution, cx) else {
+                    break;
+                };
+
+                // If the future returned immediately, it needs to be handled.
+                if result.is_ok() {
+                    // If the contribution verified, apply it and return the new best aggregate.
+                    best_aggregate = Some(self.apply_contribution(contribution));
+                    break;
+                } else {
+                    // TODO Ban peer who sent the failed contribution?
+                    //  Or penalize it when scoring contributions?
+                    debug!(
+                        ?result,
+                        ?contribution,
+                        "Verification of PendingContribution failed."
+                    );
+                }
+            }
+        }
+
+        // Drive the level update sender future. It always returns Pending.
+        let _ = self.sender.poll_unpin(cx);
+
+        // If this aggregation has already produced a final result, we return Pending instead of
+        // None to allow this aggregation to keep running so that it can send full aggregations to
+        // other nodes. This also means that the aggregation stream will never terminate.
+        if self.final_result.is_some() {
+            return Poll::Pending;
+        }
+
+        // If we don't have a best aggregate, wait for more contributions.
+        let Some(best_aggregate) = best_aggregate else {
+            return Poll::Pending;
+        };
+
+        // If the best aggregate is a full aggregation, this aggregation is finished.
+        if self.is_complete_aggregate(&best_aggregate) {
+            debug!(
+                id = ?self.protocol.identify(),
+                "Aggregation complete"
+            );
+
+            // Store the final result, so that we can give it to other nodes.
+            self.final_result = Some(best_aggregate.clone());
+
+            // Mark all levels as complete to stop sending updates.
+            for level in self.levels.iter() {
+                level.state.write().complete = true;
+            }
+        }
+
+        // Return the best aggregate.
+        return Poll::Ready(Some(best_aggregate));
     }
 }

--- a/handel/src/config.rs
+++ b/handel/src/config.rs
@@ -3,25 +3,21 @@ use std::time::Duration;
 /// Handel configuration settings
 #[derive(Clone, Debug)]
 pub struct Config {
-    /// Number of peers contacted during an update at each level
-    pub update_count: usize,
-
-    /// Frequency at which updates are sent to peers
+    /// Frequency at which updates are sent to peers.
     pub update_interval: Duration,
 
-    /// Timeout for levels
-    pub timeout: Duration,
+    /// Maximum time to wait for a level to complete before starting the next level.
+    pub level_timeout: Duration,
 
-    /// How many peers are contacted at each level
+    /// Number of peers that are contacted at each level.
     pub peer_count: usize,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
-            update_count: 1,
             update_interval: Duration::from_millis(500),
-            timeout: Duration::from_millis(400),
+            level_timeout: Duration::from_millis(400),
             peer_count: 2,
         }
     }

--- a/handel/src/contribution.rs
+++ b/handel/src/contribution.rs
@@ -16,14 +16,6 @@ pub trait AggregatableContribution:
     /// A BitSet signaling which contributors have contributed in this Contribution
     fn contributors(&self) -> BitSet;
 
-    /// Returns the id of the single contributor
-    ///
-    /// Panics if there is more than one contributor
-    fn contributor(&self) -> usize {
-        assert_eq!(self.num_contributors(), 1);
-        self.contributors().iter().next().unwrap()
-    }
-
     /// Returns the number of contributions aggregated in this contribution.
     fn num_contributors(&self) -> usize {
         self.contributors().len()
@@ -36,6 +28,6 @@ pub trait AggregatableContribution:
 
     /// Combines this contribution with `other_contribution` to create the aggregate of the two.
     ///
-    /// The combining contributions must be disjoint. The original must be retained in case of an error
+    /// The combining contributions must be disjoint. The original must be retained in case of an error.
     fn combine(&mut self, other_contribution: &Self) -> Result<(), ContributionError>;
 }

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -7,7 +7,7 @@ use crate::{
     contribution::AggregatableContribution,
     evaluator::VerificationError::{
         InvalidContributors, InvalidFullAggregate, InvalidIndividualContribution, InvalidLevel,
-        OriginNotInContributors, OriginNotInRange,
+        InvalidOrigin,
     },
     identity::{Identity, IdentityRegistry, WeightRegistry},
     partitioner::Partitioner,
@@ -96,13 +96,9 @@ pub enum VerificationError {
         weight: usize,
         expected_weight: usize,
     },
-    OriginNotInRange {
+    InvalidOrigin {
         origin: usize,
         range: RangeInclusive<usize>,
-    },
-    OriginNotInContributors {
-        origin: usize,
-        contributors: Identity,
     },
     InvalidIndividualContribution {
         num_contributors: usize,
@@ -291,15 +287,7 @@ where
         // Check that the message origin is a valid contributor.
         let origin = msg.origin as usize;
         if !range.contains(&origin) {
-            return Err(OriginNotInRange { origin, range });
-        }
-
-        // The origin must be part of the contributors.
-        if !contributors.contains(origin) {
-            return Err(OriginNotInContributors {
-                origin,
-                contributors,
-            });
+            return Err(InvalidOrigin { origin, range });
         }
 
         // Check that the signer of the individual contribution corresponds to the message origin.

--- a/handel/src/evaluator.rs
+++ b/handel/src/evaluator.rs
@@ -269,24 +269,10 @@ where
         }
 
         // Check that all contributors to the aggregate contribution are allowed on this level.
-        // Contributors can come from lower levels, so we need to check on all levels up to the
-        // given one.
-        // FIXME
-        'outer: for contributor in msg.aggregate.contributors().iter() {
-            for lvl in 0..=level {
-                // If the level is empty, check the next level.
-                let Ok(range) = self.partitioner.range(lvl) else {
-                    continue;
-                };
-
-                // If we found the contributor on this level, check the next contributor.
-                if range.contains(&contributor) {
-                    continue 'outer;
-                }
+        for contributor in msg.aggregate.contributors().iter() {
+            if !range.contains(&contributor) {
+                return false;
             }
-
-            // We didn't find the contributor on any level, thus the aggregate is invalid.
-            return false;
         }
 
         true

--- a/handel/src/identity.rs
+++ b/handel/src/identity.rs
@@ -15,7 +15,7 @@ pub struct Identity {
 impl Identity {
     /// An Identity containing no one.
     pub const NOBODY: Self = Identity {
-        identities: BitSet::EMPTY,
+        identities: BitSet::new(),
     };
 
     /// Creates a new identity given a bitset of identities, i.e signers of a contribution.
@@ -25,7 +25,7 @@ impl Identity {
 
     /// Creates an Identity containing solely the given identifier.
     pub fn single<T: Into<usize>>(identifier: T) -> Self {
-        let mut identities = BitSet::EMPTY;
+        let mut identities = BitSet::new();
         identities.insert(identifier.into());
         Self { identities }
     }

--- a/handel/src/identity.rs
+++ b/handel/src/identity.rs
@@ -28,6 +28,10 @@ impl Identity {
         self.signers.is_empty()
     }
 
+    pub fn contains(&self, value: usize) -> bool {
+        self.signers.contains(value)
+    }
+
     /// Returns whether this identity is a superset of another identity.
     pub fn is_superset_of(&self, other: &Self) -> bool {
         self.signers.is_superset(&other.signers)

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -3,10 +3,7 @@ use std::{cmp::min, sync::Arc};
 use parking_lot::RwLock;
 use rand::{seq::SliceRandom, thread_rng};
 
-use crate::{
-    contribution::AggregatableContribution,
-    partitioner::{Partitioner, PartitioningError},
-};
+use crate::partitioner::{Partitioner, PartitioningError};
 
 /// Struct that defines the state of a level
 #[derive(Clone, Debug)]
@@ -18,8 +15,6 @@ pub struct LevelState {
     pub complete: bool,
     /// The index of the next peer to send an update to.
     pub next_peer_index: usize,
-    /// The size of the signature to send.
-    pub signature_size: usize,
 }
 
 /// Struct that defines an Aggregation Level
@@ -29,9 +24,6 @@ pub struct Level {
     pub id: usize,
     /// The Peer IDs on this level
     pub peer_ids: Vec<usize>,
-    /// The full size of the expected signature of the combined signature of
-    /// all levels up to (including) the current one.
-    pub full_signature_size: usize,
     /// The state of this level
     pub state: RwLock<LevelState>,
 }
@@ -39,16 +31,14 @@ pub struct Level {
 impl Level {
     /// Creates a new level given its id, the set of peers and the expected
     /// number of peers to consider this level send complete
-    pub fn new(id: usize, peer_ids: Vec<usize>, send_expected_full_size: usize) -> Level {
+    pub fn new(id: usize, peer_ids: Vec<usize>) -> Level {
         Level {
             id,
             peer_ids,
-            full_signature_size: send_expected_full_size,
             state: RwLock::new(LevelState {
                 started: false,
                 complete: false,
                 next_peer_index: 0,
-                signature_size: 0,
             }),
         }
     }
@@ -70,7 +60,6 @@ impl Level {
     ) -> Vec<Level> {
         let mut levels: Vec<Level> = Vec::new();
         let mut first_active = false;
-        let mut send_expected_full_size: usize = 1;
         let mut rng = thread_rng();
 
         for i in 0..partitioner.levels() {
@@ -79,14 +68,13 @@ impl Level {
                     let mut ids = ids.collect::<Vec<usize>>();
                     ids.shuffle(&mut rng);
 
-                    let size = ids.len();
                     trace!(
                         ?id,
                         level = i,
                         peers = ?ids,
                         "Peers on level",
                     );
-                    let level = Level::new(i, ids, send_expected_full_size);
+                    let level = Level::new(i, ids);
 
                     if !first_active {
                         first_active = true;
@@ -94,10 +82,9 @@ impl Level {
                     }
 
                     levels.push(level);
-                    send_expected_full_size += size;
                 }
                 Err(PartitioningError::EmptyLevel { .. }) => {
-                    let level = Level::new(i, vec![], send_expected_full_size);
+                    let level = Level::new(i, vec![]);
                     levels.push(level);
                 }
                 Err(e) => panic!("{}", e),
@@ -137,29 +124,6 @@ impl Level {
         }
     }
 
-    /// Updates the signature to send
-    pub fn update_signature<C: AggregatableContribution>(&self, signature: &C) -> bool {
-        let mut state = self.state.write();
-
-        if state.signature_size >= signature.num_contributors() {
-            return false;
-        }
-
-        state.signature_size = signature.num_contributors();
-
-        if state.signature_size == self.full_signature_size {
-            log::debug!(
-                level = self.id,
-                send_signature_size = state.signature_size,
-                "Started level in update_signature_to_send"
-            );
-            state.started = true;
-            return true;
-        }
-
-        false
-    }
-
     /// Starts the level if not already started.
     /// If the level was started before returns false, otherwise returns true.
     pub fn start(&self) -> bool {
@@ -178,7 +142,7 @@ mod test {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::contribution::ContributionError;
+    use crate::contribution::{AggregatableContribution, ContributionError};
 
     /// Dump Aggregate adding numbers.
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -200,8 +164,7 @@ mod test {
     fn it_can_handle_empty_level() {
         let mut rng = thread_rng();
         let id: usize = rng.gen_range(0..10);
-        let send_expected_full_size = id + rng.gen_range(0..512);
-        let level = Level::new(id, [].to_vec(), send_expected_full_size);
+        let level = Level::new(id, [].to_vec());
 
         // Check that the level is actually empty
         assert!(level.is_empty());
@@ -221,8 +184,7 @@ mod test {
         let id: usize = rng.gen_range(0..10);
         let num_ids = rng.gen_range(1..512);
         let mut ids: Vec<usize> = (0..num_ids).map(|_| rng.gen_range(0..=10)).collect();
-        let send_expected_full_size = num_ids + rng.gen_range(0..512);
-        let level = Level::new(id, ids.clone(), send_expected_full_size);
+        let level = Level::new(id, ids.clone());
 
         // Check that the level is not empty
         assert!(!level.is_empty());
@@ -245,42 +207,5 @@ mod test {
             // For level 0 the next peers is always empty since it should be our own ID
             assert!(level.select_next_peers(select_size).is_empty());
         }
-    }
-
-    #[test]
-    fn it_updates_signature_to_send() {
-        let mut rng = thread_rng();
-        let id: usize = rng.gen_range(0..10);
-        let num_ids = rng.gen_range(1..512);
-        let ids: Vec<usize> = (0..num_ids).map(|_| rng.gen_range(0..=10)).collect();
-        let send_expected_full_size = num_ids + rng.gen_range(0..512);
-        let level = Level::new(id, ids.clone(), send_expected_full_size);
-
-        // Create a small contribution
-        let mut contributors = BitSet::new();
-        contributors.insert(1);
-        let contribution = Contribution { contributors };
-        assert!(!level.update_signature(&contribution)); // `state.send_signature_size` should be 1 now
-
-        // Add another contribution
-        let mut contributors = BitSet::new();
-        contributors.insert(3);
-        let contribution = Contribution { contributors };
-        assert!(!level.update_signature(&contribution)); // `state.send_signature_size` should be 2 now
-
-        // Add a smaller contribution
-        let mut contributors = BitSet::new();
-        contributors.insert(2);
-        let contribution = Contribution { contributors };
-        assert!(!level.update_signature(&contribution)); // `state.send_signature_size` should be still 2
-
-        // Now complete the `send_expected_full_size`
-        let mut contributors = BitSet::new();
-        for i in 0..send_expected_full_size {
-            contributors.insert(i);
-        }
-        let contribution = Contribution { contributors };
-        // After the next call, `state.send_signature_size` should be `num_ids` or `contributors.len()` and now it should return `true`
-        assert!(level.update_signature(&contribution));
     }
 }

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -11,16 +11,15 @@ use crate::{
 /// Struct that defines the state of a level
 #[derive(Clone, Debug)]
 pub struct LevelState {
-    /// Send is already started
-    pub send_started: bool,
-    /// Receive is already completed
-    pub receive_completed: bool,
-    /// The position of the peer where the next send must go to
-    pub send_peers_pos: usize,
-    /// The size of the signature to send
-    pub send_signature_size: usize,
-    /// The number of peers that a send is expected to go to
-    pub send_peers_count: usize,
+    /// Flag indicating that we have started sending updates on this level.
+    pub started: bool,
+    /// Flag indicating that this level is complete, i.e. this is true if we have aggregated all
+    /// contributions for this level.
+    pub complete: bool,
+    /// The index of the next peer to send an update to.
+    pub next_peer_index: usize,
+    /// The size of the signature to send.
+    pub signature_size: usize,
 }
 
 /// Struct that defines an Aggregation Level
@@ -32,7 +31,7 @@ pub struct Level {
     pub peer_ids: Vec<usize>,
     /// The full size of the expected signature of the combined signature of
     /// all levels up to (including) the current one.
-    pub send_expected_full_size: usize,
+    pub full_signature_size: usize,
     /// The state of this level
     pub state: RwLock<LevelState>,
 }
@@ -44,18 +43,17 @@ impl Level {
         Level {
             id,
             peer_ids,
-            send_expected_full_size,
+            full_signature_size: send_expected_full_size,
             state: RwLock::new(LevelState {
-                send_started: false,
-                receive_completed: false,
-                send_peers_pos: 0,
-                send_signature_size: 0,
-                send_peers_count: 0,
+                started: false,
+                complete: false,
+                next_peer_index: 0,
+                signature_size: 0,
             }),
         }
     }
 
-    /// Returns the number of peers in this level
+    /// Returns the number of peers on this level
     pub fn num_peers(&self) -> usize {
         self.peer_ids.len()
     }
@@ -85,14 +83,14 @@ impl Level {
                     trace!(
                         ?id,
                         level = i,
-                        peers_on_level = ?ids,
-                        "Peers on Level",
+                        peers = ?ids,
+                        "Peers on level",
                     );
                     let level = Level::new(i, ids, send_expected_full_size);
 
                     if !first_active {
                         first_active = true;
-                        level.state.write().send_started = true;
+                        level.state.write().started = true;
                     }
 
                     levels.push(level);
@@ -109,16 +107,16 @@ impl Level {
         levels
     }
 
-    /// Returns whether this level is active
-    pub fn active(&self) -> bool {
+    /// Returns whether this level has been started.
+    pub fn is_started(&self) -> bool {
         let state = self.state.read();
-        state.send_started && state.send_peers_count < self.peer_ids.len()
+        state.started
     }
 
-    /// Returns whether this level is received complete
-    pub fn receive_complete(&self) -> bool {
+    /// Returns whether this level is complete.
+    pub fn is_complete(&self) -> bool {
         let state = self.state.read();
-        state.receive_completed
+        state.complete
     }
 
     /// Selects the set of next peers to send an update to for this level given a count of them
@@ -126,17 +124,13 @@ impl Level {
         if self.id == 0 || self.is_empty() {
             vec![]
         } else {
-            let size = min(count, self.peer_ids.len());
+            let num_peers = min(count, self.peer_ids.len());
             let mut selected: Vec<usize> = Vec::new();
 
             let mut state = self.state.write();
-            for _ in 0..size {
-                // NOTE: Unwrap is safe, since we make sure at least `size` elements are in `self.peers`
-                selected.push(*self.peer_ids.get(state.send_peers_pos).unwrap());
-                state.send_peers_pos += 1;
-                if state.send_peers_pos >= self.peer_ids.len() {
-                    state.send_peers_pos = 0;
-                }
+            for _ in 0..num_peers {
+                selected.push(self.peer_ids[state.next_peer_index]);
+                state.next_peer_index = (state.next_peer_index + 1) % self.peer_ids.len();
             }
 
             selected
@@ -144,18 +138,22 @@ impl Level {
     }
 
     /// Updates the signature to send
-    pub fn update_signature_to_send<C: AggregatableContribution>(&self, signature: &C) -> bool {
+    pub fn update_signature<C: AggregatableContribution>(&self, signature: &C) -> bool {
         let mut state = self.state.write();
 
-        if state.send_signature_size >= signature.num_contributors() {
+        if state.signature_size >= signature.num_contributors() {
             return false;
         }
 
-        state.send_signature_size = signature.num_contributors();
-        state.send_peers_count = 0;
+        state.signature_size = signature.num_contributors();
 
-        if state.send_signature_size == self.send_expected_full_size {
-            state.send_started = true;
+        if state.signature_size == self.full_signature_size {
+            log::debug!(
+                level = self.id,
+                send_signature_size = state.signature_size,
+                "Started level in update_signature_to_send"
+            );
+            state.started = true;
             return true;
         }
 
@@ -163,16 +161,12 @@ impl Level {
     }
 
     /// Starts the level if not already started.
-    ///
     /// If the level was started before returns false, otherwise returns true.
     pub fn start(&self) -> bool {
         let mut state = self.state.write();
-        if state.send_started {
-            false
-        } else {
-            state.send_started = true;
-            true
-        }
+        let already_started = state.started;
+        state.started = true;
+        !already_started
     }
 }
 
@@ -215,10 +209,7 @@ mod test {
 
         // Start the level
         level.start();
-        assert!(level.state.read().send_started);
-
-        // An empty level can't be active since there is no peer to send updates to
-        assert!(!level.active());
+        assert!(level.state.read().started);
 
         // Check that it can properly select next peers (return empty vector)
         assert!(level.select_next_peers(rng.gen_range(0..512)).is_empty());
@@ -239,7 +230,6 @@ mod test {
 
         // Start the level
         level.start();
-        assert!(level.active());
 
         // Check that it can properly select next peers (return empty vector)
         let select_size = rng.gen_range(0..num_ids) + 1;
@@ -270,19 +260,19 @@ mod test {
         let mut contributors = BitSet::new();
         contributors.insert(1);
         let contribution = Contribution { contributors };
-        assert!(!level.update_signature_to_send(&contribution)); // `state.send_signature_size` should be 1 now
+        assert!(!level.update_signature(&contribution)); // `state.send_signature_size` should be 1 now
 
         // Add another contribution
         let mut contributors = BitSet::new();
         contributors.insert(3);
         let contribution = Contribution { contributors };
-        assert!(!level.update_signature_to_send(&contribution)); // `state.send_signature_size` should be 2 now
+        assert!(!level.update_signature(&contribution)); // `state.send_signature_size` should be 2 now
 
         // Add a smaller contribution
         let mut contributors = BitSet::new();
         contributors.insert(2);
         let contribution = Contribution { contributors };
-        assert!(!level.update_signature_to_send(&contribution)); // `state.send_signature_size` should be still 2
+        assert!(!level.update_signature(&contribution)); // `state.send_signature_size` should be still 2
 
         // Now complete the `send_expected_full_size`
         let mut contributors = BitSet::new();
@@ -291,6 +281,6 @@ mod test {
         }
         let contribution = Contribution { contributors };
         // After the next call, `state.send_signature_size` should be `num_ids` or `contributors.len()` and now it should return `true`
-        assert!(level.update_signature_to_send(&contribution));
+        assert!(level.update_signature(&contribution));
     }
 }

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -53,7 +53,7 @@ impl Level {
     }
 
     /// Creates a set of levels given a partitioner
-    pub fn create_levels<P: Partitioner, TId: std::fmt::Debug>(
+    pub fn create_levels<P: Partitioner, TId: std::fmt::Display>(
         partitioner: Arc<P>,
         id: TId,
         node_id: usize,
@@ -68,7 +68,7 @@ impl Level {
                     let ids = tree_rhs.clone().collect::<Vec<usize>>();
 
                     trace!(
-                        ?id,
+                        %id,
                         level = i,
                         peers = ?ids,
                         "Peers on level",

--- a/handel/src/lib.rs
+++ b/handel/src/lib.rs
@@ -21,7 +21,7 @@ pub mod store;
 pub mod update;
 pub mod verifier;
 
-use std::fmt::Debug;
+use std::fmt::Display;
 
-pub trait Identifier: Debug + Clone + Send + Unpin + 'static {}
-impl<T: Debug + Clone + Send + Unpin + 'static> Identifier for T {}
+pub trait Identifier: Display + Clone + Send + Unpin + 'static {}
+impl<T: Display + Clone + Send + Unpin + 'static> Identifier for T {}

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -100,7 +100,7 @@ impl<TNetwork: Network> LevelUpdateSender<TNetwork> {
             let recently_sent = last_update.sent_at.elapsed() < Self::ALLOW_RESEND_AFTER;
             if same_signers && recently_sent {
                 // FIXME Without this return, things are MUCH faster... why?
-                //return;
+                return;
             }
         }
 

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -29,6 +29,8 @@ pub trait Network: Unpin + Send + Sync + 'static {
         node_id: u16,
         update: LevelUpdate<Self::Contribution>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static;
+
+    fn ban_node(&self, node_id: u16) -> impl Future<Output = ()> + Send + 'static;
 }
 
 #[derive(Clone)]
@@ -197,7 +199,7 @@ impl<TNetwork: Network + Unpin> Future for LevelUpdateSender<TNetwork> {
 
 #[cfg(test)]
 mod test {
-    use std::{future::Future, sync::Arc, task::Context, time::Duration};
+    use std::{future, future::Future, sync::Arc, task::Context, time::Duration};
 
     use futures::FutureExt;
     use nimiq_collections::BitSet;
@@ -243,6 +245,10 @@ mod test {
                 nimiq_time::sleep(Duration::from_millis(100)).await;
                 Ok(())
             }
+        }
+
+        fn ban_node(&self, _node_id: u16) -> impl Future<Output = ()> + Send + 'static {
+            future::ready(())
         }
     }
 

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -97,11 +97,10 @@ impl<TNetwork: Network> NetworkHelper<TNetwork> {
         // `message_buffer` and `last_messages` have the same length, so this check prevents
         // out-of-bounds access to both of these vectors.
         if node_id >= self.num_nodes {
-            error!(
-                node_id,
-                self.num_nodes, "Attempted to send to out-of-bounds node_id"
+            panic!(
+                "Attempted to send to out-of-bounds node_id={}, num_nodes = {}",
+                node_id, self.num_nodes,
             );
-            return;
         }
 
         // If an update with the same signers was recently sent to node_id, we drop it to avoid
@@ -139,7 +138,7 @@ impl<TNetwork: Network + Unpin> Future for NetworkHelper<TNetwork> {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Drive pending ban futures.
-        while let Poll::Ready(Some(_)) = self.pending_bans.poll_next_unpin(cx) {}
+        while let Poll::Ready(Some(())) = self.pending_bans.poll_next_unpin(cx) {}
 
         // Loop here such that after polling pending futures there is an opportunity to create new
         // ones before returning.

--- a/handel/src/network.rs
+++ b/handel/src/network.rs
@@ -99,7 +99,6 @@ impl<TNetwork: Network> LevelUpdateSender<TNetwork> {
             let same_signers = last_update.signers == msg.aggregate.contributors();
             let recently_sent = last_update.sent_at.elapsed() < Self::ALLOW_RESEND_AFTER;
             if same_signers && recently_sent {
-                // FIXME Without this return, things are MUCH faster... why?
                 return;
             }
         }

--- a/handel/src/partitioner.rs
+++ b/handel/src/partitioner.rs
@@ -72,8 +72,8 @@ impl Partitioner for BinomialPartitioner {
     }
 
     fn level_size(&self, level: usize) -> usize {
-        if let Ok(range) = self.identities_on(level) {
-            range.len()
+        if let Ok(identities) = self.identities_on(level) {
+            identities.len()
         } else {
             0
         }

--- a/handel/src/partitioner.rs
+++ b/handel/src/partitioner.rs
@@ -23,6 +23,9 @@ pub trait Partitioner: Send + Sync {
     /// Number of identities at `level`
     fn level_size(&self, level: usize) -> usize;
 
+    /// Total number of identities up to `level`
+    fn cumulative_level_size(&self, level: usize) -> usize;
+
     /// Range of identities that need to be contacted at `level`
     fn range(&self, level: usize) -> Result<RangeInclusive<usize>, PartitioningError>;
 
@@ -76,6 +79,14 @@ impl Partitioner for BinomialPartitioner {
         } else {
             0
         }
+    }
+
+    fn cumulative_level_size(&self, level: usize) -> usize {
+        let mut size = 0;
+        for lvl in 0..=level {
+            size += self.level_size(lvl);
+        }
+        size
     }
 
     fn range(&self, level: usize) -> Result<RangeInclusive<usize>, PartitioningError> {

--- a/handel/src/pending_contributions.rs
+++ b/handel/src/pending_contributions.rs
@@ -2,13 +2,13 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use std::{collections::HashSet, fmt, sync::Arc};
+use std::{collections::HashSet, fmt, sync::Arc, task::Waker};
 
-use futures::{stream::BoxStream, Stream, StreamExt};
+use futures::Stream;
+use nimiq_utils::WakerExt;
 
 use crate::{
-    contribution::AggregatableContribution, evaluator::Evaluator, protocol::Protocol,
-    update::LevelUpdate, Identifier,
+    contribution::AggregatableContribution, evaluator::Evaluator, protocol::Protocol, Identifier,
 };
 
 /// A PendingContribution represents a contribution which has not yet been aggregated into the store.
@@ -62,7 +62,7 @@ impl<C: AggregatableContribution> std::hash::Hash for PendingContribution<C> {
     }
 }
 
-/// The PendingContributionlist. Implements Stream to poll for the next best scoring PendingContribution.
+/// Implements Stream to poll for the next best scoring PendingContribution.
 /// Will dry the input stream every time a PendingContribution is polled.
 pub(crate) struct PendingContributionList<TId, TProtocol>
 where
@@ -75,13 +75,8 @@ where
     list: HashSet<PendingContribution<TProtocol::Contribution>>,
     /// The evaluator used for scoring an individual PendingContribution.
     evaluator: Arc<TProtocol::Evaluator>,
-    /// The Stream where LevelUpdates can be polled from, which are subsequently converted into one or two
-    /// PendingContributions.
-    input_stream: BoxStream<'static, LevelUpdate<TProtocol::Contribution>>,
-    /// Keeps track on whether or not the PendingContributionList has been polled at least once.
-    /// Used to make sure that operations which need to happen before the first poll
-    /// are in fact executed before the first poll.
-    is_unpolled: bool,
+    /// Waker to wake the task when a contribution is added manually.
+    waker: Option<Waker>,
 }
 
 impl<TId, TProtocol> PendingContributionList<TId, TProtocol>
@@ -92,33 +87,24 @@ where
     /// Create a new PendingContributionList:
     /// * `evaluator` - The evaluator which will be used for contribution scoring
     /// * `input_stream` - The stream on which new LevelUpdates can be polled, which will then be converted into PendingContributions
-    pub fn new(
-        id: TId,
-        evaluator: Arc<TProtocol::Evaluator>,
-        input_stream: BoxStream<'static, LevelUpdate<TProtocol::Contribution>>,
-    ) -> Self {
+    pub fn new(id: TId, evaluator: Arc<TProtocol::Evaluator>) -> Self {
         Self {
             id,
             list: HashSet::new(),
             evaluator,
-            input_stream,
-            is_unpolled: true,
+            waker: None,
         }
     }
 
-    /// Safe without a wake as it is only called in the constructor of Aggregation.
     pub fn add_contribution(&mut self, contribution: TProtocol::Contribution, level: usize) {
-        // As no waker is used, this must only ever happen before the first poll.
-        assert!(self.is_unpolled);
         // Add the item to the list.
         self.list.insert(PendingContribution {
             contribution,
             level,
         });
-    }
 
-    pub fn into_stream(self) -> BoxStream<'static, LevelUpdate<TProtocol::Contribution>> {
-        self.input_stream
+        // Wake the task to process this contribution.
+        self.waker.wake();
     }
 }
 
@@ -130,134 +116,55 @@ where
     type Item = PendingContribution<TProtocol::Contribution>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // Once poll is called this list is no longer unpolled.
-        self.is_unpolled = true;
-
-        // current best score
+        // The current best score.
         let mut best_score: usize = 0;
-        // retained set of PendingContributions.
-        // Same as self.list, but did not retain 0 score PendingContributions and the best PendingContribution.
-        let mut new_set: HashSet<Self::Item> = HashSet::new();
-        // the current best PendingContribution
-        let mut best_pending_contribution: Option<Self::Item> = None;
-        // A local copy is needed so mut self is not borrowed
-        let ev = Arc::clone(&self.evaluator);
-
+        // The current best PendingContribution.
+        let mut best_contribution: Option<Self::Item> = None;
+        // Retained set of PendingContributions. Same as `self.list`, but does not retain 0-score
+        // PendingContributions and the best PendingContribution.
+        let mut retain_set: HashSet<Self::Item> = HashSet::new();
+        // A local copy is needed so self is not borrowed.
+        let evaluator = Arc::clone(&self.evaluator);
         let id = self.id.clone();
 
-        // Scoring of items needs to be done every time a item is polled, as the scores might have
-        // changed with the last aggregated contribution
+        // Scoring of items needs to be done every time an item is polled, as the scores might have
+        // changed with the last aggregated contribution.
 
-        // Score already available PendingContributions first
+        // Score already available PendingContributions first.
         for item in self.list.drain() {
-            // Have the evaluator score each PendingContribution.
-            let score = item.evaluate::<TId, TProtocol>(Arc::clone(&ev), id.clone());
-            // if an item has a score greater than 0 it is retained. Otherwise it is discarded
-            if score > 0 {
-                if score > best_score {
-                    // In case it's a new best remember it and push the old best into the retained set.
-                    if let Some(pending_contribution) = best_pending_contribution {
-                        new_set.insert(pending_contribution);
-                    }
-                    best_pending_contribution = Some(item);
-                    // remember the new best score
-                    best_score = score;
-                } else {
-                    // in case the item is not the new best scoring item, push it into the retained set.
-                    new_set.insert(item);
-                }
+            // Use the evaluator to compute the score of the contribution.
+            let score = item.evaluate::<TId, TProtocol>(Arc::clone(&evaluator), id.clone());
+
+            // If an item has a score of 0, it is discarded.
+            if score == 0 {
+                continue;
             }
-        }
 
-        // The list must be empty now since it is going to be overwritten.
-        assert!(self.list.is_empty());
-
-        // Update PendingContributions with the the retained list of PendingContributions
-        self.list = new_set;
-
-        // Scan the input for better PendingContributions. The loop exits once the input has run out of LevelUpdates.
-        // Note that computations are limited to the bare minimum. No verification in particular.
-        // As Verification is very computationally expensive it should only be done for the PendingContribution with the highest score.
-        while let Poll::Ready(Some(msg)) = self.input_stream.poll_next_unpin(cx) {
-            // TODO the case where the msg is None is not being handled which could mean that:
-            // The input has ended, i.e. there is no producer left.
-            // In Test cases that could mean the other instances have completed their aggregations and dropped their network instances.
-            // In reality this should never happen as the network should not terminate those streams, but try to acquire new Peers in this situation.
-            // Panic here is viable, but makes testing a bit harder.
-            // TODO more robust handling of this case, as the aggregation might not be able to finish here (depending on what PendingContributions are left).
-
-            // A new LevelUpdate is available when the msg is Some:
-            if self.evaluator.level_contains_origin(&msg) {
-                // Every LevelUpdate contains an aggregate which can be turned into a PendingContribution.
-                let pending_aggregate_contribution = PendingContribution {
-                    contribution: msg.aggregate,
-                    level: msg.level as usize,
-                };
-                // Score the newly created PendingContribution for the aggregate of the LevelUpdate
-                let score = pending_aggregate_contribution
-                    .evaluate::<TId, TProtocol>(Arc::clone(&self.evaluator), id.clone());
-                // PendingContributions with a score of 0 are discarded (meaning not added to the set).
-                if score > 0 {
-                    trace!(
-                        id = ?self.id,
-                        ?score,
-                        ?pending_aggregate_contribution,
-                        "New PendingContribution",
-                    );
-                    if score > best_score {
-                        // If the score is a new best remember the score and put the former best item into the list.
-                        best_score = score;
-                        if let Some(pending_contribution) = best_pending_contribution {
-                            self.list.insert(pending_contribution);
-                        }
-                        best_pending_contribution = Some(pending_aggregate_contribution);
-                    } else {
-                        // If the score is not a new best put the PendingContribution in the list.
-                        self.list.insert(pending_aggregate_contribution);
-                    }
+            // Check if this item is the new best.
+            if score > best_score {
+                // Push the old best into the retained set.
+                if let Some(old_best) = best_contribution.take() {
+                    retain_set.insert(old_best);
                 }
-                // Some of the LevelUpdates also contain an individual Signature in which case it is also converted into a PendingContribution.
-                if let Some(individual) = msg.individual {
-                    let pending_individual_contribution = PendingContribution {
-                        contribution: individual,
-                        level: msg.level as usize,
-                    };
-                    // Score the newly created PendingContribution for the individual contribution of the LevelUpdate.
-                    let score = pending_individual_contribution
-                        .evaluate::<TId, TProtocol>(Arc::clone(&self.evaluator), self.id.clone());
-                    // PendingContributions with a score of 0 are discarded (meaning not added to the set).
-                    if score > 0 {
-                        if score > best_score {
-                            // If the score is a new best remember the score and put the former best item into the list.
-                            best_score = score;
-                            if let Some(pending_contribution) = best_pending_contribution {
-                                self.list.insert(pending_contribution);
-                            }
-                            best_pending_contribution = Some(pending_individual_contribution);
-                        } else {
-                            // If the score is not a new best put the PendingContribution in the list.
-                            self.list.insert(pending_individual_contribution);
-                        }
-                    }
-                }
+                // Remember the new best.
+                best_score = score;
+                best_contribution = Some(item);
             } else {
-                trace!(
-                    sender = ?msg.origin,
-                    level = ?msg.level,
-                    "Sender of update is not on the correct level",
-                );
+                // In case the item is not the new best, push it into the retained set.
+                retain_set.insert(item);
             }
         }
 
-        // If the best item has a score higher than 0 return it otherwise signal
-        // that no new aggregate is currently available.
-        if best_score > 0 {
-            // The function returns Poll<Option<PendingContribution<C>>> but Ready(None) is never returned.
-            return Poll::Ready(Some(best_pending_contribution.expect(
-                "Score was higher than 0 but there was no best PendingContribution.",
-            )));
+        // Update PendingContributions with the retained list of PendingContributions.
+        self.list = retain_set;
+
+        // Return the best contribution if we have one.
+        if best_contribution.is_some() {
+            return Poll::Ready(best_contribution);
         }
 
+        // Wait for more contributions.
+        self.waker.store_waker(cx);
         Poll::Pending
     }
 }

--- a/handel/src/pending_contributions.rs
+++ b/handel/src/pending_contributions.rs
@@ -19,6 +19,8 @@ pub(crate) struct PendingContribution<C: AggregatableContribution> {
     pub contribution: C,
     /// The level the contribution belongs to.
     pub level: usize,
+    /// The sender of this contribution.
+    pub origin: usize,
 }
 
 impl<C: AggregatableContribution> fmt::Debug for PendingContribution<C> {
@@ -96,11 +98,17 @@ where
         }
     }
 
-    pub fn add_contribution(&mut self, contribution: TProtocol::Contribution, level: usize) {
+    pub fn add_contribution(
+        &mut self,
+        contribution: TProtocol::Contribution,
+        level: usize,
+        origin: usize,
+    ) {
         // Add the item to the list.
         self.list.insert(PendingContribution {
             contribution,
             level,
+            origin,
         });
 
         // Wake the task to process this contribution.

--- a/handel/src/pending_contributions.rs
+++ b/handel/src/pending_contributions.rs
@@ -21,6 +21,9 @@ pub(crate) struct PendingContribution<C: AggregatableContribution> {
     pub level: usize,
     /// The sender of this contribution.
     pub origin: usize,
+    /// Indicates if the LevelUpdates is added from a trusted source.
+    /// If so the signature does not need to be verified
+    trusted: bool,
 }
 
 impl<C: AggregatableContribution> fmt::Debug for PendingContribution<C> {
@@ -44,6 +47,13 @@ impl<C: AggregatableContribution> PendingContribution<C> {
         id: TId,
     ) -> usize {
         evaluator.evaluate(&self.contribution, self.level, id)
+    }
+
+    /// Returns true if the LevelUpdate was created by a trusted source.
+    /// One example would be the LevelUpdate was created locally.
+    /// Returns false otherwise.
+    pub fn trusted(&self) -> bool {
+        self.trusted
     }
 }
 
@@ -103,12 +113,14 @@ where
         contribution: TProtocol::Contribution,
         level: usize,
         origin: usize,
+        trusted: bool,
     ) {
         // Add the item to the list.
         self.list.insert(PendingContribution {
             contribution,
             level,
             origin,
+            trusted,
         });
 
         // Wake the task to process this contribution.

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -113,7 +113,7 @@ where
         let Some((best_contribution, best_contributors)) = best_contribution else {
             // This is normal whenever the first signature for a level is processed.
             trace!(
-                id = ?identifier,
+                id = %identifier,
                 level,
                 contributors = %contribution.contributors(),
                 "Level was empty",
@@ -123,7 +123,7 @@ where
         };
 
         trace!(
-            id = ?identifier,
+            id = %identifier,
             level,
             ?best_contribution,
             "Current best for level"
@@ -141,7 +141,7 @@ where
             // Merging failed. Check if contribution is a superset of `best_contribution`.
             if contributors.is_superset_of(best_contributors) {
                 trace!(
-                    id = ?identifier,
+                    id = %identifier,
                     level,
                     ?contribution,
                     ?best_contribution,
@@ -150,7 +150,7 @@ where
                 return Some((contribution, contributors));
             } else {
                 trace!(
-                    id = ?identifier,
+                    id = %identifier,
                     level,
                     ?contribution,
                     ?best_contribution,
@@ -179,7 +179,7 @@ where
             // This should not be observed really as the evaluator should filter signatures which cannot provide
             // improvements out.
             trace!(
-                id = ?identifier,
+                id = %identifier,
                 "No improvement possible",
             );
             return None;
@@ -238,7 +238,7 @@ where
                 .insert(level, (best_contribution, best_identity));
             if level > self.best_level {
                 trace!(
-                    id = ?identifier,
+                    id = %identifier,
                     level,
                     "Best level is now",
                 );
@@ -330,20 +330,22 @@ mod tests {
 
     /// Dummy Protocol. Unused, except for Generic
     pub struct TestProtocol {
-        evaluator: Arc<<Self as Protocol<()>>::Evaluator>,
-        partitioner: Arc<<Self as Protocol<()>>::Partitioner>,
-        registry: Arc<<Self as Protocol<()>>::Registry>,
-        verifier: Arc<<Self as Protocol<()>>::Verifier>,
-        store: Arc<RwLock<<Self as Protocol<()>>::Store>>,
+        evaluator: Arc<<Self as Protocol<u8>>::Evaluator>,
+        partitioner: Arc<<Self as Protocol<u8>>::Partitioner>,
+        registry: Arc<<Self as Protocol<u8>>::Registry>,
+        verifier: Arc<<Self as Protocol<u8>>::Verifier>,
+        store: Arc<RwLock<<Self as Protocol<u8>>::Store>>,
     }
-    impl Protocol<()> for TestProtocol {
+    impl Protocol<u8> for TestProtocol {
         type Contribution = Contribution;
-        type Evaluator = WeightedVote<(), Self>;
+        type Evaluator = WeightedVote<u8, Self>;
         type Partitioner = BinomialPartitioner;
         type Registry = TestRegistry;
         type Verifier = TestVerifier;
-        type Store = ReplaceStore<(), Self>;
-        fn identify(&self) {}
+        type Store = ReplaceStore<u8, Self>;
+        fn identify(&self) -> u8 {
+            0
+        }
         fn node_id(&self) -> usize {
             0
         }
@@ -403,7 +405,7 @@ mod tests {
         // Create the partitions
         let partitioner = Arc::new(BinomialPartitioner::new(node_id, num_ids));
 
-        let store = Arc::new(RwLock::new(ReplaceStore::<(), TestProtocol>::new(
+        let store = Arc::new(RwLock::new(ReplaceStore::<u8, TestProtocol>::new(
             partitioner.clone(),
         )));
 
@@ -423,7 +425,7 @@ mod tests {
             first_contribution.clone(),
             level,
             Arc::new(TestRegistry {}),
-            (),
+            0,
         );
 
         {
@@ -449,7 +451,7 @@ mod tests {
             second_contribution.clone(),
             level,
             Arc::new(TestRegistry {}),
-            (),
+            0,
         );
 
         {
@@ -485,7 +487,7 @@ mod tests {
         // Create the partitions
         let partitioner = Arc::new(BinomialPartitioner::new(node_id, num_ids));
 
-        let store = Arc::new(RwLock::new(ReplaceStore::<(), TestProtocol>::new(
+        let store = Arc::new(RwLock::new(ReplaceStore::<u8, TestProtocol>::new(
             partitioner.clone(),
         )));
 
@@ -508,7 +510,7 @@ mod tests {
             first_contribution.clone(),
             level,
             Arc::new(TestRegistry {}),
-            (),
+            0,
         );
 
         {
@@ -536,7 +538,7 @@ mod tests {
             second_contribution.clone(),
             level,
             Arc::new(TestRegistry {}),
-            (),
+            0,
         );
 
         {
@@ -578,7 +580,7 @@ mod tests {
             third_contribution.clone(),
             level,
             Arc::new(TestRegistry {}),
-            (),
+            0,
         );
 
         {

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -240,7 +240,7 @@ impl<N: NetworkInterface<PeerId = MockPeerId>> Network for NetworkWrapper<N> {
 #[test(tokio::test)]
 async fn handel_aggregation() {
     let config = Config {
-        update_interval: Duration::from_millis(500),
+        update_interval: Duration::from_millis(100),
         level_timeout: Duration::from_millis(500),
         peer_count: 1,
     };
@@ -249,7 +249,7 @@ async fn handel_aggregation() {
 
     let mut hub = MockHub::default();
 
-    let num_contributors: usize = 12;
+    let num_contributors: usize = 20;
     log::info!(num_contributors, "Running with");
 
     // The final value needs to be the sum of all contributions.
@@ -324,7 +324,7 @@ async fn handel_aggregation() {
     // Check that all aggregations completed.
     let mut num_finished = 0usize;
     loop {
-        let _ = timeout(Duration::from_secs(5), receiver.recv())
+        let _ = timeout(Duration::from_secs(2), receiver.recv())
             .await
             .expect("An aggregation took too long to return");
         num_finished += 1;

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -18,7 +18,7 @@ use nimiq_handel::{
     verifier::{VerificationResult, Verifier},
 };
 use nimiq_network_interface::{
-    network::Network as NetworkInterface,
+    network::{CloseReason, Network as NetworkInterface},
     request::{MessageMarker, OutboundRequestError, RequestCommon, RequestError},
 };
 use nimiq_network_mock::{MockHub, MockNetwork, MockPeerId};
@@ -231,6 +231,16 @@ impl<N: NetworkInterface<PeerId = MockPeerId>> Network for NetworkWrapper<N> {
                 log::error!(?this_id, node_id, ?update, "Peer does not exist",);
                 Err(OutboundRequestError::DialFailure.into())
             }
+        }
+    }
+
+    fn ban_node(&self, node_id: u16) -> impl Future<Output = ()> + Send + 'static {
+        let peer_id = MockPeerId(node_id as u64);
+        let network = Arc::clone(&self.0);
+        async move {
+            network
+                .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                .await
         }
     }
 }

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -1,10 +1,7 @@
-use std::{fmt::Formatter, sync::Arc, time::Duration};
+use std::{fmt::Formatter, future::Future, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use futures::{
-    future::{BoxFuture, FutureExt},
-    StreamExt,
-};
+use futures::StreamExt;
 use nimiq_bls::PublicKey;
 use nimiq_collections::bitset::BitSet;
 use nimiq_handel::{
@@ -217,7 +214,7 @@ impl<N: NetworkInterface<PeerId = MockPeerId>> Network for NetworkWrapper<N> {
         &self,
         node_id: u16,
         update: LevelUpdate<Self::Contribution>,
-    ) -> BoxFuture<'static, Result<(), Self::Error>> {
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
         let update = Update(update.into());
         let network = Arc::clone(&self.0);
         async move {
@@ -235,7 +232,6 @@ impl<N: NetworkInterface<PeerId = MockPeerId>> Network for NetworkWrapper<N> {
                 Err(OutboundRequestError::DialFailure.into())
             }
         }
-        .boxed()
     }
 }
 

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -5,7 +5,6 @@ use futures::{
     future::{BoxFuture, FutureExt},
     stream::StreamExt,
 };
-use instant::Instant;
 use nimiq_bls::PublicKey;
 use nimiq_collections::bitset::BitSet;
 use nimiq_handel::{
@@ -23,13 +22,13 @@ use nimiq_handel::{
 };
 use nimiq_network_interface::{
     network::Network as NetworkInterface,
-    request::{MessageMarker, RequestCommon},
+    request::{MessageMarker, OutboundRequestError, RequestCommon, RequestError},
 };
 use nimiq_network_mock::{MockHub, MockNetwork, MockPeerId};
 use nimiq_test_log::test;
+use nimiq_time::timeout;
 use nimiq_utils::spawn;
 use parking_lot::RwLock;
-use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -210,23 +209,28 @@ struct NetworkWrapper<N: NetworkInterface<PeerId = MockPeerId>>(Arc<N>);
 
 impl<N: NetworkInterface<PeerId = MockPeerId>> Network for NetworkWrapper<N> {
     type Contribution = Contribution;
+    type Error = RequestError;
 
-    fn send_to(
+    fn send_update(
         &self,
-        (msg, recipient): (LevelUpdate<Self::Contribution>, u16),
-    ) -> BoxFuture<'static, ()> {
-        let update = Update(msg.into());
-        let nw = Arc::clone(&self.0);
+        node_id: u16,
+        update: LevelUpdate<Self::Contribution>,
+    ) -> BoxFuture<'static, Result<(), Self::Error>> {
+        let update = Update(update.into());
+        let network = Arc::clone(&self.0);
         async move {
-            let peer_id = MockPeerId(recipient as u64);
+            let peer_id = MockPeerId(node_id as u64);
 
-            if nw.has_peer(peer_id) {
-                if let Err(err) = nw.message(update, peer_id).await {
-                    log::error!("Error sending request to {}: {:?}", recipient, err);
+            if network.has_peer(peer_id) {
+                let result = network.message(update, peer_id).await;
+                if let Err(err) = &result {
+                    log::error!("Error sending request to {}: {:?}", node_id, err);
                 }
+                result
             } else {
-                let this_id = nw.get_local_peer_id();
-                log::error!(?this_id, ?recipient, ?update, "Peer does not exist",);
+                let this_id = network.get_local_peer_id();
+                log::error!(?this_id, node_id, ?update, "Peer does not exist",);
+                Err(OutboundRequestError::DialFailure.into())
             }
         }
         .boxed()
@@ -234,11 +238,10 @@ impl<N: NetworkInterface<PeerId = MockPeerId>> Network for NetworkWrapper<N> {
 }
 
 #[test(tokio::test)]
-async fn it_can_aggregate() {
+async fn handel_aggregation() {
     let config = Config {
-        update_count: 1,
         update_interval: Duration::from_millis(500),
-        timeout: Duration::from_millis(500),
+        level_timeout: Duration::from_millis(500),
         peer_count: 1,
     };
 
@@ -246,189 +249,148 @@ async fn it_can_aggregate() {
 
     let mut hub = MockHub::default();
 
-    let mut rng = thread_rng();
-    let contributor_num: usize = rng.gen_range(7..15);
-    log::info!(contributor_num, "Running with");
+    let num_contributors: usize = 12;
+    log::info!(num_contributors, "Running with");
 
-    let (sender, mut receiver) = mpsc::channel(contributor_num);
+    // The final value needs to be the sum of all contributions.
+    // For instance for `contributor_num = 7: 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1 = 36`
+    let mut expected_aggregation_value = 0u64;
+    for i in 0..num_contributors {
+        expected_aggregation_value += i as u64 + 1u64;
+    }
+
+    let (sender, mut receiver) = mpsc::channel(num_contributors);
 
     let mut networks: Vec<Arc<MockNetwork>> = vec![];
-    // Initialize `contributor_num` networks and Handel Aggregations. Connect all the networks with each other.
-    for id in 0..contributor_num {
+    // Initialize `num_contributors` networks and Handel Aggregations. Connect all the networks with
+    // each other.
+    for id in 0..num_contributors {
         // Create a network with id = `id`
         let net = Arc::new(hub.new_network_with_address(id as u64));
-        // Create a protocol with `contributor_num + 1` peers set its id to `id`. Require `contributor_num` contributions
-        // meaning all contributions need to be aggregated with the additional node initialized after this for loop.
-        let protocol = Protocol::new(id, contributor_num + 1, contributor_num);
-        // the sole contributor for soon to be created contribution is this node.
+        // Create a protocol with `num_contributors` peers and set its id to `id`. Require
+        // `num_contributors` contributions, meaning all contributions need to be aggregated.
+        let protocol = Protocol::new(id, num_contributors, num_contributors);
+        // The sole contributor is this node.
         let mut contributors = BitSet::new();
         contributors.insert(id);
 
-        // create a contribution for this node with a value of `id + 1` (So no node has value 0 which doesn't show up in addition).
+        // Create a contribution for this node with a value of `id + 1`.
+        // This is to ensure that no node has value 0 which doesn't show up in addition.
         let contribution = Contribution {
-            value: id as u64 + 1u64,
+            value: id as u64 + 1,
             contributors,
         };
-        // connect the network to all already existing networks.
+
+        // Connect the network to all already existing networks.
         for network in &networks {
             net.dial_mock(network);
         }
-        // remember the network so that subsequently created networks can connect to it.
+
+        // Remember the network so that subsequently created networks can connect to it.
         networks.push(net.clone());
 
-        // spawn a task for this Handel Aggregation and Network instance.
+        // Spawn a task for this Handel Aggregation and Network instance.
         let mut aggregation = Aggregation::new(
             protocol,
             config.clone(),
             contribution,
-            Box::pin(
-                net.receive_messages::<Update<Contribution>>()
-                    .map(move |msg| msg.0 .0.into_level_update(msg.1 .0 as u16)),
-            ),
+            net.receive_messages::<Update<Contribution>>()
+                .map(move |msg| msg.0.0.into_level_update(msg.1.0 as u16))
+                .boxed(),
             NetworkWrapper(net),
         );
 
-        let r = stopped.clone();
-        let s = sender.clone();
+        let stopped = stopped.clone();
+        let sender = sender.clone();
         spawn(async move {
-            // have them just run until the aggregation is finished
-            while let Some(contribution) = aggregation.next().await {
-                if contribution.num_contributors() == contributor_num + 1 {
-                    s.send(()).await.expect("Send should never fail");
+            loop {
+                // Use a timeout here to eventually check the `stopped` flag if the aggregation
+                // stream is not producing any more items.
+                let item = timeout(Duration::from_secs(1), aggregation.next()).await;
+                if let Ok(Some(contribution)) = item {
+                    if contribution.num_contributors() == num_contributors {
+                        assert_eq!(contribution.value, expected_aggregation_value);
+                        sender.send(()).await.expect("Send should never fail");
+                    }
                 }
 
-                if *r.read() {
+                if *stopped.read() {
                     return;
                 }
             }
         });
     }
 
-    // same as in the for loop, except we want to keep the handel instance and not spawn it.
-    let net = Arc::new(hub.new_network_with_address(contributor_num as u64));
-    let protocol = Protocol::new(contributor_num, contributor_num + 1, contributor_num + 1);
-    let mut contributors = BitSet::new();
-    contributors.insert(contributor_num);
-    let contribution = Contribution {
-        value: contributor_num as u64 + 1u64,
-        contributors,
-    };
-    for network in &networks {
-        net.dial_mock(network);
-    }
-
-    // instead of spawning the aggregation task await its result here.
-    let mut aggregation = Aggregation::new(
-        protocol,
-        config.clone(),
-        contribution,
-        Box::pin(
-            net.receive_messages::<Update<Contribution>>()
-                .map(move |msg| msg.0 .0.into_level_update(msg.1 .0 as u16)),
-        ),
-        NetworkWrapper(Arc::clone(&net)),
-    );
-
-    // aggregating should not take more than 1s per each 7 contributors
-    let timeout_ms = 1000u64 * (contributor_num / 7 + 1) as u64;
-
-    let deadline = Instant::now()
-        .checked_add(Duration::from_millis(timeout_ms))
-        .unwrap();
-
-    // The final value needs to be the sum of all contributions.
-    // For instance for `contributor_num = 7: 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1 = 36`
-    let mut exp_agg_value = 0u64;
-    for i in 0..=contributor_num {
-        exp_agg_value += i as u64 + 1u64;
-    }
-
+    // Check that all aggregations completed.
+    let mut num_finished = 0usize;
     loop {
-        match nimiq_time::timeout(
-            deadline.saturating_duration_since(Instant::now()),
-            aggregation.next(),
-        )
-        .await
-        {
-            Ok(Some(aggregate)) => {
-                if aggregate.num_contributors() == contributor_num + 1
-                    && aggregate.value == exp_agg_value
-                {
-                    // fully aggregated the result. break the loop here
-                    break;
-                }
-            }
-            Ok(None) => panic!("Aggregate returned a None value, which should be unreachable!()"),
-            Err(_) => panic!("Aggregate took too long"),
-        }
-    }
-
-    drop(aggregation);
-    net.disconnect();
-
-    // give the other aggregations time to complete themselves
-    let mut finished_count = 0usize;
-    loop {
-        let _ = receiver.recv().await;
-        finished_count += 1;
-        if finished_count == contributor_num {
+        let _ = timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("An aggregation took too long to return");
+        num_finished += 1;
+        log::info!(num_finished, "Finished count");
+        if num_finished == num_contributors {
             break;
         }
     }
 
-    // after we have the final aggregate create a new instance and have it (without any other instances)
-    // return a fully aggregated contribution and terminate.
-    // Same as before
-    // let net = Arc::new(hub.new_network_with_address(contributor_num as u64));
-    let protocol = Protocol::new(contributor_num, contributor_num + 1, contributor_num + 1);
-    let mut contributors = BitSet::new();
-    contributors.insert(contributor_num);
-    let contribution = Contribution {
-        value: contributor_num as u64 + 1u64,
-        contributors,
-    };
-    for network in &networks {
-        net.dial_mock(network);
-    }
-
-    // instead of spawning the aggregation task await its result here.
-    let mut aggregation = Aggregation::new(
-        protocol,
-        config.clone(),
-        contribution,
-        Box::pin(
-            net.receive_messages::<Update<Contribution>>()
-                .map(move |msg| msg.0 .0.into_level_update(msg.1 .0 as u16)),
-        ),
-        NetworkWrapper(net),
-    );
-
-    // first poll will add the nodes individual contribution and send its LevelUpdate
-    // which should be responded to with a full aggregation
-    let _ = aggregation.next().await;
-    // Second poll must return a full contribution
-    let last_aggregate = aggregation.next().await;
-
-    // An aggregation needs to be present
-    assert!(last_aggregate.is_some(), "Nothing was aggregated!");
-
-    let last_aggregate = last_aggregate.unwrap();
-
-    // All nodes need to contribute
-    assert_eq!(
-        last_aggregate.num_contributors(),
-        contributor_num + 1,
-        "Not all contributions are present: {:?}",
-        last_aggregate,
-    );
-
-    // the final value needs to be the sum of all contributions: `exp_agg_value`
-    assert_eq!(
-        last_aggregate.value, exp_agg_value,
-        "Wrong aggregation result",
-    );
-
     *stopped.write() = true;
+
+    return;
+
+    // // after we have the final aggregate create a new instance and have it (without any other instances)
+    // // return a fully aggregated contribution and terminate.
+    // // Same as before
+    // // let net = Arc::new(hub.new_network_with_address(contributor_num as u64));
+    // let protocol = Protocol::new(num_contributors, num_contributors + 1, num_contributors + 1);
+    // let mut contributors = BitSet::new();
+    // contributors.insert(num_contributors);
+    // let contribution = Contribution {
+    //     value: num_contributors as u64 + 1u64,
+    //     contributors,
+    // };
+    // for network in &networks {
+    //     net.dial_mock(network);
+    // }
+    //
+    // // instead of spawning the aggregation task await its result here.
+    // let mut aggregation = Aggregation::new(
+    //     protocol,
+    //     config.clone(),
+    //     contribution,
+    //     Box::pin(
+    //         net.receive_messages::<Update<Contribution>>()
+    //             .map(move |msg| msg.0 .0),
+    //     ),
+    //     NetworkWrapper(net),
+    // );
+    //
+    // // first poll will add the nodes individual contribution and send its LevelUpdate
+    // // which should be responded to with a full aggregation
+    // let _ = aggregation.next().await;
+    // // Second poll must return a full contribution
+    // let last_aggregate = aggregation.next().await;
+    //
+    // // An aggregation needs to be present
+    // assert!(last_aggregate.is_some(), "Nothing was aggregated!");
+    //
+    // let last_aggregate = last_aggregate.unwrap();
+    //
+    // // All nodes need to contribute
+    // assert_eq!(
+    //     last_aggregate.num_contributors(),
+    //     num_contributors + 1,
+    //     "Not all contributions are present: {:?}",
+    //     last_aggregate,
+    // );
+    //
+    // // the final value needs to be the sum of all contributions: `exp_agg_value`
+    // assert_eq!(
+    //     last_aggregate.value, expected_aggregation_value,
+    //     "Wrong aggregation result",
+    // );
+    //
+    // *stopped.write() = true;
 }
 
 // additional tests:

--- a/network-mock/src/hub.rs
+++ b/network-mock/src/hub.rs
@@ -145,7 +145,7 @@ impl MockHub {
 
     pub fn new_network_with_address<A: Into<MockAddress>>(&mut self, address: A) -> MockNetwork {
         let address: MockAddress = address.into();
-        log::debug!("New mock network with address={}", address);
+        log::trace!("New mock network with address={}", address);
         MockNetwork::new(address, Arc::clone(&self.inner))
     }
 }

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -119,7 +119,7 @@ impl MockNetwork {
     fn dial_mock_address(&self, address: MockAddress) -> Result<(), MockNetworkError> {
         let hub = self.hub.lock();
 
-        log::debug!("Peer {} dialing peer {}", self.address, address);
+        log::trace!("Peer {} dialing peer {}", self.address, address);
 
         // Insert ourselves into peer's peer list.
         // This also makes sure the other peer actually exists.

--- a/primitives/src/tendermint.rs
+++ b/primitives/src/tendermint.rs
@@ -1,4 +1,7 @@
-use std::io;
+use std::{
+    fmt::{Display, Formatter},
+    io,
+};
 
 use nimiq_hash::{Blake2sHash, SerializeContent};
 use nimiq_serde::{Deserialize, Serialize, SerializedSize};
@@ -40,6 +43,16 @@ pub struct TendermintIdentifier {
 
 impl SerializedSize for TendermintIdentifier {
     const SIZE: usize = u8::SIZE + 2 * 4 + TendermintStep::SIZE;
+}
+
+impl Display for TendermintIdentifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}:{:?}",
+            self.block_number, self.round_number, self.step
+        )
+    }
 }
 
 // Multiple things this needs to take care of when it comes to what needs signing here:

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -52,6 +52,19 @@ pub trait ValidatorNetwork: Send + Sync {
     where
         M: Message + Clone;
 
+    /// Receives requests from peers.
+    /// This function returns a stream where the requests are going to be propagated.
+    fn receive_requests<TRequest: Request>(
+        &self,
+    ) -> BoxStream<'static, (TRequest, <Self::NetworkType as Network>::RequestId, u16)>;
+
+    /// Sends a response to a specific request.
+    async fn respond<TRequest: Request>(
+        &self,
+        request_id: <Self::NetworkType as Network>::RequestId,
+        response: TRequest::Response,
+    ) -> Result<(), Self::Error>;
+
     /// Publishes an item into a Gossipsub topic.
     async fn publish<TTopic: Topic + Sync>(&self, item: TTopic::Item) -> Result<(), Self::Error>;
 

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -94,4 +94,7 @@ pub trait ValidatorNetwork: Send + Sync {
     fn validate_message<TTopic>(&self, id: PubsubId<Self>, acceptance: MsgAcceptance)
     where
         TTopic: Topic + Sync;
+
+    /// Returns the network peer ID for the given `validator_id` if it is known.
+    fn get_peer_id(&self, validator_id: u16) -> Option<<Self::NetworkType as Network>::PeerId>;
 }

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -502,4 +502,9 @@ where
     {
         self.network.validate_message::<TTopic>(id, acceptance);
     }
+
+    fn get_peer_id(&self, validator_id: u16) -> Option<<Self::NetworkType as Network>::PeerId> {
+        self.get_validator_cache(validator_id)
+            .potentially_outdated_peer_id()
+    }
 }

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -1,15 +1,9 @@
-use std::{
-    fmt,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-    time::Duration,
-};
+use std::{fmt, sync::Arc, time::Duration};
 
 use futures::{
-    future::FutureExt,
-    ready,
-    stream::{BoxStream, Stream, StreamExt},
+    future,
+    future::{BoxFuture, FutureExt},
+    stream::StreamExt,
 };
 use nimiq_block::{MultiSignature, SignedSkipBlockInfo, SkipBlockInfo, SkipBlockProof};
 use nimiq_bls::{AggregateSignature, KeyPair};
@@ -36,51 +30,6 @@ use super::{
     registry::ValidatorRegistry, update::SerializableLevelUpdate, verifier::MultithreadedVerifier,
 };
 
-enum SkipBlockResult {
-    SkipBlock(SignedSkipBlockMessage),
-}
-
-/// Switch for incoming SkipBlockInfo.
-/// Keeps track of SkipBlockInfo for future Aggregations in order to be able to sync the state of this node with others
-/// in case it recognizes it is behind.
-struct InputStreamSwitch {
-    input: BoxStream<'static, (SkipBlockUpdate, u16)>,
-    current_skip_block: SkipBlockInfo,
-}
-
-impl InputStreamSwitch {
-    fn new(
-        input: BoxStream<'static, (SkipBlockUpdate, u16)>,
-        current_skip_block: SkipBlockInfo,
-    ) -> Self {
-        Self {
-            input,
-            current_skip_block,
-        }
-    }
-}
-
-impl Stream for InputStreamSwitch {
-    type Item = LevelUpdate<SignedSkipBlockMessage>;
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        while let Some((message, origin)) = ready!(self.input.poll_next_unpin(cx)) {
-            if message.info.block_number != self.current_skip_block.block_number
-                || message.info.vrf_entropy != self.current_skip_block.vrf_entropy
-            {
-                // The LevelUpdate is not for this skip block and thus irrelevant.
-                // TODO If it is for a future skip block we might want to shortcut a HeadRequest here.
-                continue;
-            }
-
-            return Poll::Ready(Some(message.level_update.into_level_update(origin)));
-        }
-
-        // We have exited the loop, so poll_next() must have returned Poll::Ready(None).
-        // Thus, we terminate the stream.
-        Poll::Ready(None)
-    }
-}
-
 struct NetworkWrapper<TValidatorNetwork: ValidatorNetwork> {
     network: Arc<TValidatorNetwork>,
     tag: SkipBlockInfo,
@@ -95,27 +44,24 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
     for NetworkWrapper<TValidatorNetwork>
 {
     type Contribution = SignedSkipBlockMessage;
+    type Error = TValidatorNetwork::Error;
 
-    fn send_to(
+    fn send_update(
         &self,
-        (msg, recipient): (LevelUpdate<Self::Contribution>, u16),
-    ) -> futures::future::BoxFuture<'static, ()> {
+        node_id: u16,
+        update: LevelUpdate<Self::Contribution>,
+    ) -> BoxFuture<'static, Result<(), Self::Error>> {
         // Create the update.
         let update_message = SkipBlockUpdate {
-            level_update: msg.into(),
+            level_update: update.into(),
             info: self.tag.clone(),
         };
 
-        // clone network so it can be moved into the future
-        let nw = Arc::clone(&self.network);
+        // Clone network so it can be moved into the future.
+        let network = Arc::clone(&self.network);
 
-        // create the send future and return it.
-        async move {
-            if let Err(error) = nw.send_to(recipient, update_message).await {
-                log::error!(?error, recipient, "Failed to send message");
-            }
-        }
-        .boxed()
+        // Create the request future and return it.
+        async move { network.send_to(node_id, update_message).await }.boxed()
     }
 }
 
@@ -147,10 +93,10 @@ struct SkipBlockUpdate {
 
 impl RequestCommon for SkipBlockUpdate {
     type Kind = MessageMarker;
+    type Response = ();
     const TYPE_ID: u16 = 123;
     const MAX_REQUESTS: u32 = 500;
     const TIME_WINDOW: Duration = Duration::from_millis(500);
-    type Response = ();
 }
 
 struct SkipBlockAggregationProtocol {
@@ -253,7 +199,7 @@ impl SkipBlockAggregation {
         active_validators: Validators,
         network: Arc<N>,
     ) -> (SkipBlockInfo, SkipBlockProof) {
-        // TODO expose this somewehere else so we don't need to clone here.
+        // TODO expose this somewhere else so we don't need to clone here.
         let weights = Arc::new(ValidatorRegistry::new(active_validators.clone()));
 
         let slots = active_validators.validators[validator_id as usize]
@@ -293,44 +239,54 @@ impl SkipBlockAggregation {
             skip_block_info.block_number,
         );
 
-        let input_switch = InputStreamSwitch::new(
-            Box::pin(network.receive::<SkipBlockUpdate>()),
-            skip_block_info.clone(),
-        );
+        let current_skip_block = skip_block_info.clone();
+        let input_stream = network
+            .receive::<SkipBlockUpdate>()
+            .filter_map(move |(item, validator_id)| {
+                // Check that the update is for the current skip block aggregation.
+                if item.info != current_skip_block {
+                    return future::ready(None);
+                }
 
-        let aggregation = Aggregation::new(
+                future::ready(Some(item.level_update.into_level_update(validator_id)))
+            })
+            .boxed();
+
+        let mut aggregation = Aggregation::new(
             protocol,
             Config::default(),
             own_contribution,
-            Box::pin(input_switch),
+            input_stream,
             NetworkWrapper::new(skip_block_info.clone(), Arc::clone(&network)),
         );
 
-        let mut stream = aggregation.map(SkipBlockResult::SkipBlock);
-        while let Some(msg) = stream.next().await {
-            match msg {
-                SkipBlockResult::SkipBlock(sb_msg) => {
-                    if let Some(aggregate_weight) = weights.signature_weight(&sb_msg) {
-                        info!(
-                            aggregate_weight,
-                            signers = %sb_msg.contributors(),
-                            "New skip block aggregate weight {}/{} with signers {}",
-                            aggregate_weight,
-                            policy::Policy::TWO_F_PLUS_ONE,
-                            &sb_msg.contributors(),
-                        );
+        while let Some(msg) = aggregation.next().await {
+            let Some(aggregate_weight) = weights.signature_weight(&msg) else {
+                error!(
+                    signers = %msg.contributors(),
+                    block_number = skip_block_info.block_number,
+                    "Failed to determine skip block aggregate signature weight"
+                );
+                continue;
+            };
 
-                        // Check if the combined weight of the aggregation is at least 2f+1.
-                        if aggregate_weight >= policy::Policy::TWO_F_PLUS_ONE as usize {
-                            // Create SkipBlockProof out of the aggregate
-                            let skip_block_proof = SkipBlockProof { sig: sb_msg.proof };
-                            trace!("Skip block completed, proof={:?}", &skip_block_proof);
+            info!(
+                aggregate_weight,
+                signers = %msg.contributors(),
+                block_number = skip_block_info.block_number,
+                "New skip block aggregate weight {}/{} with signers {}",
+                aggregate_weight,
+                policy::Policy::TWO_F_PLUS_ONE,
+                &msg.contributors(),
+            );
 
-                            // return the SkipBlockProof
-                            return (skip_block_info, skip_block_proof);
-                        }
-                    }
-                }
+            // Check if the combined weight of the aggregation is at least 2f+1.
+            if aggregate_weight >= policy::Policy::TWO_F_PLUS_ONE as usize {
+                // Create SkipBlockProof from the aggregate.
+                let skip_block_proof = SkipBlockProof { sig: msg.proof };
+
+                // Return the SkipBlockProof.
+                return (skip_block_info, skip_block_proof);
             }
         }
 

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -114,7 +114,6 @@ impl SkipBlockAggregationProtocol {
     pub fn new(
         validators: Validators,
         node_id: usize,
-        threshold: usize,
         message_hash: Blake2sHash,
         block_height: u32,
     ) -> Self {
@@ -133,7 +132,6 @@ impl SkipBlockAggregationProtocol {
             Arc::clone(&store),
             Arc::clone(&registry),
             Arc::clone(&partitioner),
-            threshold,
         ));
 
         SkipBlockAggregationProtocol {
@@ -234,7 +232,6 @@ impl SkipBlockAggregation {
         let protocol = SkipBlockAggregationProtocol::new(
             active_validators.clone(),
             validator_id as usize,
-            policy::Policy::TWO_F_PLUS_ONE as usize,
             message_hash,
             skip_block_info.block_number,
         );

--- a/validator/src/aggregation/tendermint/protocol.rs
+++ b/validator/src/aggregation/tendermint/protocol.rs
@@ -28,7 +28,6 @@ impl TendermintAggregationProtocol {
     pub(crate) fn new(
         validators: Arc<ValidatorRegistry>,
         node_id: usize,
-        threshold: usize,
         id: TendermintIdentifier,
     ) -> Self {
         let partitioner = Arc::new(BinomialPartitioner::new(node_id, validators.len()));
@@ -41,7 +40,6 @@ impl TendermintAggregationProtocol {
             Arc::clone(&store),
             validators.clone(),
             Arc::clone(&partitioner),
-            threshold,
         ));
 
         let verifier = Arc::new(TendermintVerifier::new(validators.clone(), id.clone()));

--- a/validator/src/aggregation/tendermint/update_message.rs
+++ b/validator/src/aggregation/tendermint/update_message.rs
@@ -15,13 +15,13 @@ pub(crate) struct TendermintUpdate {
     /// this will be an outgoing message and the origin will be set by the ValidatorNetwork in its own structure.
     pub message: TaggedAggregationMessage<SerializableLevelUpdate<TendermintContribution>>,
     /// The height this aggregation runs over.
-    pub height: u32,
+    pub block_number: u32,
 }
 
 impl RequestCommon for TendermintUpdate {
     type Kind = MessageMarker;
+    type Response = ();
     const TYPE_ID: u16 = 124;
     const MAX_REQUESTS: u32 = 500;
     const TIME_WINDOW: Duration = Duration::from_millis(500);
-    type Response = ();
 }

--- a/validator/src/aggregation/verifier.rs
+++ b/validator/src/aggregation/verifier.rs
@@ -26,7 +26,6 @@ impl<I: IdentityRegistry> MultithreadedVerifier<I> {
 
 #[async_trait]
 impl<I: IdentityRegistry + Sync + Send + 'static> Verifier for MultithreadedVerifier<I> {
-    // type Output = CpuFuture<VerificationResult, ()>;
     type Contribution = SignedSkipBlockMessage;
 
     async fn verify(&self, contribution: &Self::Contribution) -> VerificationResult {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use futures::{
     future::{self, BoxFuture, FutureExt},
@@ -77,7 +77,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
         &self,
         node_id: u16,
         update: LevelUpdate<Self::Contribution>,
-    ) -> BoxFuture<'static, Result<(), Self::Error>> {
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
         // Tag the LevelUpdate, while also converting it to the serializable representation.
         // The origin gets lost here, but will get re-set by the ValidatorNetwork in its sent_to call.
         let tagged_aggregation_message = TaggedAggregationMessage {
@@ -94,7 +94,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
         let network = Arc::clone(&self.network);
 
         // Create the request future and return it.
-        async move { network.send_to(node_id, update_message).await }.boxed()
+        async move { network.send_to(node_id, update_message).await }
     }
 }
 

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -401,7 +401,6 @@ where
         let protocol = TendermintAggregationProtocol::new(
             Arc::clone(&self.validator_registry),
             self.validator_slot_band as usize,
-            1, // to be removed
             id,
         );
 
@@ -437,7 +436,6 @@ where
         let protocol = TendermintAggregationProtocol::new(
             Arc::clone(&self.validator_registry),
             self.validator_slot_band as usize,
-            1,
             id,
         );
 

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -12,6 +12,7 @@ use nimiq_handel::{
     aggregation::Aggregation,
     identity::IdentityRegistry,
     protocol::Protocol as _,
+    update::LevelUpdate,
     verifier::{VerificationResult, Verifier},
 };
 use nimiq_hash::{Blake2sHash, Hash};
@@ -70,33 +71,30 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> nimiq_handel::network::Netwo
     for NetworkWrapper<TValidatorNetwork>
 {
     type Contribution = TendermintContribution;
+    type Error = TValidatorNetwork::Error;
 
-    fn send_to(
+    fn send_update(
         &self,
-        (msg, recipient): (nimiq_handel::update::LevelUpdate<Self::Contribution>, u16),
-    ) -> BoxFuture<'static, ()> {
+        node_id: u16,
+        update: LevelUpdate<Self::Contribution>,
+    ) -> BoxFuture<'static, Result<(), Self::Error>> {
         // Tag the LevelUpdate, while also converting it to the serializable representation.
         // The origin gets lost here, but will get re-set by the ValidatorNetwork in its sent_to call.
         let tagged_aggregation_message = TaggedAggregationMessage {
             tag: self.tag,
-            aggregation: msg.into(),
+            aggregation: update.into(),
         };
-        // and create the update.
+        // And create the update.
         let update_message = TendermintUpdate {
             message: tagged_aggregation_message,
-            height: self.height,
+            block_number: self.height,
         };
 
-        // clone network so it can be moved into the future
-        let nw = Arc::clone(&self.network);
+        // Clone network so it can be moved into the future.
+        let network = Arc::clone(&self.network);
 
-        // create the send future and return it.
-        async move {
-            if let Err(error) = nw.send_to(recipient, update_message).await {
-                log::error!(?error, recipient, "Failed to send message");
-            }
-        }
-        .boxed()
+        // Create the request future and return it.
+        async move { network.send_to(node_id, update_message).await }.boxed()
     }
 }
 


### PR DESCRIPTION
This PR updates Handel.

Among the changes:

* Adds more testing
* It makes the difference between the signers slots of an aggregation in contrast to the signers of an aggregation more clear by using `Identity` for the latter.
* It makes the choice of the first recipients of messages deterministic. It is also pair wise symetric such that the overall coverage of messages should improve.
* Removes the `FinishedAggreation` in favour of a better mechanism to stop sending updates, except for the full one.
  * Polling of updates moved from the `PendingContributionList` to `Aggregation` to facilitate this auto response.
* Deduplicate send messages on a per peer basis. It will not send an identical message twice in a row.
* Cleanup of parts of the validator.

Likely there is a bunch more to say here and will be updated at a later time.