### PR TITLE
Set new network config settings for the web-client

### DIFF
--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -162,6 +162,9 @@ impl Client {
         config.network.only_secure_ws_connections = true;
         config.network_id = web_config.network_id;
         config.network.desired_peer_count = 6;
+        config.network.peer_count_max = 50;
+        config.network.peer_count_per_ip_max = 10;
+        config.network.peer_count_per_subnet_max = 10;
 
         log::info!(?config, "Final configuration");
 


### PR DESCRIPTION
Otherwise these settings default to 0 and prevent the web-client from connecting to any peers.

This was overlooked in #2998.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
