### PR TITLE
network-libp2p: Fix double increments and missing decrements for peer/IP counters in Connection Pool Behaviour

### DIFF
--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Maximum simultaneous libp2p connections per peer
-const MAX_CONNECTIONS_PER_PEER: u32 = 2;
+const MAX_CONNECTIONS_PER_PEER: u32 = 3;
 
 /// Network behaviour.
 /// This is composed of several other behaviours that build a tree of behaviours using

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     net::IpAddr,
     pin::Pin,
     sync::Arc,
@@ -16,7 +16,7 @@ use libp2p::{
         behaviour::{ConnectionClosed, ConnectionEstablished, DialFailure},
         dial_opts::{DialOpts, PeerCondition},
         dummy, CloseConnection, ConnectionDenied, ConnectionId, DialError, FromSwarm,
-        NetworkBehaviour, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+        ListenFailure, NetworkBehaviour, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
     },
     Multiaddr, PeerId, TransportError,
 };
@@ -672,21 +672,6 @@ impl Behaviour {
             return;
         }
 
-        // Get IP from multiaddress if it exists.
-        let ip_info = self.get_ip_info_from_multiaddr(address);
-        if let Some(ip_info) = ip_info {
-            // Increment peer counts per IP
-            if let Some(subnet_ip) = ip_info.subnet_ip {
-                let value = self.limits.ip_subnet_count.entry(subnet_ip).or_insert(0);
-                *value = value.saturating_add(1);
-            }
-
-            let value = self.limits.ip_count.entry(ip_info.ip).or_insert(0);
-            *value = value.saturating_add(1);
-
-            self.limits.peer_count = self.limits.peer_count.saturating_add(1);
-        }
-
         // Peer is connected, mark it as such.
         let peer_services = self
             .contacts
@@ -708,11 +693,6 @@ impl Behaviour {
         endpoint: &ConnectedPoint,
         remaining_established: usize,
     ) {
-        // Check there are no more remaining connections to this peer
-        if remaining_established > 0 {
-            return;
-        }
-
         let address = endpoint.get_remote_address();
 
         // Get IP from multiaddress if it exists.
@@ -720,22 +700,14 @@ impl Behaviour {
 
         // Decrement IP counters if needed
         if let Some(ip_info) = ip_info {
-            let value = self.limits.ip_count.entry(ip_info.ip).or_insert(1);
-            *value = value.saturating_sub(1);
-            if *self.limits.ip_count.get(&ip_info.ip).unwrap() == 0 {
-                self.limits.ip_count.remove(&ip_info.ip);
-            }
-
-            if let Some(subnet_ip) = ip_info.subnet_ip {
-                let value = self.limits.ip_subnet_count.entry(subnet_ip).or_insert(1);
-                *value = value.saturating_sub(1);
-                if *self.limits.ip_subnet_count.get(&subnet_ip).unwrap() == 0 {
-                    self.limits.ip_subnet_count.remove(&subnet_ip);
-                }
-            }
+            self.decrement_ip_counters(&ip_info);
         }
 
         self.limits.peer_count = self.limits.peer_count.saturating_sub(1);
+        // Check there are no more remaining connections to this peer
+        if remaining_established > 0 {
+            return;
+        }
 
         self.addresses.mark_closed(address.clone());
         self.peer_ids.mark_closed(*peer_id);
@@ -817,6 +789,98 @@ impl Behaviour {
             }
         }
     }
