### PR TITLE
Don't require genesis accounts data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,8 @@ dependencies = [
  "convert_case",
  "hex",
  "nimiq-bls",
+ "nimiq-database",
+ "nimiq-genesis-builder",
  "nimiq-hash",
  "nimiq-keys",
  "nimiq-primitives",
@@ -4731,6 +4733,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.85",
  "thiserror",
+ "toml",
  "tracing",
 ]
 

--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -48,6 +48,18 @@ pub enum BlockchainError {
     InvalidEpoch,
     #[error("Accounts diff not found")]
     AccountsDiffNotFound,
+    #[error(
+        "A full genesis config is required for initializing a history node on \
+        the mainnet for the first time. Obtain the full genesis config (it's \
+        not in the repository) and set the `NIMIQ_OVERRIDE_MAINNET_CONFIG` \
+        environment variable to point to the full genesis config for the \
+        first start"
+    )]
+    GenesisAccountsRequiredMainnet,
+    #[error(
+        "A full genesis config is required for initializing a history node for the first time"
+    )]
+    GenesisAccountsRequired,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -28,7 +28,7 @@ nimiq-bls = { workspace = true, features = ["serde-derive"] }
 nimiq-database = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true, features = ["serde-derive"] }
-nimiq-primitives = { workspace = true, features = ["serde-derive", "tree-proof"] }
+nimiq-primitives = { workspace = true, features = ["serde-derive", "slots", "tree-proof"] }
 nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true }
 nimiq-trie = { workspace = true }

--- a/pow-migration/src/genesis.rs
+++ b/pow-migration/src/genesis.rs
@@ -130,6 +130,10 @@ pub async fn get_pos_genesis(
         basic_accounts: genesis_accounts.basic_accounts,
         vesting_accounts: genesis_accounts.vesting_accounts,
         htlc_accounts: genesis_accounts.htlc_accounts,
+
+        supply: None,
+        state_root: None,
+        slots: Vec::new(),
     })
 }
 

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -50,6 +50,12 @@ impl Accounts {
         Accounts { env, tree }
     }
 
