### PR TITLE
Align example config path with docs

### DIFF
--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -122,7 +122,7 @@ impl ConfigFile {
 
         // The config doesn't exist. Create an example config file and tell
         // the user to create a config.
-        let example = paths::home().join("client.toml.example");
+        let example = paths::home().join("client.example.toml");
         let example_message = Self::create_example(&example)
             .map(|()| format!("see example config file at {}", example.display()))
             .unwrap_or_else(|error| {


### PR DESCRIPTION
## What's in this pull request?

The Dockerfile and README create the example config at `client.example.toml`.
Running `nimiq-client` creates `client.toml.example`.

I picked `client.example.toml`.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
