### PR TITLE
Restrict Block topics from gossipsub to two blocks per second

### DIFF
--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -143,7 +143,7 @@ impl Topic for BlockHeaderTopic {
     const BUFFER_SIZE: usize = 16;
     const NAME: &'static str = "block-header";
     const VALIDATE: bool = true;
-    const MAX_MESSAGES: u32 = 50;
+    const MAX_MESSAGES: u32 = 20;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -155,7 +155,7 @@ impl Topic for BlockBodyTopic {
     const BUFFER_SIZE: usize = 16;
     const NAME: &'static str = "block-body";
     const VALIDATE: bool = true;
-    const MAX_MESSAGES: u32 = 50;
+    const MAX_MESSAGES: u32 = BlockHeaderTopic::MAX_MESSAGES;
 }
 
 /*


### PR DESCRIPTION
## What's in this pull request?
The live sync relies on this constant being tight so that the peers do not trigger too many concurrent requests that ultimately could prevent the peer from syncing.

This PR, restricts block topics of gossipsub to 2 blocks per second or more precisely 20 blocks every 10 seconds. The rate limiting works on a per progataion source and message type.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
