### PR TITLE
consensus: Fix transaction proofs for non finalized blocks

### DIFF
--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -559,8 +559,8 @@ impl RequestTransactionsProof {
             let block_number = hist_txn.block_number;
 
             let proving_block_number = if block_number <= election_head {
-                // If the txn is in a finalized epoch, we use the last election block
-                election_head
+                // If the txn is in a finalized epoch, we use the election block of that epoch
+                Policy::election_block_after(block_number)
             } else if block_number <= macro_head {
                 // If the txn is in a finalized batch in the current epoch, we use the last checkpoint block
                 macro_head

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -546,6 +546,7 @@ impl RequestTransactionsProof {
         let mut verifier_state = None;
         let election_head = blockchain.election_head().block_number();
         let macro_head = blockchain.macro_head().block_number();
+        let current_head = blockchain.head().block_number();
 
         // Get the historic transaction from the history store
         let historic_transaction = blockchain
@@ -578,10 +579,8 @@ impl RequestTransactionsProof {
                 return Err(ResponseTransactionProofError::BlockNotFound);
             };
 
-            // If it is a checkpoint block, we have some extra work to do
-            if Policy::is_macro_block_at(proving_block_number)
-                && !Policy::is_election_block_at(proving_block_number)
-            {
+            // We have some extra work in the current epoch, if the block we are proving is not our current head
+            if proving_block_number > election_head && proving_block_number < current_head {
                 let chain_info = blockchain.get_chain_info(&block.hash(), false, None);
                 let history_tree_len = chain_info.unwrap().history_tree_len;
                 verifier_state = Some(history_tree_len as usize);


### PR DESCRIPTION
Fix transaction proofs for non finalized blocks in `prove_transaction` which is called when a transaction proof is requested without specifying a block. In this case if the transaction is found to be within the current batch (not finalized) it was incorrectly generating the proof against the head of the blockchain instead of the proving block which in this case is the block that included the transaction.
This was a condition that was overseen in #1517.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
