### PR TITLE
Add blockchain & staking metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4416,6 +4416,7 @@ dependencies = [
  "nimiq-mempool",
  "nimiq-network-interface",
  "nimiq-network-libp2p",
+ "nimiq-primitives",
  "nimiq-utils",
  "parking_lot",
  "prometheus-client",

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -406,12 +406,11 @@ impl Blockchain {
         let chunk_result = this.commit_chunks(chunks, &block_hash);
         let duration = start.elapsed();
 
-        let num_transactions = this.state.main_chain.head.num_transactions();
         #[cfg(feature = "metrics")]
-        this.metrics.note_extend(num_transactions);
+        this.metrics.note_extend(&this.state.main_chain.head);
         debug!(
             block = %this.state.main_chain.head,
-            num_transactions,
+            num_transactions = this.state.main_chain.head.num_transactions(),
             kind = "extend",
             ?duration,
             "Accepted block",

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -133,12 +133,11 @@ impl Blockchain {
         // Downgrade the lock again as the notify listeners might want to acquire read access themselves.
         let this = RwLockWriteGuard::downgrade_to_upgradable(this);
 
-        let num_transactions = this.state.main_chain.head.num_transactions();
         #[cfg(feature = "metrics")]
-        this.metrics.note_extend(num_transactions);
+        this.metrics.note_extend(&this.state.main_chain.head);
         debug!(
             block = %this.state.main_chain.head,
-            num_transactions,
+            num_transactions = this.state.main_chain.head.num_transactions(),
             kind = "push_zkp",
             "Accepted block",
         );
@@ -315,12 +314,11 @@ impl Blockchain {
         // Downgrade the lock again as the notify listeners might want to acquire read access themselves.
         let this = RwLockWriteGuard::downgrade_to_upgradable(this);
 
-        let num_transactions = this.state.main_chain.head.num_transactions();
         #[cfg(feature = "metrics")]
-        this.metrics.note_extend(num_transactions);
+        this.metrics.note_extend(&this.state.main_chain.head);
         debug!(
             block = %this.state.main_chain.head,
-            num_transactions,
+            num_transactions = this.state.main_chain.head.num_transactions(),
             kind = "push_macro",
             "Accepted block",
         );

--- a/blockchain/src/chain_metrics.rs
+++ b/blockchain/src/chain_metrics.rs
@@ -1,4 +1,4 @@
-use nimiq_block::Block;
+use nimiq_block::{Block, EquivocationProof};
 use nimiq_blockchain_interface::{ChunksPushError, ChunksPushResult, PushError, PushResult};
 use nimiq_hash::Blake2bHash;
 use prometheus_client::{
@@ -12,6 +12,7 @@ pub struct BlockchainMetrics {
     block_push_counts: Family<PushResultLabels, Counter>,
     transactions_counts: Family<TransactionProcessedLabels, Counter>,
     skip_blocks: Counter,
+    equivocation_counts: Family<EquivocationProofLabels, Counter>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
@@ -41,6 +42,18 @@ enum TransactionProcessed {
     Reverted,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct EquivocationProofLabels {
+    ty: EquivocationProofType,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+enum EquivocationProofType {
+    Fork,
+    DoubleVote,
+    DoubleProposal,
+}
+
 impl BlockchainMetrics {
     pub fn register(&self, registry: &mut Registry) {
         registry.register(
@@ -59,6 +72,12 @@ impl BlockchainMetrics {
             "skip_blocks",
             "Number of skip blocks applied",
             self.skip_blocks.clone(),
+        );
+
+        registry.register(
+            "equivocation_counts",
+            "Count of equivocation proofs applied",
+            self.equivocation_counts.clone(),
         );
     }
 
@@ -104,6 +123,20 @@ impl BlockchainMetrics {
         if block.is_skip() {
             self.skip_blocks.inc();
         }
+
+        if block.is_micro() && block.has_body() {
+            let body = block.unwrap_micro_ref().body.as_ref().unwrap();
+            for equivocation in &body.equivocation_proofs {
+                let ty = match equivocation {
+                    EquivocationProof::Fork(_) => EquivocationProofType::Fork,
+                    EquivocationProof::DoubleVote(_) => EquivocationProofType::DoubleVote,
+                    EquivocationProof::DoubleProposal(_) => EquivocationProofType::DoubleProposal,
+                };
+                self.equivocation_counts
+                    .get_or_create(&EquivocationProofLabels { ty })
+                    .inc();
+            }
+        }
     }
 
     #[inline]
@@ -123,17 +156,7 @@ impl BlockchainMetrics {
         }
 
         for (_, block) in adopted_blocks {
-            if block.is_micro() {
-                self.transactions_counts
-                    .get_or_create(&TransactionProcessedLabels {
-                        ty: TransactionProcessed::Applied,
-                    })
-                    .inc_by(block.num_transactions() as u64);
-            }
-
-            if block.is_skip() {
-                self.skip_blocks.inc();
-            }
+            self.note_extend(block);
         }
     }
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,7 +32,6 @@ nimiq-utils = { workspace = true, features = ["spawn"] }
 workspace = true
 features = [
     "database-storage",
-    "extended-metrics",
     "full-consensus",
     "logging",
     "loki",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,7 +32,7 @@ nimiq-utils = { workspace = true, features = ["spawn"] }
 workspace = true
 features = [
     "database-storage",
-    "deadlock",
+    "extended-metrics",
     "full-consensus",
     "logging",
     "loki",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -91,6 +91,7 @@ nimiq-test-log = { workspace = true }
 database-storage = ["nimiq-database", "nimiq-zkp-component/database-storage"]
 deadlock = ["parking_lot/deadlock_detection"]
 default = ["full-consensus"]
+extended-metrics = ["nimiq-metrics-server/extended-staking"]
 full-consensus = [
     "database-storage",
     "nimiq-blockchain",

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -43,4 +43,8 @@ nimiq-consensus = { workspace = true, features = ["full"] }
 nimiq-mempool = { workspace = true, features = ["metrics"] }
 nimiq-network-interface = { workspace = true }
 nimiq-network-libp2p = { workspace = true, features = ["metrics"] }
+nimiq-primitives = { workspace = true, features = ["coin"], optional = true }
 nimiq-utils = { workspace = true, features = ["spawn"] }
+
+[features]
+extended-staking = ["nimiq-primitives/coin"]

--- a/metrics-server/src/chain.rs
+++ b/metrics-server/src/chain.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_primitives::coin::Coin;
 use parking_lot::RwLock;
 use prometheus_client::registry::Registry;
 
@@ -24,7 +25,8 @@ impl BlockMetrics {
     fn register_staking(registry: &mut Registry, blockchain: Arc<RwLock<Blockchain>>) {
         let sub_registry = registry.sub_registry_with_prefix("staking");
 
-        let bc = blockchain;
+        // Number of active validators
+        let bc = Arc::clone(&blockchain);
         let closure = NumericClosureMetric::new_gauge(Box::new(move || {
             bc.read()
                 .get_staking_contract_if_complete(None)
@@ -32,6 +34,109 @@ impl BlockMetrics {
                 .unwrap_or(0)
         }));
         sub_registry.register("active_validators", "Number of active validators", closure);
+
+        // Total stake
+        let bc = Arc::clone(&blockchain);
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            bc.read()
+                .get_staking_contract_if_complete(None)
+                .map(|contract| u64::from(contract.balance) as i64)
+                .unwrap_or(0)
+        }));
+        sub_registry.register("total_stake", "Total stake", closure);
+
+        #[cfg(feature = "extended-staking")]
+        Self::register_extended_staking(sub_registry, blockchain);
+    }
+
+    #[cfg(feature = "extended-staking")]
+    fn register_extended_staking(registry: &mut Registry, blockchain: Arc<RwLock<Blockchain>>) {
+        // Total active stake
+        let bc = Arc::clone(&blockchain);
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            let Some(contract) = bc.read().get_staking_contract_if_complete(None) else {
+                return 0;
+            };
+            let sum = contract.active_validators.values().cloned().sum::<Coin>();
+            u64::from(sum) as i64
+        }));
+        registry.register("active_stake", "Total active stake", closure);
+
+        // Number of inactive validators
+        let bc = Arc::clone(&blockchain);
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            let blockchain = bc.read();
+            let Some(contract) = blockchain.get_staking_contract_if_complete(None) else {
+                return 0;
+            };
+
+            let txn = blockchain.read_transaction();
+            let data_store = blockchain.get_staking_contract_store();
+            contract
+                .iter_validators(&data_store.read(&txn))
+                .filter(|validator| validator.inactive_from.is_some())
+                .count() as i64
+        }));
+        registry.register(
+            "inactive_validators",
+            "Number of inactive validators",
+            closure,
+        );
+
+        // Total inactive stake
+        let bc = Arc::clone(&blockchain);
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            let blockchain = bc.read();
+            let Some(contract) = blockchain.get_staking_contract_if_complete(None) else {
+                return 0;
+            };
+
+            let txn = blockchain.read_transaction();
+            let data_store = blockchain.get_staking_contract_store();
+            let stake = contract
+                .iter_validators(&data_store.read(&txn))
+                .filter(|validator| validator.inactive_from.is_some())
+                .map(|validator| validator.total_stake)
+                .sum::<Coin>();
+            u64::from(stake) as i64
+        }));
+        registry.register("inactive_stake", "Total inactive stake", closure);
+
+        // Number of jailed validators
+        let bc = Arc::clone(&blockchain);
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            let blockchain = bc.read();
+            let Some(contract) = blockchain.get_staking_contract_if_complete(None) else {
+                return 0;
+            };
+
+            let txn = blockchain.read_transaction();
+            let data_store = blockchain.get_staking_contract_store();
+            contract
+                .iter_validators(&data_store.read(&txn))
+                .filter(|validator| validator.jailed_from.is_some())
+                .count() as i64
+        }));
+        registry.register("jailed_validators", "Number of jailed validators", closure);
+
+        // Total jailed stake
+        let bc = Arc::clone(&blockchain);
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            let blockchain = bc.read();
+            let Some(contract) = blockchain.get_staking_contract_if_complete(None) else {
+                return 0;
+            };
+
+            let txn = blockchain.read_transaction();
+            let data_store = blockchain.get_staking_contract_store();
+            let stake = contract
+                .iter_validators(&data_store.read(&txn))
+                .filter(|validator| validator.jailed_from.is_some())
+                .map(|validator| validator.total_stake)
+                .sum::<Coin>();
+            u64::from(stake) as i64
+        }));
+        registry.register("jailed_stake", "Total jailed stake", closure);
     }
 
     fn register_accounts_trie(registry: &mut Registry, blockchain: Arc<RwLock<Blockchain>>) {

--- a/metrics-server/src/chain.rs
+++ b/metrics-server/src/chain.rs
@@ -52,9 +52,37 @@ impl BlockMetrics {
     fn register_chain(registry: &mut Registry, blockchain: BlockchainProxy) {
         let sub_registry = registry.sub_registry_with_prefix("blockchain");
 
-        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
-            blockchain.read().block_number() as i64
-        }));
+        let bc = blockchain.clone();
+        let closure =
+            NumericClosureMetric::new_gauge(Box::new(move || bc.read().block_number() as i64));
         sub_registry.register("block_number", "Number of latest block", closure);
