### PR TITLE
Make sure that light blockchain uses and stores cached hashes

### DIFF
--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -53,7 +53,10 @@ impl LightBlockchain {
     }
 
     /// Creates a new blockchain with a given network ID and genesis block.
-    pub fn with_genesis(network_id: NetworkId, genesis_block: Block) -> Self {
+    pub fn with_genesis(network_id: NetworkId, mut genesis_block: Block) -> Self {
+        // Make sure genesis block has hash populated.
+        genesis_block.hash_cached();
+
         let time = Arc::new(OffsetTime::new());
 
         let chain_info = ChainInfo::new(genesis_block.clone(), true);

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -68,8 +68,8 @@ impl ChainStore {
 
     /// Adds a chain info to the ChainStore.
     pub fn put_chain_info(&mut self, mut chain_info: ChainInfo) {
-        // Get the block hash.
-        let hash = chain_info.head.hash();
+        // Get the block hash and make sure it is saved.
+        let hash = chain_info.head.hash_cached();
 
         // We only store in the ChainStore:
         // - Micro blocks: Headers and Justifications

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -34,7 +34,7 @@ impl LightBlockchain {
         }
 
         // Check if we already know this block.
-        if this.get_chain_info(&block.hash(), false).is_ok() {
+        if this.get_chain_info(&block.hash_cached(), false).is_ok() {
             return Ok(PushResult::Known);
         }
 

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -25,7 +25,7 @@ impl LightBlockchain {
         // Must be an election block.
         assert!(block.is_election());
 
-        let block_hash_blake2b = block.hash();
+        let block_hash_blake2b = block.hash_cached();
         let block_hash_blake2s = block.unwrap_macro_ref().hash_blake2s();
 
         // Check if we already know this block.
@@ -116,7 +116,7 @@ impl LightBlockchain {
         // Must be a macro block.
         assert!(block.is_macro());
 
-        let block_hash = block.hash();
+        let block_hash = block.hash_cached();
 
         // Check if we already know this block.
         if this.chain_store.get_chain_info(&block_hash, false).is_ok() {


### PR DESCRIPTION
## What's in this pull request?
Moving the `Validators` object into the header, an unintended consequence was that nodes will have to calculate the hash over this object more often.
#2924 introduced caching of the block hash. This was mostly missing for the light client.
This PR adds `hash_cached()` in key places of the light blockchain.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
