### PR TITLE
Validator health status

### DIFF
--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -46,7 +46,9 @@ use crate::{
 ///      in the first place.
 /// (**) The validator may be set to automatically reactivate itself upon inactivation.
 ///      If this setting is not enabled the state change can only be triggered manually.
-///
+///      However, there is a delay incurred if the validator is deactivated multiple consecutive times
+///      in the current epoch. The delay is a function of the number of deactivations and is reduced
+///      if the validator starts producing blocks in time.
 /// Create, Update, Deactivate, Retire and Re-activate are incoming transactions to the staking contract.
 /// Delete is an outgoing transaction from the staking contract.
 /// To Create, Update or Delete, the cold key must be used (the one corresponding to the validator

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -124,6 +124,14 @@ pub enum HashAlgorithm {
     Sha512 = 4,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum ValidatorHealth {
+    Green = 1,
+    Yellow = 2,
+    Red = 3,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use nimiq_keys::Address;
 
-use crate::types::RPCResult;
+use crate::types::{RPCResult, ValidatorHealth};
 
 #[nimiq_jsonrpc_derive::proxy(name = "ValidatorProxy", rename_all = "camelCase")]
 #[async_trait]
@@ -19,6 +19,9 @@ pub trait ValidatorInterface {
 
     /// Returns all available voting keys.
     async fn get_voting_keys(&mut self) -> RPCResult<Vec<String>, (), Self::Error>;
+
+    /// Returns the current validator health.
+    async fn get_validator_health(&mut self) -> RPCResult<ValidatorHealth, (), Self::Error>;
 
     // Adds a voting key that will be used when the key expected by the chain changes
     async fn add_voting_key(&mut self, secret_key: String) -> RPCResult<(), (), Self::Error>;

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -5,9 +5,12 @@ use nimiq_bls::{KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
 use nimiq_consensus::ConsensusProxy;
 use nimiq_keys::Address;
 use nimiq_network_libp2p::Network;
-use nimiq_rpc_interface::{types::RPCResult, validator::ValidatorInterface};
+use nimiq_rpc_interface::{
+    types::{RPCResult, ValidatorHealth},
+    validator::ValidatorInterface,
+};
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_validator::validator::ValidatorState;
+use nimiq_validator::{health::ValidatorHealthState, validator::ValidatorState};
 use parking_lot::RwLock;
 
 use crate::error::Error;
@@ -62,6 +65,14 @@ impl ValidatorInterface for ValidatorDispatcher {
             .map(|key| hex::encode(key.secret_key.serialize_to_vec()))
             .collect::<Vec<String>>()
             .into())
+    }
+
+    async fn get_validator_health(&mut self) -> RPCResult<ValidatorHealth, (), Self::Error> {
+        Ok(match self.validator.read().validator_health.health() {
+            ValidatorHealthState::Green => ValidatorHealth::Green.into(),
+            ValidatorHealthState::Yellow => ValidatorHealth::Yellow.into(),
+            ValidatorHealthState::Red => ValidatorHealth::Red.into(),
+        })
     }
 
     async fn add_voting_key(&mut self, secret_key: String) -> RPCResult<(), (), Self::Error> {

--- a/test-utils/src/validator.rs
+++ b/test-utils/src/validator.rs
@@ -66,6 +66,7 @@ pub async fn build_validators<N: TestNetwork + NetworkInterface>(
     peer_ids: &[u64],
     hub: &mut Option<MockHub>,
     is_prover_active: bool,
+    automatic_reactivate: bool,
 ) -> Vec<Validator<ValidatorNetworkImpl<N>>>
 where
     N::Error: Send + Sync,
@@ -113,7 +114,7 @@ where
         let (v, c) = build_validator(
             peer_ids[i],
             Address::from(&validator_keys[i]),
-            false,
+            automatic_reactivate,
             signing_keys[i].clone(),
             voting_keys[i].clone(),
             fee_keys[i].clone(),

--- a/validator/src/health.rs
+++ b/validator/src/health.rs
@@ -1,0 +1,159 @@
+use std::cmp;
+
+use nimiq_keys::Address;
+
+/// Enum that represents the overall health of a validator
+/// - Green means the Validator is working as expected.
+/// - Yellow means there has been more than 'VALIDATOR_YELLOW_HEALTH_INACTIVATIONS' consecutive inactivations
+///   in the current epoch.
+/// - Red means there has been more than 'VALIDATOR_RED_HEALTH_INACTIVATIONS' consecutive inactivations
+///   in the current epoch.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ValidatorHealthState {
+    Green,
+    Yellow,
+    Red,
+}
+
+/// Struct that represents the overall Validator Health
+pub struct ValidatorHealth {
+    /// The current validator health
+    health: ValidatorHealthState,
+    /// Validator address
+    address: Address,
+    /// Only used for testing purposes controls whether blocks are published by the validator
+    publish: bool,
+    /// Number of consecutive inactivations that have occurred in the current epoch
+    inactivations: u32,
+    /// Next block number indicating when the re-activate transaction should be sent
+    reactivate_block_number: u32,
+    /// Flag that indicates if we are currently inactive
+    inactive: bool,
+}
+
+impl ValidatorHealth {
+    /// The number of consecutive inactivations from which a validator is considered with yellow health
+    const VALIDATOR_YELLOW_HEALTH_INACTIVATIONS: u32 = 2;
+    /// The number of consecutive inactivations from which a validator is considered with red health
+    const VALIDATOR_RED_HEALTH_INACTIVATIONS: u32 = 4;
+    // The maximum number of blocks the reactivate transaction can be delayed
+    const MAX_REACTIVATE_DELAY: u32 = 10_000;
+
+    /// Creates a new instance of the validator health structure
+    pub fn new(validator_address: &Address) -> ValidatorHealth {
+        ValidatorHealth {
+            health: ValidatorHealthState::Green,
+            publish: true,
+            inactivations: 0,
+            reactivate_block_number: 0,
+            inactive: false,
+            address: validator_address.clone(),
+        }
+    }
+
+    /// Computes the associated delay based on the current number of inactivations
+    fn get_reactivate_delay(&self) -> u32 {
+        cmp::min(self.inactivations.pow(2), Self::MAX_REACTIVATE_DELAY)
+    }
+
+    /// Returns the current health state of the validator
+    pub fn health(&self) -> ValidatorHealthState {
+        self.health
+    }
+
+    /// This flag should only be set in testing environments.
+    pub fn _set_publish_flag(&mut self, publish: bool) {
+        self.publish = publish
+    }
+
+    /// Decides if blocks should be published by the validator (only used for testing)
+    pub fn publish_block(&self) -> bool {
+        self.publish
+    }
+
+    /// Recomputes the current validator health state
+    pub fn refresh_validator_health_status(&mut self) {
+        log::trace!(
+            address=%self.address,
+            self.inactivations,
+            "Current validator Inactivations counter"
+        );
+
+        match self.health {
+            ValidatorHealthState::Green => {}
+            ValidatorHealthState::Yellow => {
+                if self.inactivations < Self::VALIDATOR_YELLOW_HEALTH_INACTIVATIONS {
+                    log::info!(self.inactivations, "Changed validator health to green");
+                    self.health = ValidatorHealthState::Green;
+                }
+            }
+            ValidatorHealthState::Red => {
+                if self.inactivations < Self::VALIDATOR_RED_HEALTH_INACTIVATIONS {
+                    log::info!(self.inactivations, "Changed validator health to yellow");
+                    self.health = ValidatorHealthState::Yellow;
+                }
+            }
+        }
+    }
+
+    /// Decreases the number of consecutive deactivations
+    pub fn block_produced(&mut self) {
+        self.inactivations = self.inactivations.saturating_sub(1);
+    }
+
+    /// Increases the number of consecutive deactivations
+    pub fn inactivate(&mut self, block_number: u32) {
+        if self.inactive {
+            // If we are currently inactive, then we dont have anything to do.
+            return;
+        }
+
+        self.inactivations = self.inactivations.saturating_add(1);
+        self.reactivate_block_number = block_number + self.get_reactivate_delay();
+        self.inactive = true;
+
+        match self.health {
+            ValidatorHealthState::Green => {
+                if self.inactivations >= Self::VALIDATOR_YELLOW_HEALTH_INACTIVATIONS {
+                    log::warn!(self.inactivations, "Changed validator health to yellow");
+                    self.health = ValidatorHealthState::Yellow;
+                }
+            }
+            ValidatorHealthState::Yellow => {
+                if self.inactivations >= Self::VALIDATOR_RED_HEALTH_INACTIVATIONS {
+                    log::warn!(self.inactivations, "Changed validator health to red");
+                    self.health = ValidatorHealthState::Red;
+                }
+            }
+            ValidatorHealthState::Red => {
+                log::warn!("Validator health is still red")
+            }
+        }
+
+        log::debug!(
+            address=%self.address,
+            self.inactivations,
+            self.reactivate_block_number,
+            block_number,
+            "New inactivation, current status",
+        );
+    }
+
+    /// Resets the internal counters and validator health state for a new epoch
+    pub fn reset_epoch(&mut self) {
+        // Reset the inactivations counter
+        self.inactivations = 0;
+        // Reset the validator health every epoch
+        self.health = ValidatorHealthState::Green;
+    }
+
+    /// Resets the pending reactivation flag
+    pub fn reactivate(&mut self) {
+        self.inactive = false;
+    }
+
+    /// Returns the block number for the next re-activate transaction
+    pub fn get_reactivate_block_number(&self) -> u32 {
+        self.reactivate_block_number
+    }
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 pub mod aggregation;
+pub mod health;
 mod jail;
 pub mod key_utils;
 mod r#macro;

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -18,7 +18,10 @@ use nimiq_validator_network::ValidatorNetwork;
 use nimiq_vrf::VrfSeed;
 use parking_lot::RwLock;
 
-use crate::{aggregation::skip_block::SkipBlockAggregation, validator::Validator};
+use crate::{
+    aggregation::skip_block::SkipBlockAggregation,
+    validator::{Validator, ValidatorState},
+};
 
 pub(crate) enum ProduceMicroBlockEvent {
     MicroBlock,
@@ -36,6 +39,7 @@ struct NextProduceMicroBlockEvent<TValidatorNetwork> {
     block_number: u32,
     producer_timeout: Duration,
     block_separation_time: Duration,
+    state: Arc<RwLock<ValidatorState>>,
 }
 
 impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<TValidatorNetwork> {
@@ -53,6 +57,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         block_number: u32,
         producer_timeout: Duration,
         block_separation_time: Duration,
+        state: Arc<RwLock<ValidatorState>>,
     ) -> Self {
         Self {
             blockchain,
@@ -65,6 +70,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             block_number,
             producer_timeout,
             block_separation_time,
+            state,
         }
     }
 
@@ -117,6 +123,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             info!(
                 block_number = self.block_number,
                 slot_band = self.validator_slot_band,
+                address = %self.state.read().validator_address,
                 "Our turn, producing micro block #{}",
                 self.block_number,
             );
@@ -153,6 +160,11 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
                 num_transactions
             );
 
+            if !self.state.read().validator_health.publish_block() {
+                log::warn!(block = block.block_number(), "Not publishing block");
+                break Some(Some(ProduceMicroBlockEvent::MicroBlock));
+            }
+
             // Publish the block. It is valid as we have just created it.
             Validator::publish_block(Arc::clone(&self.network), block.clone());
 
@@ -180,6 +192,9 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
                 delay = Duration::from_millis(50);
                 continue;
             }
+
+            // Each successful block will decrease the number of inactivations
+            self.state.write().validator_health.block_produced();
 
             let event = result
                 .map(move |_result| ProduceMicroBlockEvent::MicroBlock)
@@ -404,6 +419,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> ProduceMicroBlock<TValidator
         block_number: u32,
         producer_timeout: Duration,
         block_separation_time: Duration,
+        state: Arc<RwLock<ValidatorState>>,
     ) -> Self {
         let next_event = NextProduceMicroBlockEvent::new(
             blockchain,
@@ -416,6 +432,7 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> ProduceMicroBlock<TValidator
             block_number,
             producer_timeout,
             block_separation_time,
+            state,
         )
         .next()
         .boxed();

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -40,6 +40,7 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use crate::{
     aggregation::tendermint::{proposal::RequestProposal, state::MacroState},
+    health::ValidatorHealth,
     jail::EquivocationProofPool,
     key_utils::VotingKeys,
     micro::ProduceMicroBlock,
@@ -72,6 +73,7 @@ pub struct ValidatorState {
     pub automatic_reactivate: bool,
     pub slot_band: Option<u16>,
     pub consensus: ConsensusState,
+    pub validator_health: ValidatorHealth,
 }
 
 declare_table!(ValidatorTable, "ValidatorState", () => MacroState);
@@ -201,6 +203,8 @@ where
                 .await
         });
 
+        let validator_health = ValidatorHealth::new(&validator_address);
+
         Self {
             consensus: consensus.proxy(),
             blockchain,
@@ -217,6 +221,7 @@ where
                 automatic_reactivate,
                 slot_band: None,
                 consensus: blockchain_state,
+                validator_health,
             })),
             inactivity_state: None,
 
@@ -450,6 +455,7 @@ where
                     next_block_number,
                     Self::compute_micro_block_producer_timeout(head, &blockchain),
                     Self::BLOCK_SEPARATION_TIME,
+                    Arc::clone(&self.state),
                 ));
             }
         }
