### PR TITLE
Deduplicate jail logs

### DIFF
--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -726,7 +726,6 @@ impl AccountInherentInteraction for StakingContract {
                 inherent_logger.push_tx_logger(tx_logger);
 
                 let newly_deactivated = receipt.newly_deactivated;
-                let newly_jailed = receipt.old_jailed_from.is_none();
 
                 // Register the validator slots as punished
                 let (old_previous_batch_punished_slots, old_current_batch_punished_slots) =
@@ -735,12 +734,6 @@ impl AccountInherentInteraction for StakingContract {
                         block_state.number,
                         new_epoch_slot_range.clone(),
                     );
-
-                inherent_logger.push_log(Log::Jail {
-                    validator_address: jailed_validator.validator_address.clone(),
-                    event_block: jailed_validator.offense_event_block,
-                    newly_jailed,
-                });
 
                 Ok(Some(
                     JailReceipt {
@@ -822,7 +815,6 @@ impl AccountInherentInteraction for StakingContract {
             } => {
                 let receipt: JailReceipt =
                     receipt.ok_or(AccountError::InvalidReceipt)?.try_into()?;
-                let newly_jailed = receipt.old_jailed_from.is_none();
                 let jail_receipt = JailValidatorReceipt::from(&receipt);
 
                 self.punished_slots.revert_register_jail(
@@ -830,12 +822,6 @@ impl AccountInherentInteraction for StakingContract {
                     receipt.old_previous_batch_punished_slots,
                     receipt.old_current_batch_punished_slots,
                 );
-
-                inherent_logger.push_log(Log::Jail {
-                    validator_address: jailed_validator.validator_address.clone(),
-                    event_block: jailed_validator.offense_event_block,
-                    newly_jailed,
-                });
 
                 let mut tx_logger = TransactionLog::empty();
                 self.revert_jail_validator(

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -458,7 +458,8 @@ impl StakingContract {
 
         tx_logger.push_log(Log::JailValidator {
             validator_address: validator_address.clone(),
-            jailed_from: block_number,
+            event_block: block_number,
+            newly_jailed: old_jailed_from.is_none(),
         });
         if newly_deactivated {
             tx_logger.push_log(Log::DeactivateValidator {
@@ -508,7 +509,8 @@ impl StakingContract {
         });
         tx_logger.push_log(Log::JailValidator {
             validator_address: validator_address.clone(),
-            jailed_from,
+            event_block: jailed_from,
+            newly_jailed: receipt.old_jailed_from.is_none(),
         });
 
         Ok(())

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -90,14 +90,6 @@ pub enum Log {
         inactive_from: u32,
     },
 
-    /// The validator with the given address has been jailed.
-    /// It is jailed from the given block number.
-    #[serde(rename_all = "camelCase")]
-    JailValidator {
-        validator_address: Address,
-        jailed_from: u32,
-    },
-
     #[serde(rename_all = "camelCase")]
     ReactivateValidator { validator_address: Address },
 
@@ -179,7 +171,7 @@ pub enum Log {
     },
 
     #[serde(rename_all = "camelCase")]
-    Jail {
+    JailValidator {
         validator_address: Address,
         event_block: u32,
         newly_jailed: bool,
@@ -258,11 +250,8 @@ impl Log {
             Log::DeactivateValidator {
                 validator_address, ..
             }
-            | Log::JailValidator {
-                validator_address, ..
-            } => validator_address == address,
-            Log::ReactivateValidator { validator_address } => validator_address == address,
-            Log::RetireValidator { validator_address } => validator_address == address,
+            | Log::ReactivateValidator { validator_address }
+            | Log::RetireValidator { validator_address } => validator_address == address,
             Log::DeleteValidator {
                 validator_address,
                 reward_address,
@@ -334,7 +323,7 @@ impl Log {
             Log::Penalize {
                 validator_address, ..
             }
-            | Log::Jail {
+            | Log::JailValidator {
                 validator_address, ..
             } => validator_address == address,
             Log::RevertContract { contract_address } => contract_address == address,

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -1726,16 +1726,12 @@ fn jail_and_revert() {
         vec![
             Log::JailValidator {
                 validator_address: validator_address.clone(),
-                jailed_from: block_state.number
+                event_block: block_state.number,
+                newly_jailed: true
             },
             Log::DeactivateValidator {
                 validator_address: validator_address.clone(),
                 inactive_from: Policy::election_block_after(block_state.number)
-            },
-            Log::Jail {
-                validator_address: validator_address.clone(),
-                event_block: 1,
-                newly_jailed: true
             },
         ]
     );
@@ -1844,17 +1840,11 @@ fn jail_inactive_and_revert() {
     );
     assert_eq!(
         logs,
-        vec![
-            Log::JailValidator {
-                validator_address: validator_address.clone(),
-                jailed_from: block_state.number
-            },
-            Log::Jail {
-                validator_address: validator_address.clone(),
-                event_block: 1,
-                newly_jailed: true
-            },
-        ]
+        vec![Log::JailValidator {
+            validator_address: validator_address.clone(),
+            event_block: block_state.number,
+            newly_jailed: true
+        },]
     );
     let validator = staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address)
@@ -1946,17 +1936,11 @@ fn can_jail_twice() {
 
     assert_eq!(
         logs,
-        vec![
-            Log::JailValidator {
-                validator_address: jailed_setup.validator_address.clone(),
-                jailed_from: second_jail_block_state.number,
-            },
-            Log::Jail {
-                validator_address: jailed_setup.validator_address.clone(),
-                event_block: second_jail_block_state.number,
-                newly_jailed: false
-            },
-        ]
+        vec![Log::JailValidator {
+            validator_address: jailed_setup.validator_address.clone(),
+            event_block: second_jail_block_state.number,
+            newly_jailed: false
+        },]
     );
 
     // Make sure that the jail release is replaced to the new jail release block height.
@@ -2468,17 +2452,11 @@ fn penalize_and_jail_and_revert_twice() {
     );
     assert_eq!(
         logs,
-        vec![
-            Log::JailValidator {
-                validator_address: validator_address.clone(),
-                jailed_from: block_state.number,
-            },
-            Log::Jail {
-                validator_address: validator_address.clone(),
-                event_block: 2,
-                newly_jailed: true
-            },
-        ]
+        vec![Log::JailValidator {
+            validator_address: validator_address.clone(),
+            event_block: block_state.number,
+            newly_jailed: true
+        },]
     );
 
     let validator = staking_contract

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -1064,7 +1064,7 @@ pub enum LogType {
     ValidatorFeeDeduction,
     DeactivateValidator,
     ReactivateValidator,
-    JailValidator,
+
     RetireValidator,
     DeleteValidator,
     CreateStaker,
@@ -1077,7 +1077,7 @@ pub enum LogType {
     StakerFeeDeduction,
     PayoutReward,
     Penalize,
-    Jail,
+    JailValidator,
     RevertContract,
     FailedTransaction,
 }
@@ -1117,7 +1117,7 @@ impl LogType {
             Log::UpdateValidator { .. } => Self::UpdateValidator,
             Log::DeactivateValidator { .. } => Self::DeactivateValidator,
             Log::ReactivateValidator { .. } => Self::ReactivateValidator,
-            Log::JailValidator { .. } => Self::JailValidator,
+
             Log::CreateStaker { .. } => Self::CreateStaker,
             Log::Stake { .. } => Self::Stake,
             Log::UpdateStaker { .. } => Self::UpdateStaker,
@@ -1129,7 +1129,7 @@ impl LogType {
             Log::DeleteStaker { .. } => Self::DeleteStaker,
             Log::PayoutReward { .. } => Self::PayoutReward,
             Log::Penalize { .. } => Self::Penalize,
-            Log::Jail { .. } => Self::Jail,
+            Log::JailValidator { .. } => Self::JailValidator,
             Log::RevertContract { .. } => Self::RevertContract,
             Log::FailedTransaction { .. } => Self::FailedTransaction,
             Log::ValidatorFeeDeduction { .. } => Self::ValidatorFeeDeduction,


### PR DESCRIPTION
## What's in this pull request?
The jail logs were repeated. This happened due to the renaming of the legacy slash term from the codebase from [this commit](https://github.com/nimiq/core-rs-albatross/commit/9480298e633b1ea77842892838788e4b6357f043).

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
