### PR TITLE
Clarify `BlockBodyMessage::header_hash`

### DIFF
--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -59,26 +59,26 @@ impl BlockHeaderMessage {
     pub fn split_block(block: Block) -> (BlockHeaderMessage, BlockBodyMessage) {
         match block {
             Block::Macro(block) => {
-                let header = BlockHeaderMessage::Macro {
+                let header_message = BlockHeaderMessage::Macro {
                     header: block.header,
                     justification: block.justification.expect("Justification is required"),
                 };
-                let body = BlockBodyMessage {
-                    header_hash: header.hash(),
+                let body_message = BlockBodyMessage {
+                    header_message_hash: header_message.hash(),
                     body: BlockBody::Macro(block.body.expect("Body is required")),
                 };
-                (header, body)
+                (header_message, body_message)
             }
             Block::Micro(block) => {
-                let header = BlockHeaderMessage::Micro {
+                let header_message = BlockHeaderMessage::Micro {
                     header: block.header,
                     justification: block.justification.expect("Justification is required"),
                 };
-                let body = BlockBodyMessage {
-                    header_hash: header.hash(),
+                let body_message = BlockBodyMessage {
+                    header_message_hash: header_message.hash(),
                     body: BlockBody::Micro(block.body.expect("Body is required")),
                 };
-                (header, body)
+                (header_message, body_message)
             }
         }
     }
@@ -124,7 +124,12 @@ impl From<BlockHeaderMessage> for Block {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockBodyMessage {
-    pub header_hash: Blake2bHash,
+    /// Hash of the corresponding [`BlockHeaderMessage`].
+    ///
+    /// This is used instead of the hash of the contained
+    /// [`MacroHeader`]/[`MicroHeader`] since the header hash wouldn't capture
+    /// the justification.
+    pub header_message_hash: Blake2bHash,
     pub body: BlockBody,
 }
 

--- a/consensus/src/sync/live/block_queue/assembler.rs
+++ b/consensus/src/sync/live/block_queue/assembler.rs
@@ -137,9 +137,9 @@ impl<N: Network> Stream for BlockAssembler<N> {
             };
 
             let hash = body.0.body.hash();
-            if let Some(header) = self.cached_headers.get(&body.0.header_hash) {
+            if let Some(header) = self.cached_headers.get(&body.0.header_message_hash) {
                 if *header.0.body_root() == hash {
-                    let header = self.cached_headers.remove(&body.0.header_hash).unwrap();
+                    let header = self.cached_headers.remove(&body.0.header_message_hash).unwrap();
 
                     // Check that header and body type match.
                     if header.0.ty() != body.0.body.ty() {
@@ -162,7 +162,7 @@ impl<N: Network> Stream for BlockAssembler<N> {
                 }
             }
 
-            let body_key = (hash, body.0.header_hash);
+            let body_key = (hash, body.0.header_message_hash);
             let cached_body = (body.0.body, body.1);
             self.cached_bodies.insert(body_key, cached_body);
         }

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -282,13 +282,10 @@ where
             proposal_hash,
         };
 
-        SingleResponseRequester::new(
-            Arc::clone(&self.network),
-            candidate_peers,
-            request,
-            (Arc::clone(&self.blockchain), self.block_height),
-            3,
-            |response, (blockchain, block_height)| {
+        SingleResponseRequester::new(Arc::clone(&self.network), candidate_peers, request, 3, {
+            let blockchain = Arc::clone(&self.blockchain);
+            let block_height = self.block_height;
+            Box::new(move |response| {
                 if let Some(signed_proposal) = response {
                     let blockchain = blockchain.read();
 
@@ -327,8 +324,8 @@ where
                     }
                 }
                 None
-            },
-        )
+            })
+        })
         .boxed()
     }
 


### PR DESCRIPTION
Refactor `BlockAssembler::poll_next` a bit: Explicitly name the body cache key members and destructure tuples with explicit names.