### PR TITLE
Use `tokio::sync::broadcast::Sender::new` instead of `channel`

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -21,12 +21,12 @@ use nimiq_primitives::{
 };
 use nimiq_trie::WriteTransactionProxy as TrieMdbxWriteTransaction;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
-use tokio::sync::broadcast::Sender as BroadcastSender;
+use tokio::sync::broadcast;
 
 use super::PostValidationHook;
 use crate::{interface::HistoryInterface, Blockchain};
 
-fn send_vec(log_notifier: &BroadcastSender<BlockLog>, logs: Vec<BlockLog>) {
+fn send_vec(log_notifier: &broadcast::Sender<BlockLog>, logs: Vec<BlockLog>) {
     for log in logs {
         // The log notifier is for informational purposes only, thus may have no listeners.
         // Therefore, no error logs should be produced in this case.

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -2,7 +2,7 @@ use futures::stream::BoxStream;
 use nimiq_block::Block;
 use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
 pub use proxy::BlockQueueProxy as BlockQueue;
-use tokio::sync::oneshot::Sender as OneshotSender;
+use tokio::sync::oneshot;
 
 use crate::{
     consensus::ResolveBlockError,
@@ -20,7 +20,7 @@ pub type GossipSubBlockStream<N> = BoxStream<'static, (Block, <N as Network>::Pu
 
 pub type BlockAndSource<N> = (Block, BlockSource<N>);
 
-pub type ResolveBlockSender<N> = OneshotSender<Result<Block, ResolveBlockError<N>>>;
+pub type ResolveBlockSender<N> = oneshot::Sender<Result<Block, ResolveBlockError<N>>>;
 
 pub enum QueuedBlock<N: Network> {
     Head(BlockAndSource<N>),

--- a/consensus/src/sync/live/mod.rs
+++ b/consensus/src/sync/live/mod.rs
@@ -11,7 +11,7 @@ use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_bls::cache::PublicKeyCache;
 use nimiq_network_interface::network::Network;
 use parking_lot::Mutex;
-use tokio::sync::mpsc::{channel as mpsc, Sender as MpscSender};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 #[cfg(feature = "full")]
@@ -53,7 +53,7 @@ pub struct LiveSyncer<N: Network, Q: LiveSyncQueue<N>> {
     /// Channel used to communicate additional blocks to the queue.
     /// We use this to wake up the queue and pass in new, unknown blocks
     /// received in the consensus as part of the head requests.
-    block_tx: MpscSender<BlockAndSource<N>>,
+    block_tx: mpsc::Sender<BlockAndSource<N>>,
 }
 
 impl<N: Network, Q: LiveSyncQueue<N>> LiveSyncer<N, Q> {
@@ -63,7 +63,7 @@ impl<N: Network, Q: LiveSyncQueue<N>> LiveSyncer<N, Q> {
         mut queue: Q,
         bls_cache: Arc<Mutex<PublicKeyCache>>,
     ) -> Self {
-        let (tx, rx) = mpsc(MAX_BLOCK_STREAM_BUFFER);
+        let (tx, rx) = mpsc::channel(MAX_BLOCK_STREAM_BUFFER);
         queue.add_block_stream(ReceiverStream::new(rx));
         Self {
             blockchain,

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -105,7 +105,7 @@ impl Network {
         let local_peer_id = *Swarm::local_peer_id(&swarm);
         let connected_peers = Arc::new(RwLock::new(HashMap::new()));
 
-        let (events_tx, _) = broadcast::channel(64);
+        let events_tx = broadcast::Sender::new(64);
         let (action_tx, action_rx) = mpsc::channel(64);
         let (validate_tx, validate_rx) = mpsc::unbounded_channel();
 

--- a/network-mock/src/hub.rs
+++ b/network-mock/src/hub.rs
@@ -89,7 +89,7 @@ impl MockHubInner {
             .entry(topic_name)
             .or_insert_with(|| MockTopic {
                 peers: HashSet::new(),
-                sender: broadcast::channel(16).0,
+                sender: broadcast::Sender::new(16),
             });
 
         // Add the peer address to the subscribed peer list.

--- a/network-mock/src/observable_hash_map.rs
+++ b/network-mock/src/observable_hash_map.rs
@@ -33,8 +33,10 @@ impl<K: Clone + Eq + Hash, V: Clone> Default for ObservableHashMap<K, V> {
 
 impl<K: Clone + Eq + Hash, V: Clone> From<HashMap<K, V>> for ObservableHashMap<K, V> {
     fn from(inner: HashMap<K, V>) -> ObservableHashMap<K, V> {
-        let (tx, _) = broadcast::channel(64);
-        ObservableHashMap { inner, tx }
+        ObservableHashMap {
+            inner,
+            tx: broadcast::Sender::new(64),
+        }
     }
 }
 


### PR DESCRIPTION
Using `channel` creates an unneeded receiver.