### PR TITLE
Rename the mainnet genesis override env variable

### DIFF
--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -166,12 +166,12 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                 use std::sync::OnceLock;
                 static OVERRIDE: OnceLock<Option<NetworkInfo>> = OnceLock::new();
                 if let Some(info) = OVERRIDE.get_or_init(|| {
-                    let override_path = env::var_os("NIMIQ_OVERRIDE_MAINET_CONFIG");
+                    let override_path = env::var_os("NIMIQ_OVERRIDE_MAINNET_CONFIG");
                     override_path.map(|p| NetworkInfo {
                         network_id: NetworkId::MainAlbatross,
                         name: "main-albatross",
                         genesis: read_genesis_config(Path::new(&p))
-                            .expect("failure reading provided NIMIQ_OVERRIDE_MAINET_CONFIG"),
+                            .expect("failure reading provided NIMIQ_OVERRIDE_MAINNET_CONFIG"),
                     })
                 }) {
                     return Some(info);

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -243,7 +243,7 @@ async fn main() {
         // Check that we are doing the migration for a supported network ID and set the genesis environment variable name
         let genesis_env_var_name = match config.network_id {
             NetworkId::TestAlbatross => "NIMIQ_OVERRIDE_TESTNET_CONFIG",
-            NetworkId::MainAlbatross => "NIMIQ_OVERRIDE_MAINET_CONFIG",
+            NetworkId::MainAlbatross => "NIMIQ_OVERRIDE_MAINNET_CONFIG",
             _ => {
                 log::error!(%config.network_id, "Unsupported network ID as a target for the migration process");
                 exit(1);


### PR DESCRIPTION
Rename the mainnet genesis override env variable from
    `NIMIQ_OVERRIDE_MAINET_CONFIG` to `NIMIQ_OVERRIDE_MAINNET_CONFIG`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
