### PR TITLE
Re-add accounts diff pruning

### DIFF
--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -53,10 +53,6 @@ impl Blockchain {
                     return Err(PushError::MissingAccountsTrieDiff);
                 }
 
-                // Macro blocks are final and receipts for the previous batch are no longer necessary
-                // as rebranching across this block is not possible.
-                self.chain_store.clear_revert_infos(txn.raw());
-
                 let total_tx_size = self
                     .history_store
                     .add_block(txn.raw(), block, inherents)

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -352,10 +352,6 @@ impl Blockchain {
         // Unwrap the block.
         let macro_block = block.unwrap_macro_ref();
 
-        // Macro blocks are final and receipts for the previous batch are no longer necessary
-        // as rebranching across this block is not possible.
-        this.chain_store.clear_revert_infos(&mut txn);
-
         // Store the new historic transactions into the History tree.
         this.history_store.add_to_history(
             &mut txn,
@@ -411,6 +407,8 @@ impl Blockchain {
             this.metrics.note_invalid_block();
             return Err(PushError::InvalidBlock(BlockError::AccountsHashMismatch));
         }
+
+        this.chain_store.finalize_batch(&mut txn);
 
         // Give up database transactions and push lock before creating notifications.
         txn.commit();

--- a/blockchain/src/chain_store.rs
+++ b/blockchain/src/chain_store.rs
@@ -6,7 +6,7 @@ use nimiq_blockchain_interface::{BlockchainError, ChainInfo, Direction};
 use nimiq_database::{
     declare_table,
     mdbx::{MdbxDatabase, MdbxReadTransaction, MdbxWriteTransaction, OptionalTransaction},
-    traits::{Database, DupReadCursor, ReadCursor, ReadTransaction, WriteCursor, WriteTransaction},
+    traits::{Database, DupReadCursor, ReadCursor, ReadTransaction, WriteTransaction},
 };
 use nimiq_database_value_derive::DbSerializable;
 use nimiq_hash::Blake2bHash;
@@ -620,6 +620,7 @@ impl ChainStore {
                 if chain_info.prunable {
                     txn.remove(&self.chain_table, &hash);
                     txn.remove(&self.pushed_block_table, &hash);
+                    txn.remove(&self.accounts_diff_table, &hash);
                     txn.remove_item(&self.height_idx, &height, &hash);
                 }
             }
@@ -641,6 +642,9 @@ impl ChainStore {
         }
         // Then clear the stored block table
         txn.clear_table(&self.stored_block_table);
+        // Macro blocks are final and receipts for the previous batch are no longer necessary
+        // as rebranching across this block is not possible.
+        txn.clear_table(&self.revert_table);
     }
 
     /// Puts a revert info for a block height
@@ -662,16 +666,6 @@ impl ChainStore {
         let txn = txn_option.or_new(&self.db);
 
         txn.get(&self.revert_table, &block_height)
-    }
-
-    pub fn clear_revert_infos(&self, txn: &mut MdbxWriteTransaction) {
-        let mut cursor = WriteTransaction::cursor(txn, &self.revert_table);
-        let mut pos: Option<(u32, RevertInfo)> = cursor.first();
-
-        while pos.is_some() {
-            cursor.remove();
-            pos = cursor.next();
-        }
     }
 
     pub fn put_accounts_diff(


### PR DESCRIPTION
- Improve clearing revert infos.
- Prune accounts diffs.

This reverts the revert of the original commit on 5de29b8.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
