### PR TITLE
nimiq-client: Adhere to `mempool` section in `client.toml`

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -937,6 +937,13 @@ impl ClientConfigBuilder {
             }
         }
 
+        #[cfg(feature = "nimiq-mempool")]
+        {
+            if let Some(mempool_settings) = &config_file.mempool {
+                self.mempool = Some(MempoolConfig::from(mempool_settings.clone()));
+            }
+        }
+
         Ok(self)
     }
 


### PR DESCRIPTION
## What's in this pull request?
Fix that the whole `mempool` section, including the rules and filters, was ignored.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
