### PR TITLE
Update list of gossipsub topics known to metrics server

### DIFF
--- a/network-libp2p/src/network_metrics.rs
+++ b/network-libp2p/src/network_metrics.rs
@@ -50,7 +50,17 @@ impl NetworkMetrics {
     }
 
     pub(crate) fn note_received_pubsub_message(&self, topic: &TopicHash) {
-        if ["blocks", "transactions", "tendermint-proposal"].contains(&&*topic.to_string()) {
+        if [
+            "address-subscription",
+            "block-body",
+            "block-header",
+            "control-transaction",
+            "regular-transaction",
+            "tendermint-proposal",
+            "zk-proof",
+        ]
+        .contains(&&*topic.to_string())
+        {
             self.gossipsub_messages_received
                 .get_or_create(&TopicLabels {
                     topic: topic.to_string(),


### PR DESCRIPTION
The list in the metrics server hasn't been updated for quite a while. Since then e.g. the `transactions` and `blocks` topics were split into two. I also added two new topics.

#### This fixes #2986.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
