### PR TITLE
Add validator info to PeerContacts and add some additional checks

### DIFF
--- a/network-libp2p/src/dht.rs
+++ b/network-libp2p/src/dht.rs
@@ -1,17 +1,25 @@
 use libp2p::{kad::Record, PeerId};
 use nimiq_keys::Address;
+use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_serde::DeserializeError;
 use nimiq_validator_network::validator_record::ValidatorRecord;
 
 pub use crate::network_types::DhtRecord;
+use crate::Network;
 
 #[derive(Debug)]
 pub enum DhtVerifierError {
     MalformedTag,
+    UnknownTag,
     MalformedKey(DeserializeError),
     MalformedValue(DeserializeError),
-    UnknownTag,
     UnknownValidator(Address),
+    AddressMismatch(Address, Address),
+    PublisherMissing,
+    PublisherMismatch(
+        <Network as NetworkInterface>::PeerId,
+        <Network as NetworkInterface>::PeerId,
+    ),
     StateIncomplete,
     InvalidSignature,
 }

--- a/network-libp2p/src/dht.rs
+++ b/network-libp2p/src/dht.rs
@@ -23,9 +23,10 @@ pub trait Verifier: Send + Sync {
 /// Dummy implementation for testcases
 impl Verifier for () {
     fn verify(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError> {
+        let peer_id = PeerId::random();
         Ok(DhtRecord::Validator(
-            PeerId::random(),
-            ValidatorRecord::<PeerId>::new(PeerId::random(), 0u64),
+            peer_id,
+            ValidatorRecord::<PeerId>::new(peer_id, Address::default(), 0u64),
             record.clone(),
         ))
     }

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -293,7 +293,7 @@ async fn create_network_with_n_peers(
 
     // Wait for all PeerJoined events
     let all_joined = futures::stream::select_all(events)
-        .filter(|(local_peer_id, event)| {
+        .filter(|(_local_peer_id, event)| {
             std::future::ready(matches!(event, Ok(NetworkEvent::PeerJoined(..))))
         })
         .take(n_peers * (n_peers - 1))
@@ -490,17 +490,19 @@ async fn dht_put_and_get() {
     // FIXME: Add delay while networks share their addresses
     sleep(Duration::from_secs(2)).await;
 
-    let put_record = ValidatorRecord {
-        peer_id: net1.get_local_peer_id(),
-        timestamp: 0x42u64,
-    };
-
     // Generate a key
     let mut rng = test_rng(false);
     let keypair = KeyPair::generate(&mut rng);
 
     // Put it into the keys collection.
     let key: Address = (&keypair.public).into();
+
+    let put_record = ValidatorRecord {
+        peer_id: net1.get_local_peer_id(),
+        validator_address: key.clone(),
+        timestamp: 0x42u64,
+    };
+
     assert!(keys.write().insert(key.clone(), keypair.public).is_none());
 
     // Put the record into the dht, keyed by the address.

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -493,6 +493,7 @@ where
         let peer_id = self.network.get_local_peer_id();
         let record = ValidatorRecord::new(
             peer_id,
+            validator_address.clone(),
             (OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000) as u64,
         );
         self.network

--- a/validator-network/src/validator_record.rs
+++ b/validator-network/src/validator_record.rs
@@ -1,3 +1,4 @@
+use nimiq_keys::Address;
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_utils::tagged_signing::TaggedSignable;
 
@@ -17,6 +18,8 @@ where
 {
     /// Validator Peer ID
     pub peer_id: TPeerId,
+    /// The Address of the validator. This is the unique identifier of a validator.
+    pub validator_address: Address,
     /// Record timestamp in milliseconds since 1970-01-01 00:00:00 UTC, excluding leap seconds (Unix time)
     pub timestamp: u64,
 }
@@ -25,8 +28,12 @@ impl<TPeerId> ValidatorRecord<TPeerId>
 where
     TPeerId: Serialize + Deserialize,
 {
-    pub fn new(peer_id: TPeerId, timestamp: u64) -> Self {
-        Self { peer_id, timestamp }
+    pub fn new(peer_id: TPeerId, validator_address: Address, timestamp: u64) -> Self {
+        Self {
+            peer_id,
+            validator_address,
+            timestamp,
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds an optional validator info to PeerContacts. It is unused in this PR but will see use to resolve Validators alongside the Dht. Furthermore this introduces checks to make sure that peer_id and validator_addresses are matching for given records.