### PR TITLE
Avoid double-wrapping wasm libp2p transport in only_secure_ws_transport

### DIFF
--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -261,8 +261,7 @@ fn new_transport(
         }
 
         #[cfg(all(target_family = "wasm", not(feature = "tokio-websocket")))]
-        let transport =
-            crate::only_secure_ws_transport::Transport::new(websocket_websys::Transport::default());
+        let transport = websocket_websys::Transport::default();
 
         #[cfg(all(not(feature = "tokio-websocket"), not(target_family = "wasm")))]
         let transport = MemoryTransport::default();


### PR DESCRIPTION
This was preventing the config setting `network.only_secure_ws_connections` from taking effect.

#### This fixes #3117.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
