### PR TITLE
Improve logging for Tendermint State Update

### DIFF
--- a/validator/src/aggregation/tendermint/contribution.rs
+++ b/validator/src/aggregation/tendermint/contribution.rs
@@ -25,6 +25,19 @@ impl std::fmt::Debug for TendermintContribution {
     }
 }
 
+impl std::fmt::Display for TendermintContribution {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut debug = f.debug_map();
+        // Use short string for hashes.
+        debug.entries(
+            self.contributions
+                .iter()
+                .map(|(v, m)| (v.as_ref().map(|hash| hash.to_short_str()), &m.signers)),
+        );
+        debug.finish()
+    }
+}
+
 impl TendermintContribution {
     pub(crate) fn from_vote(
         vote: TendermintVote,

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -603,7 +603,7 @@ where
                 // In case of a new state update we need to store the new version of it disregarding
                 // any old state which potentially still lingers.
                 MappedReturn::Update(update) => {
-                    trace!(?update, "Tendermint state update");
+                    debug!(?update, "Tendermint state update");
 
                     let expected_block_number = self.blockchain.read().block_number() + 1;
                     if expected_block_number != update.block_number {


### PR DESCRIPTION
## What's in this pull request?
This PR bumps the state update log to _debug_ level while shortening the output.
Hashes will only be displayed in its short form.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
