### PR TITLE
RPC client `create_validator` uses the configuration as input

### DIFF
--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -56,6 +56,7 @@ enum Command {
 
     /// Shows and modifies validator information.
     /// Create, signs and send transactions referring to the local validator.
+    /// These operations only work if the current client is configured as a validator.
     #[clap(flatten)]
     Validator(ValidatorCommand),
 


### PR DESCRIPTION
## What's in this pull request?
The RPC client's operations for the validator were designed to be applied to the local validator. The create validator was the exception. This PR standardizes it.
To submit txs regarding other validators one can use the send raw transaction.

#### This fixes #3225.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
