### PR TITLE
Validator address as key for the Dht

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,6 +3826,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nimiq-dht"
+version = "1.0.0-rc.2"
+dependencies = [
+ "nimiq-blockchain-interface",
+ "nimiq-blockchain-proxy",
+ "nimiq-keys",
+ "nimiq-log",
+ "nimiq-network-libp2p",
+ "nimiq-serde",
+ "nimiq-utils",
+ "nimiq-validator-network",
+ "tracing",
+]
+
+[[package]]
 name = "nimiq-fuzz"
 version = "1.0.0-rc.2"
 dependencies = [
@@ -4060,6 +4075,7 @@ dependencies = [
  "nimiq-bls",
  "nimiq-consensus",
  "nimiq-database",
+ "nimiq-dht",
  "nimiq-genesis",
  "nimiq-hash",
  "nimiq-jsonrpc-core",
@@ -4284,8 +4300,8 @@ dependencies = [
  "instant",
  "ip_network",
  "libp2p",
- "nimiq-bls",
  "nimiq-hash",
+ "nimiq-keys",
  "nimiq-macros",
  "nimiq-network-interface",
  "nimiq-serde",
@@ -4862,8 +4878,9 @@ version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "futures-util",
- "nimiq-bls",
+ "nimiq-keys",
  "nimiq-network-interface",
+ "nimiq-primitives",
  "nimiq-serde",
  "nimiq-utils",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "database",
   "database/database-value",
   "database/database-value-derive",
+  "dht",
   "fuzz",
   "genesis",
   "genesis-builder",
@@ -189,6 +190,7 @@ nimiq-consensus = { path = "consensus", default-features = false }
 nimiq-database = { path = "database", default-features = false }
 nimiq-database-value = { path = "database/database-value", default-features = false }
 nimiq-database-value-derive = { path = "database/database-value-derive", default-features = false }
+nimiq-dht = { path = "dht", default-features = false }
 nimiq-genesis = { path = "genesis", default-features = false }
 nimiq-genesis-builder = { path = "genesis-builder", default-features = false }
 nimiq-handel = { path = "handel", default-features = false }

--- a/dht/Cargo.toml
+++ b/dht/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "nimiq-validator-network"
+name = "nimiq-dht"
 version.workspace = true
 authors.workspace = true
-license.workspace = true
 edition.workspace = true
-description = "Nimiq's validator network abstraction in Rust"
+description = "Nimiq Dht verifier implementation."
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 categories.workspace = true
 keywords.workspace = true
 
@@ -20,17 +20,14 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-async-trait = "0.1"
-futures = { workspace = true }
 log = { workspace = true }
-parking_lot = "0.12"
-serde = "1.0"
-thiserror = "1.0"
-time = { version = "0.3" }
-tokio = { version = "1.41", features = ["rt"] }
 
+nimiq-blockchain-interface = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true }
 nimiq-keys = { workspace = true }
-nimiq-network-interface = { workspace = true }
-nimiq-primitives = { workspace = true }
+nimiq-log = { workspace = true, optional = true }
+nimiq-network-libp2p = { workspace = true }
 nimiq-serde = { workspace = true }
-nimiq-utils = { workspace = true, features = ["futures", "spawn", "tagged-signing"] }
+nimiq-utils = { workspace = true }
+nimiq-validator-network = { workspace = true }
+

--- a/dht/src/lib.rs
+++ b/dht/src/lib.rs
@@ -1,0 +1,85 @@
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_keys::{Address, KeyPair};
+use nimiq_network_libp2p::{
+    dht::{DhtRecord, DhtVerifierError, Verifier as DhtVerifier},
+    libp2p::kad::Record,
+    PeerId,
+};
+use nimiq_serde::Deserialize;
+use nimiq_utils::tagged_signing::{TaggedSignable, TaggedSigned};
+use nimiq_validator_network::validator_record::ValidatorRecord;
+
+pub struct Verifier {
+    blockchain: BlockchainProxy,
+}
+
+impl Verifier {
+    pub fn new(blockchain: BlockchainProxy) -> Self {
+        Self { blockchain }
+    }
+
+    fn verify_validator_record(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError> {
+        // Deserialize the value of the record, which is a ValidatorRecord. If it fails return an error.
+        let validator_record =
+            TaggedSigned::<ValidatorRecord<PeerId>, KeyPair>::deserialize_from_vec(&record.value)
+                .map_err(DhtVerifierError::MalformedValue)?;
+
+        // Deserialize the key of the record which is an Address. If it fails return an error.
+        let validator_address = Address::deserialize_from_vec(record.key.as_ref())
+            .map_err(DhtVerifierError::MalformedKey)?;
+
+        // Acquire blockchain read access. For now exclude Light clients.
+        let blockchain = match self.blockchain {
+            BlockchainProxy::Light(ref _light_blockchain) => {
+                return Err(DhtVerifierError::UnknownTag)
+            }
+            BlockchainProxy::Full(ref full_blockchain) => full_blockchain,
+        };
+        let blockchain_read = blockchain.read();
+
+        // Get the staking contract to retrieve the public key for verification.
+        let staking_contract = blockchain_read
+            .get_staking_contract_if_complete(None)
+            .ok_or(DhtVerifierError::StateIncomplete)?;
+
+        // Get the public key needed for verification.
+        let data_store = blockchain_read.get_staking_contract_store();
+        let txn = blockchain_read.read_transaction();
+        let public_key = staking_contract
+            .get_validator(&data_store.read(&txn), &validator_address)
+            .ok_or(DhtVerifierError::UnknownValidator(validator_address))?
+            .signing_key;
+
+        // Verify the record.
+        validator_record
+            .verify(&public_key)
+            .then(|| {
+                DhtRecord::Validator(
+                    record.publisher.unwrap(),
+                    validator_record.record,
+                    record.clone(),
+                )
+            })
+            .ok_or(DhtVerifierError::InvalidSignature)
+    }
+}
+
+impl DhtVerifier for Verifier {
+    fn verify(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError> {
+        // Peek the tag to know what kind of record this is.
+        let Some(tag) = TaggedSigned::<ValidatorRecord<PeerId>, KeyPair>::peek_tag(&record.value)
+        else {
+            log::warn!(?record, "DHT Tag not peekable.");
+            return Err(DhtVerifierError::MalformedTag);
+        };
+
+        // Depending on tag perform the verification.
+        match tag {
+            ValidatorRecord::<PeerId>::TAG => self.verify_validator_record(record),
+            _ => {
+                log::error!(tag, "DHT invalid record tag received");
+                Err(DhtVerifierError::UnknownTag)
+            }
+        }
+    }
+}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,6 +57,7 @@ nimiq-blockchain-proxy = { workspace = true, default-features = false }
 nimiq-bls = { workspace = true }
 nimiq-consensus = { workspace = true, default-features = false }
 nimiq-database = { workspace = true, optional = true }
+nimiq-dht = { workspace = true }
 nimiq-genesis = { workspace = true, default-features = false }
 nimiq-hash = { workspace = true }
 nimiq-jsonrpc-core = { workspace = true, optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,7 +57,7 @@ nimiq-blockchain-proxy = { workspace = true, default-features = false }
 nimiq-bls = { workspace = true }
 nimiq-consensus = { workspace = true, default-features = false }
 nimiq-database = { workspace = true, optional = true }
-nimiq-dht = { workspace = true }
+nimiq-dht = { workspace = true, optional = true }
 nimiq-genesis = { workspace = true, default-features = false }
 nimiq-hash = { workspace = true }
 nimiq-jsonrpc-core = { workspace = true, optional = true }
@@ -95,6 +95,7 @@ full-consensus = [
     "database-storage",
     "nimiq-blockchain",
     "nimiq-consensus/full",
+    "nimiq-dht",
     "nimiq-network-libp2p/kad",
 ]
 launcher = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -95,6 +95,7 @@ full-consensus = [
     "database-storage",
     "nimiq-blockchain",
     "nimiq-consensus/full",
+    "nimiq-network-libp2p/kad",
 ]
 launcher = []
 logging = ["nimiq-log", "serde_json", "tokio", "tracing-subscriber"]

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -13,6 +13,7 @@ use nimiq_consensus::{
     sync::syncer_proxy::SyncerProxy, Consensus as AbstractConsensus,
     ConsensusProxy as AbstractConsensusProxy,
 };
+#[cfg(feature = "full-consensus")]
 use nimiq_dht::Verifier;
 #[cfg(feature = "zkp-prover")]
 use nimiq_genesis::NetworkId;
@@ -417,10 +418,18 @@ impl ClientInner {
         };
 
         // Create the Dht verifier
+        #[cfg(feature = "full-consensus")]
         let dht_verifier = Verifier::new(blockchain_proxy.clone());
 
         // Create the network.
-        let network = Arc::new(Network::new(network_config, dht_verifier).await);
+        let network = Arc::new(
+            Network::new(
+                network_config,
+                #[cfg(feature = "full-consensus")]
+                dht_verifier,
+            )
+            .await,
+        );
 
         // Start buffering network events as early as possible
         let network_events = network.subscribe_events();

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -25,6 +25,7 @@ pub static NIMIQ_MODULES: &[&str] = &[
     "nimiq_collections",
     "nimiq_consensus",
     "nimiq_database",
+    "nimiq_dht",
     "nimiq_genesis",
     "nimiq_genesis_builder",
     "nimiq_handel",

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -42,7 +42,7 @@ tokio-stream = "0.1"
 unsigned-varint = "0.8"
 void = "1.0"
 
-nimiq-bls = { workspace = true }
+nimiq-keys = { workspace = true } 
 nimiq-macros = { workspace = true }
 nimiq-network-interface = { workspace = true }
 nimiq-hash = { workspace = true }

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -42,7 +42,7 @@ tokio-stream = "0.1"
 unsigned-varint = "0.8"
 void = "1.0"
 
-nimiq-keys = { workspace = true } 
+nimiq-keys = { workspace = true }
 nimiq-macros = { workspace = true }
 nimiq-network-interface = { workspace = true }
 nimiq-hash = { workspace = true }
@@ -92,5 +92,6 @@ nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }
 
 [features]
+kad = []
 metrics = ["prometheus-client"]
 tokio-websocket = ["libp2p/dns", "libp2p/tcp", "libp2p/tokio", "libp2p/websocket"]

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -37,6 +37,7 @@ pub struct Behaviour {
     pub discovery: discovery::Behaviour,
     pub autonat_server: autonat::server::Behaviour,
     pub autonat_client: autonat::client::Behaviour,
+    #[cfg(feature = "kad")]
     pub dht: kad::Behaviour<MemoryStore>,
     pub gossipsub: gossipsub::Behaviour,
     pub ping: ping::Behaviour,
@@ -55,7 +56,9 @@ impl Behaviour {
 
         // DHT behaviour
         let store = MemoryStore::new(peer_id);
+        #[cfg(feature = "kad")]
         let mut dht = kad::Behaviour::with_config(peer_id, store, config.kademlia);
+        #[cfg(feature = "kad")]
         if force_dht_server_mode {
             dht.set_mode(Some(kad::Mode::Server));
         }
@@ -125,6 +128,7 @@ impl Behaviour {
         let connection_limits = connection_limits::Behaviour::new(limits);
 
         Self {
+            #[cfg(feature = "kad")]
             dht,
             discovery,
             gossipsub,
@@ -140,17 +144,20 @@ impl Behaviour {
     /// Adds a peer address into the DHT
     pub fn add_peer_address(&mut self, peer_id: PeerId, address: Multiaddr) {
         // Add address to the DHT
+        #[cfg(feature = "kad")]
         self.dht.add_address(&peer_id, address);
     }
 
     /// Removes a peer from the DHT
     pub fn remove_peer(&mut self, peer_id: PeerId) {
+        #[cfg(feature = "kad")]
         self.dht.remove_peer(&peer_id);
     }
 
     /// Removes a peer address from the DHT
     pub fn remove_peer_address(&mut self, peer_id: PeerId, address: Multiaddr) {
         // Remove address from the DHT
+        #[cfg(feature = "kad")]
         self.dht.remove_address(&peer_id, &address);
     }
 

--- a/network-libp2p/src/dht.rs
+++ b/network-libp2p/src/dht.rs
@@ -1,0 +1,32 @@
+use libp2p::{kad::Record, PeerId};
+use nimiq_keys::Address;
+use nimiq_serde::DeserializeError;
+use nimiq_validator_network::validator_record::ValidatorRecord;
+
+pub use crate::network_types::DhtRecord;
+
+#[derive(Debug)]
+pub enum DhtVerifierError {
+    MalformedTag,
+    MalformedKey(DeserializeError),
+    MalformedValue(DeserializeError),
+    UnknownTag,
+    UnknownValidator(Address),
+    StateIncomplete,
+    InvalidSignature,
+}
+
+pub trait Verifier: Send + Sync {
+    fn verify(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError>;
+}
+
+/// Dummy implementation for testcases
+impl Verifier for () {
+    fn verify(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError> {
+        Ok(DhtRecord::Validator(
+            PeerId::random(),
+            ValidatorRecord::<PeerId>::new(PeerId::random(), 0u64),
+            record.clone(),
+        ))
+    }
+}

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -5,6 +5,7 @@ mod autonat;
 mod behaviour;
 mod config;
 mod connection_pool;
+pub mod dht;
 pub mod discovery;
 pub mod dispatch;
 mod error;

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -37,6 +37,7 @@ use tokio_stream::wrappers::{BroadcastStream, ReceiverStream};
 #[cfg(feature = "metrics")]
 use crate::network_metrics::NetworkMetrics;
 use crate::{
+    dht,
     discovery::peer_contacts::PeerContactBook,
     network_types::{GossipsubId, NetworkAction, ValidateMessage},
     rate_limiting::RateLimitConfig,
@@ -74,8 +75,9 @@ impl Network {
     /// # Arguments
     ///
     ///  - `config`: The network configuration, containing key pair, and other behavior-specific configuration.
+    ///  - `dht_verifier`: The verifier used to verify all Dht records.
     ///
-    pub async fn new(config: Config) -> Self {
+    pub async fn new(config: Config, dht_verifier: impl dht::Verifier + 'static) -> Self {
         let required_services = config.required_services;
         // TODO: persist to disk
         let own_peer_contact = config.peer_contact.clone();
@@ -122,6 +124,7 @@ impl Network {
             Arc::clone(&connected_peers),
             update_scores,
             Arc::clone(&contacts),
+            dht_verifier,
             force_dht_server_mode,
             dht_quorum,
             #[cfg(feature = "metrics")]

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -77,7 +77,10 @@ impl Network {
     ///  - `config`: The network configuration, containing key pair, and other behavior-specific configuration.
     ///  - `dht_verifier`: The verifier used to verify all Dht records.
     ///
-    pub async fn new(config: Config, dht_verifier: impl dht::Verifier + 'static) -> Self {
+    pub async fn new(
+        config: Config,
+        #[cfg(feature = "kad")] dht_verifier: impl dht::Verifier + 'static,
+    ) -> Self {
         let required_services = config.required_services;
         // TODO: persist to disk
         let own_peer_contact = config.peer_contact.clone();
@@ -124,6 +127,7 @@ impl Network {
             Arc::clone(&connected_peers),
             update_scores,
             Arc::clone(&contacts),
+            #[cfg(feature = "kad")]
             dht_verifier,
             force_dht_server_mode,
             dht_quorum,

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -10,7 +10,7 @@ use libp2p::{
     swarm::NetworkInfo,
     Multiaddr, PeerId,
 };
-use nimiq_bls::KeyPair;
+use nimiq_keys::KeyPair;
 use nimiq_network_interface::{
     network::{CloseReason, MsgAcceptance, PubsubId, Topic},
     peer_info::Services,
@@ -140,7 +140,7 @@ pub(crate) enum DhtBootStrapState {
 
 /// Enum over all of the possible DHT records values
 #[derive(Clone, PartialEq)]
-pub(crate) enum DhtRecord {
+pub enum DhtRecord {
     /// Validator record with its publisher Peer ID,
     /// the decoded validator record and the original serialized record.
     Validator(PeerId, ValidatorRecord<PeerId>, Record),
@@ -174,7 +174,7 @@ impl PartialOrd for DhtRecord {
 
 /// DHT record decoding errors
 #[derive(Debug, Error)]
-pub(crate) enum DhtRecordError {
+pub enum DhtRecordError {
     /// Tag is unknown
     #[error("Unknown record tag")]
     UnknownTag,

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -62,6 +62,7 @@ struct EventInfo<'a> {
     state: &'a mut TaskState,
     connected_peers: &'a RwLock<HashMap<PeerId, PeerInfo>>,
     rate_limiting: &'a mut RateLimits,
+    #[cfg(feature = "kad")]
     dht_verifier: &'a dyn dht::Verifier,
     #[cfg(feature = "metrics")]
     metrics: &'a Arc<NetworkMetrics>,
@@ -113,7 +114,7 @@ pub(crate) async fn swarm_task(
     connected_peers: Arc<RwLock<HashMap<PeerId, PeerInfo>>>,
     mut update_scores: Interval,
     contacts: Arc<RwLock<PeerContactBook>>,
-    dht_verifier: impl dht::Verifier,
+    #[cfg(feature = "kad")] dht_verifier: impl dht::Verifier,
     force_dht_server_mode: bool,
     dht_quorum: NonZeroU8,
     #[cfg(feature = "metrics")] metrics: Arc<NetworkMetrics>,
@@ -160,6 +161,7 @@ pub(crate) async fn swarm_task(
                                 state: &mut task_state,
                                 connected_peers: &connected_peers,
                                 rate_limiting: &mut rate_limiting,
+                                #[cfg(feature = "kad")]
                                 dht_verifier: &dht_verifier,
                                 #[cfg( feature = "metrics")] metrics: &metrics,
                             },

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -113,10 +113,10 @@ impl TestNetwork {
         let addr1 = multiaddr![Memory(rng.gen::<u64>())];
         let addr2 = multiaddr![Memory(rng.gen::<u64>())];
 
-        let net1 = Network::new(network_config(addr1.clone())).await;
+        let net1 = Network::new(network_config(addr1.clone()), ()).await;
         net1.listen_on(vec![addr1.clone()]).await;
 
-        let net2 = Network::new(network_config(addr2.clone())).await;
+        let net2 = Network::new(network_config(addr2.clone()), ()).await;
         net2.listen_on(vec![addr2.clone()]).await;
 
         log::debug!(address = %addr1, peer_id = %net1.get_local_peer_id(), "Network 1");
@@ -154,16 +154,16 @@ impl TestNetwork {
         let addr3 = multiaddr![Memory(rng.gen::<u64>())];
         let addr4 = multiaddr![Memory(rng.gen::<u64>())];
 
-        let net1 = Network::new(network_config(addr1.clone())).await;
+        let net1 = Network::new(network_config(addr1.clone()), ()).await;
         net1.listen_on(vec![addr1.clone()]).await;
 
-        let net2 = Network::new(network_config(addr2.clone())).await;
+        let net2 = Network::new(network_config(addr2.clone()), ()).await;
         net2.listen_on(vec![addr2.clone()]).await;
 
-        let net3 = Network::new(network_config(addr3.clone())).await;
+        let net3 = Network::new(network_config(addr3.clone()), ()).await;
         net3.listen_on(vec![addr3.clone()]).await;
 
-        let net4 = Network::new(network_config(addr4.clone())).await;
+        let net4 = Network::new(network_config(addr4.clone()), ()).await;
         net4.listen_on(vec![addr4.clone()]).await;
 
         log::debug!(address = %addr1, peer_id = %net1.get_local_peer_id(), "Network 1");

--- a/network-mock/src/lib.rs
+++ b/network-mock/src/lib.rs
@@ -152,6 +152,7 @@ pub mod tests {
     }
 
     #[test(tokio::test)]
+    #[cfg(feature = "kad")]
     async fn dht_put_and_get() {
         let mut hub = MockHub::new();
         let mut rng = test_rng(false);

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -82,7 +82,7 @@ impl TestNetwork for Network {
             true,
             NonZeroU8::new(1).unwrap(),
         );
-        let network = Arc::new(Network::new(config).await);
+        let network = Arc::new(Network::new(config, ()).await);
         network.listen_on(vec![peer_address]).await;
         network
     }

--- a/validator-network/src/lib.rs
+++ b/validator-network/src/lib.rs
@@ -5,11 +5,12 @@ pub mod validator_record;
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use nimiq_bls::{lazy::LazyPublicKey, CompressedPublicKey, SecretKey};
+use nimiq_keys::{Address, KeyPair};
 use nimiq_network_interface::{
     network::{CloseReason, MsgAcceptance, Network, SubscribeEvents, Topic},
     request::{Message, Request, RequestCommon},
 };
+use nimiq_primitives::slots_allocation::Validators;
 
 pub use crate::error::NetworkError;
 
@@ -28,9 +29,9 @@ pub trait ValidatorNetwork: Send + Sync {
     /// `None`, otherwise.
     fn set_validator_id(&self, validator_id: Option<u16>);
 
-    /// Tells the validator network the validator keys for the current set of active validators.
+    /// Tells the validator network the validator addresses for the current set of active validators.
     /// The keys must be ordered, such that the k-th entry is the validator with ID k.
-    async fn set_validators(&self, validator_keys: Vec<LazyPublicKey>);
+    fn set_validators(&self, validators: &Validators);
 
     /// Sends a message to a validator identified by its ID (position) in the `validator keys`.
     /// It must make a reasonable effort to establish a connection to the peer denoted with `validator_id`
@@ -79,8 +80,8 @@ pub trait ValidatorNetwork: Send + Sync {
     /// Sets this node peer ID using its secret key and public key.
     async fn set_public_key(
         &self,
-        public_key: &CompressedPublicKey,
-        secret_key: &SecretKey,
+        validator_address: &Address,
+        signing_key_pair: &KeyPair,
     ) -> Result<(), Self::Error>;
 
     /// Closes the connection to the peer with `peer_id` with the given `close_reason`.


### PR DESCRIPTION
Previous to this PR The Dht used the voting public key as the key in the dht. The record was also signed by this key. In this PR that changes to the record using the validator address as key and signing it using the signing key. Obviously the verifying key now needs to be obtained elsewhere as it is no longer part of the record itself.

The validator address is unambiguous. There exists only one validator with that address. The public key (signing or voting) could, in theory, be used by multiple validators.

When rotating keys this also provided a challenge, since the public key in the current validators set will not change as it is obtained from the previous election block. So the lookup key (old public key) must still be retained until the epoch ends to renew these entries (which was also not happening).

Lastly the change of the signature makes sense as there is no benefit in using the voting key over the signing key. Also semantically it makes far more sense to use the signing key here.

## Remaining todos:
- [ ] Light client support: Light clients do not have access to a staking contract. A different means of acquiring the verification key is required.
- [ ] Triggering an immediate Dht put with the updated signature in case the signing key is changed. The old entry will no longer verify as the current staking contracts keys are used.