### PR TITLE
database: Allow full nodes to index history items

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -425,7 +425,7 @@ impl ClientInner {
             #[cfg(feature = "full-consensus")]
             SyncMode::Full => {
                 blockchain_config.keep_history = false;
-                blockchain_config.index_history = false;
+                blockchain_config.index_history = config.consensus.index_history;
 
                 let blockchain = match Blockchain::new(
                     environment.clone(),

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -106,9 +106,8 @@ sync_mode = "full"
 # Default: 10800 (3 hours worth of blocks)
 #full_sync_threshold = 10800
 
-# Enable or disable transaction indexing for history nodes.
-# This property only has an effect when the sync_mode is "history"
-# Default: true
+# Enable or disable transaction indexing for history and full nodes.
+# Default: true when the sync_mode is "history" and false when the sync_mode is "full".
 #index_history = true
 
 ##############################################################################

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -220,9 +220,9 @@ pub struct ConsensusSettings {
     pub min_peers: Option<usize>,
     /// Minimum distance away, in number of blocks, from the head to switch from state sync to live sync
     pub full_sync_threshold: Option<u32>,
-    /// History indices enabled. Only effective for history nodes (default: `true`)
-    #[serde(default = "default_true")]
-    pub index_history: bool,
+    /// History indices enabled. Only effective for history and full nodes.
+    #[serde(default)]
+    pub index_history: Option<bool>,
 }
 
 impl Default for ConsensusSettings {
@@ -233,7 +233,7 @@ impl Default for ConsensusSettings {
             network: None,
             min_peers: None,
             full_sync_threshold: None,
-            index_history: true,
+            index_history: None,
         }
     }
 }


### PR DESCRIPTION
## What's in this pull request?
Optionally allow full nodes to also index the history. The default for `index_history` per node type remains untouched: `true` for history nodes, `false` for the other node types. By being able to index the history allows full nodes to use RPC methods where the index is required: `get_transaction_by_hash`, `get_transaction_hashes_by_address` and `get_transactions_by_address`.

Setting `index_history` to `true` for light nodes won't change the behaviour of the node as this property is ignored.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
