### PR TITLE
DB: Liforeclaim -> true

### DIFF
--- a/database/src/mdbx/database.rs
+++ b/database/src/mdbx/database.rs
@@ -59,6 +59,7 @@ impl From<DatabaseConfig> for libmdbx::DatabaseOptions {
                 max_size: value.size.map(|r| r.end),
                 ..Default::default()
             }),
+            liforeclaim: true,
             ..Default::default()
         }
     }


### PR DESCRIPTION
Setting liforeclaim to true provides better performance when prunning epochs with lots of data


...
#### This fixes #___.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
