### PR TITLE
Increase timeouts for devnet and release scenarios 

### DIFF
--- a/.github/workflows/devnet_scenarios.yml
+++ b/.github/workflows/devnet_scenarios.yml
@@ -21,13 +21,13 @@ jobs:
 
         include:
         - test: FourValidatorsReconnect
-          devnet_args: -t .github/devnet_topologies/four_validators.toml -dt 20
+          devnet_args: -t .github/devnet_topologies/four_validators.toml -dt 30
         - test: MultipleValidatorsDown
-          devnet_args: -t .github/devnet_topologies/four_validators.toml -k 2 -ut 100 -dt 20 -as
+          devnet_args: -t .github/devnet_topologies/four_validators.toml -k 2 -ut 100 -dt 30 -as
         - test: FourValidatorsReconnectRmDatabase
-          devnet_args: -t .github/devnet_topologies/four_validators.toml -d -ut 100 -dt 20
+          devnet_args: -t .github/devnet_topologies/four_validators.toml -d -ut 100 -dt 30
         - test: FourValidatorsReconnectSpammer
-          devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -ut 250 -dt 10
+          devnet_args: -t .github/devnet_topologies/four_validators_spammer_1.toml -ut 250 -dt 30
         - test: MacroBlockProduction
           # The number of blocks per epoch needs to stay the same (because of the ZKP keys)
           pre: "grep 'blocks_per_batch: 60,' primitives/src/policy.rs &&

--- a/scripts/devnet/devnet.py
+++ b/scripts/devnet/devnet.py
@@ -70,9 +70,9 @@ def parse_args():
     parser.add_argument('-k', "--kills", type=int, default=1,
                         help="How many validators are killed each cycle, by "
                         "default just 1")
-    parser.add_argument('-dt', "--down-time", type=check_positive, default=10,
+    parser.add_argument('-dt', "--down-time", type=check_positive, default=30,
                         help="Time in seconds that validators are taken down, "
-                        "by default 10s")
+                        "by default 30s")
     parser.add_argument('-ut', "--up-time", type=check_positive, default=100,
                         help="Time in seconds during which all validators are "
                         "up, by default 100s")


### PR DESCRIPTION
## What's in this pull request?
CI runs have many false positives due to the small timeouts. This PR increases the default downtime from 10 to 30 seconds.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
