### PR TITLE
Set pre-genesis flag before using it

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -265,6 +265,13 @@ impl ClientInner {
                 _ => true,
             }
         });
+
+        // Set pre-genesis flag.
+        #[cfg(feature = "database-storage")]
+        if config.storage.has_pre_genesis_database(config.network_id) {
+            provided_services |= Services::PRE_GENESIS_TRANSACTIONS;
+        }
+
         let peer_contact = PeerContact::new(
             peer_contact_addresses,
             identity_keypair.public(),
@@ -353,7 +360,6 @@ impl ClientInner {
         #[cfg(feature = "database-storage")]
         let pre_genesis_environment = if config.storage.has_pre_genesis_database(config.network_id)
         {
-            provided_services |= Services::PRE_GENESIS_TRANSACTIONS;
             Some(
                 config
                     .storage


### PR DESCRIPTION
## What's in this pull request?
The pre-genesis flag was set only after we created our peer contact.
That was possible as it implements `Copy`.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
