### PR TITLE
RPC Server: handle `create_basic_transaction_with_data` method hex decoding errors gracefully

### DIFF
--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -145,7 +145,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         let transaction = TransactionBuilder::new_basic_with_data(
             &self.get_wallet_keypair(&wallet)?,
             recipient,
-            hex::decode(data).unwrap(),
+            hex::decode(data)?,
             value,
             fee,
             self.validity_start_height(validity_start_height),


### PR DESCRIPTION
## What's in this pull request?
Instead of panicking during a failed hex decoding, gracefully handle the error.

Properly informing the consumer that a hex representation is expected will be part of different PR.

#### This fixes #3197.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
