### PR TITLE
Install curl in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install dependencies in a single layer to reduce the number of image layers.
 RUN apt-get update && \
-    apt-get --no-install-recommends -y install libssl3 tini && \
+    apt-get --no-install-recommends -y install libssl3 tini curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Run as an unprivileged user, combining commands to reduce layers.


### PR DESCRIPTION
To do automatic healthchecks with Docker, usually the `curl` command is used to check a certain HTTP endpoint. A curl command is also what Coolify auto-generates (no way to change that part). The healthchecks on my containers where failing because curl was not available in the container.

Same as https://github.com/nimiq/core-js/pull/655