### PR TITLE
Fix migration client transaction history

### DIFF
--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -248,6 +248,7 @@ async fn main() {
             config.network_id,
             pow_client.clone(),
             block_windows.block_confirmations,
+            config.consensus.index_history,
         ));
 
         // Check that the `nimiq-client` exists


### PR DESCRIPTION
## What's in this pull request?
The migration client was not respecting the history index config option.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
