### PR TITLE
Validator: don't panic when micro block production fails

### DIFF
--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -19,7 +19,7 @@ use crate::{interface::HistoryInterface, Blockchain};
 
 #[derive(Debug, Error)]
 pub enum BlockProducerError {
-    #[error("Failed to commit: error={0}, account={1:?}, transactions={2:?}, inherents={3:?}")]
+    #[error("Failed to commit: error={0}, account={1:#?}, transactions={2:#?}, inherents={3:#?}")]
     AccountsError(AccountsError, Account, Vec<Transaction>, Vec<Inherent>),
     #[error("Failed to add to history")]
     HistoryError,

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -68,8 +68,6 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         }
     }
 
-    // TODO Remove this line
-    #[allow(unreachable_code)]
     async fn next(
         self,
     ) -> (
@@ -131,11 +129,6 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
                         %error,
                         "Failed to construct micro block"
                     );
-
-                    // Add an artificial panic here so that it's easier to catch any remaining
-                    // mempool bugs.
-                    // TODO Remove this line and the #[allow(unreachable_code)] annotation on this function.
-                    panic!("Failed to construct micro block");
 
                     // Sleep a bit to allow the task to be cancelled externally if needed.
                     delay = Duration::from_millis(50);


### PR DESCRIPTION
Remove artificial panic when block production fails.

Also pretty-print the corresponding error message to avoid it being truncated.