### PR TITLE
Changing the max connections per peer so that the seed nodes become public

### DIFF
--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Maximum simultaneous libp2p connections per peer
-const MAX_CONNECTIONS_PER_PEER: u32 = 3;
+const MAX_CONNECTIONS_PER_PEER: u32 = 5;
 
 /// Network behaviour.
 /// This is composed of several other behaviours that build a tree of behaviours using


### PR DESCRIPTION
## What's in this pull request?
Changes the max connections per peer. The seed nodes have many connections, and this constant is being exceeded. This leads them to get errors when connecting to peers; thus, we mistakenly assume we are not public.

#### This fixes #3069.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