+
+    fn on_listen_failure(&mut self, send_back_addr: &Multiaddr) {
+        // Get IP from multiaddress if it exists.
+        let ip_info = self.get_ip_info_from_multiaddr(send_back_addr);
+
+        // Decrement IP counters if needed
+        if let Some(ip_info) = ip_info {
+            self.decrement_ip_counters(&ip_info);
+        }
+        self.limits.peer_count = self.limits.peer_count.saturating_sub(1);
+    }
+
+    fn increment_and_check_peer_limit(&mut self) -> Result<(), ConnectionDenied> {
+        self.limits.peer_count = self.limits.peer_count.saturating_add(1);
+
+        // Check for the maximum peer count limit
+        if self.limits.peer_count > self.config.peer_count_max {
+            debug!(
+                connections = self.limits.peer_count,
+                "Max peer connections limit reached"
+            );
+            return Err(ConnectionDenied::new(Error::MaxPeerConnectionsReached));
+        }
+
+        Ok(())
+    }
+
+    fn reached_ip_limit(&mut self, ip_info: &IpInfo) -> Result<(), ConnectionDenied> {
+        // Increment peer IP counter
+        let ip_count = self
+            .limits
+            .ip_count
+            .entry(ip_info.ip)
+            .and_modify(|counter| *counter = counter.saturating_add(1))
+            .or_insert(1);
+
+        // Increment peer subnet IP counter
+        let subnet_ip_count = if let Some(subnet_ip) = ip_info.subnet_ip {
+            Some(
+                self.limits
+                    .ip_subnet_count
+                    .entry(subnet_ip)
+                    .and_modify(|counter| *counter = counter.saturating_add(1))
+                    .or_insert(1),
+            )
+        } else {
+            None
+        };
+
+        // Check if peer IP limit is reached
+        if *ip_count > self.config.peer_count_per_ip_max {
+            // IP address
+            debug!(ip=%ip_info.ip, limit=self.config.peer_count_per_ip_max, "Max peer connections per IP limit reached");
+            return Err(ConnectionDenied::new(Error::MaxPeerPerIPConnectionsReached));
+        }
+
+        // Check if peer subnet IP limit is reached
+        if let Some(subnet_ip_count) = subnet_ip_count {
+            if *subnet_ip_count > self.config.peer_count_per_subnet_max {
+                // Subnet mask
+                debug!(
+                    subnet_ip = %ip_info.subnet_ip.unwrap(),
+                    limit = self.config.peer_count_per_subnet_max,
+                    "Max peer connections per IP subnet limit reached"
+                );
+                return Err(ConnectionDenied::new(Error::MaxSubnetConnectionsReached));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decrement_ip_counters(&mut self, ip_info: &IpInfo) {
+        // Decrement peer IP counter
+        if let Entry::Occupied(mut ip_count) = self.limits.ip_count.entry(ip_info.ip) {
+            *ip_count.get_mut() = ip_count.get().saturating_sub(1);
+            if *ip_count.get() == 0 {
+                ip_count.remove();
+            }
+        }
+
+        // Decrement peer subnet IP counter
+        if let Some(subnet_ip) = ip_info.subnet_ip {
+            if let Entry::Occupied(mut subnet_count) = self.limits.ip_subnet_count.entry(subnet_ip)
+            {
+                *subnet_count.get_mut() = subnet_count.get().saturating_sub(1);
+                if *subnet_count.get() == 0 {
+                    subnet_count.remove();
+                }
+            }
+        }
+    }
 }
 
 impl NetworkBehaviour for Behaviour {
@@ -850,6 +914,9 @@ impl NetworkBehaviour for Behaviour {
             }
             FromSwarm::DialFailure(DialFailure { peer_id, error, .. }) => {
                 self.on_dial_failure(peer_id, error)
+            }
+            FromSwarm::ListenFailure(ListenFailure { send_back_addr, .. }) => {
+                self.on_listen_failure(send_back_addr)
             }
             _ => {}
         }
@@ -897,47 +964,8 @@ impl NetworkBehaviour for Behaviour {
         }
 
         // Get IP from multiaddress if it exists.
-        let ip_info = self.get_ip_info_from_multiaddr(remote_addr);
-
-        // If we have an IP, check connection limits per IP.
-        if let Some(ip_info) = ip_info.clone() {
-            if self.config.peer_count_per_ip_max
-                < self
-                    .limits
-                    .ip_count
-                    .get(&ip_info.ip)
-                    .unwrap_or(&0)
-                    .saturating_add(1)
-            {
-                // Subnet mask
-                debug!(ip=%ip_info.ip, limit=self.config.peer_count_per_ip_max, "Max peer connections per IP limit reached");
-                return Err(ConnectionDenied::new(Error::MaxPeerPerIPConnectionsReached));
-            }
-
-            // If we have the subnet IP, check connection limits per subnet
-            if let Some(subnet_ip) = ip_info.subnet_ip {
-                if self.config.peer_count_per_subnet_max
-                    < self
-                        .limits
-                        .ip_subnet_count
-                        .get(&subnet_ip)
-                        .unwrap_or(&0)
-                        .saturating_add(1)
-                {
-                    // Subnet mask
-                    debug!(%subnet_ip, limit=self.config.peer_count_per_subnet_max, "Max peer connections per IP subnet limit reached");
-                    return Err(ConnectionDenied::new(Error::MaxSubnetConnectionsReached));
-                }
-            }
-        }
-
-        // Check for the maximum peer count limit
-        if self.config.peer_count_max < self.limits.peer_count.saturating_add(1) {
-            debug!(
-                connections = self.limits.peer_count,
-                "Max peer connections limit reached"
-            );
-            return Err(ConnectionDenied::new(Error::MaxPeerConnectionsReached));
+        if let Some(ip_info) = self.get_ip_info_from_multiaddr(remote_addr) {
+            self.reached_ip_limit(&ip_info)?;
         }
 
         Ok(())
@@ -956,6 +984,7 @@ impl NetworkBehaviour for Behaviour {
             debug!(peer_id=%peer, "Peer is banned");
             return Err(ConnectionDenied::new(Error::BannedPeer));
         }
+        self.increment_and_check_peer_limit()?;
 
         Ok(dummy::ConnectionHandler)
     }
@@ -964,10 +993,15 @@ impl NetworkBehaviour for Behaviour {
         &mut self,
         _connection_id: ConnectionId,
         _peer: PeerId,
-        _addr: &Multiaddr,
+        addr: &Multiaddr,
         _role_override: Endpoint,
         _port_use: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
+        if let Some(ip_info) = self.get_ip_info_from_multiaddr(addr) {
+            self.reached_ip_limit(&ip_info)?;
+        }
+        self.increment_and_check_peer_limit()?;
+
         Ok(dummy::ConnectionHandler)
     }
 


### PR DESCRIPTION
- Incrementing the counters happened in both `handle_pending_inbound_connection` and `on_connection_established`.
- Secondly due to early returns, there were scenarios where some counters wouldn't get decremented.
- Lastly decrement the limit counters on a listen failure.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