+    /// Creates a new Accounts, marked as incomplete.
+    pub fn new_incomplete(env: MdbxDatabase) -> Self {
+        let tree = AccountsTrie::new_incomplete(&env, AccountsTrieTable);
+        Accounts { env, tree }
+    }
+
     /// Initializes the Accounts struct with a given list of accounts.
     pub fn init(&self, txn: &mut WriteTransactionProxy, genesis_accounts: Vec<TrieItem>) {
         self.tree.init(txn, genesis_accounts)

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -458,11 +458,11 @@ fn accounts_performance() {
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
-    let length = genesis_info.accounts.len();
+    let length = genesis_info.accounts.as_ref().unwrap().len();
     let accounts = Accounts::new(env.clone());
     let mut txn = env.write_transaction();
     let start = Instant::now();
-    accounts.init(&mut (&mut txn).into(), genesis_info.accounts);
+    accounts.init(&mut (&mut txn).into(), genesis_info.accounts.unwrap());
     let duration = start.elapsed();
     println!(
         "Time elapsed after account init: {} ms, Accounts per second {}",
@@ -581,11 +581,11 @@ fn accounts_performance_history_sync_batches_single_sender() {
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
-    let length = genesis_info.accounts.len();
+    let length = genesis_info.accounts.as_ref().unwrap().len();
     let accounts = Accounts::new(env.clone());
     let mut txn = env.write_transaction();
     let start = Instant::now();
-    accounts.init(&mut (&mut txn).into(), genesis_info.accounts);
+    accounts.init(&mut (&mut txn).into(), genesis_info.accounts.unwrap());
     let duration = start.elapsed();
     log::debug!(
         "Time elapsed after account init: {} ms, Accounts per second {}",
@@ -710,11 +710,11 @@ fn accounts_performance_history_sync_batches_many_to_many() {
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
-    let length = genesis_info.accounts.len();
+    let length = genesis_info.accounts.as_ref().unwrap().len();
     let accounts = Accounts::new(env.clone());
     let mut txn = env.write_transaction();
     let start = Instant::now();
-    accounts.init(&mut (&mut txn).into(), genesis_info.accounts);
+    accounts.init(&mut (&mut txn).into(), genesis_info.accounts.unwrap());
     let duration = start.elapsed();
     log::debug!(
         "Time elapsed after account init: {} ms, Accounts per second {}",

--- a/test-utils/src/mock_node.rs
+++ b/test-utils/src/mock_node.rs
@@ -135,7 +135,7 @@ impl<N: NetworkInterface + TestNetwork> MockNode<N> {
     pub async fn new(
         peer_id: u64,
         block: Block,
-        accounts: Vec<TrieItem>,
+        accounts: Option<Vec<TrieItem>>,
         hub: &mut Option<MockHub>,
     ) -> Self {
         let network = N::build_network(peer_id, block.hash(), hub).await;

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -41,7 +41,7 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
         Self::new_history(
             peer_id,
             genesis_info.block,
-            genesis_info.accounts,
+            genesis_info.accounts.expect("history nodes need accounts"),
             hub,
             is_prover_active,
         )
@@ -65,7 +65,7 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
                 Arc::clone(&clock),
                 NetworkId::UnitAlbatross,
                 block,
-                accounts,
+                Some(accounts),
             )
             .unwrap(),
         ));

--- a/test-utils/src/performance/accounts-tree/main.rs
+++ b/test-utils/src/performance/accounts-tree/main.rs
@@ -78,12 +78,12 @@ fn accounts_tree_populate(
     );
 
     let genesis_info = genesis_builder.generate(env.clone()).unwrap();
-    let length = genesis_info.accounts.len();
+    let length = genesis_info.accounts.as_ref().unwrap().len();
     let accounts = Accounts::new(env.clone());
     let mut txn = env.write_transaction();
 
     let start = Instant::now();
-    accounts.init(&mut (&mut txn).into(), genesis_info.accounts);
+    accounts.init(&mut (&mut txn).into(), genesis_info.accounts.unwrap());
     let duration = start.elapsed();
     println!(
         "Time elapsed after account init: {} ms, Accounts per second {}",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -29,6 +29,10 @@ path = "src/signtx/main.rs"
 name = "nimiq-rpc-schema"
 path = "src/rpc-schema/main.rs"
 
+[[bin]]
+name = "nimiq-trim-genesis-config"
+path = "src/trim-genesis-config/main.rs"
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["cargo"] }
@@ -42,8 +46,11 @@ serde = "1.0"
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full"] }
 thiserror = "1.0"
+toml = "0.8"
 
 nimiq-bls = { workspace = true }
+nimiq-database = { workspace = true }
+nimiq-genesis-builder = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }
 nimiq-primitives = { workspace = true }

--- a/tools/src/trim-genesis-config/main.rs
+++ b/tools/src/trim-genesis-config/main.rs
@@ -1,0 +1,80 @@
+use std::process;
+
+use clap::{Arg, ArgAction, Command};
+use nimiq_database::mdbx::{DatabaseConfig, MdbxDatabase};
+use nimiq_genesis_builder::{config::GenesisConfig, GenesisBuilder};
+
+fn db() -> MdbxDatabase {
+    MdbxDatabase::new_volatile(DatabaseConfig {
+        size: Some(0..100 * 1024 * 1024 * 1024),
+        ..Default::default()
+    })
+    .expect("couldn't open volatile database")
+}
+
+fn main() {
+    let matches = Command::new("nimiq-trim-genesis-config")
+        .about("Trims genesis config to not contain the state")
+        .arg(
+            Arg::new("genesis-config")
+                .value_name("GENESIS_INFO")
+                .help("Path to genesis config toml")
+                .required(true),
+        )
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .action(ArgAction::SetTrue)
+                .help("Show status information"),
+        )
+        .arg(
+            Arg::new("no-verify")
+                .long("no-verify")
+                .action(ArgAction::SetTrue)
+                .help("Don't check that the generated config file is equivalent"),
+        )
+        .get_matches();
+
+    let genesis_config = matches.get_one::<String>("genesis-config").unwrap();
+    let verbose = matches.get_flag("verbose");
+    let no_verify = matches.get_flag("no-verify");
+
+    macro_rules! log {
+        ($($args:tt)*) => {
+            if verbose {
+                eprintln!($($args)*);
+            }
+        }
+    }
+
+    log!("reading genesis config...");
+    let genesis_builder = GenesisBuilder::from_config_file(genesis_config).unwrap();
+    log!("generating genesis block...");
+    let genesis_info = genesis_builder.generate(db()).unwrap();
+    let hash = genesis_info.block.hash();
+    log!("{}: generated genesis block hash", hash);
+    log!("generating config...");
+    let genesis_config_trimmed =
+        GenesisConfig::trimmed_from_genesis(&genesis_info.block.unwrap_macro().header);
+
+    if !no_verify {
+        log!("reading trimmed config...");
+        let genesis_builder = GenesisBuilder::from_config(genesis_config_trimmed.clone()).unwrap();
+        log!("generating genesis block from trimmed config...");
+        let genesis_info = genesis_builder.generate(db()).unwrap();
+        let hash_trimmed = genesis_info.block.hash();
+        log!("{}: genesis block hash generated from trimmed config", hash);
+        if hash_trimmed == hash {
+            log!("hashes match");
+        } else {
+            eprintln!("hash mismatch, {} != {}", hash_trimmed, hash);
+            eprintln!("aborting");
+            process::exit(1);
+        }
+    }
+    log!("done");
+    log!("");
+
+    print!("{}", toml::to_string(&genesis_config_trimmed).unwrap());
+}


### PR DESCRIPTION
Since the mainnet's genesis account data is going to be over 100 MiB in size, it's a good optimization to not require that account data except for initializing a history node.

History node operators starting their history node for the first time get a message explaining that they need to obtain a copy of the
mainnet's genesis account and set the `NIMIQ_OVERRIDE_MAINNET_CONFIG` environment variable to start their history node for the first time.

This cuts down the required genesis config from over 100 MiB to ~4 KiB.

Also add a tool to trim genesis configs.

Fixes #3049.