### PR TITLE
As validator, check keys per epoch

### DIFF
--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -405,6 +405,18 @@ where
             id: id.clone(),
         };
 
+        let one_of_our_slots = self
+            .validator_registry
+            .get_slots(self.validator_slot_band)
+            .start;
+
+        let public_key = self
+            .validator_registry
+            .public_key(one_of_our_slots as usize)
+            .expect("Key must be be present");
+
+        assert_eq!(self.block_producer.voting_key.public_key, public_key);
+
         let own_contribution = TendermintContribution::from_vote(
             tendermint_vote,
             &self.block_producer.voting_key.secret_key,

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -355,6 +355,11 @@ where
             {
                 panic!("Invalid validator configuration: None of the voting keys match the one expected from this validator in the current epoch")
             }
+
+            // Compare configured validator signing key to the one in the current epoch to make sure it is the same.
+            if epoch_validator.signing_key != self.signing_key().public {
+                panic!("Invalid validator configuration: Configured signing key does not match signing key in this epoch");
+            }
         } else {
             log::info!(
                 validator_address = %self.validator_address(),
@@ -368,19 +373,6 @@ where
 
         // Set the elected validators of the current epoch in the network as well.
         self.network.set_validators(validators);
-
-        // Check validator configuration
-        if let Some(validator) = self.get_validator(&blockchain) {
-            // Compare configured validator voting key to the one in the contract to make sure it is the same.
-            if validator.voting_key != self.current_voting_key().public_key.compress() {
-                error!("Invalid validator configuration: Configured voting key does not match voting key in staking contract");
-            }
-
-            // Compare configured validator signing key to the one in the contract to make sure it is the same.
-            if validator.signing_key != self.signing_key().public {
-                error!("Invalid validator configuration: Configured signing key does not match signing key in staking contract");
-            }
-        }
     }
 
     fn init_block_producer(&mut self, head_hash: Option<&Blake2bHash>) {


### PR DESCRIPTION
Since keys can change, this PR adds a basic check to the validator which makes sure its keys are consistent with the ones the election block expects. Similar checks are introduced to signing Level updates and Micro blocks such that a validator will not produce blocks if the keys do not match and not sign any LevelUpdates.
