### PR TITLE
Fix clippy warnings

### DIFF
--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -251,7 +251,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     // Verify the history chunk
                     let valid_chunk = chunk
                         .verify(&expected_root, leaf_index as usize)
-                        .map_or(false, |result| result);
+                        .is_some_and(|result| result);
 
                     if !valid_chunk {
                         // If the chunk doesn't verify we disconnect from the peer

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -724,7 +724,7 @@ impl<N: Network> BlockQueue<N> {
         if self
             .buffer
             .get(&block_number)
-            .map_or(false, |blocks| blocks.contains_key(&block_hash))
+            .is_some_and(|blocks| blocks.contains_key(&block_hash))
         {
             // Block is already buffered and will be pushed sometime soon. No need to request it.
             return;

--- a/mnemonic/src/lib.rs
+++ b/mnemonic/src/lib.rs
@@ -165,7 +165,7 @@ impl Entropy {
 
 const WORDLIST_SIZE: usize = 2048;
 pub type Wordlist<'a> = [&'a str; WORDLIST_SIZE];
-pub const WORDLIST_EN: Wordlist<'static> = [
+pub static WORDLIST_EN: Wordlist<'static> = [
     "abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd",
     "abuse", "access", "accident", "account", "accuse", "achieve", "acid", "acoustic", "acquire",
     "across", "act", "action", "actor", "actress", "actual", "adapt", "add", "addict", "address",

--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -275,7 +275,7 @@ impl PeerContactInfo {
     pub fn exceeds_age(&self, max_age: Duration, unix_time: Duration) -> bool {
         unix_time
             .checked_sub(Duration::from_secs(self.contact.inner.timestamp()))
-            .map_or(false, |age| age > max_age)
+            .is_some_and(|age| age > max_age)
     }
 
     /// Returns true if the services provided are interesting to me

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -259,7 +259,7 @@ impl Accounts {
         let missing = self
             .tree
             .get_missing_range(txn)
-            .map_or(false, |range| range.contains(&rightmost_key));
+            .is_some_and(|range| range.contains(&rightmost_key));
 
         if missing {
             self.tree


### PR DESCRIPTION
Fix clippy warnings that arose after updating to rust 1.84.0.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
