### PR TITLE
Web-client: Make client worker initialization more resilient

### DIFF
--- a/web-client/dist/bundler/worker.js
+++ b/web-client/dist/bundler/worker.js
@@ -32,10 +32,16 @@ async function init(config) {
 };
 
 self.addEventListener('message', async (event) => {
-    const { type } = event.data;
+    const data = event.data;
+
+    if (data === 'NIMIQ_CHECKREADY') {
+        self.postMessage('NIMIQ_READY');
+        return;
+    }
+
+    const { type, config } = data;
     if (type !== 'NIMIQ_INIT') return;
 
-    let { config } = event.data;
     if (!config || typeof config !== 'object') config = {};
 
     try {
@@ -46,5 +52,4 @@ self.addEventListener('message', async (event) => {
     }
 });
 
-self.postMessage('NIMIQ_ONLOAD');
-console.debug('Launched client WASM worker, ready for init');
+console.debug('Client WASM worker ready');

--- a/web-client/dist/nodejs/worker.js
+++ b/web-client/dist/nodejs/worker.js
@@ -45,10 +45,16 @@ async function init(config) {
 };
 
 parentPort.addListener('message', async (event) => {
-    const { type } = event;
+    const data = event.data;
+
+    if (data === 'NIMIQ_CHECKREADY') {
+        parentPort.postMessage('NIMIQ_READY');
+        return;
+    }
+
+    const { type, config } = data;
     if (type !== 'NIMIQ_INIT') return;
 
-    let { config } = event;
     if (!config || typeof config !== 'object') config = {};
 
     try {
@@ -59,5 +65,4 @@ parentPort.addListener('message', async (event) => {
     }
 });
 
-parentPort.postMessage('NIMIQ_ONLOAD');
-console.debug('Launched client WASM worker, ready for init');
+console.debug('Client WASM worker ready');

--- a/web-client/dist/nodejs/worker.mjs
+++ b/web-client/dist/nodejs/worker.mjs
@@ -45,10 +45,16 @@ async function init(config) {
 };
 
 parentPort.addListener('message', async (event) => {
-    const { type } = event;
+    const data = event.data;
+
+    if (data === 'NIMIQ_CHECKREADY') {
+        parentPort.postMessage('NIMIQ_READY');
+        return;
+    }
+
+    const { type, config } = data;
     if (type !== 'NIMIQ_INIT') return;
 
-    let { config } = event;
     if (!config || typeof config !== 'object') config = {};
 
     try {
@@ -59,5 +65,4 @@ parentPort.addListener('message', async (event) => {
     }
 });
 
-parentPort.postMessage('NIMIQ_ONLOAD');
-console.debug('Launched client WASM worker, ready for init');
+console.debug('Client WASM worker ready');

--- a/web-client/dist/web/worker.js
+++ b/web-client/dist/web/worker.js
@@ -39,10 +39,16 @@ async function init(config) {
 };
 
 self.addEventListener('message', async (event) => {
-    const { type } = event.data;
+    const data = event.data;
+
+    if (data === 'NIMIQ_CHECKREADY') {
+        self.postMessage('NIMIQ_READY');
+        return;
+    }
+
+    const { type, config } = data;
     if (type !== 'NIMIQ_INIT') return;
 
-    let { config } = event.data;
     if (!config || typeof config !== 'object') config = {};
 
     try {
@@ -53,5 +59,4 @@ self.addEventListener('message', async (event) => {
     }
 });
 
-self.postMessage('NIMIQ_ONLOAD');
-console.debug('Launched client WASM worker, ready for init');
+console.debug('Client WASM worker ready');

--- a/web-client/extras/launcher/client-proxy.ts
+++ b/web-client/extras/launcher/client-proxy.ts
@@ -59,8 +59,7 @@ export function clientFactory(workerFactory: () => Worker, comlinkWrapper: (work
             await new Promise<void>((resolve, reject) => {
                 addEventListener(worker, 'message', (event) => {
                     const eventData = getEventData(event);
-
-                    if (!('ok' in eventData)) return;
+                    if (typeof eventData !== 'object' || !('ok' in eventData)) return;
 
                     if (eventData.ok === true) resolve();
                     if (eventData.ok === false && 'error' in eventData && typeof eventData.error === 'string') {


### PR DESCRIPTION
## What's in this pull request?

Change client web-worker initialization signal from push-based to pull-based, i.e. change from the worker sending a signal that it's ready (which can be missed (race-condition) if the worker initializes too quickly) to polling the worker from the main thread, which is more resilient. 

#### This fixes iOS worker initialization problems in the Nimiq Pay app (and possibly other devices & apps).

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
