### PR TITLE
Handel: parameterize `complete` condition

### DIFF
--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -188,7 +188,7 @@ where
     }
 
     fn is_complete_aggregate(&self, aggregate: &P::Contribution) -> bool {
-        self.num_contributors(aggregate) == self.protocol.partitioner().size()
+        self.protocol.evaluator().is_complete(aggregate)
     }
 
     /// Check if the given level was completed. If so mark it as such.

--- a/handel/tests/mod.rs
+++ b/handel/tests/mod.rs
@@ -11,7 +11,7 @@ use nimiq_handel::{
     evaluator::WeightedVote,
     identity::{Identity, IdentityRegistry, WeightRegistry},
     network::Network,
-    partitioner::BinomialPartitioner,
+    partitioner::{BinomialPartitioner, Partitioner},
     protocol,
     store::ReplaceStore,
     update::LevelUpdate,
@@ -113,6 +113,9 @@ impl Protocol {
             store.clone(),
             Arc::clone(&registry),
             partitioner.clone(),
+            |aggregate: &Contribution, registry: &Registry, partitioner: &BinomialPartitioner| {
+                registry.signers_identity(&aggregate.contributors()).len() == partitioner.size()
+            },
         ));
 
         Protocol {

--- a/validator/src/aggregation/tendermint/protocol.rs
+++ b/validator/src/aggregation/tendermint/protocol.rs
@@ -42,9 +42,14 @@ impl TendermintAggregationProtocol {
             Arc::clone(&registry),
             Arc::clone(&partitioner),
             |aggregate: &TendermintContribution, _, _| {
-                aggregate.proposals().iter().any(|(_, contributor_count)| {
-                    *contributor_count >= Policy::TWO_F_PLUS_ONE as usize
-                })
+                // We accept full aggregations and aggregations that collected 2f+1 signatures for a single proposal/None.
+                aggregate.all_contributors().len() == Policy::SLOTS as usize
+                    || aggregate
+                        .contributions
+                        .iter()
+                        .any(|(_hash_option, contributor_count)| {
+                            contributor_count.signers.len() >= Policy::TWO_F_PLUS_ONE as usize
+                        })
             },
         ));
 


### PR DESCRIPTION
Allow handel implementers to specify a custom `complete` condition. This enables handel to fast-track aggregations that are considered complete before all contributions have been aggregated.