### PR TITLE
NAT: Replace the state of addresses

### DIFF
--- a/network-libp2p/src/autonat.rs
+++ b/network-libp2p/src/autonat.rs
@@ -40,12 +40,9 @@ impl NatState {
 
     /// Set the NAT status of address
     pub fn set_address_nat(&mut self, address: Multiaddr, nat_status: NatStatus) {
-        let address_status = self
-            .address_status
-            .entry(address.clone())
-            .or_insert(nat_status);
+        self.address_status.insert(address.clone(), nat_status);
 
-        if *address_status == NatStatus::Public {
+        if nat_status == NatStatus::Public {
             self.confirmed_addresses.insert(address);
         } else {
             self.confirmed_addresses.remove(&address);
@@ -55,8 +52,8 @@ impl NatState {
 
     /// Mark the address as confirmed thus publicly reachable
     pub fn add_confirmed_address(&mut self, address: Multiaddr) {
-        let address_status = self.address_status.entry(address.clone()).or_default();
-        *address_status = NatStatus::Public;
+        self.address_status
+            .insert(address.clone(), NatStatus::Public);
 
         self.confirmed_addresses.insert(address);
         self.update_state();


### PR DESCRIPTION
## What's in this pull request?
Replace the state of addresses if they have already been added. The current code maintains the old state.

This might influence #3069.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
