### PR TITLE
Remove incorrect implementation of `DataStoreReadOps`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,12 @@
 [[disallowed-methods]]
+path = "futures::executor::block_on"
+reason = "calling asynchronous code from synchronous code is almost always an error, use `tokio::runtime::Handle::current().block_on` if it's not an error"
+
+[[disallowed-methods]]
+path = "futures_executor::block_on"
+reason = "calling asynchronous code from synchronous code is almost always an error, use `tokio::runtime::Handle::current().block_on` if it's not an error"
+
+[[disallowed-methods]]
 path = "tokio::task::spawn"
 reason = "use `nimiq_utils::spawn` instead, it is also supported in WASM environments"
 

--- a/consensus/src/consensus/remote_data_store.rs
+++ b/consensus/src/consensus/remote_data_store.rs
@@ -366,22 +366,8 @@ impl<N: Network> RemoteDataStore<N> {
 
 impl<N: Network> DataStoreReadOps for RemoteDataStore<N> {
     fn get<T: Deserialize>(&self, key: &KeyNibbles) -> Option<T> {
-        let proof = futures_executor::block_on(Self::get_trie(
-            Arc::clone(&self.network),
-            self.blockchain.clone(),
-            &[key.clone()],
-            self.min_peers,
-        ))
-        .ok();
-        if let Some(mut proof) = proof {
-            if proof.len() != 1 {
-                log::error!(len = proof.len(), "Unexpected amount of proved items");
-                None
-            } else {
-                proof.remove(key).flatten()
-            }
-        } else {
-            None
-        }
+        unimplemented!(
+            "this function is not implementable: a sync function cannot call an async one",
+        );
     }
 }


### PR DESCRIPTION
Previously, the function would try to block the whole thread whenever requesting something from other peers.

This wasn't noticed since the implementation is only used in light clients that were **NOT** compiled for WASM.

I noticed this implementation when reviewing #3159, which would have caused these thread blockings to continue for longer times.