### PR TITLE
Blockchain: add `network_id` to `SkipBlockInfo`

### DIFF
--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -135,6 +135,7 @@ impl BlockProducer {
 
         let skip_block_info = if skip_block_proof.is_some() {
             Some(SkipBlockInfo {
+                network_id: blockchain.network_id,
                 block_number,
                 vrf_entropy: prev_seed.entropy(),
             })

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -30,6 +30,7 @@ fn test_skip_block_single_signature() {
 
     // create skip block data
     let skip_block_info = SkipBlockInfo {
+        network_id: NetworkId::UnitAlbatross,
         block_number: 1234,
         vrf_entropy: VrfEntropy::default(),
     };

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -101,6 +101,7 @@ impl MicroBlock {
         match justification {
             MicroJustification::Skip(proof) => {
                 let skip_block = SkipBlockInfo {
+                    network_id: self.header.network,
                     block_number: self.header.block_number,
                     vrf_entropy: self.header.seed.entropy(),
                 };

--- a/primitives/block/src/skip_block.rs
+++ b/primitives/block/src/skip_block.rs
@@ -3,7 +3,8 @@ use std::fmt::Debug;
 use nimiq_bls::AggregatePublicKey;
 use nimiq_hash_derive::SerializeContent;
 use nimiq_primitives::{
-    policy::Policy, slots_allocation::Validators, Message, SignedMessage, PREFIX_SKIP_BLOCK_INFO,
+    networks::NetworkId, policy::Policy, slots_allocation::Validators, Message, SignedMessage,
+    PREFIX_SKIP_BLOCK_INFO,
 };
 use nimiq_serde::{Deserialize, Serialize, SerializedMaxSize};
 use nimiq_vrf::VrfEntropy;
@@ -17,6 +18,9 @@ pub type SignedSkipBlockInfo = SignedMessage<SkipBlockInfo>;
     Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Deserialize, Serialize, SerializeContent,
 )]
 pub struct SkipBlockInfo {
+    /// The network of this skip block.
+    pub network_id: NetworkId,
+
     /// The number of the block for which the skip block is constructed.
     pub block_number: u32,
 
@@ -31,6 +35,7 @@ impl SkipBlockInfo {
     pub fn from_micro_block(block: &MicroBlock) -> Option<Self> {
         if block.is_skip_block() {
             Some(SkipBlockInfo {
+                network_id: block.header.network,
                 block_number: block.header.block_number,
                 vrf_entropy: block.header.seed.entropy(),
             })

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -286,6 +286,7 @@ impl TemporaryBlockProducer {
         let skip_block_info = {
             let blockchain = self.blockchain.read();
             SkipBlockInfo {
+                network_id: blockchain.network_id,
                 block_number: blockchain.block_number() + 1,
                 vrf_entropy: blockchain.head().seed().entropy(),
             }

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -209,6 +209,7 @@ pub fn next_skip_block(
     let prev_seed = blockchain.head().seed().clone();
 
     let skip_block_info = SkipBlockInfo {
+        network_id: blockchain.network_id,
         block_number,
         vrf_entropy: prev_seed.entropy(),
     };
@@ -490,6 +491,7 @@ fn create_skip_block_proof(
         .unwrap_or_else(|| blockchain.head().seed().clone());
 
     let skip_block_info = SkipBlockInfo {
+        network_id: blockchain.network_id,
         block_number: (blockchain.block_number() as i32 + 1 + config.block_number_offset) as u32,
         vrf_entropy: seed.entropy(),
     };

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -239,6 +239,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         }
 
         let skip_block_info = SkipBlockInfo {
+            network_id: self.blockchain.read().network_id,
             block_number: self.block_number,
             vrf_entropy: self.prev_seed.entropy(),
         };

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -288,6 +288,7 @@ async fn validator_can_catch_up() {
         .collect();
 
     let skip_block_info = SkipBlockInfo {
+        network_id: blockchain.read().network_id,
         block_number: 1,
         vrf_entropy: blockchain.read().head().seed().entropy(),
     };


### PR DESCRIPTION
Add `network_id` to `SkipBlockInfo` to prevent usage of the skip block signature across networks.