### PR TITLE
Block: remove unnecessary `clone` when accessing block body

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -22,9 +22,9 @@ impl Blockchain {
         trusted: bool,
     ) -> Result<(), PushError> {
         // We expect full blocks (with body) here.
-        block
-            .body()
-            .ok_or(PushError::InvalidBlock(BlockError::MissingBody))?;
+        if !block.has_body() {
+            return Err(PushError::InvalidBlock(BlockError::MissingBody));
+        }
 
         // Perform block intrinsic checks.
         block.verify(self.network_id)?;

--- a/blockchain/src/chain_metrics.rs
+++ b/blockchain/src/chain_metrics.rs
@@ -1,4 +1,4 @@
-use nimiq_block::{Block, BlockBody::Micro};
+use nimiq_block::Block;
 use nimiq_blockchain_interface::{ChunksPushError, ChunksPushResult, PushError, PushResult};
 use nimiq_hash::Blake2bHash;
 use prometheus_client::{
@@ -101,23 +101,23 @@ impl BlockchainMetrics {
         reverted_blocks: &[(Blake2bHash, Block)],
         adopted_blocks: &[(Blake2bHash, Block)],
     ) {
-        for (_, micro_block) in reverted_blocks {
-            if let Some(Micro(micro_body)) = micro_block.body() {
+        for (_, block) in reverted_blocks {
+            if block.is_micro() {
                 self.transactions_counts
                     .get_or_create(&TransactionProcessedLabels {
                         ty: TransactionProcessed::Reverted,
                     })
-                    .inc_by(micro_body.transactions.len() as u64);
+                    .inc_by(block.num_transactions() as u64);
             }
         }
 
-        for (_, micro_block) in adopted_blocks {
-            if let Some(Micro(micro_body)) = micro_block.body() {
+        for (_, block) in adopted_blocks {
+            if block.is_micro() {
                 self.transactions_counts
                     .get_or_create(&TransactionProcessedLabels {
                         ty: TransactionProcessed::Applied,
                     })
-                    .inc_by(micro_body.transactions.len() as u64);
+                    .inc_by(block.num_transactions() as u64);
             }
         }
     }

--- a/consensus/src/sync/live/block_queue/block_request_component.rs
+++ b/consensus/src/sync/live/block_queue/block_request_component.rs
@@ -188,10 +188,10 @@ impl<N: Network> BlockRequestComponent<N> {
                     }
 
                     for block in blocks.iter() {
-                        if block.body().is_some() != request.include_body {
+                        if block.has_body() != request.include_body {
                             log::error!(
                                 is_macro = block.is_macro(),
-                                has_body = block.body().is_some(),
+                                has_body = block.has_body(),
                                 include_body = request.include_body,
                                 "Received block with body where none was expected or vice versa",
                             );

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -153,7 +153,7 @@ impl<N: Network> BlockQueue<N> {
         block_source: BlockSource<N>,
     ) -> Option<QueuedBlock<N>> {
         // Reject block if it includes a body when we didn't request one or vice versa.
-        if block.body().is_some() != self.config.include_body {
+        if block.has_body() != self.config.include_body {
             block_source.reject_block(&self.network);
             return None;
         }

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -27,7 +27,7 @@ impl ChainStore {
             .chain_db
             .get(hash)
             .ok_or(BlockchainError::BlockNotFound)?;
-        if include_body && chain_info.head.body().is_none() {
+        if include_body && !chain_info.head.has_body() {
             return Err(BlockchainError::BlockBodyNotFound);
         }
         Ok(chain_info)
@@ -287,7 +287,7 @@ impl ChainStore {
                 .get(&hash)
                 .map(|chain_info| chain_info.head.clone())
             {
-                if include_body && block.body().is_none() {
+                if include_body && !block.has_body() {
                     return Err(BlockchainError::BlockBodyNotFound);
                 }
                 hash = block.parent_hash().clone();
@@ -321,7 +321,7 @@ impl ChainStore {
 
                 chain_info = chain_info_opt.unwrap();
                 let block = chain_info.head.clone();
-                if include_body && block.body().is_none() {
+                if include_body && !block.has_body() {
                     return Err(BlockchainError::BlockBodyNotFound);
                 }
                 blocks.push(block);
@@ -421,7 +421,7 @@ mod tests {
             }
             Ok(info) => {
                 assert!(info.on_main_chain);
-                assert!(info.head.body().is_none());
+                assert!(!info.head.has_body());
                 assert_eq!(info.head.hash(), block_1.hash());
             }
         }
@@ -438,7 +438,7 @@ mod tests {
             }
             Ok(info) => {
                 assert!(info.on_main_chain);
-                assert!(info.head.body().is_none());
+                assert!(!info.head.has_body());
                 assert_eq!(info.head.hash(), block_1.hash());
             }
         }


### PR DESCRIPTION
Remove unused `BlockJustification` as well.
