### PR TITLE
Fix feature compilation for several subcrates

### DIFF
--- a/dht/Cargo.toml
+++ b/dht/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 log = { workspace = true }
 
 nimiq-blockchain-interface = { workspace = true }
-nimiq-blockchain-proxy = { workspace = true }
+nimiq-blockchain-proxy = { workspace = true, features = ["full"] }
 nimiq-keys = { workspace = true }
 nimiq-log = { workspace = true, optional = true }
 nimiq-network-libp2p = { workspace = true }

--- a/mnemonic/Cargo.toml
+++ b/mnemonic/Cargo.toml
@@ -29,7 +29,7 @@ unicode-normalization = "0.1"
 nimiq-hash = { workspace = true }
 nimiq-key-derivation = { workspace = true, optional = true }
 nimiq-macros = { workspace = true }
-nimiq-utils = { workspace = true, features = ["crc", "otp"] }
+nimiq-utils = { workspace = true, features = ["crc", "key-rng", "otp"] }
 
 [dev-dependencies]
 nimiq-test-log = { workspace = true }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -62,7 +62,7 @@ nimiq-keys = { workspace = true }
 nimiq-log = { workspace = true }
 nimiq-mempool = { workspace = true }
 nimiq-network-interface = { workspace = true }
-nimiq-network-libp2p = { workspace = true }
+nimiq-network-libp2p = { workspace = true, features = ["kad"] }
 nimiq-network-mock = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["tendermint"] }
 nimiq-serde = { workspace = true }

--- a/validator-network/Cargo.toml
+++ b/validator-network/Cargo.toml
@@ -29,8 +29,8 @@ thiserror = "1.0"
 time = { version = "0.3" }
 tokio = { version = "1.41", features = ["rt"] }
 
-nimiq-keys = { workspace = true }
+nimiq-keys = { workspace = true, features = ["serde-derive"] }
 nimiq-network-interface = { workspace = true }
-nimiq-primitives = { workspace = true }
+nimiq-primitives = { workspace = true, features = ["slots"] }
 nimiq-serde = { workspace = true }
 nimiq-utils = { workspace = true, features = ["futures", "spawn", "tagged-signing"] }


### PR DESCRIPTION
Fix feature compilation for the following subcrates:
- `dht`
- `mnemonic`
- `test-utils`
- `validator-network`

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
