### PR TITLE
Only ever prune beyond `max_epochs_stored`

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -358,19 +358,19 @@ impl Blockchain {
             let max_epochs_stored =
                 cmp::max(this.config.max_epochs_stored, Policy::MIN_EPOCHS_STORED);
 
-            // Calculate the epoch to be pruned. Saturate at zero.
-            let pruned_epoch = Policy::epoch_at(block_number).saturating_sub(max_epochs_stored);
+            // Calculate the epoch to be pruned.
+            let pruned_epoch = Policy::epoch_at(block_number).checked_sub(max_epochs_stored);
 
-            // Prune the Chain Store.
-            this.chain_store.prune_epoch(pruned_epoch, &mut txn);
+            if let Some(pruned_epoch) = pruned_epoch {
+                // Prune the Chain Store.
+                this.chain_store.prune_epoch(pruned_epoch, &mut txn);
 
-            if !this.config.keep_history {
-                // Prune the History Store.
-                // We will never prune pre-genesis data here.
-                let pruned_history_epoch = Policy::epoch_at(block_number).saturating_sub(1);
-                if pruned_history_epoch > 0 {
-                    this.history_store
-                        .remove_history(&mut txn, pruned_history_epoch);
+                if !this.config.keep_history {
+                    // Prune the History Store.
+                    // We will never prune pre-genesis data here.
+                    if pruned_epoch > 0 {
+                        this.history_store.remove_history(&mut txn, pruned_epoch);
+                    }
                 }
             }
         }

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -867,6 +867,7 @@ impl ClientConfigBuilder {
                 config_file.consensus.index_history,
                 config_file.consensus.sync_mode.into(),
             )
+            .max_epochs_stored(config_file.consensus.max_epochs_stored as u32)
             .build()
             .unwrap();
         if let Some(min_peers) = config_file.consensus.min_peers {


### PR DESCRIPTION
## What's in this pull request?
- Use `max_epochs_stored` to identify history to be pruned
- Do not use saturating sub to avoid pruning epochs too early
- Add missing call in config builder to read setting from config file

#### This fixes #3110 .

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
