### PR TITLE
Remove and simplify unused JS lib code

### DIFF
--- a/web-client/extras/lib/ArrayUtils.ts
+++ b/web-client/extras/lib/ArrayUtils.ts
@@ -1,53 +1,15 @@
 export class ArrayUtils {
-    static randomElement<T>(arr: T[]): T {
-        return arr[Math.floor(Math.random() * arr.length)];
-    }
-
-    static subarray(uintarr: Uint8Array, begin?: number, end?: number): Uint8Array {
+    static subarray(uintarr: Uint8Array, begin = 0, end = uintarr.byteLength): Uint8Array {
         function clamp(v: number, min: number, max: number) {
             return v < min ? min : v > max ? max : v;
         }
-
-        if (begin === undefined) begin = 0;
-        if (end === undefined) end = uintarr.byteLength;
 
         begin = clamp(begin, 0, uintarr.byteLength);
         end = clamp(end, 0, uintarr.byteLength);
 
         let len = end - begin;
-        if (len < 0) {
-            len = 0;
-        }
+        if (len < 0) len = 0;
 
         return new Uint8Array(uintarr.buffer, uintarr.byteOffset + begin, len);
-    }
-
-    static *k_combinations(list: any[], k: number): Generator<any[]> {
-        const n = list.length;
-        // Shortcut:
-        if (k > n) {
-            return;
-        }
-        const indices = Array.from(new Array(k), (x, i) => i);
-        yield indices.map(i => list[i]);
-        const reverseRange = Array.from(new Array(k), (x, i) => k - i - 1);
-        /*eslint no-constant-condition: ["error", { "checkLoops": false }]*/
-        while (true) {
-            let i = k - 1, found = false;
-            for (i of reverseRange) {
-                if (indices[i] !== i + n - k) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return;
-            }
-            indices[i] += 1;
-            for (const j of Array.from(new Array(k - i - 1), (x, k) => i + k + 1)) {
-                indices[j] = indices[j - 1] + 1;
-            }
-            yield indices.map(i => list[i]);
-        }
     }
 }

--- a/web-client/extras/lib/NumberUtils.ts
+++ b/web-client/extras/lib/NumberUtils.ts
@@ -27,16 +27,4 @@ export class NumberUtils {
         return NumberUtils.isInteger(val)
             && val >= 0 && val <= NumberUtils.UINT64_MAX;
     }
-
-    static randomUint32(): number {
-        return Math.floor(Math.random() * (NumberUtils.UINT32_MAX + 1));
-    }
-
-    static randomUint64(): number {
-        return Math.floor(Math.random() * (NumberUtils.UINT64_MAX + 1));
-    }
-
-    static fromBinary(bin: string): number {
-        return parseInt(bin, 2);
-    }
 }

--- a/web-client/extras/lib/SerialBuffer.ts
+++ b/web-client/extras/lib/SerialBuffer.ts
@@ -159,12 +159,12 @@ export class SerialBuffer extends Uint8Array {
 
     readString(length: number): string {
         const bytes = this.read(length);
-        return BufferUtils.toAscii(bytes);
+        return BufferUtils.toUtf8(bytes);
     }
 
     writeString(value: string, length: number): void {
         if (StringUtils.isMultibyte(value) || value.length !== length) throw new Error('Malformed value/length');
-        const bytes = BufferUtils.fromAscii(value);
+        const bytes = BufferUtils.fromUtf8(value);
         this.write(bytes);
     }
 
@@ -173,12 +173,12 @@ export class SerialBuffer extends Uint8Array {
         let i = 0;
         while (i < length && bytes[i] !== 0x0) i++;
         const view = new Uint8Array(bytes.buffer, bytes.byteOffset, i);
-        return BufferUtils.toAscii(view);
+        return BufferUtils.toUtf8(view);
     }
 
     writePaddedString(value: string, length: number): void {
         if (StringUtils.isMultibyte(value) || value.length > length) throw new Error('Malformed value/length');
-        const bytes = BufferUtils.fromAscii(value);
+        const bytes = BufferUtils.fromUtf8(value);
         this.write(bytes);
         const padding = length - bytes.byteLength;
         this.write(new Uint8Array(padding));
@@ -188,12 +188,12 @@ export class SerialBuffer extends Uint8Array {
         const length = this.readUint8();
         if (this._readPos + length > this.length) throw new Error('Malformed length');
         const bytes = this.read(length);
-        return BufferUtils.toAscii(bytes);
+        return BufferUtils.toUtf8(bytes);
     }
 
     writeVarLengthString(value: string): void {
         if (StringUtils.isMultibyte(value) || !NumberUtils.isUint8(value.length)) throw new Error('Malformed value');
-        const bytes = BufferUtils.fromAscii(value);
+        const bytes = BufferUtils.fromUtf8(value);
         this.writeUint8(bytes.byteLength);
         this.write(bytes);
     }

--- a/web-client/extras/lib/StringUtils.ts
+++ b/web-client/extras/lib/StringUtils.ts
@@ -13,17 +13,4 @@ export class StringUtils {
         if (typeof length === 'number' && str.length / 2 !== length) return false;
         return true;
     }
-
-    static commonPrefix(str1: string, str2: string): string {
-        let i = 0;
-        for (; i < str1.length; ++i) {
-            if (str1[i] !== str2[i]) break;
-        }
-        return str1.substring(0, i);
-    }
-
-    static lpad(str: string, padString: string, length: number): string {
-        while (str.length < length) str = padString + str;
-        return str;
-    }
 }

--- a/web-client/extras/package.json
+++ b/web-client/extras/package.json
@@ -6,6 +6,7 @@
     "comlink": "^4.4.1"
   },
   "devDependencies": {
+    "@types/node": "^22.7.5",
     "dprint": "^0.47.0",
     "tsup": "^8.1.0",
     "typescript": "^5.5.2"

--- a/web-client/extras/yarn.lock
+++ b/web-client/extras/yarn.lock
@@ -290,6 +290,13 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/node@^22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
+
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -884,6 +891,11 @@ typescript@^5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
   integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
- Remove ArrayUtils.randomElement & ArrayUtils.*k_combinations, as public key combination for multisig is done in Rust
- Replace BufferUtils from/to Ascii methods with from/to Utf8 methods
- Remove manual utf8 encoding in favor of requiring TextEncoder
- Remove BufferUtils.toBinary, BufferUtils.concatTypedArrays
- Use Node's Buffer for base64 encoding when available
- Remove padding dots (.) for base64url encoding
- Remove NumberUtils.randomUint*, NumberUtils.fromBinary
- Remove StringUtils.commonPrefix

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
