### PR TITLE
Remove wasm-pack build step from web-client CI job

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -113,9 +113,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Install wasm-pack
       run: cargo install wasm-pack
-    - name: Compile to wasm and generate bindings
-      working-directory: ./web-client
-      run: wasm-pack build --target web
     - name: Execute wasm unittests
       working-directory: ./web-client
       run: wasm-pack test --chrome --headless


### PR DESCRIPTION
`wasm-pack build` runs wasm-opt automatically, which [currently fails for an unknown reason](https://github.com/nimiq/core-rs-albatross/actions/runs/11397282578/job/31712490950).

The wasm tests themselves are run with `wasm-pack test`, which compiles to a debug target and doesn't use wasm-opt, so doesn't trigger the problem.

An actual production build test will be added to the CI as part of PR #2715.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
