### PR TITLE
Changing basic transaction data input from hexcode to plain string

### DIFF
--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -145,7 +145,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         let transaction = TransactionBuilder::new_basic_with_data(
             &self.get_wallet_keypair(&wallet)?,
             recipient,
-            hex::decode(data).unwrap(),
+            data.as_bytes().to_vec(),
             value,
             fee,
             self.validity_start_height(validity_start_height),


### PR DESCRIPTION
## What's in this pull request?
Requested by frontend. Changes data input from hexcode to plain string for the rpc method basic transaction with data. These are the only functions with the expectation of a hex string as input.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
