### PR TITLE
handel: Fix clippy warning

### DIFF
--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -140,7 +140,7 @@ impl Level {
             identities.rotate_left(state.next_peer_index);
 
             for ident in identities.iter().take(num_peers) {
-                selected.combine(&ident, false);
+                selected.combine(ident, false);
             }
             state.next_peer_index = (state.next_peer_index + num_peers) % self.peer_ids.len();
 


### PR DESCRIPTION
Fix clippy warning in handel related to a unnecessary borrow.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
