### PR TITLE
Fix TS types of web-client transaction sender & recipient types

### DIFF
--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -16,12 +16,7 @@ use crate::{
     derive(nimiq_serde::Serialize, nimiq_serde::Deserialize)
 )]
 #[cfg_attr(feature = "serde-derive", serde(try_from = "u8", into = "u8"))]
-#[cfg_attr(
-    feature = "ts-types",
-    derive(tsify::Tsify),
-    serde(rename = "PlainAccountType", rename_all = "lowercase"),
-    wasm_bindgen::prelude::wasm_bindgen
-)]
+#[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen)]
 pub enum AccountType {
     Basic = 0,
     Vesting = 1,

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -770,15 +770,13 @@ pub struct PlainTransaction {
     pub format: TransactionFormat,
     /// The transaction's sender address in human-readable IBAN format.
     pub sender: String,
-    /// The type of the transaction's sender. "basic" are regular private-key controlled addresses,
-    /// "vesting" and "htlc" are those contract types respectively, and "staking" is the staking contract.
-    #[tsify(type = "PlainAccountType")]
+    /// The account type of the transaction's sender. `0` are basic private-key controlled accounts,
+    /// `1` are vesting contracts, `2` are HTLCs, and `3` is the staking contract.
     pub sender_type: AccountType,
     /// The transaction's recipient address in human-readable IBAN format.
     pub recipient: String,
-    /// The type of the transaction's sender. "basic" are regular private-key controlled addresses,
-    /// "vesting" and "htlc" are those contract types respectively, and "staking" is the staking contract.
-    #[tsify(type = "PlainAccountType")]
+    /// The account type of the transaction's recipient. `0` are basic private-key controlled accounts,
+    /// `1` are vesting contracts, `2` are HTLCs, and `3` is the staking contract.
     pub recipient_type: AccountType,
     // The transaction's value in luna (NIM's smallest unit).
     pub value: u64,


### PR DESCRIPTION
Somewhere the conversion from number to string got lost, but the type annotations for the resulting object didn't get updated.
