### PR TITLE
Pre-genesis flag when requesting txns by address

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -105,14 +105,19 @@ impl<N: Network> ConsensusProxy<N> {
         min_peers: usize,
         max: Option<u16>,
         start_at: Option<Blake2bHash>,
+        include_pre_genesis: bool,
     ) -> Result<Vec<(Blake2bHash, u32)>, RequestError> {
         let mut obtained_receipts = HashSet::new();
 
+        // If we need to include pre-genesis data, we set the appropiate services flag
+        let services = if include_pre_genesis {
+            Services::PRE_GENESIS_TRANSACTIONS | Services::TRANSACTION_INDEX
+        } else {
+            Services::TRANSACTION_INDEX
+        };
+
         // We obtain a list of connected peers that could satisfy our request and perform the request to each one:
-        for peer_id in self
-            .get_peers_for_service(Services::TRANSACTION_INDEX, min_peers)
-            .await?
-        {
+        for peer_id in self.get_peers_for_service(services, min_peers).await? {
             log::debug!(
                 peer_id = %peer_id,
                 "Performing txn receipts by address request to peer",

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -92,7 +92,13 @@ async fn test_request_transactions_by_address() {
     let key_pair = KeyPair::from(PrivateKey::from_str(REWARD_KEY).unwrap());
 
     let receipts = consensus_proxy
-        .request_transaction_receipts_by_address(Address::from(&key_pair.public), 1, None, None)
+        .request_transaction_receipts_by_address(
+            Address::from(&key_pair.public),
+            1,
+            None,
+            None,
+            false,
+        )
         .await;
     assert!(receipts.is_ok());
     let res = consensus_proxy

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -700,6 +700,7 @@ impl Client {
                 min_peers.unwrap_or(1),
                 limit,
                 start_at,
+                true,
             )
             .await?;
 
@@ -772,11 +773,19 @@ impl Client {
             }
         }
 
+        let include_pre_genesis = since_block_height < Policy::genesis_block_number();
+
         // Fetch transaction receipts.
         let receipts: HashMap<_, _> = self
             .inner
             .consensus_proxy()
-            .request_transaction_receipts_by_address(address, min_peers, limit, start_at)
+            .request_transaction_receipts_by_address(
+                address,
+                min_peers,
+                limit,
+                start_at,
+                include_pre_genesis,
+            )
             .await?
             .into_iter()
             .collect();


### PR DESCRIPTION
Use the appropriate services flag when transactions from the PoW chain are required from a specific address

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
