### PR TITLE
pow-migration: Use the config file to initialize logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,7 +4362,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.18",
  "url",
 ]
 

--- a/lib/src/extras/logging.rs
+++ b/lib/src/extras/logging.rs
@@ -97,6 +97,7 @@ pub fn initialize_logging(
     let mut filter = Targets::new()
         .with_default(DEFAULT_LEVEL)
         .with_nimiq_targets(settings.level.unwrap_or(DEFAULT_LEVEL))
+        .with_target("hyper", LevelFilter::WARN)
         .with_target("r1cs", LevelFilter::WARN);
     // Set logging level for specific selected modules
     filter = filter.with_targets(settings.tags);

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -64,7 +64,6 @@ tokio = { version = "1.40", features = [
     "tracing",
 ] }
 toml = "0.8"
-tracing-subscriber = { version = "0.3", features = ["registry"] }
 url = "2.5"
 
 [dev-dependencies]


### PR DESCRIPTION
Use the config file settings for initializing logging.
This fixes #2950.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
