### PR TITLE
lib: Update config file settings for mainnet

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -633,15 +633,10 @@ pub struct ClientConfig {
 
     /// The Nimiq network the client should connect to. Usually this should be either `Test` or
     /// `Main` for the Nimiq 1.0 networks. For Albatross there is `MainAlbatross`, `TestAlbatross`
-    /// and `DevAlbatross` available. Since Albatross is still in development at time of writing,
-    /// it is recommended to use `TestAlbatross`.
+    /// and `DevAlbatross` available.
     ///
-    /// Default is `TestAlbatross`
-    ///
-    /// # TODO
-    ///
-    ///  - Rename, to avoid confusion with the libp2p network
-    #[builder(default = "NetworkId::TestAlbatross")]
+    /// Default is `MainAlbatross`
+    #[builder(default = "NetworkId::MainAlbatross")]
     pub network_id: NetworkId,
 
     /// Determines where the database is stored.
@@ -711,6 +706,11 @@ impl ClientConfigBuilder {
     /// Sets the network ID to the Albatross TestNet
     pub fn test(&mut self) -> &mut Self {
         self.network_id(NetworkId::TestAlbatross)
+    }
+
+    /// Sets the network ID to the Albatross MainNet
+    pub fn main(&mut self) -> &mut Self {
+        self.network_id(NetworkId::MainAlbatross)
     }
 
     /// Configuration for Light Client

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -26,7 +26,10 @@ listen_addresses = [
 
 # Seed nodes to connect to when the node starts up. Multiple addresses can be specified.
 seed_nodes = [
-  { address = "/dns4/seed1.pos.nimiq-testnet.com/tcp/8443/wss" },
+  { address = "/dns4/seed-1.pos.nimiq.com/tcp/8443/wss" },
+  { address = "/dns4/seed-2.pos.nimiq.com/tcp/8443/wss" },
+  { address = "/dns4/seed-3.pos.nimiq.com/tcp/8443/wss" },
+  { address = "/dns4/seed-4.pos.nimiq.com/tcp/8443/wss" },
 ]
 
 # Address(es) that will be advertised to peers instead of the ones in `listen_addresses`.
@@ -96,8 +99,8 @@ seed_nodes = [
 
 # The network to connect to.
 # Possible values: "main-albatross", "test-albatross", "dev-albatross"
-# Default: "test-albatross"
-network = "test-albatross"
+# Default: "main-albatross"
+network = "main-albatross"
 
 # The sync mode, which determines the client type.
 # Validator nodes require "full" or "history" sync mode.


### PR DESCRIPTION
Update configuration file settings for mainnet by:
- Pointing to mainnet seed nodes.
- Setting `main-albatross` as the network.

Also updated the default value of the network ID to be `MainAlbatross`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
