### PR TITLE
Add RPC call and config option to rotate keys without restarting

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -36,6 +36,8 @@ use nimiq_primitives::policy::Policy;
 #[cfg(feature = "full-consensus")]
 use nimiq_utils::time::OffsetTime;
 #[cfg(feature = "validator")]
+use nimiq_validator::key_utils::VotingKeys;
+#[cfg(feature = "validator")]
 use nimiq_validator::validator::Validator as AbstractValidator;
 #[cfg(feature = "validator")]
 use nimiq_validator::validator::ValidatorProxy as AbstractValidatorProxy;
@@ -552,7 +554,7 @@ impl ClientInner {
                     let signing_key = config.storage.signing_keypair()?;
 
                     // Load validator key (before we give away ownership of the storage config)
-                    let voting_key = config.storage.voting_keypair()?;
+                    let voting_keys = VotingKeys::new(config.storage.voting_keypairs()?);
 
                     // Load fee key (before we give away ownership of the storage config)
                     let fee_key = config.storage.fee_keypair()?;
@@ -568,7 +570,7 @@ impl ClientInner {
                         validator_address,
                         automatic_reactivate,
                         signing_key,
-                        voting_key,
+                        voting_keys,
                         fee_key,
                         config.mempool.clone(),
                     );

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -352,12 +352,12 @@ level = "debug"
 # Default: randomly generated
 #signing_key = ""
 
-# Where to store the validator voting key.
-# Default: "~/.nimiq/voting_key.dat"
-#voting_key_file = "voting_key.dat"
+# Locations of voting keys.
+# Multiple paths can be provided in case a key-rotation is planned.
+#voting_key_files = [ "voting_key.dat" ]
 
 # The validator voting key. This must be a BLS private key in hex format.
-# Only used when the `voting_key_file` does not exist.
+# Only used when `voting_key_files` does not exist.
 # Default: randomly generated
 #voting_key = ""
 

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -495,6 +495,7 @@ pub struct ValidatorSettings {
     pub signing_key_file: Option<String>,
     pub signing_key: Option<Sensitive<String>>,
     pub voting_key_file: Option<String>,
+    pub voting_key_files: Option<Vec<String>>,
     pub voting_key: Option<Sensitive<String>>,
     pub fee_key_file: Option<String>,
     pub fee_key: Option<Sensitive<String>>,

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -14,8 +14,14 @@ pub trait ValidatorInterface {
     /// Returns our validator signing key.
     async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error>;
 
-    /// Returns our validator voting key.
+    /// Returns our current validator voting key.
     async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error>;
+
+    /// Returns all available voting keys.
+    async fn get_voting_keys(&mut self) -> RPCResult<Vec<String>, (), Self::Error>;
+
+    // Adds a voting key that will be used when the key expected by the chain changes
+    async fn add_voting_key(&mut self, secret_key: String) -> RPCResult<(), (), Self::Error>;
 
     /// Updates the configuration setting to automatically reactivate our validator.
     async fn set_automatic_reactivation(

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -13,7 +13,7 @@ use nimiq_network_mock::MockHub;
 use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_utils::spawn;
-use nimiq_validator::validator::Validator;
+use nimiq_validator::{key_utils::VotingKeys, validator::Validator};
 use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
 use rand::{rngs::StdRng, SeedableRng};
 use tokio_stream::wrappers::BroadcastStream;
@@ -53,7 +53,7 @@ where
             validator_address,
             automatic_reactivate,
             signing_key,
-            voting_key,
+            VotingKeys::new(vec![voting_key]),
             fee_key,
             MempoolConfig::default(),
         ),
@@ -166,7 +166,8 @@ where
     validators
         .iter()
         .find(|validator| {
-            &validator.voting_key().public_key.compress() == slot.validator.voting_key.compressed()
+            &validator.current_voting_key().public_key.compress()
+                == slot.validator.voting_key.compressed()
         })
         .unwrap()
 }
@@ -192,7 +193,8 @@ where
     let index = validators
         .iter()
         .position(|validator| {
-            &validator.voting_key().public_key.compress() == slot.validator.voting_key.compressed()
+            &validator.current_voting_key().public_key.compress()
+                == slot.validator.voting_key.compressed()
         })
         .unwrap();
     validators.remove(index)

--- a/validator/src/key_utils.rs
+++ b/validator/src/key_utils.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+use nimiq_bls::{CompressedPublicKey, KeyPair as BlsKeyPair};
+
+pub struct VotingKeys {
+    keys: HashMap<CompressedPublicKey, BlsKeyPair>,
+    current_key: BlsKeyPair,
+}
+
+impl VotingKeys {
+    pub fn new(keys: Vec<BlsKeyPair>) -> Self {
+        assert!(!keys.is_empty());
+        let mut key_hm = HashMap::new();
+        for key in &keys {
+            key_hm.insert(key.public_key.compress(), key.clone());
+        }
+        VotingKeys {
+            keys: key_hm,
+            current_key: keys.first().unwrap().clone(),
+        }
+    }
+
+    pub fn add_key(&mut self, key: BlsKeyPair) {
+        self.keys.insert(key.public_key.compress(), key);
+    }
+
+    pub fn get_current_key(&self) -> BlsKeyPair {
+        self.current_key.clone()
+    }
+
+    pub fn get_keys(&self) -> Vec<BlsKeyPair> {
+        self.keys.values().cloned().collect()
+    }
+
+    #[allow(clippy::result_unit_err)]
+    pub fn update_current_key(&mut self, public_key: &CompressedPublicKey) -> Result<(), ()> {
+        self.current_key = self.keys.get(public_key).ok_or(())?.clone();
+        Ok(())
+    }
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -3,6 +3,7 @@ extern crate log;
 
 pub mod aggregation;
 mod jail;
+pub mod key_utils;
 mod r#macro;
 mod micro;
 mod proposal_buffer;

--- a/validator/tests/key_utils.rs
+++ b/validator/tests/key_utils.rs
@@ -1,0 +1,49 @@
+use nimiq_bls::KeyPair as BlsKeyPair;
+use nimiq_utils::key_rng::SecureGenerate;
+use nimiq_validator::key_utils::VotingKeys;
+use rand::{self, rngs::StdRng, thread_rng, SeedableRng};
+
+#[test]
+fn test_voting_keys() {
+    let mut rng = StdRng::from_rng(thread_rng()).expect("Could not initialize test rng");
+
+    // Initialize the VotingKeys
+    let key1 = BlsKeyPair::generate(&mut rng);
+    let key2 = BlsKeyPair::generate(&mut rng);
+    let mut bls_keys = Vec::new();
+    bls_keys.push(key1.clone());
+    bls_keys.push(key2.clone());
+
+    let mut voting_keys = VotingKeys::new(bls_keys.clone());
+    assert_eq!(voting_keys.get_keys().len(), 2);
+    for bls_key in &bls_keys {
+        assert!(voting_keys.get_keys().contains(bls_key));
+    }
+
+    // Updating to a non-available key produces an error
+    let additional_key = BlsKeyPair::generate(&mut rng);
+    assert_eq!(
+        voting_keys.update_current_key(&additional_key.public_key.compress()),
+        Err(())
+    );
+
+    // Add a key
+    voting_keys.add_key(additional_key.clone());
+    bls_keys.push(additional_key.clone());
+    assert_eq!(voting_keys.get_keys().len(), 3);
+    for bls_key in &bls_keys {
+        assert!(voting_keys.get_keys().contains(bls_key));
+    }
+
+    // Verify that the current key is correctly set/returned
+    assert_eq!(
+        voting_keys.update_current_key(&additional_key.public_key.compress()),
+        Ok(())
+    );
+    assert_eq!(voting_keys.get_current_key(), additional_key);
+    assert_eq!(
+        voting_keys.update_current_key(&key1.public_key.compress()),
+        Ok(())
+    );
+    assert_eq!(voting_keys.get_current_key(), key1);
+}

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -296,7 +296,7 @@ async fn validator_can_catch_up() {
     // Manually construct a skip block for the validator
     let vc = create_skip_block_update(
         skip_block_info,
-        validator.voting_key(),
+        validator.current_voting_key(),
         validator.validator_slot_band(),
         &slots,
     );


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.