+
+        let bc = blockchain.clone();
+        let closure =
+            NumericClosureMetric::new_gauge(Box::new(move || bc.read().batch_number() as i64));
+        sub_registry.register("batch_number", "Number of latest batch", closure);
+
+        let bc = blockchain.clone();
+        let closure =
+            NumericClosureMetric::new_gauge(Box::new(move || bc.read().epoch_number() as i64));
+        sub_registry.register("epoch_number", "Number of latest epoch", closure);
+
+        let bc = blockchain.clone();
+        let closure =
+            NumericClosureMetric::new_gauge(Box::new(move || bc.read().timestamp() as i64));
+        sub_registry.register("timestamp", "Timestamp of latest block", closure);
+
+        let closure = NumericClosureMetric::new_gauge(Box::new(move || {
+            blockchain
+                .read()
+                .current_validators()
+                .map(|validators| validators.num_validators())
+                .unwrap_or(0) as i64
+        }));
+        sub_registry.register(
+            "elected_validators",
+            "Number of elected validators",
+            closure,
+        );
     }
 }

--- a/metrics-server/src/chain.rs
+++ b/metrics-server/src/chain.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
+#[cfg(feature = "extended-staking")]
 use nimiq_primitives::coin::Coin;
 use parking_lot::RwLock;
 use prometheus_client::registry::Registry;


### PR DESCRIPTION
New blockchain metrics:
- `batch_number`
- `epoch_number`
- `timestamp`
- `elected_validators`
- `skip_blocks`
- `equivocation_proofs` (by type)

New staking metrics:
- `total_stake`

Extended staking metrics (potentially expensive and therefore behind the `extended-metrics` feature flag):
- `active_stake`
- `inactive_stake`
- `jailed_stake`
- `inactive_validators`
- `jailed_validators`

Inlcudes #3072 to avoid merge conflicts. 