### PR TITLE
Add missing methods to web-api primitives

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -133,7 +133,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Compile to wasm and generate bindings
       working-directory: ./web-client
-      run: ./scripts/build.sh --only nodejs
+      run: ./scripts/build.sh --only nodejs,types
     - name: Install dependencies in the web-client/dist folder
       working-directory: ./web-client/dist
       run: yarn install

--- a/web-client/scripts/build.sh
+++ b/web-client/scripts/build.sh
@@ -7,9 +7,8 @@ set -e
 # Defaults
 CARGO_PROFILE="release-wasm"
 CARGO_TARGET="wasm32-unknown-unknown"
-TARGETS="bundler,web,nodejs"
+TARGETS="bundler,web,nodejs,types"
 RUN_WASM_OPT=true
-BUILD_TYPES=true
 BUILD_LAUNCHER=true
 BUILD_LIB=true
 
@@ -21,7 +20,6 @@ while [[ "$#" -gt 0 ]]; do
         --cargo-dir) CARGO_OUTPUT="$2/nimiq_web_client.wasm"; shift ;;
         -o|--only) TARGETS="$2"; shift ;;
         --skip-wasm-opt) RUN_WASM_OPT=false ;;
-        --skip-types) BUILD_TYPES=false ;;
         --skip-launcher) BUILD_LAUNCHER=false ;;
         --skip-lib) BUILD_LIB=false ;;
         *) echo "Unknown argument: $1"; exit 1 ;;
@@ -118,7 +116,7 @@ if contains "nodejs" "$TARGETS"; then
 fi
 
 # Types
-if [ "$BUILD_TYPES" = "true" ]; then
+if contains "types" "$TARGETS"; then
     echo "Building types..."
     compile "client,crypto,primitives"
     wasm-bindgen --weak-refs --target web --out-name web --out-dir dist/types/wasm "$CARGO_OUTPUT"

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -25,6 +25,12 @@ impl Address {
         )))
     }
 
+    /// Deserializes an address from a byte array.
+    pub fn deserialize(bytes: &[u8]) -> Result<Address, JsError> {
+        let address = nimiq_keys::Address::deserialize_from_vec(bytes)?;
+        Ok(Address::from(address))
+    }
+
     /// Parses an address from an {@link Address} instance, a hex string representation, or a byte array.
     ///
     /// Throws when an address cannot be parsed from the argument.

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -369,6 +369,12 @@ impl Transaction {
         Ok(serde_wasm_bindgen::to_value(&plain)?.into())
     }
 
+    /// Deserializes a transaction from a byte array.
+    pub fn deserialize(bytes: &[u8]) -> Result<Transaction, JsError> {
+        let tx = nimiq_transaction::Transaction::deserialize_from_vec(bytes)?;
+        Ok(Transaction::from(tx))
+    }
+
     /// Parses a transaction from a {@link Transaction} instance, a plain object, a hex string
     /// representation, or a byte array.
     ///


### PR DESCRIPTION
## What's in this pull request?

- Add `PublicKey.fromAny`
- Add `Transaction.deserialize`
- Add `Address.deserialze`
- Add `TransactionFlag` enum

#### This fixes #3127.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
