### PR TITLE
Fix TS types of web-client transaction sender & recipient types, this time for real

### DIFF
--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -16,7 +16,12 @@ use crate::{
     derive(nimiq_serde::Serialize, nimiq_serde::Deserialize)
 )]
 #[cfg_attr(feature = "serde-derive", serde(try_from = "u8", into = "u8"))]
-#[cfg_attr(feature = "ts-types", wasm_bindgen::prelude::wasm_bindgen)]
+#[cfg_attr(
+    feature = "ts-types",
+    derive(tsify::Tsify),
+    serde(rename = "PlainAccountType", rename_all = "lowercase"),
+    wasm_bindgen::prelude::wasm_bindgen
+)]
 pub enum AccountType {
     Basic = 0,
     Vesting = 1,

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -1,6 +1,7 @@
 use std::{convert::TryFrom, fmt};
 
 use nimiq_keys::Address;
+use nimiq_serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
@@ -9,13 +10,8 @@ use crate::{
     trie::error::MerkleRadixTrieError,
 };
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Serialize, Deserialize)]
 #[repr(u8)]
-#[cfg_attr(
-    any(feature = "serde-derive", feature = "ts-types"),
-    derive(nimiq_serde::Serialize, nimiq_serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde-derive", serde(try_from = "u8", into = "u8"))]
 #[cfg_attr(
     feature = "ts-types",
     derive(tsify::Tsify),
@@ -53,6 +49,7 @@ impl TryFrom<u8> for AccountType {
     }
 }
 
+#[cfg(not(feature = "ts-types"))]
 impl From<AccountType> for u8 {
     fn from(ty: AccountType) -> Self {
         match ty {

--- a/web-client/extras/tests/Transaction.test.ts
+++ b/web-client/extras/tests/Transaction.test.ts
@@ -1,0 +1,39 @@
+import { PrivateKey, PublicKey, KeyPair, Transaction, AccountType, TransactionFormat, Address } from '@nimiq/core';
+import { describe, expect, it } from 'vitest';
+
+describe('Transaction', () => {
+    it('has the correct types for format and sender/recipient type', () => {
+        const sender = PrivateKey.fromHex("41771e617f4a847642f9c0cd0fdb9b22b0c9dfdd2548fe7a6cad0a782e588f63")
+        const recipient = Address.fromUserFriendlyAddress("NQ72 9DS3 CQHA G44E ND6G DCQT 561M 3G2A H9FL");
+
+        const transaction = new Transaction(
+            PublicKey.derive(sender).toAddress(),
+            AccountType.Basic,
+            new Uint8Array(0),
+            recipient,
+            AccountType.Basic,
+            new Uint8Array(0),
+            100_00000n,
+            0n,
+            0,
+            1,
+            6,
+        );
+        transaction.sign(KeyPair.derive(sender));
+
+        // Verify that the enums are numbers
+        expect(AccountType.Basic).toBe(0);
+        expect(TransactionFormat.Basic).toBe(0);
+
+        // Now check the transaction fields
+        expect(transaction.format).toBe(TransactionFormat.Basic);
+        expect(transaction.senderType).toBe(AccountType.Basic);
+        expect(transaction.recipientType).toBe(AccountType.Basic);
+
+        // In plain format, the fields should now be strings
+        const plain = transaction.toPlain();
+        expect(plain.format).toBe('basic');
+        expect(plain.senderType).toBe('basic');
+        expect(plain.recipientType).toBe('basic');
+    });
+});

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -770,13 +770,15 @@ pub struct PlainTransaction {
     pub format: TransactionFormat,
     /// The transaction's sender address in human-readable IBAN format.
     pub sender: String,
-    /// The account type of the transaction's sender. `0` are basic private-key controlled accounts,
-    /// `1` are vesting contracts, `2` are HTLCs, and `3` is the staking contract.
+    /// The type of the transaction's sender. "basic" are regular private-key controlled addresses,
+    /// "vesting" and "htlc" are those contract types respectively, and "staking" is the staking contract.
+    #[tsify(type = "PlainAccountType")]
     pub sender_type: AccountType,
     /// The transaction's recipient address in human-readable IBAN format.
     pub recipient: String,
-    /// The account type of the transaction's recipient. `0` are basic private-key controlled accounts,
-    /// `1` are vesting contracts, `2` are HTLCs, and `3` is the staking contract.
+    /// The type of the transaction's sender. "basic" are regular private-key controlled addresses,
+    /// "vesting" and "htlc" are those contract types respectively, and "staking" is the staking contract.
+    #[tsify(type = "PlainAccountType")]
     pub recipient_type: AccountType,
     // The transaction's value in luna (NIM's smallest unit).
     pub value: u64,

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -507,14 +507,14 @@ impl Transaction {
     pub fn from_plain_transaction(plain: &PlainTransaction) -> Result<Transaction, JsError> {
         let mut tx = Transaction::new(
             &Address::from_string(&plain.sender)?,
-            Some(plain.sender_type.into()),
+            Some(plain.sender_type as u8),
             Some(hex::decode(match plain.sender_data {
                 PlainTransactionSenderData::Raw(ref data) => &data.raw,
                 PlainTransactionSenderData::RemoveStake(ref data) => &data.raw,
                 PlainTransactionSenderData::DeleteValidator(ref data) => &data.raw,
             })?),
             &Address::from_string(&plain.recipient)?,
-            Some(plain.recipient_type.into()),
+            Some(plain.recipient_type as u8),
             Some(hex::decode(match plain.data {
                 PlainTransactionRecipientData::Raw(ref data) => &data.raw,
                 PlainTransactionRecipientData::Vesting(ref data) => &data.raw,
@@ -770,14 +770,14 @@ pub struct PlainTransaction {
     pub format: TransactionFormat,
     /// The transaction's sender address in human-readable IBAN format.
     pub sender: String,
-    /// The type of the transaction's sender. "basic" are regular private-key controlled addresses,
-    /// "vesting" and "htlc" are those contract types respectively, and "staking" is the staking contract.
+    /// The account type of the transaction's sender. "basic" are regular private-key controlled accounts,
+    /// "vesting" and "htlc" are contracts, and "staking" is the staking contract.
     #[tsify(type = "PlainAccountType")]
     pub sender_type: AccountType,
     /// The transaction's recipient address in human-readable IBAN format.
     pub recipient: String,
-    /// The type of the transaction's sender. "basic" are regular private-key controlled addresses,
-    /// "vesting" and "htlc" are those contract types respectively, and "staking" is the staking contract.
+    /// The account type of the transaction's recipient. "basic" are regular private-key controlled accounts,
+    /// "vesting" and "htlc" are contracts, and "staking" is the staking contract.
     #[tsify(type = "PlainAccountType")]
     pub recipient_type: AccountType,
     // The transaction's value in luna (NIM's smallest unit).


### PR DESCRIPTION
Turns out we need strings, not numbers for the plain transaction object.

I also added a test to ensure this doesn't regress.