### PR TITLE
RPC Server: `pushTransaction` and `pushHighPriorityTransaction` methods broadcast the transaction

### DIFF
--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -49,7 +49,7 @@ pub fn initialize_rpc_server(
     ));
     dispatcher.add(NetworkDispatcher::new(client.network()));
     if let Some(mempool) = client.mempool() {
-        dispatcher.add(MempoolDispatcher::new(mempool));
+        dispatcher.add(MempoolDispatcher::new(client.consensus_proxy(), mempool));
     }
     dispatcher.add(PolicyDispatcher {});
     if let Some(validator_proxy) = client.validator_proxy() {

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -612,7 +612,7 @@ impl Mempool {
         (txs, size)
     }
 
-    /// Adds a transaction to the Mempool.
+    /// Adds a transaction to the local mempool without broadcasting it over the network.
     pub fn add_transaction(
         &self,
         transaction: Transaction,

--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -9,11 +9,11 @@ use crate::types::{HashOrTx, MempoolInfo, RPCResult};
 pub trait MempoolInterface {
     type Error;
 
-    /// Pushes a raw transaction into the mempool, it will be assigned a default priority.
+    /// Pushes a raw transaction with a default priority assigned into the mempool and broadcast it to the network.
     async fn push_transaction(&mut self, raw_tx: String)
         -> RPCResult<Blake2bHash, (), Self::Error>;
 
-    /// Pushes a raw transaction into the mempool with high priority.
+    /// Pushes a raw transaction with a high priority assigned into the mempool and broadcast it to the network.
     async fn push_high_priority_transaction(
         &mut self,
         raw_tx: String,


### PR DESCRIPTION
## What's in this pull request?
By only pushing the transaction into the local mempool, the transaction never gets adopted if the node itself isn't an elected block producer.

#### This fixes #3131.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
