### PR TITLE
Update the nimiq-jsonrpc dependencies to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-client"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54afbd4c624118e2b4b95b81e50f818f17b83a710c35eb7b38caa61e1df30952"
+checksum = "844a8fceaf19654c3b911e580f9fc425b4c8ce4d81e91ef4d43a237255fc830f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4147,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3216e2054d8dde6aa7b3aa5de730aece728b48c1b253c2e89d723da8947fa0"
+checksum = "419861fe0523ec2ed2a22a91bc5de37281af742aa5e5f4b8b848a3bb4cebf152"
 dependencies = [
  "log",
  "serde",
@@ -4159,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3bbea8c1aaccd18a92991467b42f3907954f37847775a915a1e45d69a41462"
+checksum = "90e0815fbdb9b4f1b3d4b01f2b92015270a9b5b6b6a03a952ddb994e55c50042"
 dependencies = [
  "darling",
  "heck 0.5.0",
@@ -4175,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-server"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed08070ec277f8206c2aac1f731f552264601af089c39fe11920d9421e662af"
+checksum = "d6a1a4219d02f3ff48ed75883f0d3025c2fb5d5bfa49fb1a92f955cc7927cf5c"
 dependencies = [
  "async-trait",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,10 +196,10 @@ nimiq-genesis-builder = { path = "genesis-builder", default-features = false }
 nimiq-handel = { path = "handel", default-features = false }
 nimiq-hash = { path = "hash", default-features = false }
 nimiq-hash_derive = { path = "hash/hash_derive", default-features = false }
-nimiq-jsonrpc-client = { version = "0.1", default-features = false }
-nimiq-jsonrpc-core = { version = "0.1", default-features = false }
-nimiq-jsonrpc-derive = { version = "0.1", default-features = false }
-nimiq-jsonrpc-server = { version = "0.1", default-features = false }
+nimiq-jsonrpc-client = { version = "0.1.1", default-features = false }
+nimiq-jsonrpc-core = { version = "0.1.1", default-features = false }
+nimiq-jsonrpc-derive = { version = "0.1.1", default-features = false }
+nimiq-jsonrpc-server = { version = "0.1.1", default-features = false }
 nimiq-key-derivation = { path = "key-derivation", default-features = false }
 nimiq-keys = { path = "keys", default-features = false }
 nimiq-light-blockchain = { path = "light-blockchain", default-features = false }


### PR DESCRIPTION
Update the `nimiq-jsonrpc` dependencies to the latest v0.1.1 release.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
