### PR TITLE
light-blockchain: Always provide some blocks from ChainStore

### DIFF
--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -166,12 +166,11 @@ impl LightBlockchain {
         chain_info.on_main_chain = true;
         prev_info.main_chain_successor = Some(block_hash.clone());
 
-        // If it's a macro block then we need to clear the ChainStore (since we only want to keep
-        // the current batch in memory). Otherwise, we need to update the previous ChainInfo.
+        // Update the chain store: Update previous ChainInfo and clear old blocks on macro blocks
+        this.chain_store.put_chain_info(prev_info);
         if chain_info.head.is_macro() {
-            this.chain_store.clear();
-        } else {
-            this.chain_store.put_chain_info(prev_info);
+            this.chain_store
+                .clear_old_blocks(chain_info.head.block_number());
         }
 
         // Update the head of the blockchain.

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -75,7 +75,8 @@ impl LightBlockchain {
 
         // Since it's a macro block, we have to clear the ChainStore. If we are syncing for the first
         // time, this should be empty. But we clear it just in case it's not our first time.
-        this.chain_store.clear();
+        this.chain_store
+            .clear_old_blocks(chain_info.head.block_number());
 
         // Store the block chain info.
         this.chain_store.put_chain_info(chain_info);
@@ -151,8 +152,9 @@ impl LightBlockchain {
         // Create the chain info for the new block.
         let chain_info = ChainInfo::new(block.clone(), true);
 
-        // Since it's a macro block, we have to clear the ChainStore.
-        this.chain_store.clear();
+        // Remove old blocks from the ChainStore.
+        this.chain_store
+            .clear_old_blocks(chain_info.head.block_number());
 
         // Store the block chain info.
         this.chain_store.put_chain_info(chain_info);


### PR DESCRIPTION
Currently, when a HeadChangedListener is called on a macro block, calling get_block right afterwards doesn't work, as the ChainStore is cleared even before the event gets signaled.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
