### PR TITLE
Separate pre-genesis data into different database

### DIFF
--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -18,9 +18,8 @@ use tokio::sync::broadcast;
 #[cfg(feature = "metrics")]
 use crate::chain_metrics::BlockchainMetrics;
 use crate::{
-    blockchain_state::BlockchainState, chain_store::ChainStore, history::HistoryStore,
-    history_store_proxy::HistoryStoreProxy, interface::HistoryInterface,
-    reward::genesis_parameters, HistoryStoreIndex,
+    blockchain_state::BlockchainState, chain_store::ChainStore,
+    history_store_proxy::MergedHistoryStoreProxy, reward::genesis_parameters,
 };
 
 const BROADCAST_MAX_CAPACITY: usize = 256;
@@ -45,7 +44,7 @@ pub struct Blockchain {
     /// The chain store is a database containing all of the chain infos, blocks and receipts.
     pub chain_store: ChainStore,
     /// The history store is a database containing all of the history trees and transactions.
-    pub history_store: Arc<HistoryStoreProxy>,
+    pub history_store: Arc<MergedHistoryStoreProxy>,
     /// The current state of the blockchain.
     pub state: BlockchainState,
     /// A reference to a "function" to test whether a given transaction is known and valid.
@@ -87,8 +86,10 @@ impl Default for BlockchainConfig {
 /// Implements methods to start a Blockchain.
 impl Blockchain {
     /// Creates a new blockchain from a given environment and network ID.
-    pub fn new(
+    /// This method allows to pass a separate database for pre-genesis history.
+    pub fn new_merged(
         env: MdbxDatabase,
+        pre_genesis_env: Option<MdbxDatabase>,
         config: BlockchainConfig,
         network_id: NetworkId,
         time: Arc<OffsetTime>,
@@ -97,8 +98,39 @@ impl Blockchain {
         let genesis_block = network_info.genesis_block();
         let genesis_accounts = network_info.genesis_accounts();
 
-        Self::with_genesis(
+        Self::with_genesis_merged(
             env,
+            pre_genesis_env,
+            config,
+            time,
+            network_id,
+            genesis_block,
+            genesis_accounts,
+        )
+    }
+
+    /// Creates a new blockchain from a given environment and network ID.
+    pub fn new(
+        env: MdbxDatabase,
+        config: BlockchainConfig,
+        network_id: NetworkId,
+        time: Arc<OffsetTime>,
+    ) -> Result<Self, BlockchainError> {
+        Self::new_merged(env, None, config, network_id, time)
+    }
+
+    /// Creates a new blockchain with the given genesis block.
+    pub fn with_genesis(
+        env: MdbxDatabase,
+        config: BlockchainConfig,
+        time: Arc<OffsetTime>,
+        network_id: NetworkId,
+        genesis_block: Block,
+        genesis_accounts: Vec<TrieItem>,
+    ) -> Result<Self, BlockchainError> {
+        Self::with_genesis_merged(
+            env,
+            None,
             config,
             time,
             network_id,
@@ -108,8 +140,10 @@ impl Blockchain {
     }
 
     /// Creates a new blockchain with the given genesis block.
-    pub fn with_genesis(
+    /// This method also allows to pass a separate database for pre-genesis history.
+    pub fn with_genesis_merged(
         env: MdbxDatabase,
+        pre_genesis_env: Option<MdbxDatabase>,
         config: BlockchainConfig,
         time: Arc<OffsetTime>,
         network_id: NetworkId,
@@ -136,18 +170,12 @@ impl Blockchain {
             return Err(BlockchainError::InvalidGenesisBlock);
         }
 
-        let history_store = if config.index_history {
-            Arc::new(HistoryStoreProxy::WithIndex(HistoryStoreIndex::new(
-                env.clone(),
-                network_id,
-            )))
-        } else {
-            Arc::new(HistoryStoreProxy::WithoutIndex(Box::new(HistoryStore::new(
-                env.clone(),
-                network_id,
-            ))
-                as Box<dyn HistoryInterface + Sync + Send>))
-        };
+        let history_store = Arc::new(MergedHistoryStoreProxy::new_merged(
+            env.clone(),
+            pre_genesis_env,
+            config.index_history,
+            network_id,
+        ));
 
         let chain_store = ChainStore::new(env.clone(), Arc::clone(&history_store));
 
@@ -180,7 +208,7 @@ impl Blockchain {
         env: MdbxDatabase,
         config: BlockchainConfig,
         chain_store: ChainStore,
-        history_store: Arc<HistoryStoreProxy>,
+        history_store: Arc<MergedHistoryStoreProxy>,
         time: Arc<OffsetTime>,
         network_id: NetworkId,
         genesis_block: Block,
@@ -313,7 +341,7 @@ impl Blockchain {
         env: MdbxDatabase,
         config: BlockchainConfig,
         chain_store: ChainStore,
-        history_store: Arc<HistoryStoreProxy>,
+        history_store: Arc<MergedHistoryStoreProxy>,
         time: Arc<OffsetTime>,
         network_id: NetworkId,
         genesis_block: Block,

--- a/blockchain/src/chain_store.rs
+++ b/blockchain/src/chain_store.rs
@@ -14,7 +14,7 @@ use nimiq_primitives::{policy::Policy, trie::trie_diff::TrieDiff};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_transaction::{historic_transaction::HistoricTransactionData, reward::RewardTransaction};
 
-use crate::{history::interface::HistoryInterface, history_store_proxy::HistoryStoreProxy};
+use crate::{history_store_proxy::MergedHistoryStoreProxy, interface::HistoryInterface};
 
 declare_table!(HeadTable, "Head", () => Blake2bHash);
 declare_table!(ChainTable, "ChainData", Blake2bHash => ChainInfo);
@@ -61,7 +61,7 @@ impl PushedBlock {
     fn populate_body(
         self,
         block: &mut Block,
-        history_store: &Arc<HistoryStoreProxy>,
+        history_store: &Arc<MergedHistoryStoreProxy>,
         txn: &MdbxReadTransaction,
     ) {
         assert_eq!(self.ty(), block.ty());
@@ -133,11 +133,11 @@ pub struct ChainStore {
     /// A database of accounts trie diffs for a block.
     accounts_diff_table: AccountsDiffTable,
     /// A reference to the history store to recover micro block transactions.
-    history_store: Arc<HistoryStoreProxy>,
+    history_store: Arc<MergedHistoryStoreProxy>,
 }
 
 impl ChainStore {
-    pub fn new(db: MdbxDatabase, history_store: Arc<HistoryStoreProxy>) -> Self {
+    pub fn new(db: MdbxDatabase, history_store: Arc<MergedHistoryStoreProxy>) -> Self {
         let chain_store = ChainStore {
             db,
             head_table: HeadTable,

--- a/blockchain/src/history/history_store_index.rs
+++ b/blockchain/src/history/history_store_index.rs
@@ -38,7 +38,7 @@ declare_table!(AddressTable, "TxHashesByAddress", Address => EpochBasedIndex => 
 /// A struct that contains databases to store history indices.
 pub struct HistoryStoreIndex {
     /// Database handle.
-    db: MdbxDatabase,
+    pub(crate) db: MdbxDatabase,
     /// A database of all epoch numbers and leaf indices indexed by the hash of the (raw) transaction. This way we
     /// can start with a raw transaction hash and find it in the MMR.
     /// Mapping of raw tx hash to epoch number and leaf index.

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use nimiq_block::{Block, MicroBlock};
 use nimiq_database::mdbx::{MdbxReadTransaction, MdbxWriteTransaction};
 use nimiq_hash::Blake2bHash;
@@ -16,7 +18,7 @@ use nimiq_transaction::{
 use crate::HistoryTreeChunk;
 
 /// Defines several methods to interact with a history store.
-pub trait HistoryInterface: std::fmt::Debug {
+pub trait HistoryInterface: Debug {
     /// Adds all the transactions included in a given block into the history store.
     fn add_block(
         &self,
@@ -185,7 +187,7 @@ pub trait HistoryInterface: std::fmt::Debug {
 }
 
 /// Defines several methods to interact with a history store.
-pub trait HistoryIndexInterface {
+pub trait HistoryIndexInterface: HistoryInterface {
     /// Gets an historic transaction given its transaction hash.
     fn get_hist_tx_by_hash(
         &self,

--- a/blockchain/src/history/mod.rs
+++ b/blockchain/src/history/mod.rs
@@ -1,6 +1,7 @@
 pub use history_store::HistoryStore;
 pub use history_store_index::HistoryStoreIndex;
 pub use history_tree_chunk::{HistoryTreeChunk, CHUNK_SIZE};
+pub use pre_genesis::HistoryStoreMerger;
 
 mod history_store;
 mod history_store_index;
@@ -8,5 +9,6 @@ pub mod history_store_proxy;
 mod history_tree_chunk;
 pub mod interface;
 mod mmr_store;
+mod pre_genesis;
 mod utils;
 mod validity_store;

--- a/blockchain/src/history/mod.rs
+++ b/blockchain/src/history/mod.rs
@@ -1,14 +1,14 @@
 pub use history_store::HistoryStore;
 pub use history_store_index::HistoryStoreIndex;
 pub use history_tree_chunk::{HistoryTreeChunk, CHUNK_SIZE};
-pub use pre_genesis::HistoryStoreMerger;
+pub use merged_history_store::HistoryStoreMerger;
 
 mod history_store;
 mod history_store_index;
 pub mod history_store_proxy;
 mod history_tree_chunk;
 pub mod interface;
+mod merged_history_store;
 mod mmr_store;
-mod pre_genesis;
 mod utils;
 mod validity_store;

--- a/blockchain/src/history/pre_genesis.rs
+++ b/blockchain/src/history/pre_genesis.rs
@@ -1,0 +1,397 @@
+use std::cmp;
+
+use nimiq_block::{Block, MicroBlock};
+use nimiq_database::mdbx::{MdbxReadTransaction, MdbxWriteTransaction};
+use nimiq_hash::Blake2bHash;
+use nimiq_keys::Address;
+use nimiq_mmr::{
+    error::Error,
+    mmr::proof::{RangeProof, SizeProof},
+};
+use nimiq_primitives::policy::Policy;
+use nimiq_transaction::{
+    historic_transaction::{HistoricTransaction, RawTransactionHash},
+    history_proof::HistoryTreeProof,
+    inherent::Inherent,
+    EquivocationLocator,
+};
+
+use super::interface::{HistoryIndexInterface, HistoryInterface};
+
+/// A wrapper around two history stores, one for the pre-genesis epoch and one for the main epoch.
+#[derive(Debug)]
+pub struct HistoryStoreMerger<S: HistoryInterface> {
+    /// The pre-genesis history store is read-only.
+    /// When populating it, we load it separately.
+    pre_genesis: Option<S>,
+    /// The main history store.
+    main: S,
+}
+
+impl<S: HistoryInterface> HistoryStoreMerger<S> {
+    pub(crate) fn new(pre_genesis: Option<S>, main: S) -> Self {
+        Self { pre_genesis, main }
+    }
+}
+
+impl<S: HistoryInterface> HistoryInterface for HistoryStoreMerger<S> {
+    fn add_block(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        block: &Block,
+        inherents: Vec<Inherent>,
+    ) -> Option<(Blake2bHash, u64)> {
+        assert_ne!(
+            Policy::epoch_at(block.block_number()),
+            0,
+            "Epoch 0 is pre-genesis"
+        );
+        self.main.add_block(txn, block, inherents)
+    }
+
+    fn remove_block(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        block: &MicroBlock,
+        inherents: Vec<Inherent>,
+    ) -> Option<u64> {
+        assert_ne!(
+            Policy::epoch_at(block.block_number()),
+            0,
+            "Epoch 0 is pre-genesis"
+        );
+        self.main.remove_block(txn, block, inherents)
+    }
+
+    fn remove_history(&self, txn: &mut MdbxWriteTransaction, epoch_number: u32) -> Option<()> {
+        assert_ne!(epoch_number, 0, "Epoch 0 is pre-genesis");
+        self.main.remove_history(txn, epoch_number)
+    }
+
+    fn get_history_tree_root(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Option<Blake2bHash> {
+        if Policy::epoch_at(block_number) == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()?
+                .get_history_tree_root(block_number, None)
+        } else {
+            self.main.get_history_tree_root(block_number, txn_option)
+        }
+    }
+
+    fn clear(&self, txn: &mut MdbxWriteTransaction) {
+        self.main.clear(txn);
+    }
+
+    fn length_at(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Option<u32> {
+        if Policy::epoch_at(block_number) == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis.as_ref()?.length_at(block_number, None)
+        } else {
+            self.main.length_at(block_number, txn_option)
+        }
+    }
+
+    fn total_len_at_epoch(
+        &self,
+        epoch_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> usize {
+        if epoch_number == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .map(|pre_genesis| pre_genesis.total_len_at_epoch(0, None))
+                .unwrap_or_default()
+        } else {
+            self.main.total_len_at_epoch(epoch_number, txn_option)
+        }
+    }
+
+    fn history_store_range(&self, txn_option: Option<&MdbxReadTransaction>) -> (u32, u32) {
+        let (pre_genesis_start, pre_genesis_end) = self
+            .pre_genesis
+            .as_ref()
+            .map(|pre_genesis| pre_genesis.history_store_range(None))
+            .unwrap_or_default();
+        let (main_start, main_end) = self.main.history_store_range(txn_option);
+        (
+            cmp::min(pre_genesis_start, main_start),
+            cmp::max(pre_genesis_end, main_end),
+        )
+    }
+
+    fn add_to_history(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        block_number: u32,
+        hist_txs: &[HistoricTransaction],
+    ) -> Option<(Blake2bHash, u64)> {
+        assert_ne!(Policy::epoch_at(block_number), 0, "Epoch 0 is pre-genesis");
+        self.main.add_to_history(txn, block_number, hist_txs)
+    }
+
+    fn add_to_history_for_epoch(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        epoch_number: u32,
+        block_number: u32,
+        hist_txs: &[HistoricTransaction],
+    ) -> Option<(Blake2bHash, u64)> {
+        assert_ne!(epoch_number, 0, "Epoch 0 is pre-genesis");
+        self.main
+            .add_to_history_for_epoch(txn, epoch_number, block_number, hist_txs)
+    }
+
+    fn remove_partial_history(
+        &self,
+        txn: &mut MdbxWriteTransaction,
+        epoch_number: u32,
+        num_hist_txs: usize,
+    ) -> Option<(Blake2bHash, u64)> {
+        assert_ne!(epoch_number, 0, "Epoch 0 is pre-genesis");
+        self.main
+            .remove_partial_history(txn, epoch_number, num_hist_txs)
+    }
+
+    fn tx_in_validity_window(
+        &self,
+        raw_tx_hash: &RawTransactionHash,
+        txn_opt: Option<&MdbxReadTransaction>,
+    ) -> bool {
+        self.main.tx_in_validity_window(raw_tx_hash, txn_opt)
+    }
+
+    fn get_block_transactions(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Vec<HistoricTransaction> {
+        if Policy::epoch_at(block_number) == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .map(|pre_genesis| pre_genesis.get_block_transactions(block_number, None))
+                .unwrap_or_default()
+        } else {
+            self.main.get_block_transactions(block_number, txn_option)
+        }
+    }
+
+    fn get_epoch_transactions(
+        &self,
+        epoch_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Vec<HistoricTransaction> {
+        if epoch_number == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .map(|pre_genesis| pre_genesis.get_epoch_transactions(epoch_number, None))
+                .unwrap_or_default()
+        } else {
+            self.main.get_epoch_transactions(epoch_number, txn_option)
+        }
+    }
+
+    fn num_epoch_transactions(
+        &self,
+        epoch_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> usize {
+        if epoch_number == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .map(|pre_genesis| pre_genesis.num_epoch_transactions(epoch_number, None))
+                .unwrap_or_default()
+        } else {
+            self.main.num_epoch_transactions(epoch_number, txn_option)
+        }
+    }
+
+    fn num_epoch_transactions_before(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> usize {
+        if Policy::epoch_at(block_number) == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .map(|pre_genesis| pre_genesis.num_epoch_transactions_before(block_number, None))
+                .unwrap_or_default()
+        } else {
+            self.main
+                .num_epoch_transactions_before(block_number, txn_option)
+        }
+    }
+
+    fn get_epoch_transactions_after(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Vec<HistoricTransaction> {
+        if Policy::epoch_at(block_number) == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .map(|pre_genesis| pre_genesis.get_epoch_transactions_after(block_number, None))
+                .unwrap_or_default()
+        } else {
+            self.main
+                .get_epoch_transactions_after(block_number, txn_option)
+        }
+    }
+
+    fn prove_chunk(
+        &self,
+        epoch_number: u32,
+        verifier_block_number: u32,
+        chunk_size: usize,
+        chunk_index: usize,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Option<super::HistoryTreeChunk> {
+        if epoch_number == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis.as_ref()?.prove_chunk(
+                epoch_number,
+                verifier_block_number,
+                chunk_size,
+                chunk_index,
+                None,
+            )
+        } else {
+            self.main.prove_chunk(
+                epoch_number,
+                verifier_block_number,
+                chunk_size,
+                chunk_index,
+                txn_option,
+            )
+        }
+    }
+
+    fn tree_from_chunks(
+        &self,
+        epoch_number: u32,
+        chunks: Vec<(Vec<HistoricTransaction>, RangeProof<Blake2bHash>)>,
+        txn: &mut MdbxWriteTransaction,
+    ) -> Result<Blake2bHash, Error> {
+        assert_ne!(epoch_number, 0, "Epoch 0 is pre-genesis");
+        self.main.tree_from_chunks(epoch_number, chunks, txn)
+    }
+
+    fn get_last_leaf_block_number(&self, txn_option: Option<&MdbxReadTransaction>) -> Option<u32> {
+        self.main
+            .get_last_leaf_block_number(txn_option)
+            .or_else(|| self.pre_genesis.as_ref()?.get_last_leaf_block_number(None))
+    }
+
+    fn has_equivocation_proof(
+        &self,
+        locator: EquivocationLocator,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> bool {
+        self.main.has_equivocation_proof(locator, txn_option)
+    }
+
+    fn prove_num_leaves(
+        &self,
+        block_number: u32,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Result<SizeProof<Blake2bHash, HistoricTransaction>, Error> {
+        if Policy::epoch_at(block_number) == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()
+                .ok_or(Error::EmptyTree)?
+                .prove_num_leaves(block_number, None)
+        } else {
+            self.main.prove_num_leaves(block_number, txn_option)
+        }
+    }
+}
+
+impl<S: HistoryInterface + HistoryIndexInterface> HistoryIndexInterface for HistoryStoreMerger<S> {
+    fn get_hist_tx_by_hash(
+        &self,
+        raw_tx_hash: &Blake2bHash,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Option<HistoricTransaction> {
+        self.main
+            .get_hist_tx_by_hash(raw_tx_hash, txn_option)
+            .or_else(|| {
+                self.pre_genesis
+                    .as_ref()?
+                    .get_hist_tx_by_hash(raw_tx_hash, None)
+            })
+    }
+
+    fn get_tx_hashes_by_address(
+        &self,
+        address: &Address,
+        max: u16,
+        start_at: Option<Blake2bHash>,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Vec<Blake2bHash> {
+        let mut tx_hashes =
+            self.main
+                .get_tx_hashes_by_address(address, max, start_at.clone(), txn_option);
+
+        // Fill up from pre-genesis if necessary.
+        if tx_hashes.len() < max as usize && self.pre_genesis.is_some() {
+            // If the transaction hashes are empty, we can start at the given hash
+            // because the hash does not seem to be in the main database.
+            let pre_genesis_start = if tx_hashes.is_empty() { start_at } else { None };
+
+            let mut pre_genesis_tx_hashes =
+                self.pre_genesis.as_ref().unwrap().get_tx_hashes_by_address(
+                    address,
+                    max - tx_hashes.len() as u16,
+                    pre_genesis_start,
+                    None,
+                );
+            tx_hashes.append(&mut pre_genesis_tx_hashes);
+        }
+
+        tx_hashes
+    }
+
+    fn prove(
+        &self,
+        epoch_number: u32,
+        hashes: Vec<&Blake2bHash>,
+        verifier_state: Option<usize>,
+        txn_option: Option<&MdbxReadTransaction>,
+    ) -> Option<HistoryTreeProof> {
+        if epoch_number == 0 {
+            // The pre-genesis database has separate transactions.
+            // Since it is read-only, we can pass None as the transaction.
+            self.pre_genesis
+                .as_ref()?
+                .prove(epoch_number, hashes, verifier_state, None)
+        } else {
+            self.main
+                .prove(epoch_number, hashes, verifier_state, txn_option)
+        }
+    }
+}

--- a/blockchain/tests/merged_history_store.rs
+++ b/blockchain/tests/merged_history_store.rs
@@ -1,0 +1,428 @@
+use nimiq_block::{
+    Block, DoubleProposalProof, DoubleVoteProof, EquivocationProof, ForkProof, MacroHeader,
+    MicroHeader,
+};
+use nimiq_blockchain::interface::HistoryInterface;
+use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
+use nimiq_bls::AggregateSignature;
+use nimiq_database::traits::WriteTransaction;
+use nimiq_genesis::NetworkId;
+use nimiq_hash::{Blake2sHash, HashOutput};
+use nimiq_keys::{KeyPair, PrivateKey};
+use nimiq_primitives::{policy::Policy, TendermintIdentifier, TendermintStep, TendermintVote};
+use nimiq_serde::Deserialize;
+use nimiq_test_log::test;
+use nimiq_test_utils::{
+    block_production::TemporaryBlockProducer,
+    blockchain::{generate_transactions, produce_macro_blocks, validator_address},
+    test_custom_block::{next_micro_block, BlockConfig},
+};
+use nimiq_transaction::{
+    historic_transaction::{
+        EquivocationEvent, HistoricTransaction, HistoricTransactionData, JailEvent, PenalizeEvent,
+        RewardEvent,
+    },
+    ExecutedTransaction, Transaction,
+};
+
+fn key_pair_with_funds() -> KeyPair {
+    let priv_key = PrivateKey::deserialize_from_vec(
+        &hex::decode("6c9320ac201caf1f8eaa5b05f5d67a9e77826f3f6be266a0ecccc20416dc6587").unwrap(),
+    )
+    .unwrap();
+    priv_key.into()
+}
+
+fn get_hist_tx(temp_producer: &TemporaryBlockProducer) -> Vec<HistoricTransaction> {
+    let blockchain = temp_producer.blockchain.read();
+    blockchain.history_store.get_epoch_transactions(1, None)
+}
+
+// Revert block and assert that history store is reverted as well.
+fn revert_block(temp_producer: &TemporaryBlockProducer, hist_tx_pre: &[HistoricTransaction]) {
+    let blockchain = temp_producer.blockchain.read();
+    let mut txn = blockchain.write_transaction();
+    blockchain.revert_blocks(1, &mut txn).unwrap();
+    txn.commit();
+
+    let hist_tx_revert = get_hist_tx(&temp_producer);
+
+    assert_eq!(hist_tx_pre, &hist_tx_revert);
+}
+
+fn setup_blockchain_with_history() -> (TemporaryBlockProducer, TemporaryBlockProducer) {
+    let temp_producer1 = TemporaryBlockProducer::new_merged();
+    let temp_producer2 = TemporaryBlockProducer::new_merged();
+    assert_eq!(
+        temp_producer2.push(temp_producer1.next_block(vec![], false)),
+        Ok(PushResult::Extended)
+    );
+
+    add_block_assert_history_store(&temp_producer1, vec![], vec![], true);
+
+    let block = temp_producer1.blockchain.read().head().clone();
+
+    assert_eq!(&temp_producer2.push(block), &Ok(PushResult::Extended));
+
+    (temp_producer1, temp_producer2)
+}
+
+fn do_fork(
+    temp_producer1: &TemporaryBlockProducer,
+    temp_producer2: &TemporaryBlockProducer,
+) -> EquivocationProof {
+    let config = BlockConfig::default();
+
+    // Produce a fork in producer 1.
+
+    // Generates the first block_1a.
+    let block_1a = temp_producer1.next_block(vec![], false).unwrap_micro();
+    let header_1a = block_1a.header.clone();
+
+    // Generates the fork block block_2a.
+    let block_2a = {
+        let blockchain = &temp_producer2.blockchain.read();
+        next_micro_block(&temp_producer1.producer.signing_key, blockchain, &config)
+    };
+    let header_2a = block_2a.header.clone();
+
+    // Pushes fork block to producer 1.
+    assert_eq!(
+        &temp_producer1.push(Block::Micro(block_2a.clone())),
+        &Ok(PushResult::Forked)
+    );
+    // Also adds the block to producer 2 (but this one will not have a fork).
+    assert_eq!(
+        &temp_producer2.push(Block::Micro(block_1a)),
+        &Ok(PushResult::Extended)
+    );
+
+    // Builds the equivocation proof.
+    let signing_key = temp_producer1.producer.signing_key.clone();
+    let justification1 = signing_key.sign(MicroHeader::hash(&header_1a).as_bytes());
+    let justification2 = signing_key.sign(MicroHeader::hash(&header_2a).as_bytes());
+
+    ForkProof::new(
+        validator_address(),
+        header_1a,
+        justification1,
+        header_2a.clone(),
+        justification2,
+    )
+    .into()
+}
+
+fn do_double_proposal(
+    temp_producer1: &TemporaryBlockProducer,
+    temp_producer2: &TemporaryBlockProducer,
+) -> EquivocationProof {
+    // Make double proposal on macro block.
+    produce_macro_blocks(&temp_producer1.producer, &temp_producer1.blockchain, 1);
+    produce_macro_blocks(&temp_producer2.producer, &temp_producer2.blockchain, 1);
+    let signing_key = temp_producer1.producer.signing_key.clone();
+
+    let header1 = temp_producer1
+        .blockchain
+        .read()
+        .head()
+        .clone()
+        .unwrap_macro()
+        .header;
+    let header2 = temp_producer2
+        .blockchain
+        .read()
+        .head()
+        .clone()
+        .unwrap_macro()
+        .header;
+    let justification1 = signing_key.sign(MacroHeader::hash(&header1).as_bytes());
+    let justification2 = signing_key.sign(MacroHeader::hash(&header2).as_bytes());
+
+    // Produce the double proposal proof.
+    EquivocationProof::DoubleProposal(DoubleProposalProof::new(
+        validator_address(),
+        header1.clone(),
+        justification1,
+        header2,
+        justification2,
+    ))
+}
+
+fn do_double_vote(temp_producer1: &TemporaryBlockProducer) -> EquivocationProof {
+    // Make double proposal on macro block.
+    produce_macro_blocks(&temp_producer1.producer, &temp_producer1.blockchain, 1);
+
+    let voting_key = temp_producer1.producer.voting_key.clone();
+    let header = temp_producer1
+        .blockchain
+        .read()
+        .head()
+        .clone()
+        .unwrap_macro()
+        .header;
+
+    let validators = temp_producer1
+        .blockchain
+        .read()
+        .get_validators_for_epoch(Policy::epoch_at(header.block_number), None)
+        .unwrap();
+    let validator = validators.validators[0].clone();
+    let slots = validator.slots;
+
+    let tendermint_id = TendermintIdentifier {
+        network: header.network,
+        block_number: header.block_number,
+        round_number: header.round,
+        step: TendermintStep::PreVote,
+    };
+    let signature1 = voting_key.sign(&TendermintVote {
+        proposal_hash: None,
+        id: tendermint_id.clone(),
+    });
+    let signature2 = voting_key.sign(&TendermintVote {
+        proposal_hash: Some(Blake2sHash::default()),
+        id: tendermint_id.clone(),
+    });
+
+    // Produce the double proposal proof.
+    EquivocationProof::DoubleVote(DoubleVoteProof::new(
+        tendermint_id,
+        validator_address(),
+        None,
+        AggregateSignature::from_signatures(&slots.clone().map(|_| signature1).collect::<Vec<_>>()),
+        slots.clone().map(|i| i.into()).collect(),
+        Some(Blake2sHash::default()),
+        AggregateSignature::from_signatures(&slots.clone().map(|_| signature2).collect::<Vec<_>>()),
+        slots.clone().map(|i| i.into()).collect(),
+    ))
+}
+
+fn add_block_assert_history_store(
+    temp_producer1: &TemporaryBlockProducer,
+    equivocation_proofs: Vec<EquivocationProof>,
+    transactions: Vec<Transaction>,
+    is_skip_block: bool,
+) -> (Vec<HistoricTransaction>, Vec<HistoricTransaction>) {
+    // Get initial history store.
+    let hist_tx_pre = get_hist_tx(&temp_producer1);
+
+    // Add a block with the equivocation proofs.
+    let skip_block_proof = if is_skip_block {
+        Some(temp_producer1.create_skip_block_proof())
+    } else {
+        None
+    };
+    let micro_block = next_micro_block(
+        &temp_producer1.producer.signing_key,
+        &temp_producer1.blockchain.read(),
+        &BlockConfig {
+            equivocation_proofs: equivocation_proofs.clone(),
+            test_macro: false,
+            test_election: false,
+            skip_block_proof,
+            transactions: transactions.clone(),
+            ..Default::default()
+        },
+    );
+    let header = micro_block.header.clone();
+    let is_skip_block = micro_block.is_skip_block();
+
+    assert_eq!(
+        &temp_producer1.push(Block::Micro(micro_block)),
+        &Ok(PushResult::Extended)
+    );
+
+    // Get the new history store after the block push.
+    let hist_tx_after = get_hist_tx(&temp_producer1);
+
+    // Assert that the jail inherent and equivocation proofs are present in history store.
+    // There is 1 inherent and 1 event generated per equivocation proof.
+    let mut expected_len = hist_tx_pre.len() + equivocation_proofs.len() * 2 + transactions.len();
+    if is_skip_block {
+        expected_len += 1;
+    }
+    assert_eq!(hist_tx_after.len(), expected_len);
+
+    let mut i = hist_tx_pre.len();
+    for transaction in transactions {
+        let hist_tx_equiv = &hist_tx_after[i];
+        i += 1;
+
+        assert_eq!(hist_tx_equiv.block_number, header.block_number);
+        assert_eq!(
+            hist_tx_equiv.data,
+            HistoricTransactionData::Basic(ExecutedTransaction::Ok(transaction))
+        );
+    }
+
+    for equivocation_proof in equivocation_proofs.iter() {
+        let hist_tx_equiv = &hist_tx_after[i];
+        i += 1;
+
+        assert_eq!(hist_tx_equiv.block_number, header.block_number);
+        assert_eq!(
+            hist_tx_equiv.data,
+            HistoricTransactionData::Equivocation(EquivocationEvent {
+                locator: equivocation_proof.locator()
+            })
+        );
+    }
+
+    for equivocation_proof in equivocation_proofs.iter() {
+        let hist_tx_inherent = &hist_tx_after[i];
+        i += 1;
+
+        assert_eq!(hist_tx_inherent.block_number, header.block_number);
+        assert_eq!(
+            hist_tx_inherent.data,
+            HistoricTransactionData::Jail(JailEvent {
+                validator_address: validator_address(),
+                slots: 0..512,
+                offense_event_block: equivocation_proof.block_number(),
+                new_epoch_slot_range: None
+            })
+        )
+    }
+
+    if is_skip_block {
+        let hist_tx_inherent = &hist_tx_after[i];
+
+        assert_eq!(hist_tx_inherent.block_number, header.block_number);
+        assert_eq!(
+            hist_tx_inherent.data,
+            HistoricTransactionData::Penalize(PenalizeEvent {
+                validator_address: validator_address(),
+                slot: 0,
+                offense_event_block: header.block_number
+            })
+        );
+    }
+
+    (hist_tx_pre, hist_tx_after)
+}
+
+#[test]
+fn it_pushes_and_reverts_fork_equivocation_block() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, temp_producer2) = setup_blockchain_with_history();
+
+    let fork_equivocation = do_fork(&temp_producer1, &temp_producer2);
+
+    // Get initial history store.
+    let (hist_tx_pre, _) =
+        add_block_assert_history_store(&temp_producer1, vec![fork_equivocation], vec![], false);
+
+    // Revert block and assert that history store is reverted as well.
+    revert_block(&temp_producer1, &hist_tx_pre);
+}
+
+#[test]
+fn it_pushes_and_reverts_double_proposal_equivocation_block() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, temp_producer2) = setup_blockchain_with_history();
+
+    let double_proposal_proof = do_double_proposal(&temp_producer1, &temp_producer2);
+
+    // Get initial history store.
+    let (hist_tx_pre, _) =
+        add_block_assert_history_store(&temp_producer1, vec![double_proposal_proof], vec![], false);
+
+    // Revert block and assert that history store is reverted as well.
+    revert_block(&temp_producer1, &hist_tx_pre);
+}
+
+#[test]
+fn it_pushes_and_reverts_double_vote_equivocation_block() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, _temp_producer2) = setup_blockchain_with_history();
+
+    let double_vote_proof = do_double_vote(&temp_producer1);
+
+    // Get initial history store.
+    let (hist_tx_pre, _) =
+        add_block_assert_history_store(&temp_producer1, vec![double_vote_proof], vec![], false);
+
+    // Revert block and assert that history store is reverted as well.
+    revert_block(&temp_producer1, &hist_tx_pre);
+}
+
+#[test]
+fn it_pushes_and_reverts_skip_block() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, _temp_producer2) = setup_blockchain_with_history();
+
+    // Get initial history store.
+    let hist_tx_pre = get_hist_tx(&temp_producer1);
+
+    // Adds skip block.
+    add_block_assert_history_store(&temp_producer1, vec![], vec![], true);
+
+    // Revert block and assert that history store is reverted as well.
+    revert_block(&temp_producer1, &hist_tx_pre);
+}
+
+#[test]
+fn it_pushes_and_reverts_block_with_txns() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, _temp_producer2) = setup_blockchain_with_history();
+
+    // Get initial history store.
+    let hist_tx_pre = get_hist_tx(&temp_producer1);
+
+    // Adds block with transactions.
+    let key_pair = key_pair_with_funds();
+    let mut txns = generate_transactions(
+        &key_pair,
+        temp_producer1.blockchain.read().block_number(),
+        NetworkId::UnitAlbatross,
+        3,
+        0,
+    );
+    txns.sort_unstable();
+
+    add_block_assert_history_store(&temp_producer1, vec![], txns, false);
+
+    // Revert block and assert that history store is reverted as well.
+    revert_block(&temp_producer1, &hist_tx_pre);
+}
+
+#[test]
+fn it_pushes_macro_block_with_rewards() {
+    // Adds the same initial block to both producers.
+    let (temp_producer1, _temp_producer2) = setup_blockchain_with_history();
+
+    // Get initial history store.
+    let hist_tx_pre = get_hist_tx(&temp_producer1);
+
+    // Adds block with transactions.
+    produce_macro_blocks(&temp_producer1.producer, &temp_producer1.blockchain, 2);
+
+    let hist_tx_after = get_hist_tx(&temp_producer1);
+
+    // Simple case. 1x Reward to validator.
+    let reward_txs = {
+        let macro_block = temp_producer1
+            .blockchain
+            .read()
+            .head()
+            .clone()
+            .unwrap_macro();
+        macro_block.body.unwrap().transactions
+    };
+    assert_eq!(reward_txs.len(), 1);
+
+    assert_eq!(hist_tx_after.len(), hist_tx_pre.len() + reward_txs.len());
+
+    let mut i = hist_tx_pre.len();
+    for reward_tx in reward_txs {
+        assert_eq!(
+            &RewardEvent {
+                validator_address: reward_tx.validator_address,
+                reward_address: reward_tx.recipient,
+                value: reward_tx.value
+            },
+            hist_tx_after[i].unwrap_reward()
+        );
+        i += 1;
+    }
+}

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -350,6 +350,20 @@ impl ClientInner {
         // Start buffering network events as early as possible
         let network_events = network.subscribe_events();
 
+        // We update the services flags depending on the pre-genesis database file being present
+        #[cfg(feature = "database-storage")]
+        let pre_genesis_environment = if config.storage.has_pre_genesis_database(config.network_id)
+        {
+            provided_services |= Services::PRE_GENESIS_TRANSACTIONS;
+            Some(
+                config
+                    .storage
+                    .pre_genesis_database(config.network_id, config.database.clone())?,
+            )
+        } else {
+            None
+        };
+
         // Open database
         #[cfg(feature = "database-storage")]
         let environment = config.storage.database(
@@ -387,8 +401,9 @@ impl ClientInner {
             SyncMode::History => {
                 blockchain_config.keep_history = true;
                 blockchain_config.index_history = config.consensus.index_history;
-                let blockchain = match Blockchain::new(
+                let blockchain = match Blockchain::new_merged(
                     environment.clone(),
+                    pre_genesis_environment,
                     blockchain_config,
                     config.network_id,
                     time,
@@ -433,8 +448,9 @@ impl ClientInner {
                 blockchain_config.keep_history = false;
                 blockchain_config.index_history = config.consensus.index_history;
 
-                let blockchain = match Blockchain::new(
+                let blockchain = match Blockchain::new_merged(
                     environment.clone(),
+                    pre_genesis_environment,
                     blockchain_config,
                     config.network_id,
                     time,

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -356,6 +356,7 @@ impl StorageConfig {
     ///
     /// * `network_id` - The network ID of the database
     /// * `consensus` - The consensus type
+    /// * `db_config` - The database configuration
     ///
     /// # Return Value
     ///
@@ -368,9 +369,57 @@ impl StorageConfig {
         sync_mode: SyncMode,
         db_config: DatabaseConfig,
     ) -> Result<MdbxDatabase, Error> {
+        let db_name = format!("{network_id}-{sync_mode}-consensus").to_lowercase();
+        self.open_database(db_config, db_name)
+    }
+
+    /// Returns the database environment for the pre-genesis database.
+    ///
+    /// # Arguments
+    ///
+    /// * `network_id` - The network ID of the database
+    /// * `db_config` - The database configuration
+    ///
+    /// # Return Value
+    ///
+    /// Returns a `Result` which is either a `Environment` or a `Error`.
+    ///
+    #[cfg(feature = "database-storage")]
+    pub fn pre_genesis_database(
+        &self,
+        network_id: NetworkId,
+        db_config: DatabaseConfig,
+    ) -> Result<MdbxDatabase, Error> {
+        assert!(
+            matches!(self, StorageConfig::Filesystem(_)),
+            "Pre-genesis database is only supported with filesystem storage"
+        );
+        let db_name = format!("{network_id}-pre-genesis").to_lowercase();
+        self.open_database(db_config, db_name)
+    }
+
+    /// Checks for the existence of the pre-genesis database.
+    #[cfg(feature = "database-storage")]
+    pub fn has_pre_genesis_database(&self, network_id: NetworkId) -> bool {
+        let db_name = format!("{network_id}-pre-genesis").to_lowercase();
+        match self {
+            StorageConfig::Volatile => false,
+            StorageConfig::Filesystem(file_storage) => {
+                let db_path = file_storage.database_parent.join(db_name);
+                db_path.exists()
+            }
+        }
+    }
+
+    /// Internal helper function to initiate a `MdbxDatabase` with the given `DatabaseConfig`.
+    #[cfg(feature = "database-storage")]
+    fn open_database(
+        &self,
+        db_config: DatabaseConfig,
+        db_name: String,
+    ) -> Result<MdbxDatabase, Error> {
         use nimiq_database::mdbx;
 
-        let db_name = format!("{network_id}-{sync_mode}-consensus").to_lowercase();
         log::info!("Opening database: {}", db_name);
 
         let config = mdbx::DatabaseConfig {

--- a/network-interface/src/peer_info.rs
+++ b/network-interface/src/peer_info.rs
@@ -41,6 +41,9 @@ bitflags! {
 
         /// This node is configured as a validator, so it is interested for other validator nodes.
         const VALIDATOR = 1 << 7;
+
+        /// This node provides pre-genesis information.
+        const PRE_GENESIS_TRANSACTIONS = 1 << 8;
     }
 }
 

--- a/pow-migration/src/history.rs
+++ b/pow-migration/src/history.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 use nimiq_blockchain::{
-    history_store_proxy::HistoryStoreProxy, interface::HistoryInterface, HistoryStore,
-    HistoryStoreIndex,
+    history_store_proxy::UnmergedHistoryStoreProxy, interface::HistoryInterface, HistoryStore,
 };
 use nimiq_database::{
     mdbx::MdbxDatabase,
@@ -125,12 +124,7 @@ pub async fn migrate_history(
     index_history: bool,
 ) {
     let mut history_store_height = get_history_store_height(env.clone(), network_id).await;
-    let history_store = if index_history {
-        HistoryStoreProxy::WithIndex(HistoryStoreIndex::new(env.clone(), network_id))
-    } else {
-        HistoryStoreProxy::WithoutIndex(Box::new(HistoryStore::new(env.clone(), network_id))
-            as Box<dyn HistoryInterface + Sync + Send>)
-    };
+    let history_store = UnmergedHistoryStoreProxy::new(env.clone(), index_history, network_id);
     let mut pow_head_height = async_retryer(|| pow_client.block_number()).await.unwrap();
 
     while let Some(candidate_block) = rx_candidate_block.recv().await {

--- a/pow-migration/src/history.rs
+++ b/pow-migration/src/history.rs
@@ -81,7 +81,7 @@ fn from_pow_transaction(pow_transaction: &PoWTransaction) -> Result<Transaction,
 async fn remove_history(
     env: &MdbxDatabase,
     pow_client: &Client,
-    history_store: &HistoryStoreProxy,
+    history_store: &UnmergedHistoryStoreProxy,
     history_store_height: u32,
     wanted_history_store_height: u32,
 ) {

--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -225,7 +225,7 @@ pub async fn migrate(
     block_windows: &BlockWindows,
     candidate_block: u32,
     genesis_hashes: Vec<Blake2bHash>,
-    env: MdbxDatabase,
+    pre_genesis_env: MdbxDatabase,
     validator_address: &Option<Address>,
     network_id: NetworkId,
 ) -> Result<MigrateWindowResult, Error> {
@@ -384,7 +384,7 @@ pub async fn migrate(
         block_windows,
         candidate_block,
         network_id,
-        env.clone(),
+        pre_genesis_env,
         PoSRegisteredAgents {
             active_validators: active_validators.clone(),
             inactive_validators: inactive_validators.clone(),

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -7,9 +7,7 @@ use nimiq::{
     config::{config::ClientConfig, config_file::ConfigFile},
     extras::logging::initialize_logging,
 };
-use nimiq_blockchain::{
-    chain_store::ChainStore, history_store_proxy::HistoryStoreProxy, HistoryStore,
-};
+use nimiq_blockchain::{chain_store::ChainStore, history_store_proxy::MergedHistoryStoreProxy};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_pow_migration::{
@@ -212,6 +210,28 @@ async fn main() {
             None
         };
 
+        // Check that we have not finished migrating yet
+        let env = config
+            .storage
+            .database(
+                config.network_id,
+                config.consensus.sync_mode,
+                config.database.clone(),
+            )
+            .unwrap_or_else(|error| {
+                exit_with_error(error, "Unable to create pre-genesis DB environment")
+            });
+        let history_store = Arc::new(MergedHistoryStoreProxy::new_merged(
+            env.clone(),
+            None,
+            false,
+            config.network_id,
+        ));
+        let chain_store = ChainStore::new(env, history_store);
+        if chain_store.get_head(None).is_some() {
+            panic!("We already have blocks in the chain store")
+        }
+
         // Create DB environments
         let pre_genesis_env = config
             .storage
@@ -229,18 +249,6 @@ async fn main() {
                 exit(1);
             }
         };
-
-        // Check that we have not migrated before
-        let history_store = Arc::new(HistoryStoreProxy::WithoutIndex(Box::new(
-            HistoryStore::new(env.clone(), config.network_id),
-        )));
-
-        let chain_store = ChainStore::new(env.clone(), history_store);
-
-        if chain_store.get_head(None).is_some() {
-            log::error!("We already have blocks in the chain store");
-            exit(1);
-        }
 
         // Create channels in order to communicate with the PoW-to-PoS history migrator
         let (tx_candidate_block, rx_candidate_block) = mpsc::channel(16);

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -212,15 +212,13 @@ async fn main() {
             None
         };
 
-        // Create DB environment
-        let env = config
+        // Create DB environments
+        let pre_genesis_env = config
             .storage
-            .database(
-                config.network_id,
-                config.consensus.sync_mode,
-                config.database,
-            )
-            .unwrap_or_else(|error| exit_with_error(error, "Unable to create DB environment"));
+            .pre_genesis_database(config.network_id, config.database)
+            .unwrap_or_else(|error| {
+                exit_with_error(error, "Unable to create pre-genesis DB environment")
+            });
 
         // Check that we are doing the migration for a supported network ID and set the genesis environment variable name
         let genesis_env_var_name = match config.network_id {
@@ -246,14 +244,15 @@ async fn main() {
 
         // Create channels in order to communicate with the PoW-to-PoS history migrator
         let (tx_candidate_block, rx_candidate_block) = mpsc::channel(16);
-        let (tx_migration_completed, rx_migration_completed) =
-            watch::channel(get_history_store_height(env.clone(), config.network_id).await);
+        let (tx_migration_completed, rx_migration_completed) = watch::channel(
+            get_history_store_height(pre_genesis_env.clone(), config.network_id).await,
+        );
 
         // Spawn PoW-to-PoS migrator as separate task
         spawn(migrate_history(
             rx_candidate_block,
             tx_migration_completed,
-            env.clone(),
+            pre_genesis_env.clone(),
             config.network_id,
             pow_client.clone(),
             block_windows.block_confirmations,
@@ -348,7 +347,7 @@ async fn main() {
                 block_windows,
                 candidate_block,
                 genesis_hashes.clone(),
-                env.clone(),
+                pre_genesis_env.clone(),
                 &validator_address,
                 config.network_id,
             )

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -61,18 +61,38 @@ impl TemporaryBlockProducer {
         producer
     }
 
+    pub fn new_merged() -> Self {
+        let time = Arc::new(OffsetTime::new());
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let pre_genesis_env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let blockchain = Blockchain::new_merged(
+            env,
+            Some(pre_genesis_env),
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap();
+
+        Self::with_blockchain(blockchain)
+    }
+
     pub fn new() -> Self {
         let time = Arc::new(OffsetTime::new());
         let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
-        let blockchain = Arc::new(RwLock::new(
-            Blockchain::new(
-                env,
-                BlockchainConfig::default(),
-                NetworkId::UnitAlbatross,
-                time,
-            )
-            .unwrap(),
-        ));
+        let blockchain = Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap();
+
+        Self::with_blockchain(blockchain)
+    }
+
+    fn with_blockchain(blockchain: Blockchain) -> Self {
+        let blockchain = Arc::new(RwLock::new(blockchain));
 
         let signing_key = SchnorrKeyPair::from(
             SchnorrPrivateKey::deserialize_from_vec(&hex::decode(SIGNING_KEY).unwrap()).unwrap(),


### PR DESCRIPTION
## What's in this pull request?
This PR separates pre-genesis and PoS transaction history into different databases.
This increases portability.

- The migration client uses `HistoryStore`/`HistoryStoreIndex` as if there was only one database.
- The PoS client uses a `HistoryStoreMerger` to merge both databases.
    - The merger uses the pre-genesis data read-only.
    - Without the pre-genesis data present, the methods have the same behaviour as previously.
    - Methods that write into the database will panic if we write epoch 0 (pre-genesis data).

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
