### PR TITLE
Fix `DoubleProposalProof`s

### DIFF
--- a/blockchain/tests/history_store.rs
+++ b/blockchain/tests/history_store.rs
@@ -136,37 +136,25 @@ fn do_double_proposal(
         .clone()
         .unwrap_macro()
         .header;
-    let round = 0;
-    let valid_round = None;
-    let justification1 = signing_key.sign(
-        TendermintProposal {
-            proposal: &header1,
-            round,
-            valid_round,
-        }
-        .hash()
-        .as_bytes(),
-    );
-    let justification2 = signing_key.sign(
-        TendermintProposal {
-            proposal: &header2,
-            round,
-            valid_round,
-        }
-        .hash()
-        .as_bytes(),
-    );
+    let proposal1 = TendermintProposal {
+        proposal: header1,
+        round: 0,
+        valid_round: None,
+    };
+    let proposal2 = TendermintProposal {
+        proposal: header2,
+        round: 0,
+        valid_round: None,
+    };
+    let justification1 = signing_key.sign(proposal1.hash().as_bytes());
+    let justification2 = signing_key.sign(proposal2.hash().as_bytes());
 
     // Produce the double proposal proof.
     EquivocationProof::DoubleProposal(DoubleProposalProof::new(
         validator_address(),
-        header1,
-        round,
-        valid_round,
+        proposal1,
         justification1,
-        header2,
-        round,
-        valid_round,
+        proposal2,
         justification2,
     ))
 }

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -16,7 +16,7 @@ use nimiq_primitives::{
     networks::NetworkId,
     policy::Policy,
     slots_allocation::{JailedValidator, PenalizedSlot},
-    TendermintIdentifier, TendermintStep, TendermintVote,
+    TendermintIdentifier, TendermintProposal, TendermintStep, TendermintVote,
 };
 use nimiq_test_log::test;
 use nimiq_test_utils::{
@@ -513,17 +513,37 @@ fn it_correctly_creates_inherents_from_double_proposal_proof() {
         .next_block(vec![], false)
         .unwrap_macro()
         .header;
-    let header1_hash: Blake2bHash = header1.hash();
-    let header2_hash: Blake2bHash = header2.hash();
-    let justification1 = signing_key.sign(header1_hash.as_bytes());
-    let justification2 = signing_key.sign(header2_hash.as_bytes());
+    let round = 0;
+    let valid_round = None;
+    let justification1 = signing_key.sign(
+        TendermintProposal {
+            proposal: &header1,
+            round,
+            valid_round,
+        }
+        .hash()
+        .as_bytes(),
+    );
+    let justification2 = signing_key.sign(
+        TendermintProposal {
+            proposal: &header2,
+            round,
+            valid_round,
+        }
+        .hash()
+        .as_bytes(),
+    );
 
     // Produce the double proposal proof.
     let double_proposal_proof = DoubleProposalProof::new(
         validator_address(),
         header1.clone(),
+        round,
+        valid_round,
         justification1,
         header2,
+        round,
+        valid_round,
         justification2,
     );
 

--- a/blockchain/tests/merged_history_store.rs
+++ b/blockchain/tests/merged_history_store.rs
@@ -136,37 +136,25 @@ fn do_double_proposal(
         .clone()
         .unwrap_macro()
         .header;
-    let round = 0;
-    let valid_round = None;
-    let justification1 = signing_key.sign(
-        TendermintProposal {
-            proposal: &header1,
-            round,
-            valid_round,
-        }
-        .hash()
-        .as_bytes(),
-    );
-    let justification2 = signing_key.sign(
-        TendermintProposal {
-            proposal: &header2,
-            round,
-            valid_round,
-        }
-        .hash()
-        .as_bytes(),
-    );
+    let proposal1 = TendermintProposal {
+        proposal: header1,
+        round: 0,
+        valid_round: None,
+    };
+    let proposal2 = TendermintProposal {
+        proposal: header2,
+        round: 0,
+        valid_round: None,
+    };
+    let justification1 = signing_key.sign(proposal1.hash().as_bytes());
+    let justification2 = signing_key.sign(proposal2.hash().as_bytes());
 
     // Produce the double proposal proof.
     EquivocationProof::DoubleProposal(DoubleProposalProof::new(
         validator_address(),
-        header1,
-        round,
-        valid_round,
+        proposal1,
         justification1,
-        header2,
-        round,
-        valid_round,
+        proposal2,
         justification2,
     ))
 }

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -14,7 +14,7 @@ use nimiq_hash::{Blake2bHash, Blake2sHash, HashOutput};
 use nimiq_keys::KeyPair;
 use nimiq_primitives::{
     key_nibbles::KeyNibbles, networks::NetworkId, policy::Policy, TendermintIdentifier,
-    TendermintStep,
+    TendermintProposal, TendermintStep,
 };
 use nimiq_test_log::test;
 use nimiq_test_utils::{
@@ -484,18 +484,38 @@ fn it_validates_double_proposal_proofs() {
         .header;
     let mut header2 = header1.clone();
     header2.timestamp += 1;
-    let header1_hash: Blake2bHash = header1.hash();
-    let header2_hash: Blake2bHash = header2.hash();
-    let justification1 = signing_key.sign(header1_hash.as_bytes());
-    let justification2 = signing_key.sign(header2_hash.as_bytes());
+    let round = 0;
+    let valid_round = None;
+    let justification1 = signing_key.sign(
+        TendermintProposal {
+            proposal: &header1,
+            round,
+            valid_round,
+        }
+        .hash()
+        .as_bytes(),
+    );
+    let justification2 = signing_key.sign(
+        TendermintProposal {
+            proposal: &header2,
+            round,
+            valid_round,
+        }
+        .hash()
+        .as_bytes(),
+    );
 
     expect_push_micro_block(
         BlockConfig {
             equivocation_proofs: vec![DoubleProposalProof::new(
                 validator_address(),
                 header1,
+                round,
+                valid_round,
                 justification1,
                 header2,
+                round,
+                valid_round,
                 justification2,
             )
             .into()],

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -484,38 +484,26 @@ fn it_validates_double_proposal_proofs() {
         .header;
     let mut header2 = header1.clone();
     header2.timestamp += 1;
-    let round = 0;
-    let valid_round = None;
-    let justification1 = signing_key.sign(
-        TendermintProposal {
-            proposal: &header1,
-            round,
-            valid_round,
-        }
-        .hash()
-        .as_bytes(),
-    );
-    let justification2 = signing_key.sign(
-        TendermintProposal {
-            proposal: &header2,
-            round,
-            valid_round,
-        }
-        .hash()
-        .as_bytes(),
-    );
+    let proposal1 = TendermintProposal {
+        proposal: header1,
+        round: 0,
+        valid_round: None,
+    };
+    let proposal2 = TendermintProposal {
+        proposal: header2,
+        round: 0,
+        valid_round: None,
+    };
+    let justification1 = signing_key.sign(proposal1.hash().as_bytes());
+    let justification2 = signing_key.sign(proposal2.hash().as_bytes());
 
     expect_push_micro_block(
         BlockConfig {
             equivocation_proofs: vec![DoubleProposalProof::new(
                 validator_address(),
-                header1,
-                round,
-                valid_round,
+                proposal1,
                 justification1,
-                header2,
-                round,
-                valid_round,
+                proposal2,
                 justification2,
             )
             .into()],

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -372,7 +372,7 @@ impl DoubleProposalProof {
     }
     /// Round of the proposals.
     pub fn round(&self) -> u32 {
-        self.proposal1.proposal.round
+        self.proposal1.round
     }
     /// Hash of header number 1.
     pub fn header1_hash(&self) -> Blake2bHash {
@@ -404,7 +404,6 @@ impl DoubleProposalProof {
         }
 
         if self.proposal1.proposal.block_number != self.proposal2.proposal.block_number
-            || self.proposal1.proposal.round != self.proposal2.proposal.round
             || self.proposal1.round != self.proposal2.round
         {
             return Err(EquivocationProofError::SlotMismatch);
@@ -810,8 +809,8 @@ mod test {
         let proposals: Vec<_> = headers
             .into_iter()
             .map(|header| TendermintProposal {
+                round: header.round,
                 proposal: header,
-                round: 0,
                 valid_round: None,
             })
             .collect();

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -314,13 +314,9 @@ pub struct DoubleProposalProof {
     /// Address of the offending validator.
     validator_address: Address,
     /// Header number 1.
-    header1: MacroHeader,
+    proposal1: TendermintProposal<MacroHeader>,
     /// Header number 2.
-    header2: MacroHeader,
-    round1: u32,
-    round2: u32,
-    valid_round1: Option<u32>,
-    valid_round2: Option<u32>,
+    proposal2: TendermintProposal<MacroHeader>,
     /// Justification for header number 1.
     justification1: SchnorrSignature,
     /// Justification for header number 2.
@@ -330,31 +326,21 @@ pub struct DoubleProposalProof {
 impl DoubleProposalProof {
     pub fn new(
         validator_address: Address,
-        mut header1: MacroHeader,
-        mut round1: u32,
-        mut valid_round1: Option<u32>,
+        mut proposal1: TendermintProposal<MacroHeader>,
         mut justification1: SchnorrSignature,
-        mut header2: MacroHeader,
-        mut round2: u32,
-        mut valid_round2: Option<u32>,
+        mut proposal2: TendermintProposal<MacroHeader>,
         mut justification2: SchnorrSignature,
     ) -> DoubleProposalProof {
-        let hash1: Blake2bHash = header1.hash();
-        let hash2: Blake2bHash = header2.hash();
+        let hash1: Blake2bHash = proposal1.proposal.hash();
+        let hash2: Blake2bHash = proposal2.proposal.hash();
         if hash1 > hash2 {
-            mem::swap(&mut header1, &mut header2);
+            mem::swap(&mut proposal1, &mut proposal2);
             mem::swap(&mut justification1, &mut justification2);
-            mem::swap(&mut round1, &mut round2);
-            mem::swap(&mut valid_round1, &mut valid_round2);
         }
         DoubleProposalProof {
             validator_address,
-            header1,
-            header2,
-            round1,
-            round2,
-            valid_round1,
-            valid_round2,
+            proposal1,
+            proposal2,
             justification1,
             justification2,
         }
@@ -374,7 +360,7 @@ impl DoubleProposalProof {
 
     /// Network ID this equivocation happened on.
     pub fn network(&self) -> NetworkId {
-        self.header1.network
+        self.proposal1.proposal.network
     }
     /// Address of the offending validator.
     pub fn validator_address(&self) -> &Address {
@@ -382,19 +368,19 @@ impl DoubleProposalProof {
     }
     /// Block number at which the offense occurred.
     pub fn block_number(&self) -> u32 {
-        self.header1.block_number
+        self.proposal1.proposal.block_number
     }
     /// Round of the proposals.
     pub fn round(&self) -> u32 {
-        self.header1.round
+        self.proposal1.proposal.round
     }
     /// Hash of header number 1.
     pub fn header1_hash(&self) -> Blake2bHash {
-        self.header1.hash()
+        self.proposal1.proposal.hash()
     }
     /// Hash of header number 2.
     pub fn header2_hash(&self) -> Blake2bHash {
-        self.header2.hash()
+        self.proposal2.proposal.hash()
     }
 
     /// Verify the validity of a double proposal proof.
@@ -402,8 +388,8 @@ impl DoubleProposalProof {
         &self,
         signing_key: &SchnorrPublicKey,
     ) -> Result<(), EquivocationProofError> {
-        let hash1: Blake2bHash = self.header1.hash();
-        let hash2: Blake2bHash = self.header2.hash();
+        let hash1: Blake2bHash = self.proposal1.proposal.hash();
+        let hash2: Blake2bHash = self.proposal2.proposal.hash();
 
         // Check that the headers are not equal and in the right order:
         match hash1.cmp(&hash2) {
@@ -413,33 +399,20 @@ impl DoubleProposalProof {
         }
 
         // Check that the headers have equal network IDs.
-        if self.header1.network != self.header2.network {
+        if self.proposal1.proposal.network != self.proposal2.proposal.network {
             return Err(EquivocationProofError::NetworkMismatch);
         }
 
-        if self.header1.block_number != self.header2.block_number
-            || self.header1.round != self.header2.round
-            || self.round1 != self.round2
+        if self.proposal1.proposal.block_number != self.proposal2.proposal.block_number
+            || self.proposal1.proposal.round != self.proposal2.proposal.round
+            || self.proposal1.round != self.proposal2.round
         {
             return Err(EquivocationProofError::SlotMismatch);
         }
 
-        let signed_hash1: Blake2sHash = TendermintProposal {
-            proposal: &self.header1,
-            round: self.round1,
-            valid_round: self.valid_round1,
-        }
-        .hash();
-        let signed_hash2: Blake2sHash = TendermintProposal {
-            proposal: &self.header2,
-            round: self.round2,
-            valid_round: self.valid_round2,
-        }
-        .hash();
-
         // Check that the justifications are valid.
-        if !signing_key.verify(&self.justification1, signed_hash1.as_slice())
-            || !signing_key.verify(&self.justification2, signed_hash2.as_slice())
+        if !signing_key.verify(&self.justification1, self.proposal1.hash().as_slice())
+            || !signing_key.verify(&self.justification2, self.proposal2.hash().as_slice())
         {
             return Err(EquivocationProofError::InvalidJustification);
         }
@@ -823,88 +796,71 @@ mod test {
         let mut header7 = header2.clone();
         header7.round += 1;
 
-        let round = 0;
-        let valid_round = None;
-        let sign = |proposal: &MacroHeader| {
-            key.sign(
-                TendermintProposal {
-                    proposal,
-                    round,
-                    valid_round,
-                }
-                .hash()
-                .as_bytes(),
-            )
-        };
+        let headers = vec![
+            Default::default(), // keep indices
+            header1,
+            header2,
+            header3,
+            header4,
+            header5,
+            header6,
+            header7,
+        ];
 
-        let justification1 = sign(&header1);
-        let justification2 = sign(&header2);
-        let justification3 = sign(&header3);
-        let justification4 = sign(&header4);
-        let justification5 = sign(&header5);
-        let justification6 = sign(&header6);
-        let justification7 = sign(&header7);
+        let proposals: Vec<_> = headers
+            .into_iter()
+            .map(|header| TendermintProposal {
+                proposal: header,
+                round: 0,
+                valid_round: None,
+            })
+            .collect();
+
+        let justifications: Vec<_> = proposals
+            .iter()
+            .map(|proposal| key.sign(proposal.hash().as_bytes()))
+            .collect();
 
         let proof1: EquivocationProof = DoubleProposalProof::new(
             Address::burn_address(),
-            header1.clone(),
-            round,
-            valid_round,
-            justification1.clone(),
-            header2.clone(),
-            round,
-            valid_round,
-            justification2.clone(),
+            proposals[1].clone(),
+            justifications[1].clone(),
+            proposals[2].clone(),
+            justifications[2].clone(),
         )
         .into();
         let proof2: EquivocationProof = DoubleProposalProof::new(
             Address::burn_address(),
-            header2.clone(),
-            round,
-            valid_round,
-            justification2.clone(),
-            header3.clone(),
-            round,
-            valid_round,
-            justification3.clone(),
+            proposals[2].clone(),
+            justifications[2].clone(),
+            proposals[3].clone(),
+            justifications[3].clone(),
         )
         .into();
         let proof3: EquivocationProof = DoubleProposalProof::new(
             Address::burn_address(),
-            header3.clone(),
-            round,
-            valid_round,
-            justification3.clone(),
-            header1.clone(),
-            round,
-            valid_round,
-            justification1.clone(),
+            proposals[3].clone(),
+            justifications[3].clone(),
+            proposals[1].clone(),
+            justifications[1].clone(),
         )
         .into();
         // Different block height.
         let proof4: EquivocationProof = DoubleProposalProof::new(
             Address::burn_address(),
-            header4.clone(),
-            round,
-            valid_round,
-            justification4.clone(),
-            header5.clone(),
-            round,
-            valid_round,
-            justification5.clone(),
+            proposals[4].clone(),
+            justifications[4].clone(),
+            proposals[5].clone(),
+            justifications[5].clone(),
         )
         .into();
         // Different round.
         let proof5: EquivocationProof = DoubleProposalProof::new(
             Address::burn_address(),
-            header6.clone(),
-            round,
-            valid_round,
-            justification6.clone(),
-            header7.clone(),
-            round,
-            valid_round,
-            justification7.clone(),
+            proposals[6].clone(),
+            justifications[6].clone(),
+            proposals[7].clone(),
+            justifications[7].clone(),
         )
         .into();
 

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -331,8 +331,8 @@ impl DoubleProposalProof {
         mut proposal2: TendermintProposal<MacroHeader>,
         mut justification2: SchnorrSignature,
     ) -> DoubleProposalProof {
-        let hash1: Blake2bHash = proposal1.proposal.hash();
-        let hash2: Blake2bHash = proposal2.proposal.hash();
+        let hash1: Blake2sHash = proposal1.hash();
+        let hash2: Blake2sHash = proposal2.hash();
         if hash1 > hash2 {
             mem::swap(&mut proposal1, &mut proposal2);
             mem::swap(&mut justification1, &mut justification2);
@@ -388,8 +388,8 @@ impl DoubleProposalProof {
         &self,
         signing_key: &SchnorrPublicKey,
     ) -> Result<(), EquivocationProofError> {
-        let hash1: Blake2bHash = self.proposal1.proposal.hash();
-        let hash2: Blake2bHash = self.proposal2.proposal.hash();
+        let hash1: Blake2sHash = self.proposal1.hash();
+        let hash2: Blake2sHash = self.proposal2.hash();
 
         // Check that the headers are not equal and in the right order:
         match hash1.cmp(&hash2) {
@@ -410,8 +410,8 @@ impl DoubleProposalProof {
         }
 
         // Check that the justifications are valid.
-        if !signing_key.verify(&self.justification1, self.proposal1.hash().as_slice())
-            || !signing_key.verify(&self.justification2, self.proposal2.hash().as_slice())
+        if !signing_key.verify(&self.justification1, hash1.as_slice())
+            || !signing_key.verify(&self.justification2, hash2.as_slice())
         {
             return Err(EquivocationProofError::InvalidJustification);
         }

--- a/primitives/src/tendermint.rs
+++ b/primitives/src/tendermint.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use nimiq_hash::{Blake2sHash, Hash, HashOutput, SerializeContent};
-use nimiq_serde::{Deserialize, Serialize, SerializedSize};
+use nimiq_serde::{Deserialize, Serialize, SerializedMaxSize, SerializedSize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::{
@@ -55,7 +55,7 @@ impl Display for TendermintIdentifier {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedMaxSize)]
 pub struct TendermintProposal<T> {
     pub proposal: T,
     pub round: u32,

--- a/primitives/src/tendermint.rs
+++ b/primitives/src/tendermint.rs
@@ -3,7 +3,7 @@ use std::{
     io,
 };
 
-use nimiq_hash::{Blake2sHash, SerializeContent};
+use nimiq_hash::{Blake2sHash, Hash, HashOutput, SerializeContent};
 use nimiq_serde::{Deserialize, Serialize, SerializedSize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -52,6 +52,31 @@ impl Display for TendermintIdentifier {
             "{}:{}:{:?}",
             self.block_number, self.round_number, self.step
         )
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct TendermintProposal<T> {
+    pub proposal: T,
+    pub round: u32,
+    pub valid_round: Option<u32>,
+}
+
+impl<T: SerializeContent> SerializeContent for TendermintProposal<T> {
+    fn serialize_content<W: io::Write, H: HashOutput>(&self, writer: &mut W) -> io::Result<()> {
+        // First of all serialize that this is a proposal, this serves as the
+        // unique prefix for this message type.
+        TendermintStep::Propose.serialize_to_writer(writer)?;
+        self.proposal.serialize_content::<_, H>(writer)?;
+        self.round.serialize_to_writer(writer)?;
+        self.valid_round.serialize_to_writer(writer)?;
+        Ok(())
+    }
+}
+
+impl<T: SerializeContent> TendermintProposal<T> {
+    pub fn hash(&self) -> Blake2sHash {
+        Hash::hash(self)
     }
 }
 

--- a/serde/derive/src/lib.rs
+++ b/serde/derive/src/lib.rs
@@ -4,7 +4,7 @@ use darling::{
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Expr, Generics, Ident, Type, TypeArray};
+use syn::{parse_macro_input, parse_quote, Expr, GenericParam, Generics, Ident, Type, TypeArray};
 
 #[derive(FromDeriveInput)]
 #[darling(attributes(serialize_size))]
@@ -91,9 +91,19 @@ fn max_size_variants(variants: &[Variant]) -> TokenStream {
 pub fn derive_serialize_size(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let Input {
         ident,
-        generics,
+        mut generics,
         data,
     } = Input::from_derive_input(&parse_macro_input!(input)).unwrap();
+
+    // Add `: SerializedSize` to every type parameter.
+    for generic in &mut generics.params {
+        if let GenericParam::Type(type_param) = generic {
+            type_param
+                .bounds
+                .push(parse_quote!(::nimiq_serde::SerializedSize));
+        }
+    }
+
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
     let size = match data {
@@ -113,9 +123,19 @@ pub fn derive_serialize_size(input: proc_macro::TokenStream) -> proc_macro::Toke
 pub fn derive_serialize_max_size(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let Input {
         ident,
-        generics,
+        mut generics,
         data,
     } = Input::from_derive_input(&parse_macro_input!(input)).unwrap();
+
+    // Add `: SerializedMaxSize` to every type parameter.
+    for generic in &mut generics.params {
+        if let GenericParam::Type(type_param) = generic {
+            type_param
+                .bounds
+                .push(parse_quote!(::nimiq_serde::SerializedMaxSize));
+        }
+    }
+
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
     let size = match data {

--- a/validator/src/aggregation/tendermint/proposal.rs
+++ b/validator/src/aggregation/tendermint/proposal.rs
@@ -1,16 +1,14 @@
 use std::sync::Arc;
 
-use byteorder::WriteBytesExt;
 use nimiq_block::{MacroBody, MacroHeader, MicroBlock};
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
-use nimiq_hash::{Blake2sHash, Blake2sHasher, Hash, Hasher, SerializeContent};
+use nimiq_hash::{Blake2sHash, Hash};
 use nimiq_keys::Ed25519Signature as SchnorrSignature;
 use nimiq_network_interface::{
     network::Network,
     request::{Handle, RequestCommon, RequestMarker},
 };
-use nimiq_primitives::TendermintStep;
 use nimiq_serde::Serialize;
 use nimiq_tendermint::{Inherent, Proposal, ProposalMessage, SignedProposalMessage};
 use parking_lot::RwLock;
@@ -56,7 +54,6 @@ pub struct SignedProposal {
 }
 
 impl SignedProposal {
-    const PROPOSAL_PREFIX: u8 = TendermintStep::Propose as u8;
     /// Transforms this SignedProposal into a SignedProposalMessage, which tendermint can understand.
     /// Optionally includes the GossipSubId if applicable, or None if the SignedProposal was not received
     /// via GossipSub, i.e. produced by this node itself.
@@ -72,27 +69,6 @@ impl SignedProposal {
                 valid_round: self.valid_round,
             },
         }
-    }
-
-    /// Hash proposal message components into a Blake2sHash while also including a Proposal Prefix.
-    /// This hash is not suited for the Aggregated signatures used for macro blocks, as it does not include
-    /// the public key tree root. It is suited to authenticate the creator of the proposal when signed.
-    pub fn hash(proposal: &MacroHeader, round: u32, valid_round: Option<u32>) -> Blake2sHash {
-        let mut h = Blake2sHasher::new();
-
-        h.write_u8(Self::PROPOSAL_PREFIX)
-            .expect("Must be able to write Prefix to hasher");
-        proposal
-            .serialize_content::<_, Blake2sHash>(&mut h)
-            .expect("Must be able to serialize content of the proposal to hasher");
-        round
-            .serialize_to_writer(&mut h)
-            .expect("Must be able to serialize content of the round to hasher ");
-        valid_round
-            .serialize_to_writer(&mut h)
-            .expect("Must be able to serialize content of the valid_round to hasher ");
-
-        h.finish()
     }
 
     /// To a given Message and predecessor as well as blockchain, this function returns true iff


### PR DESCRIPTION
They required data unrelated to the signed proposals. It now uses the same signing infrastructure by factoring it out to `TendermintProposal` in a common crate.

Fixes #2981.