### PR TITLE
Remove inactive validators from activation process

### DIFF
--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -324,10 +324,10 @@ pub async fn migrate(
         panic!("We cannot migrate with just 1 active validator");
     }
 
-    log::debug!("This is the list of stakers:");
+    log::trace!("This is the list of stakers:");
 
     for staker in &stakers {
-        log::debug!(
+        log::trace!(
             staker_address = %staker.staker_address,
             balance = %staker.balance
         );
@@ -402,15 +402,19 @@ pub async fn migrate(
         .unwrap_or_else(|error| exit_with_error(error, "Failed to serialize genesis config"));
     let genesis_config_hash = hasher.finish();
     log::info!(
-        genesis_config_hash = %genesis_config_hash,
+        genesis_hash = %genesis_config_hash,
         "PoS Genesis generation is completed"
     );
 
     loop {
         let current_height = async_retryer(|| pow_client.block_number()).await.unwrap();
-        log::info!(current_height);
-
         let next_candidate = candidate_block + block_windows.readiness_window;
+        log::info!(
+            activation_window,
+            candidate_block,
+            current_height,
+            next_candidate
+        );
 
         if current_height > next_candidate {
             log::info!(

--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -163,9 +163,9 @@ pub async fn classify_validators(
     // This function should only be exeucted if we are past the ACTIVATION_WINDOW_TRESHOLD
     // We should already have the previous genesis hashes of the preivous activation windows to this point.
     assert_eq!(genesis_hashes.len(), ACTIVATION_WINDOW_TRESHOLD as usize);
-    assert!(current_activation_window > ACTIVATION_WINDOW_TRESHOLD);
+    assert!(current_activation_window >= ACTIVATION_WINDOW_TRESHOLD);
 
-    for activation_window in ACTIVATION_WINDOW_TRESHOLD..current_activation_window {
+    for activation_window in ACTIVATION_WINDOW_TRESHOLD..(current_activation_window + 1) {
         let candidate_start =
             block_windows.election_candidate + (activation_window * block_windows.readiness_window);
         let next_candidate = candidate_start + block_windows.readiness_window;
@@ -298,22 +298,22 @@ pub async fn migrate(
     let activation_window =
         (candidate_block - block_windows.election_candidate) / block_windows.readiness_window;
 
-    let (active_validators, inactive_validators) = if activation_window > ACTIVATION_WINDOW_TRESHOLD
-    {
-        // Note that this function is called with the validators set that was returned by the get_stakers function
-        // This means the validators in this set already have their stake distribution set.
-        classify_validators(
-            pow_client,
-            block_windows,
-            genesis_hashes,
-            activation_window,
-            &validators,
-        )
-        .await
-    } else {
-        // If we are not past the activation threshold, then we consider all validators as active.
-        (validators, vec![])
-    };
+    let (active_validators, inactive_validators) =
+        if activation_window >= ACTIVATION_WINDOW_TRESHOLD {
+            // Note that this function is called with the validators set that was returned by the get_stakers function
+            // This means the validators in this set already have their stake distribution set.
+            classify_validators(
+                pow_client,
+                block_windows,
+                genesis_hashes,
+                activation_window,
+                &validators,
+            )
+            .await
+        } else {
+            // If we are not past the activation threshold, then we consider all validators as active.
+            (validators, vec![])
+        };
 
     assert_eq!(
         registered_validators.len(),

--- a/pow-migration/src/monitor.rs
+++ b/pow-migration/src/monitor.rs
@@ -159,7 +159,7 @@ pub async fn was_validator_ready(
     genesis_hash: String,
 ) -> bool {
     if let Ok(transactions) =
-        async_retryer(|| pow_client.get_transactions_by_address(&validator_address, 10)).await
+        async_retryer(|| pow_client.get_transactions_by_address(&validator_address, 100)).await
     {
         // We only keep the ones past the activation window that met the activation criteria
         let filtered_txns: Vec<TransactionDetails> = transactions

--- a/pow-migration/src/state.rs
+++ b/pow-migration/src/state.rs
@@ -34,7 +34,7 @@ pub(crate) const POW_BLOCK_TIME_MS: u64 = POW_BLOCK_TIME * 1000; // 1 min
 
 // PoW maximum amount of snapshots. This is a constant that needs to be set in the PoW client
 // such that we can get accounts snapshots of blocks within [head - `POW_MAX_SNAPSHOTS`, head].
-const POW_MAX_SNAPSHOTS: u64 = 2000;
+const POW_MAX_SNAPSHOTS: u64 = 10000;
 
 fn pos_basic_account_from_account(
     pow_account: &PoWBasicAccount,

--- a/pow-migration/src/state.rs
+++ b/pow-migration/src/state.rs
@@ -155,7 +155,7 @@ pub async fn get_accounts(
             break;
         }
         start_prefix = chunk.tail;
-        log::debug!(size = chunk.nodes.len(), "Processing accounts tree chunk");
+        log::trace!(size = chunk.nodes.len(), "Processing accounts tree chunk");
         for node in chunk.nodes {
             match node.account {
                 nimiq_rpc::primitives::Account::Basic(pow_account) => {

--- a/pow-migration/src/types.rs
+++ b/pow-migration/src/types.rs
@@ -61,8 +61,10 @@ pub struct BlockWindows {
 /// PoS agents that were registered in the PoW chain that will take part of the
 /// PoS genesis block.
 pub struct PoSRegisteredAgents {
-    /// Registered PoS validators
-    pub validators: Vec<GenesisValidator>,
+    /// Registered & Active PoS validators
+    pub active_validators: Vec<GenesisValidator>,
+    /// Registered & Inactive PoS validators
+    pub inactive_validators: Vec<GenesisValidator>,
     /// Registered PoS stakers
     pub stakers: Vec<GenesisStaker>,
 }


### PR DESCRIPTION
 - Starting at ACTIVATION_WINDOW_TRESHOLD, those validators who are not ready, are going to be inactivated in the first epoch and they are no longer considered part of the readiness voting process
    
 - Fixes a bug that always used the first candidate block when creating the genesis block irrespective of the current activation window

...
#### This fixes #2960.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
