### PR TITLE
Wait for Account proofs blocks if they are not available yet

### DIFF
--- a/blockchain-interface/src/error.rs
+++ b/blockchain-interface/src/error.rs
@@ -28,6 +28,23 @@ pub enum BlockchainEvent {
     EpochFinalized(Blake2bHash),
 }
 
+impl BlockchainEvent {
+    /// Returns all added block hashes by this event
+    pub fn added_hashes(&self) -> Vec<Blake2bHash> {
+        match self {
+            BlockchainEvent::EpochFinalized(_) => vec![],
+            BlockchainEvent::Extended(hash) => vec![hash.clone()],
+            BlockchainEvent::Finalized(_) => vec![],
+            BlockchainEvent::HistoryAdopted(hash) => vec![hash.clone()],
+            BlockchainEvent::Rebranched(adopted_blocks, _reverted_blocks) => adopted_blocks
+                .iter()
+                .map(|(hash, _block)| hash.clone())
+                .collect(),
+            BlockchainEvent::Stored(block) => vec![block.hash()],
+        }
+    }
+}
+
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BlockchainError {
     #[error("Invalid genesis block stored. Verify you are on the correct network or reset your consensus database.")]

--- a/web-client/example/index.html
+++ b/web-client/example/index.html
@@ -27,6 +27,7 @@
     </div>
     <div>
       <button id="address-book">Query address book</button>
+      <button id="query-staking-contract">Query Staking Contract balance</button>
     </div>
     <script>
       const deadMansSwitch = document.querySelector('#dead-mans-switch');

--- a/web-client/example/module.js
+++ b/web-client/example/module.js
@@ -49,6 +49,11 @@ init().then(async () => {
         console.table(contacts);
     });
 
+    document.querySelector('#query-staking-contract').addEventListener("click", async () => {
+        let account = await client.getAccount('NQ07 0000 0000 0000 0000 0000 0000 0000 0000');
+        console.log(account);
+    });
+
     /**
      * @param {string} privateKey
      * @param {string} recipient


### PR DESCRIPTION
When getting the trie in the RemoteDataStore previous to this PR the block which is referenced by the returned proof must already exist locally. That is by no means guaranteed and will result in discarding the proof. 

This PR thus added a waiting window within which the RemoteDataStore will wait for the block to arrive. It will wait a specified amount of blockchain events which have added blocks. 

Additionally whenever a proof would not verify another peer will be asked to proof an address, whereas before this PR the get_trie would simply fail at this point.

A button was added to the web client example to exercise the behaviour.