### PR TITLE
Fix panic in `IdentityRegistry::signers_identity`

### DIFF
--- a/validator/src/aggregation/update.rs
+++ b/validator/src/aggregation/update.rs
@@ -1,5 +1,9 @@
 use nimiq_handel::{contribution::AggregatableContribution, update::LevelUpdate};
-use serde::{Deserialize, Serialize};
+use nimiq_primitives::policy::Policy;
+use serde::{
+    de::{Error as _, Unexpected},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 /// The serializable/deserializable representation of a LevelUpdate. It does omit the origin of the
 /// LevelUpdate itself, as the ValidatorNetwork's ValidatorMessage already includes it.
@@ -9,9 +13,33 @@ pub struct SerializableLevelUpdate<C>
 where
     C: AggregatableContribution,
 {
-    pub aggregate: C,
-    pub individual: Option<C>,
-    pub level: u8,
+    aggregate: Checked<C>,
+    individual: Option<Checked<C>>,
+    level: u8,
+}
+
+#[derive(Clone, Debug)]
+struct Checked<C: AggregatableContribution>(C);
+
+impl<'de, C: AggregatableContribution> Deserialize<'de> for Checked<C> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let result = C::deserialize(deserializer)?;
+        for slot in result.contributors().iter() {
+            if slot >= Policy::SLOTS as usize {
+                return Err(D::Error::invalid_value(
+                    Unexpected::Unsigned(slot.try_into().unwrap()),
+                    &"slot must be smaller than 512",
+                ));
+            }
+        }
+        Ok(Checked(result))
+    }
+}
+
+impl<C: AggregatableContribution> Serialize for Checked<C> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Serialize::serialize(&self.0, serializer)
+    }
 }
 
 impl<C> SerializableLevelUpdate<C>
@@ -21,8 +49,8 @@ where
     /// Given an origin, transforms this SerializableLevelUpdate into a LevelUpdate.
     pub fn into_level_update(self, origin: u16) -> LevelUpdate<C> {
         LevelUpdate {
-            aggregate: self.aggregate,
-            individual: self.individual,
+            aggregate: self.aggregate.0,
+            individual: self.individual.map(|contribution| contribution.0),
             level: self.level,
             origin,
         }
@@ -35,8 +63,8 @@ where
 {
     fn from(value: LevelUpdate<C>) -> Self {
         Self {
-            aggregate: value.aggregate,
-            individual: value.individual,
+            aggregate: Checked(value.aggregate),
+            individual: value.individual.map(Checked),
             level: value.level,
         }
     }

--- a/validator/tests/updates.rs
+++ b/validator/tests/updates.rs
@@ -48,6 +48,8 @@ fn test_serialize_deserialize_level_update() {
 
     assert_eq!(data.len(), update.serialized_size());
     assert_eq!(update.serialized_size(), 99);
+
+    let update_2 = update_2.into_level_update(2);
     assert!(update_2.individual.is_none());
     assert_eq!(update_2.level, 2);
 }


### PR DESCRIPTION
It was reachable via `WeightedVote::verify` via the network, when a peer sent an invalid signers bitset.