### PR TITLE
Prevent pruning pre-genesis data

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -366,8 +366,12 @@ impl Blockchain {
 
             if !this.config.keep_history {
                 // Prune the History Store.
-                this.history_store
-                    .remove_history(&mut txn, Policy::epoch_at(block_number).saturating_sub(1));
+                // We will never prune pre-genesis data here.
+                let pruned_history_epoch = Policy::epoch_at(block_number).saturating_sub(1);
+                if pruned_history_epoch > 0 {
+                    this.history_store
+                        .remove_history(&mut txn, pruned_history_epoch);
+                }
             }
         }
 

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -279,8 +279,12 @@ impl Blockchain {
 
             if !this.config.keep_history {
                 // Prune the History Store.
-                this.history_store
-                    .remove_history(&mut txn, Policy::epoch_at(block_number).saturating_sub(1));
+                // We will never prune pre-genesis data here.
+                let pruned_history_epoch = Policy::epoch_at(block_number).saturating_sub(1);
+                if pruned_history_epoch > 0 {
+                    this.history_store
+                        .remove_history(&mut txn, pruned_history_epoch);
+                }
             }
         }
 


### PR DESCRIPTION
## What's in this pull request?
With the separation of the pre-genesis data, we now follow the paradigm that all pre-genesis data is stored in an immutable database.
With the exception of the migration client, no-one should attempt to write that data.

Our current blockchain code attempted to prune the data for epoch 0, which this PR now removes.
Nodes which do not want to store/serve the pre-genesis data should simply delete the file and restart their client.
Since the presence of the file also sets some service flags, this is the cleanest option.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
