### PR TITLE
Wallet Store: Allow removal of an account

### DIFF
--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -40,6 +40,10 @@ pub trait WalletInterface {
         duration: Option<u64>,
     ) -> RPCResult<bool, (), Self::Error>;
 
+    /// Removes an imported account.
+    /// IMPORTANT: This action is irreversible, and the account can only be recovered with its private key.
+    async fn remove_account(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
+
     /// Returns if the account currently is unlocked.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -128,6 +128,19 @@ impl WalletInterface for WalletDispatcher {
         Ok(is_unlocked.into())
     }
 
+    async fn remove_account(&mut self, address: Address) -> RPCResult<bool, (), Self::Error> {
+        let _account = self
+            .wallet_store
+            .get(&address, None)
+            .ok_or(Error::AccountNotFound(address.clone()))?;
+
+        let mut txn = self.wallet_store.create_write_transaction();
+        self.wallet_store.remove(&address, &mut txn);
+        txn.commit();
+
+        Ok(true.into())
+    }
+
     async fn sign(
         &mut self,
         message: String,

--- a/wallet/src/wallet_store.rs
+++ b/wallet/src/wallet_store.rs
@@ -61,4 +61,8 @@ impl WalletStore {
     ) {
         txn.put_reserve(&self.table, address, wallet);
     }
+
+    pub fn remove(&self, address: &Address, txn: &mut MdbxWriteTransaction) {
+        txn.remove(&self.table, address);
+    }
 }


### PR DESCRIPTION
* Allow removal of an account from the Wallet Store.
* Expose this method through the RPC interface.

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
