### PR TITLE
Web-client helper methods

### DIFF
--- a/primitives/transaction/src/account/vesting_contract.rs
+++ b/primitives/transaction/src/account/vesting_contract.rs
@@ -68,7 +68,7 @@ impl AccountTransactionVerification for VestingContractVerifier {
 /// Data used to create vesting contracts.
 ///
 /// Used in [`Transaction::recipient_data`].
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CreationTransactionData {
     /// The owner of the contract, the only address that can interact with it.
     pub owner: Address,

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -91,6 +91,16 @@ impl Address {
     pub fn serialize(&self) -> Vec<u8> {
         self.inner.serialize_to_vec()
     }
+
+    #[cfg(feature = "primitives")]
+    pub fn equals(&self, other: &Address) -> bool {
+        self.inner == other.inner
+    }
+
+    #[cfg(feature = "primitives")]
+    pub fn compare(&self, other: &Address) -> i32 {
+        self.inner.cmp(&other.inner) as i32
+    }
 }
 
 impl From<nimiq_keys::Address> for Address {

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -87,16 +87,22 @@ impl Address {
         self.inner.to_hex()
     }
 
+    /// Returns the byte representation of the address.
     #[cfg(feature = "primitives")]
     pub fn serialize(&self) -> Vec<u8> {
         self.inner.serialize_to_vec()
     }
 
+    /// Returns if this address is equal to the other address.
     #[cfg(feature = "primitives")]
     pub fn equals(&self, other: &Address) -> bool {
         self.inner == other.inner
     }
 
+    /// Compares this address to the other address.
+    ///
+    /// Returns -1 if this address is smaller than the other address, 0 if they are equal,
+    /// and 1 if this address is larger than the other address.
     #[cfg(feature = "primitives")]
     pub fn compare(&self, other: &Address) -> i32 {
         self.inner.cmp(&other.inner) as i32

--- a/web-client/src/common/hashed_time_locked_contract.rs
+++ b/web-client/src/common/hashed_time_locked_contract.rs
@@ -1,0 +1,132 @@
+use nimiq_keys::{PublicKey, Signature};
+use nimiq_serde::Deserialize;
+use nimiq_transaction::account::htlc_contract::{
+    AnyHash, CreationTransactionData, OutgoingHTLCTransactionProof,
+};
+use wasm_bindgen::prelude::*;
+
+use crate::common::transaction::{
+    PlainHtlcData, PlainHtlcEarlyResolveProof, PlainHtlcRegularTransferProof,
+    PlainHtlcTimeoutResolveProof, PlainTransactionProof, PlainTransactionRecipientData,
+};
+#[cfg(feature = "primitives")]
+use crate::common::transaction::{PlainTransactionProofType, PlainTransactionRecipientDataType};
+
+#[wasm_bindgen]
+pub struct HashedTimeLockedContract;
+
+#[cfg(feature = "primitives")]
+#[wasm_bindgen]
+impl HashedTimeLockedContract {
+    #[wasm_bindgen(js_name = dataToPlain)]
+    pub fn data_to_plain(data: &[u8]) -> Result<PlainTransactionRecipientDataType, JsError> {
+        let plain = HashedTimeLockedContract::parse_data(data)?;
+        Ok(serde_wasm_bindgen::to_value(&plain)?.into())
+    }
+
+    #[wasm_bindgen(js_name = proofToPlain)]
+    pub fn proof_to_plain(proof: &[u8]) -> Result<PlainTransactionProofType, JsError> {
+        let plain = HashedTimeLockedContract::parse_proof(proof)?;
+        Ok(serde_wasm_bindgen::to_value(&plain)?.into())
+    }
+}
+
+impl HashedTimeLockedContract {
+    pub fn parse_data(bytes: &[u8]) -> Result<PlainTransactionRecipientData, JsError> {
+        let data = CreationTransactionData::deserialize_all(bytes)?;
+
+        Ok(PlainTransactionRecipientData::Htlc(PlainHtlcData {
+            raw: hex::encode(bytes),
+            sender: data.sender.to_user_friendly_address(),
+            recipient: data.recipient.to_user_friendly_address(),
+            hash_algorithm: match data.hash_root {
+                AnyHash::Blake2b(_) => "blake2b".to_string(),
+                AnyHash::Sha256(_) => "sha256".to_string(),
+                AnyHash::Sha512(_) => "sha512".to_string(),
+            },
+            hash_root: data.hash_root.to_hex(),
+            hash_count: data.hash_count,
+            timeout: data.timeout,
+        }))
+    }
+
+    pub fn parse_proof(bytes: &[u8]) -> Result<PlainTransactionProof, JsError> {
+        let proof = OutgoingHTLCTransactionProof::deserialize_all(bytes)?;
+
+        Ok(match proof {
+            OutgoingHTLCTransactionProof::RegularTransfer {
+                hash_depth,
+                hash_root,
+                pre_image,
+                signature_proof,
+            } => PlainTransactionProof::RegularTransfer(PlainHtlcRegularTransferProof {
+                raw: hex::encode(bytes),
+                hash_algorithm: match hash_root {
+                    AnyHash::Blake2b(_) => "blake2b".to_string(),
+                    AnyHash::Sha256(_) => "sha256".to_string(),
+                    AnyHash::Sha512(_) => "sha512".to_string(),
+                },
+                hash_depth,
+                hash_root: hash_root.to_hex(),
+                pre_image: pre_image.to_hex(),
+                signer: signature_proof.compute_signer().to_user_friendly_address(),
+                signature: match signature_proof.signature {
+                    Signature::Ed25519(ref signature) => signature.to_hex(),
+                    Signature::ES256(ref signature) => signature.to_hex(),
+                },
+                public_key: match signature_proof.public_key {
+                    PublicKey::Ed25519(ref public_key) => public_key.to_hex(),
+                    PublicKey::ES256(ref public_key) => public_key.to_hex(),
+                },
+                path_length: signature_proof.merkle_path.len() as u8,
+            }),
+            OutgoingHTLCTransactionProof::TimeoutResolve {
+                signature_proof_sender,
+            } => PlainTransactionProof::TimeoutResolve(PlainHtlcTimeoutResolveProof {
+                raw: hex::encode(bytes),
+                creator: signature_proof_sender
+                    .compute_signer()
+                    .to_user_friendly_address(),
+                creator_signature: match signature_proof_sender.signature {
+                    Signature::Ed25519(ref signature) => signature.to_hex(),
+                    Signature::ES256(ref signature) => signature.to_hex(),
+                },
+                creator_public_key: match signature_proof_sender.public_key {
+                    PublicKey::Ed25519(ref public_key) => public_key.to_hex(),
+                    PublicKey::ES256(ref public_key) => public_key.to_hex(),
+                },
+                creator_path_length: signature_proof_sender.merkle_path.len() as u8,
+            }),
+            OutgoingHTLCTransactionProof::EarlyResolve {
+                signature_proof_recipient,
+                signature_proof_sender,
+            } => PlainTransactionProof::EarlyResolve(PlainHtlcEarlyResolveProof {
+                raw: hex::encode(bytes),
+                signer: signature_proof_recipient
+                    .compute_signer()
+                    .to_user_friendly_address(),
+                signature: match signature_proof_recipient.signature {
+                    Signature::Ed25519(ref signature) => signature.to_hex(),
+                    Signature::ES256(ref signature) => signature.to_hex(),
+                },
+                public_key: match signature_proof_recipient.public_key {
+                    PublicKey::Ed25519(ref public_key) => public_key.to_hex(),
+                    PublicKey::ES256(ref public_key) => public_key.to_hex(),
+                },
+                path_length: signature_proof_recipient.merkle_path.len() as u8,
+                creator: signature_proof_sender
+                    .compute_signer()
+                    .to_user_friendly_address(),
+                creator_signature: match signature_proof_sender.signature {
+                    Signature::Ed25519(ref signature) => signature.to_hex(),
+                    Signature::ES256(ref signature) => signature.to_hex(),
+                },
+                creator_public_key: match signature_proof_sender.public_key {
+                    PublicKey::Ed25519(ref public_key) => public_key.to_hex(),
+                    PublicKey::ES256(ref public_key) => public_key.to_hex(),
+                },
+                creator_path_length: signature_proof_sender.merkle_path.len() as u8,
+            }),
+        })
+    }
+}

--- a/web-client/src/common/hashed_time_locked_contract.rs
+++ b/web-client/src/common/hashed_time_locked_contract.rs
@@ -12,18 +12,21 @@ use crate::common::transaction::{
 #[cfg(feature = "primitives")]
 use crate::common::transaction::{PlainTransactionProofType, PlainTransactionRecipientDataType};
 
+/// Utility class providing methods to parse Hashed Time Locked Contract transaction data and proofs.
 #[wasm_bindgen]
 pub struct HashedTimeLockedContract;
 
 #[cfg(feature = "primitives")]
 #[wasm_bindgen]
 impl HashedTimeLockedContract {
+    /// Parses the data of a Hashed Time Locked Contract creation transaction into a plain object.
     #[wasm_bindgen(js_name = dataToPlain)]
     pub fn data_to_plain(data: &[u8]) -> Result<PlainTransactionRecipientDataType, JsError> {
         let plain = HashedTimeLockedContract::parse_data(data)?;
         Ok(serde_wasm_bindgen::to_value(&plain)?.into())
     }
 
+    /// Parses the proof of a Hashed Time Locked Contract settlement transaction into a plain object.
     #[wasm_bindgen(js_name = proofToPlain)]
     pub fn proof_to_plain(proof: &[u8]) -> Result<PlainTransactionProofType, JsError> {
         let plain = HashedTimeLockedContract::parse_proof(proof)?;

--- a/web-client/src/common/mod.rs
+++ b/web-client/src/common/mod.rs
@@ -1,4 +1,8 @@
 pub mod address;
 pub mod client_configuration;
+pub mod hashed_time_locked_contract;
+pub mod signature_proof;
+pub mod staking_contract;
 pub mod transaction;
 pub mod utils;
+pub mod vesting_contract;

--- a/web-client/src/common/signature_proof.rs
+++ b/web-client/src/common/signature_proof.rs
@@ -181,6 +181,8 @@ impl SignatureProof {
         self.inner.serialize_to_vec()
     }
 
+    /// Creates a JSON-compatible plain object representing the signature proof.
+    #[wasm_bindgen(js_name = toPlain)]
     pub fn to_plain(&self) -> Result<PlainTransactionProofType, JsError> {
         let plain = self.to_plain_transaction_proof();
         Ok(serde_wasm_bindgen::to_value(&plain)?.into())

--- a/web-client/src/common/staking_contract.rs
+++ b/web-client/src/common/staking_contract.rs
@@ -1,0 +1,134 @@
+use nimiq_serde::Deserialize;
+use nimiq_transaction::account::staking_contract::IncomingStakingTransactionData;
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "primitives")]
+use crate::common::transaction::{PlainTransactionProofType, PlainTransactionRecipientDataType};
+use crate::common::{
+    signature_proof::SignatureProof,
+    transaction::{
+        PlainAddStakeData, PlainCreateStakerData, PlainCreateValidatorData, PlainRawData,
+        PlainRetireStakeData, PlainSetActiveStakeData, PlainTransactionProof,
+        PlainTransactionRecipientData, PlainUpdateStakerData, PlainUpdateValidatorData,
+        PlainValidatorData,
+    },
+};
+
+#[wasm_bindgen]
+pub struct StakingContract;
+
+#[cfg(feature = "primitives")]
+#[wasm_bindgen]
+impl StakingContract {
+    #[wasm_bindgen(js_name = dataToPlain)]
+    pub fn data_to_plain(data: &[u8]) -> Result<PlainTransactionRecipientDataType, JsError> {
+        let plain = StakingContract::parse_data(data)?;
+        Ok(serde_wasm_bindgen::to_value(&plain)?.into())
+    }
+
+    #[wasm_bindgen(js_name = proofToPlain)]
+    pub fn proof_to_plain(proof: &[u8]) -> Result<PlainTransactionProofType, JsError> {
+        let plain = StakingContract::parse_proof(proof)?;
+        Ok(serde_wasm_bindgen::to_value(&plain)?.into())
+    }
+}
+
+impl StakingContract {
+    pub fn parse_data(bytes: &[u8]) -> Result<PlainTransactionRecipientData, JsError> {
+        let data = IncomingStakingTransactionData::deserialize_all(bytes)?;
+        Ok(match data {
+            IncomingStakingTransactionData::CreateStaker {
+                delegation,
+                proof: _proof,
+            } => PlainTransactionRecipientData::CreateStaker(PlainCreateStakerData {
+                raw: hex::encode(bytes),
+                delegation: delegation.map(|address| address.to_user_friendly_address()),
+            }),
+            IncomingStakingTransactionData::AddStake { staker_address } => {
+                PlainTransactionRecipientData::AddStake(PlainAddStakeData {
+                    raw: hex::encode(bytes),
+                    staker: staker_address.to_user_friendly_address(),
+                })
+            }
+            IncomingStakingTransactionData::UpdateStaker {
+                new_delegation,
+                reactivate_all_stake,
+                proof: _proof,
+            } => PlainTransactionRecipientData::UpdateStaker(PlainUpdateStakerData {
+                raw: hex::encode(bytes),
+                new_delegation: new_delegation.map(|address| address.to_user_friendly_address()),
+                reactivate_all_stake,
+            }),
+            IncomingStakingTransactionData::CreateValidator {
+                signing_key,
+                voting_key,
+                reward_address,
+                signal_data,
+                proof_of_knowledge,
+                proof: _proof,
+            } => PlainTransactionRecipientData::CreateValidator(PlainCreateValidatorData {
+                raw: hex::encode(bytes),
+                signing_key: signing_key.to_hex(),
+                voting_key: voting_key.to_hex(),
+                reward_address: reward_address.to_user_friendly_address(),
+                signal_data: signal_data.map(hex::encode),
+                proof_of_knowledge: proof_of_knowledge.to_hex(),
+            }),
+            IncomingStakingTransactionData::UpdateValidator {
+                new_signing_key,
+                new_voting_key,
+                new_reward_address,
+                new_signal_data,
+                new_proof_of_knowledge,
+                proof: _proof,
+            } => PlainTransactionRecipientData::UpdateValidator(PlainUpdateValidatorData {
+                raw: hex::encode(bytes),
+                new_signing_key: new_signing_key.map(|signing_key| signing_key.to_hex()),
+                new_voting_key: new_voting_key.map(|voting_key| voting_key.to_hex()),
+                new_reward_address: new_reward_address
+                    .map(|reward_address| reward_address.to_user_friendly_address()),
+                new_signal_data: new_signal_data.map(|signal_data| signal_data.map(hex::encode)),
+                new_proof_of_knowledge: new_proof_of_knowledge
+                    .map(|proof_of_knowledge| proof_of_knowledge.to_hex()),
+            }),
+            IncomingStakingTransactionData::DeactivateValidator {
+                validator_address,
+                proof: _proof,
+            } => PlainTransactionRecipientData::DeactivateValidator(PlainValidatorData {
+                raw: hex::encode(bytes),
+                validator: validator_address.to_user_friendly_address(),
+            }),
+            IncomingStakingTransactionData::ReactivateValidator {
+                validator_address,
+                proof: _proof,
+            } => PlainTransactionRecipientData::ReactivateValidator(PlainValidatorData {
+                raw: hex::encode(bytes),
+                validator: validator_address.to_user_friendly_address(),
+            }),
+            IncomingStakingTransactionData::RetireValidator { proof: _proof } => {
+                PlainTransactionRecipientData::RetireValidator(PlainRawData {
+                    raw: hex::encode(bytes),
+                })
+            }
+            IncomingStakingTransactionData::SetActiveStake {
+                new_active_balance,
+                proof: _proof,
+            } => PlainTransactionRecipientData::SetActiveStake(PlainSetActiveStakeData {
+                raw: hex::encode(bytes),
+                new_active_balance: new_active_balance.into(),
+            }),
+            IncomingStakingTransactionData::RetireStake {
+                retire_stake,
+                proof: _proof,
+            } => PlainTransactionRecipientData::RetireStake(PlainRetireStakeData {
+                raw: hex::encode(bytes),
+                retire_stake: retire_stake.into(),
+            }),
+        })
+    }
+
+    pub fn parse_proof(bytes: &[u8]) -> Result<PlainTransactionProof, JsError> {
+        let proof = SignatureProof::deserialize(bytes)?;
+        Ok(proof.to_plain_transaction_proof())
+    }
+}

--- a/web-client/src/common/staking_contract.rs
+++ b/web-client/src/common/staking_contract.rs
@@ -14,18 +14,21 @@ use crate::common::{
     },
 };
 
+/// Utility class providing methods to parse Staking Contract transaction data and proofs.
 #[wasm_bindgen]
 pub struct StakingContract;
 
 #[cfg(feature = "primitives")]
 #[wasm_bindgen]
 impl StakingContract {
+    /// Parses the data of a Staking Contract incoming transaction into a plain object.
     #[wasm_bindgen(js_name = dataToPlain)]
     pub fn data_to_plain(data: &[u8]) -> Result<PlainTransactionRecipientDataType, JsError> {
         let plain = StakingContract::parse_data(data)?;
         Ok(serde_wasm_bindgen::to_value(&plain)?.into())
     }
 
+    /// Parses the proof of a Staking Contract outgoing transaction into a plain object.
     #[wasm_bindgen(js_name = proofToPlain)]
     pub fn proof_to_plain(proof: &[u8]) -> Result<PlainTransactionProofType, JsError> {
         let plain = StakingContract::parse_proof(proof)?;

--- a/web-client/src/common/vesting_contract.rs
+++ b/web-client/src/common/vesting_contract.rs
@@ -1,0 +1,48 @@
+use nimiq_serde::Deserialize;
+use nimiq_transaction::account::vesting_contract::CreationTransactionData;
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "primitives")]
+use crate::common::transaction::{PlainTransactionProofType, PlainTransactionRecipientDataType};
+use crate::common::{
+    signature_proof::SignatureProof,
+    transaction::{PlainTransactionProof, PlainTransactionRecipientData, PlainVestingData},
+};
+
+#[wasm_bindgen]
+pub struct VestingContract;
+
+#[cfg(feature = "primitives")]
+#[wasm_bindgen]
+impl VestingContract {
+    #[wasm_bindgen(js_name = dataToPlain)]
+    pub fn data_to_plain(data: &[u8]) -> Result<PlainTransactionRecipientDataType, JsError> {
+        let plain = VestingContract::parse_data(data)?;
+        Ok(serde_wasm_bindgen::to_value(&plain)?.into())
+    }
+
+    #[wasm_bindgen(js_name = proofToPlain)]
+    pub fn proof_to_plain(proof: &[u8]) -> Result<PlainTransactionProofType, JsError> {
+        let plain = VestingContract::parse_proof(proof)?;
+        Ok(serde_wasm_bindgen::to_value(&plain)?.into())
+    }
+}
+
+impl VestingContract {
+    pub fn parse_data(bytes: &[u8]) -> Result<PlainTransactionRecipientData, JsError> {
+        let data = CreationTransactionData::deserialize_all(bytes)?;
+
+        Ok(PlainTransactionRecipientData::Vesting(PlainVestingData {
+            raw: hex::encode(bytes),
+            owner: data.owner.to_user_friendly_address(),
+            start_time: data.start_time,
+            step_amount: data.step_amount.into(),
+            time_step: data.time_step,
+        }))
+    }
+
+    pub fn parse_proof(bytes: &[u8]) -> Result<PlainTransactionProof, JsError> {
+        let proof = SignatureProof::deserialize(bytes)?;
+        Ok(proof.to_plain_transaction_proof())
+    }
+}

--- a/web-client/src/common/vesting_contract.rs
+++ b/web-client/src/common/vesting_contract.rs
@@ -9,18 +9,21 @@ use crate::common::{
     transaction::{PlainTransactionProof, PlainTransactionRecipientData, PlainVestingData},
 };
 
+/// Utility class providing methods to parse Vesting Contract transaction data and proofs.
 #[wasm_bindgen]
 pub struct VestingContract;
 
 #[cfg(feature = "primitives")]
 #[wasm_bindgen]
 impl VestingContract {
+    /// Parses the data of a Vesting Contract creation transaction into a plain object.
     #[wasm_bindgen(js_name = dataToPlain)]
     pub fn data_to_plain(data: &[u8]) -> Result<PlainTransactionRecipientDataType, JsError> {
         let plain = VestingContract::parse_data(data)?;
         Ok(serde_wasm_bindgen::to_value(&plain)?.into())
     }
 
+    /// Parses the proof of a Vesting Contract claiming transaction into a plain object.
     #[wasm_bindgen(js_name = proofToPlain)]
     pub fn proof_to_plain(proof: &[u8]) -> Result<PlainTransactionProofType, JsError> {
         let plain = VestingContract::parse_proof(proof)?;

--- a/web-client/src/primitives/es256_public_key.rs
+++ b/web-client/src/primitives/es256_public_key.rs
@@ -116,10 +116,15 @@ impl ES256PublicKey {
         Address::from(nimiq_keys::Address::from(&self.inner))
     }
 
+    /// Returns if this public key is equal to the other public key.
     pub fn equals(&self, other: &ES256PublicKey) -> bool {
         self.inner == other.inner
     }
 
+    /// Compares this public key to the other public key.
+    ///
+    /// Returns -1 if this public key is smaller than the other public key, 0 if they are equal,
+    /// and 1 if this public key is larger than the other public key.
     pub fn compare(&self, other: &ES256PublicKey) -> i32 {
         self.inner.cmp(&other.inner) as i32
     }

--- a/web-client/src/primitives/es256_public_key.rs
+++ b/web-client/src/primitives/es256_public_key.rs
@@ -30,10 +30,7 @@ impl ES256PublicKey {
     ///
     /// Throws when the byte array contains less than 33 bytes.
     pub fn deserialize(bytes: &[u8]) -> Result<ES256PublicKey, JsError> {
-        if bytes.len() != nimiq_keys::ES256PublicKey::SIZE {
-            return Err(JsError::new("Public key primitive: Invalid length"));
-        }
-        let key = nimiq_keys::ES256PublicKey::deserialize_from_vec(bytes)?;
+        let key = nimiq_keys::ES256PublicKey::deserialize_all(bytes)?;
         Ok(ES256PublicKey::from(key))
     }
 

--- a/web-client/src/primitives/es256_public_key.rs
+++ b/web-client/src/primitives/es256_public_key.rs
@@ -118,6 +118,14 @@ impl ES256PublicKey {
     pub fn to_address(&self) -> Address {
         Address::from(nimiq_keys::Address::from(&self.inner))
     }
+
+    pub fn equals(&self, other: &ES256PublicKey) -> bool {
+        self.inner == other.inner
+    }
+
+    pub fn compare(&self, other: &ES256PublicKey) -> i32 {
+        self.inner.cmp(&other.inner) as i32
+    }
 }
 
 impl From<nimiq_keys::ES256PublicKey> for ES256PublicKey {

--- a/web-client/src/primitives/es256_signature.rs
+++ b/web-client/src/primitives/es256_signature.rs
@@ -18,10 +18,8 @@ impl ES256Signature {
     ///
     /// Throws when the byte array contains less than 64 bytes.
     pub fn deserialize(bytes: &[u8]) -> Result<ES256Signature, JsError> {
-        match nimiq_keys::ES256Signature::from_bytes(bytes) {
-            Ok(sig) => Ok(ES256Signature::from(sig)),
-            Err(err) => Err(JsError::from(err)),
-        }
+        let sig = nimiq_keys::ES256Signature::from_bytes(bytes)?;
+        Ok(ES256Signature::from(sig))
     }
 
     /// Serializes the signature to a byte array.

--- a/web-client/src/primitives/mod.rs
+++ b/web-client/src/primitives/mod.rs
@@ -9,5 +9,4 @@ pub mod merkle_tree;
 pub mod private_key;
 pub mod public_key;
 pub mod signature;
-pub mod signature_proof;
 pub mod transaction_builder;

--- a/web-client/src/primitives/private_key.rs
+++ b/web-client/src/primitives/private_key.rs
@@ -71,6 +71,7 @@ impl PrivateKey {
         self.inner.to_hex()
     }
 
+    /// Returns if this private key is equal to the other private key.
     pub fn equals(&self, other: &PrivateKey) -> bool {
         self.inner == other.inner
     }

--- a/web-client/src/primitives/private_key.rs
+++ b/web-client/src/primitives/private_key.rs
@@ -70,6 +70,10 @@ impl PrivateKey {
     pub fn to_hex(&self) -> String {
         self.inner.to_hex()
     }
+
+    pub fn equals(&self, other: &PrivateKey) -> bool {
+        self.inner == other.inner
+    }
 }
 
 impl From<nimiq_keys::PrivateKey> for PrivateKey {

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -111,6 +111,14 @@ impl PublicKey {
     pub fn to_address(&self) -> Address {
         Address::from(nimiq_keys::Address::from(&self.inner))
     }
+
+    pub fn equals(&self, other: &PublicKey) -> bool {
+        self.inner == other.inner
+    }
+
+    pub fn compare(&self, other: &PublicKey) -> i32 {
+        self.inner.cmp(&other.inner) as i32
+    }
 }
 
 impl From<nimiq_keys::Ed25519PublicKey> for PublicKey {

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -112,10 +112,15 @@ impl PublicKey {
         Address::from(nimiq_keys::Address::from(&self.inner))
     }
 
+    /// Returns if this public key is equal to the other public key.
     pub fn equals(&self, other: &PublicKey) -> bool {
         self.inner == other.inner
     }
 
+    /// Compares this public key to the other public key.
+    ///
+    /// Returns -1 if this public key is smaller than the other public key, 0 if they are equal,
+    /// and 1 if this public key is larger than the other public key.
     pub fn compare(&self, other: &PublicKey) -> i32 {
         self.inner.cmp(&other.inner) as i32
     }

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -24,6 +24,16 @@ impl PublicKey {
 
 #[wasm_bindgen]
 impl PublicKey {
+    #[wasm_bindgen(getter = SIZE)]
+    pub fn size() -> usize {
+        nimiq_keys::Ed25519PublicKey::SIZE
+    }
+
+    #[wasm_bindgen(getter = serializedSize)]
+    pub fn serialized_size(&self) -> usize {
+        PublicKey::size()
+    }
+
     /// Derives a public key from an existing private key.
     pub fn derive(private_key: &PrivateKey) -> PublicKey {
         PublicKey::from(nimiq_keys::Ed25519PublicKey::from(private_key.native_ref()))

--- a/web-client/src/primitives/signature_proof.rs
+++ b/web-client/src/primitives/signature_proof.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use js_sys::Array;
-use nimiq_serde::Serialize;
+use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use crate::{
@@ -106,6 +106,12 @@ impl SignatureProof {
                 client_data_json,
             )?,
         ))
+    }
+
+    /// Deserializes a signature proof from a byte array.
+    pub fn deserialize(bytes: &[u8]) -> Result<SignatureProof, JsError> {
+        let proof = nimiq_transaction::SignatureProof::deserialize_from_vec(bytes)?;
+        Ok(SignatureProof::from(proof))
     }
 
     fn make_merkle_path(


### PR DESCRIPTION
## What's in this pull request?

Adds various helper methods to web-client structs that I found are used in our frontend-code, now that I am converting more of the apps.

- `.equals()` and `.compare()` methods for some primitives
- Contract creation/interaction data decoding methods

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