@@ -469,6 +475,8 @@ where
                 self.on_blockchain_extended(hash);
             }
             BlockchainEvent::EpochFinalized(ref hash) => {
+                // Reset the validator health for the new epoch
+                self.state().write().validator_health.reset_epoch();
                 self.init_epoch();
                 // The on_blockchain_extended is necessary for the order of events to not matter.
                 self.on_blockchain_extended(hash);
@@ -499,6 +507,20 @@ where
 
         self.check_reactivate(block.block_number());
         self.init_block_producer(Some(hash));
+
+        let block_number = block.block_number();
+        let blockchain = self.blockchain.read();
+
+        if block_number
+            == self
+                .state
+                .read()
+                .validator_health
+                .get_reactivate_block_number()
+        {
+            let inactivity_state = self.reactivate(&blockchain);
+            self.inactivity_state = Some(inactivity_state);
+        }
     }
 
     fn on_blockchain_rebranched(
@@ -673,7 +695,7 @@ where
 
         let cn = self.consensus.clone();
         spawn(async move {
-            debug!("Sending reactivate transaction to the network");
+            info!("Sending reactivate transaction to the network");
             if cn
                 .send_transaction(reactivate_transaction.clone())
                 .await
@@ -786,18 +808,23 @@ where
         // Once the validator can be active is established, check the validator staking state.
         if self.is_synced() {
             let blockchain = self.blockchain.read();
-            let state = self.state.read();
-            match state.get_staking_state(&blockchain) {
+            let block_number = blockchain.block_number();
+            let staking_state = self.state.read().get_staking_state(&blockchain);
+            match staking_state {
                 ValidatorStakingState::Active => {
-                    drop(state);
-                    drop(blockchain);
                     if self.inactivity_state.is_some() {
+                        drop(blockchain);
                         self.inactivity_state = None;
+                        self.state.write().validator_health.reactivate();
                         info!("Automatically reactivated.");
                     }
+
+                    self.state
+                        .write()
+                        .validator_health
+                        .refresh_validator_health_status();
                 }
                 ValidatorStakingState::Inactive(jailed_from) => {
-                    drop(state);
                     if self.inactivity_state.is_none()
                         && jailed_from
                             .map(|jailed_from| {
@@ -806,9 +833,7 @@ where
                             .unwrap_or(true)
                         && self.state.read().automatic_reactivate
                     {
-                        let inactivity_state = self.reactivate(&blockchain);
-                        drop(blockchain);
-                        self.inactivity_state = Some(inactivity_state);
+                        self.state.write().validator_health.inactivate(block_number);
                     }
                 }
                 ValidatorStakingState::UnknownOrNoStake => {}

--- a/validator/tests/integration.rs
+++ b/validator/tests/integration.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use futures::{future, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain::{BlockProducer, Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
@@ -8,15 +7,13 @@ use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_database::mdbx::MdbxDatabase;
 use nimiq_genesis::NetworkId;
 use nimiq_keys::KeyPair;
-use nimiq_network_libp2p::Network;
 use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_test_log::test;
-use nimiq_test_utils::{
-    blockchain::{produce_macro_blocks_with_txns, signing_key, validator_key, voting_key},
-    validator::build_validators,
+use nimiq_test_utils::blockchain::{
+    produce_macro_blocks_with_txns, signing_key, validator_key, voting_key,
 };
 use nimiq_transaction_builder::TransactionBuilder;
-use nimiq_utils::{key_rng::SecureGenerate, spawn, time::OffsetTime};
+use nimiq_utils::{key_rng::SecureGenerate, time::OffsetTime};
 use parking_lot::RwLock;
 
 #[test(tokio::test)]

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -1,32 +1,24 @@
 use std::{sync::Arc, task::Poll, time::Duration};
 
 use futures::{future, StreamExt};
-use nimiq_block::{MultiSignature, SignedSkipBlockInfo, SkipBlockInfo};
-use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
-use nimiq_bls::{AggregateSignature, KeyPair as BlsKeyPair};
-use nimiq_collections::BitSet;
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_database::mdbx::MdbxDatabase;
 use nimiq_genesis_builder::GenesisBuilder;
-use nimiq_handel::update::LevelUpdate;
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
-use nimiq_network_interface::{
-    network::{CloseReason, Network as NetworkInterface},
-    request::{MessageMarker, RequestCommon},
-};
+use nimiq_network_interface::request::{MessageMarker, RequestCommon};
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
-use nimiq_test_utils::{
-    test_network::TestNetwork,
-    validator::{
-        build_validator, build_validators, pop_validator_for_slot, seeded_rng, validator_for_slot,
-    },
+use nimiq_test_utils::validator::{
+    build_validator, build_validators, pop_validator_for_slot, seeded_rng,
 };
-use nimiq_time::{sleep, timeout};
+use nimiq_time::timeout;
 use nimiq_utils::spawn;
-use nimiq_validator::aggregation::{
-    skip_block::SignedSkipBlockMessage, update::SerializableLevelUpdate,
+use nimiq_validator::{
+    aggregation::{skip_block::SignedSkipBlockMessage, update::SerializableLevelUpdate},
+    health::ValidatorHealthState,
 };
 use serde::{Deserialize, Serialize};
 
@@ -105,6 +97,7 @@ async fn four_validators_can_create_micro_blocks() {
         &(1u64..=4u64).collect::<Vec<_>>(),
         &mut Some(hub),
         false,
+        false,
     )
     .await;
 
@@ -143,9 +136,14 @@ async fn validators_can_do_skip_block() {
     let env =
         MdbxDatabase::new_volatile(Default::default()).expect("Could not open a volatile database");
 
-    let mut validators =
-        build_validators::<Network>(env, &(5u64..=10u64).collect::<Vec<_>>(), &mut None, false)
-            .await;
+    let mut validators = build_validators::<Network>(
+        env,
+        &(5u64..=10u64).collect::<Vec<_>>(),
+        &mut None,
+        false,
+        false,
+    )
+    .await;
 
     // Disconnect the next block producer.
     let _validator = pop_validator_for_slot(
@@ -176,36 +174,195 @@ async fn validators_can_do_skip_block() {
     assert!(block.block_number() > Policy::genesis_block_number());
 }
 
-fn create_skip_block_update(
-    skip_block_info: SkipBlockInfo,
-    key_pair: BlsKeyPair,
-    validator_id: u16,
-    slots: &[u16],
-) -> LevelUpdate<SignedSkipBlockMessage> {
-    // get a single signature for this skip block data
-    let signed_skip_block_info =
-        SignedSkipBlockInfo::from_message(skip_block_info, &key_pair.secret_key, validator_id);
+#[test(tokio::test)]
+async fn validator_can_recover_from_yellow_health() {
+    let env =
+        MdbxDatabase::new_volatile(Default::default()).expect("Could not open a volatile database");
 
-    // multiply with number of slots to get a signature representing all the slots of this public_key
-    let signature = AggregateSignature::from_signatures(&[signed_skip_block_info
-        .signature
-        .multiply(slots.len() as u16)]);
+    let validators = build_validators::<Network>(
+        env,
+        &(5u64..=10u64).collect::<Vec<_>>(),
+        &mut None,
+        false,
+        true,
+    )
+    .await;
 
-    // compute the signers bitset (which is just all the slots)
-    let mut signers = BitSet::new();
-    for &slot in slots {
-        signers.insert(slot as usize);
+    // Listen for blockchain events from the new block producer (after a skip block).
+    let validator = validators.first().unwrap();
+    let validator_state = Arc::clone(validator.state());
+
+    let validator = validators.last().unwrap();
+    let blockchain = Arc::clone(&validator.blockchain);
+    let events = blockchain.read().notifier_as_stream();
+
+    for validator in validators {
+        log::info!(
+            "Spawning validator: {}",
+            validator.state().read().validator_address
+        );
+        spawn(validator);
     }
 
-    // the contribution is composed of the signers bitset with the signature already multiplied by the number of slots.
-    let contribution = SignedSkipBlockMessage {
-        proof: MultiSignature::new(signature, signers),
+    validator_state
+        .write()
+        .validator_health
+        ._set_publish_flag(false);
+
+    log::info!(
+        "Validator proxy address {}",
+        validator_state.read().validator_address
+    );
+
+    events.take(30).for_each(|_| future::ready(())).await;
+
+    let current_validator_health = validator_state.read().validator_health.health();
+
+    match current_validator_health {
+        ValidatorHealthState::Yellow => {
+            log::info!("Current validator health is yellow, as expected",)
+        }
+        _ => panic!("Validator Health different than expected"),
     };
 
-    LevelUpdate::new(
-        contribution.clone(),
-        Some(contribution),
-        1,
-        validator_id as usize,
+    // The validator should no longer be skip blocked:
+    validator_state
+        .write()
+        .validator_health
+        ._set_publish_flag(true);
+
+    let events = blockchain.read().notifier_as_stream();
+    events.take(30).for_each(|_| future::ready(())).await;
+
+    assert_eq!(
+        validator_state.read().validator_health.health(),
+        ValidatorHealthState::Green
+    );
+}
+
+#[test(tokio::test)]
+async fn validator_health_to_red() {
+    let env =
+        MdbxDatabase::new_volatile(Default::default()).expect("Could not open a volatile database");
+
+    let validators = build_validators::<Network>(
+        env,
+        &(5u64..=10u64).collect::<Vec<_>>(),
+        &mut None,
+        false,
+        true,
     )
+    .await;
+
+    // Listen for blockchain events from the new block producer (after a skip block).
+    let validator = validators.first().unwrap();
+    let validator_state = Arc::clone(validator.state());
+
+    let validator = validators.last().unwrap();
+    let blockchain = Arc::clone(&validator.blockchain);
+    let events = blockchain.read().notifier_as_stream();
+
+    for validator in validators {
+        log::info!(
+            "Spawning validator: {}",
+            validator.state().read().validator_address
+        );
+        spawn(validator);
+    }
+
+    validator_state
+        .write()
+        .validator_health
+        ._set_publish_flag(false);
+
+    events.take(30).for_each(|_| future::ready(())).await;
+
+    let current_validator_health = validator_state.read().validator_health.health();
+
+    match current_validator_health {
+        ValidatorHealthState::Yellow => {
+            log::info!("Current validator health is yellow, as expected",)
+        }
+        _ => panic!("Validator Health different than expected"),
+    };
+
+    let events = blockchain.read().notifier_as_stream();
+
+    // Now we produce more blocks, and the validator should be inactivated again
+    events.take(20).for_each(|_| future::ready(())).await;
+
+    let current_validator_health = validator_state.read().validator_health.health();
+
+    match current_validator_health {
+        ValidatorHealthState::Red => {
+            log::info!("Current validator health is red, as expected",)
+        }
+        _ => panic!("Validator Health different than expected"),
+    };
+}
+
+#[test(tokio::test)]
+async fn validator_health_fully_recover() {
+    let env =
+        MdbxDatabase::new_volatile(Default::default()).expect("Could not open a volatile database");
+
+    let validators = build_validators::<Network>(
+        env,
+        &(5u64..=10u64).collect::<Vec<_>>(),
+        &mut None,
+        false,
+        true,
+    )
+    .await;
+
+    // Listen for blockchain events from the new block producer (after a skip block).
+    let validator = validators.first().unwrap();
+    let validator_state = Arc::clone(validator.state());
+    let validator_address = validator_state.read().validator_address.clone();
+
+    log::info!(
+        "Listening to blockchain events from validator {} ",
+        validator_address,
+    );
+
+    let validator = validators.last().unwrap();
+    let blockchain = Arc::clone(&validator.blockchain);
+
+    let events = blockchain.read().notifier_as_stream();
+
+    for validator in validators {
+        log::info!(
+            "Spawning validator: {}",
+            validator.state().read().validator_address
+        );
+        spawn(validator);
+    }
+
+    validator_state
+        .write()
+        .validator_health
+        ._set_publish_flag(false);
+
+    events.take(50).for_each(|_| future::ready(())).await;
+
+    let current_validator_health = validator_state.read().validator_health.health();
+
+    match current_validator_health {
+        ValidatorHealthState::Red => {
+            log::info!("Current validator health is red, as expected")
+        }
+        _ => panic!("Validator Health different than expected"),
+    };
+
+    validator_state
+        .write()
+        .validator_health
+        ._set_publish_flag(true);
+
+    let events = blockchain.read().notifier_as_stream();
+    events.take(100).for_each(|_| future::ready(())).await;
+
+    let current_validator_health = validator_state.read().validator_health.health();
+
+    assert_eq!(current_validator_health, ValidatorHealthState::Green);
 }


### PR DESCRIPTION
The validator health is used to track the overall validator health based on the number of consecutive deactivations of a validator on a per epoch basis.

The number of consecutive deactivations would cause a delay in terms of when the reactivation transaction is sent. 


## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
