### PR TITLE
Mempool: Recompute balance for all known senders after rebranch

### DIFF
--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -18,6 +18,8 @@ pub enum ForkEvent {
 pub enum BlockchainEvent {
     Extended(Blake2bHash),
     HistoryAdopted(Blake2bHash),
+    /// The first and second vector are the adopted and reverted chain, respectively.
+    /// Both vectors are ordered by block height, ascending.
     Rebranched(Vec<(Blake2bHash, Block)>, Vec<(Blake2bHash, Block)>),
     /// Given Block was stored in the chain store but was not adopted as new head block.
     /// I.e. forked blocks and inferior chain blocks.

--- a/primitives/account/src/account/vesting_contract.rs
+++ b/primitives/account/src/account/vesting_contract.rs
@@ -26,7 +26,7 @@ pub struct VestingContract {
     pub balance: Coin,
     /// The owner of the contract, the only address that can interact with it.
     pub owner: Address,
-    /// The block height at which the release schedule starts.
+    /// The time at which the release schedule starts.
     #[serde(with = "nimiq_serde::fixint::be")]
     pub start_time: u64,
     /// The frequency at which funds are released.


### PR DESCRIPTION
## What's in this pull request?

Recomputing the balance of 60 addresses with a total of 3500 tx takes 9 ms.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
