### PR TITLE
Web-client multisig primitives

### DIFF
--- a/keys/src/multisig/commitment.rs
+++ b/keys/src/multisig/commitment.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 use super::{error::InvalidScalarError, MUSIG2_PARAMETER_V};
 
 /// A nonce is a "number only used once" and it is supposed to be kept secret (similar to a private key).
-#[derive(PartialEq, Eq, Debug, Clone, Copy, Zeroize)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Zeroize, Default)]
 pub struct Nonce(pub Scalar);
 
 impl Nonce {
@@ -72,7 +72,7 @@ impl<'a> From<&'a [u8; Commitment::SIZE]> for Commitment {
 
 /// A structure holding both the secret nonce and the public commitment.
 /// This is similar to a `KeyPair`.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommitmentPair {
     random_secret: Nonce,

--- a/web-client/dist/nodejs/index.mjs
+++ b/web-client/dist/nodejs/index.mjs
@@ -1,3 +1,4 @@
+import { webcrypto } from 'node:crypto';
 import { Worker } from 'node:worker_threads';
 import Comlink from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.min.mjs';
@@ -5,6 +6,11 @@ import { Address, CryptoUtils, Transaction } from './main-wasm/index.js';
 import { clientFactory } from '../launcher/node/client-proxy.mjs';
 import { cryptoUtilsWorkerFactory } from '../launcher/node/cryptoutils-worker-proxy.mjs';
 import { setupMainThreadTransferHandlers } from '../launcher/node/transfer-handlers.mjs';
+
+// NodeJS ES module support for getrandom (https://docs.rs/getrandom/latest/getrandom/#nodejs-es-module-support)
+if (typeof globalThis.crypto === 'undefined') {
+    globalThis.crypto = webcrypto;
+}
 
 setupMainThreadTransferHandlers(Comlink, {
     Address,

--- a/web-client/extras/tests/CommitmentPair.test.ts
+++ b/web-client/extras/tests/CommitmentPair.test.ts
@@ -1,0 +1,16 @@
+import {
+    Commitment,
+    CommitmentPair,
+    RandomSecret,
+} from '@nimiq/core';
+import { describe, expect, it } from 'vitest';
+
+describe('CommitmentPair', () => {
+    it('can derive the correct commitment from a random secret', () => {
+        const pair = CommitmentPair.generate();
+
+        const randomSecret = pair.secret;
+        expect(Commitment.derive(randomSecret).equals(pair.commitment)).toBe(true);
+        expect(CommitmentPair.derive(randomSecret).equals(pair)).toBe(true);
+    });
+});

--- a/web-client/extras/tests/PartialSignature.test.ts
+++ b/web-client/extras/tests/PartialSignature.test.ts
@@ -1,0 +1,46 @@
+import {
+    PrivateKey,
+    PublicKey,
+    PartialSignature,
+    CommitmentPair,
+} from '@nimiq/core';
+import { describe, expect, it } from 'vitest';
+
+describe('PartialSignature', () => {
+    it('can create a partial signature', () => {
+        const privateKey = PrivateKey.generate();
+        const publicKey = PublicKey.derive(privateKey);
+
+        const commitmentPairs = [
+            CommitmentPair.generate(),
+            CommitmentPair.generate(),
+        ];
+
+        const publicKeys = [
+            PublicKey.derive(PrivateKey.generate()),
+            PublicKey.derive(PrivateKey.generate()),
+        ]
+
+        const commitments = [
+            [
+                CommitmentPair.generate().commitment,
+                CommitmentPair.generate().commitment,
+            ],
+            [
+                CommitmentPair.generate().commitment,
+                CommitmentPair.generate().commitment,
+            ],
+        ];
+
+        const partial_signature = PartialSignature.create(
+            privateKey,
+            publicKey,
+            commitmentPairs,
+            publicKeys,
+            commitments,
+            new Uint8Array(139),
+        );
+
+        expect(partial_signature.serialize().length).toBe(32);
+    });
+});

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -1,11 +1,16 @@
 use std::str::FromStr;
 
+#[cfg(feature = "primitives")]
+use nimiq_keys::multisig::address::{combine_public_keys, compute_address};
 use nimiq_serde::Deserialize;
 #[cfg(feature = "primitives")]
 use nimiq_serde::Serialize;
 use wasm_bindgen::prelude::*;
 #[cfg(feature = "primitives")]
 use wasm_bindgen_derive::TryFromJsValue;
+
+#[cfg(feature = "primitives")]
+use crate::primitives::public_key::{PublicKey, PublicKeyAnyArrayType};
 
 /// An object representing a Nimiq address.
 /// Offers methods to parse and format addresses from and to strings.
@@ -71,6 +76,18 @@ impl Address {
         Ok(Address::from(
             nimiq_keys::Address::from_user_friendly_address(str)?,
         ))
+    }
+
+    /// Computes the multisig address of a list of signer public keys.
+    #[cfg(feature = "primitives")]
+    #[wasm_bindgen(js_name = fromPublicKeys)]
+    pub fn from_public_keys(
+        public_keys: &PublicKeyAnyArrayType,
+        num_signers: usize,
+    ) -> Result<Address, JsError> {
+        let public_keys = PublicKey::unpack_public_keys(public_keys)?;
+        let combined_public_keys = combine_public_keys(public_keys, num_signers);
+        Ok(Address::from(compute_address(&combined_public_keys)))
     }
 
     /// Formats the address into a plain string format.

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -7,6 +7,8 @@ pub mod common;
 #[cfg(any(feature = "crypto", feature = "primitives"))]
 mod crypto_utils;
 #[cfg(feature = "primitives")]
+mod multisig;
+#[cfg(feature = "primitives")]
 mod primitives;
 
 #[cfg(test)]

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -5,6 +5,8 @@ use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_derive::TryFromJsValue;
 
+use super::random_secret::RandomSecret;
+
 /// A cryptographic commitment to a {@link RandomSecret}. The commitment is public, while the secret is, well, secret.
 #[derive(TryFromJsValue)]
 #[wasm_bindgen]
@@ -23,6 +25,13 @@ impl Commitment {
     #[wasm_bindgen(getter = serializedSize)]
     pub fn serialized_size(&self) -> usize {
         Commitment::size()
+    }
+
+    /// Derives a commitment from an existing random secret.
+    pub fn derive(random_secret: &RandomSecret) -> Commitment {
+        let nonce = *random_secret.native_ref();
+        let commitment = nonce.commit();
+        Commitment::from(commitment)
     }
 
     /// Sums up multiple commitments into one aggregated commitment.

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -1,0 +1,168 @@
+use std::iter::Sum;
+
+use js_sys::Array;
+use nimiq_serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_derive::TryFromJsValue;
+
+/// A cryptographic commitment to a {@link RandomSecret}. The commitment is public, while the secret is, well, secret.
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct Commitment {
+    inner: nimiq_keys::multisig::commitment::Commitment,
+}
+
+#[wasm_bindgen]
+impl Commitment {
+    #[wasm_bindgen(getter = SIZE)]
+    pub fn size() -> usize {
+        nimiq_keys::multisig::commitment::Commitment::SIZE
+    }
+
+    #[wasm_bindgen(getter = serializedSize)]
+    pub fn serialized_size(&self) -> usize {
+        Commitment::size()
+    }
+
+    /// Sums up multiple commitments into one aggregated commitment.
+    pub fn sum(commitments: &CommitmentAnyArrayType) -> Result<Commitment, JsError> {
+        let commitments = Commitment::unpack_commitments(commitments)?;
+        let aggregate_commitment =
+            nimiq_keys::multisig::commitment::Commitment::sum(commitments.into_iter());
+        Ok(Commitment::from(aggregate_commitment))
+    }
+
+    /// Parses a commitment from a {@link Commitment} instance, a hex string representation, or a byte array.
+    ///
+    /// Throws when a Commitment cannot be parsed from the argument.
+    #[wasm_bindgen(js_name = fromAny)]
+    pub fn from_any(commitment: &CommitmentAnyType) -> Result<Commitment, JsError> {
+        let js_value: &JsValue = commitment.unchecked_ref();
+
+        if let Ok(commitment) = Commitment::try_from(js_value) {
+            return Ok(commitment);
+        }
+
+        if let Ok(string) = serde_wasm_bindgen::from_value::<String>(js_value.to_owned()) {
+            Ok(Commitment::from_hex(&string)?)
+        } else if let Ok(bytes) = serde_wasm_bindgen::from_value::<Vec<u8>>(js_value.to_owned()) {
+            Ok(Commitment::deserialize(&bytes)?)
+        } else {
+            Err(JsError::new("Could not parse commitment"))
+        }
+    }
+
+    /// Deserializes a commitment from a byte array.
+    ///
+    /// Throws when the byte array contains less than 32 bytes.
+    pub fn deserialize(bytes: &[u8]) -> Result<Commitment, JsError> {
+        let commitment = nimiq_keys::multisig::commitment::Commitment::deserialize_from_vec(bytes)?;
+        Ok(Commitment::from(commitment))
+    }
+
+    /// Creates a new commitment from a byte array.
+    ///
+    /// Throws when the byte array is not exactly 32 bytes long.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: &[u8]) -> Result<Commitment, JsError> {
+        Self::deserialize(bytes)
+    }
+
+    /// Serializes the commitment to a byte array.
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.serialize_to_vec()
+    }
+
+    /// Parses a commitment from its hex representation.
+    ///
+    /// Throws when the string is not valid hex format or when it represents less than 32 bytes.
+    #[wasm_bindgen(js_name = fromHex)]
+    pub fn from_hex(hex: &str) -> Result<Commitment, JsError> {
+        let bytes = hex::decode(hex)?;
+        Self::deserialize(&bytes)
+    }
+
+    /// Formats the commitment into a hex string.
+    #[wasm_bindgen(js_name = toHex)]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.serialize())
+    }
+
+    /// Returns if this commitment is equal to the other commitment.
+    pub fn equals(&self, other: &Commitment) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl From<nimiq_keys::multisig::commitment::Commitment> for Commitment {
+    fn from(commitment: nimiq_keys::multisig::commitment::Commitment) -> Commitment {
+        Commitment { inner: commitment }
+    }
+}
+
+impl Commitment {
+    pub fn native_ref(&self) -> &nimiq_keys::multisig::commitment::Commitment {
+        &self.inner
+    }
+
+    pub fn take_native(self) -> nimiq_keys::multisig::commitment::Commitment {
+        self.inner
+    }
+
+    pub fn unpack_commitments(
+        commitments: &CommitmentAnyArrayType,
+    ) -> Result<Vec<nimiq_keys::multisig::commitment::Commitment>, JsError> {
+        // Unpack the array of commitments
+        let js_value: &JsValue = commitments.unchecked_ref();
+        let array: &Array = js_value
+            .dyn_ref()
+            .ok_or_else(|| JsError::new("`commitments` must be an array"))?;
+
+        if array.length() == 0 {
+            return Err(JsError::new("No commitments provided"));
+        }
+
+        let mut commitments = Vec::<_>::with_capacity(array.length().try_into()?);
+        for any in array.iter() {
+            let commitment = Commitment::from_any(&any.into())?.take_native();
+            commitments.push(commitment);
+        }
+
+        Ok(commitments)
+    }
+
+    pub fn unpack_commitments_list(
+        commitments_list: &CommitmentAnyArrayArrayType,
+    ) -> Result<Vec<Vec<nimiq_keys::multisig::commitment::Commitment>>, JsError> {
+        // Unpack the outer array
+        let js_value: &JsValue = commitments_list.unchecked_ref();
+        let array: &Array = js_value
+            .dyn_ref()
+            .ok_or_else(|| JsError::new("`commitments_list` must be an array"))?;
+
+        if array.length() == 0 {
+            return Err(JsError::new("No commitments list provided"));
+        }
+
+        let mut commitments_list = Vec::<_>::with_capacity(array.length().try_into()?);
+        for any in array.iter() {
+            let commitments = Commitment::unpack_commitments(&any.into())?;
+            commitments_list.push(commitments);
+        }
+
+        Ok(commitments_list)
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "Commitment | string | Uint8Array")]
+    pub type CommitmentAnyType;
+
+    #[wasm_bindgen(typescript_type = "(Commitment | string | Uint8Array)[]")]
+    pub type CommitmentAnyArrayType;
+
+    #[wasm_bindgen(typescript_type = "(Commitment | string | Uint8Array)[][]")]
+    pub type CommitmentAnyArrayArrayType;
+}

--- a/web-client/src/multisig/commitment_pair.rs
+++ b/web-client/src/multisig/commitment_pair.rs
@@ -1,0 +1,154 @@
+use js_sys::Array;
+use nimiq_keys::SecureGenerate;
+use nimiq_serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_derive::TryFromJsValue;
+
+use super::{commitment::Commitment, random_secret::RandomSecret};
+
+/// A structure holding both a random secret and its corresponding public commitment.
+/// This is similar to a `KeyPair`.
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct CommitmentPair {
+    inner: nimiq_keys::multisig::commitment::CommitmentPair,
+}
+
+#[wasm_bindgen]
+impl CommitmentPair {
+    #[wasm_bindgen(getter = SIZE)]
+    pub fn size() -> usize {
+        nimiq_keys::multisig::commitment::Nonce::SIZE
+            + nimiq_keys::multisig::commitment::Commitment::SIZE
+    }
+
+    #[wasm_bindgen(getter = serializedSize)]
+    pub fn serialized_size(&self) -> usize {
+        CommitmentPair::size()
+    }
+
+    /// Parses a commitment pair from a {@link CommitmentPair} instance, a hex string representation, or a byte array.
+    ///
+    /// Throws when a CommitmentPair cannot be parsed from the argument.
+    #[wasm_bindgen(js_name = fromAny)]
+    pub fn from_any(pair: &CommitmentPairAnyType) -> Result<CommitmentPair, JsError> {
+        let js_value: &JsValue = pair.unchecked_ref();
+
+        if let Ok(pair) = CommitmentPair::try_from(js_value) {
+            return Ok(pair);
+        }
+
+        if let Ok(string) = serde_wasm_bindgen::from_value::<String>(js_value.to_owned()) {
+            Ok(CommitmentPair::from_hex(&string)?)
+        } else if let Ok(bytes) = serde_wasm_bindgen::from_value::<Vec<u8>>(js_value.to_owned()) {
+            Ok(CommitmentPair::deserialize(&bytes)?)
+        } else {
+            Err(JsError::new("Could not parse commitment pair"))
+        }
+    }
+
+    /// Deserializes a commitment pair from a byte array.
+    ///
+    /// Throws when the byte array contains less than 32 bytes.
+    pub fn deserialize(bytes: &[u8]) -> Result<CommitmentPair, JsError> {
+        let pair = nimiq_keys::multisig::commitment::CommitmentPair::deserialize_from_vec(bytes)?;
+        Ok(CommitmentPair::from(pair))
+    }
+
+    pub fn generate() -> CommitmentPair {
+        CommitmentPair::from(
+            nimiq_keys::multisig::commitment::CommitmentPair::generate_default_csprng(),
+        )
+    }
+
+    /// Creates a new commitment pair from a byte array.
+    ///
+    /// Throws when the byte array is not exactly 32 bytes long.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: &[u8]) -> Result<CommitmentPair, JsError> {
+        Self::deserialize(bytes)
+    }
+
+    /// Serializes the commitment pair to a byte array.
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.serialize_to_vec()
+    }
+
+    /// Parses a commitment pair from its hex representation.
+    ///
+    /// Throws when the string is not valid hex format or when it represents less than 32 bytes.
+    #[wasm_bindgen(js_name = fromHex)]
+    pub fn from_hex(hex: &str) -> Result<CommitmentPair, JsError> {
+        let bytes = hex::decode(hex)?;
+        Self::deserialize(&bytes)
+    }
+
+    /// Formats the commitment pair into a hex string.
+    #[wasm_bindgen(js_name = toHex)]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.serialize())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn secret(&self) -> RandomSecret {
+        RandomSecret::from(self.inner.nonce())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn commitment(&self) -> Commitment {
+        Commitment::from(self.inner.commitment())
+    }
+
+    /// Returns if this commitment pair is equal to the other commitment pair.
+    pub fn equals(&self, other: &CommitmentPair) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl From<nimiq_keys::multisig::commitment::CommitmentPair> for CommitmentPair {
+    fn from(pair: nimiq_keys::multisig::commitment::CommitmentPair) -> CommitmentPair {
+        CommitmentPair { inner: pair }
+    }
+}
+
+impl CommitmentPair {
+    pub fn native_ref(&self) -> &nimiq_keys::multisig::commitment::CommitmentPair {
+        &self.inner
+    }
+
+    pub fn take_native(self) -> nimiq_keys::multisig::commitment::CommitmentPair {
+        self.inner
+    }
+
+    pub fn unpack_commitment_pairs(
+        pairs: &CommitmentPairAnyArrayType,
+    ) -> Result<Vec<nimiq_keys::multisig::commitment::CommitmentPair>, JsError> {
+        // Unpack the array of pairs
+        let js_value: &JsValue = pairs.unchecked_ref();
+        let array: &Array = js_value
+            .dyn_ref()
+            .ok_or_else(|| JsError::new("`pairs` must be an array"))?;
+
+        if array.length() == 0 {
+            return Err(JsError::new("No pairs provided"));
+        }
+
+        let mut pairs = Vec::<_>::with_capacity(array.length().try_into()?);
+        for any in array.iter() {
+            let pair = CommitmentPair::from_any(&any.into())?.take_native();
+            pairs.push(pair);
+        }
+
+        Ok(pairs)
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "CommitmentPair | string | Uint8Array")]
+    pub type CommitmentPairAnyType;
+
+    #[wasm_bindgen(typescript_type = "(CommitmentPair | string | Uint8Array)[]")]
+    pub type CommitmentPairAnyArrayType;
+}

--- a/web-client/src/multisig/commitment_pair.rs
+++ b/web-client/src/multisig/commitment_pair.rs
@@ -62,12 +62,22 @@ impl CommitmentPair {
         )
     }
 
-    /// Creates a new commitment pair from a byte array.
-    ///
-    /// Throws when the byte array is not exactly 32 bytes long.
+    /// Derives a commitment pair from an existing random secret.
+    pub fn derive(random_secret: &RandomSecret) -> CommitmentPair {
+        let nonce = *random_secret.native_ref();
+        let commitment = nonce.commit();
+        let commitment_pair =
+            nimiq_keys::multisig::commitment::CommitmentPair::new(nonce, commitment);
+        CommitmentPair::from(commitment_pair)
+    }
+
     #[wasm_bindgen(constructor)]
-    pub fn new(bytes: &[u8]) -> Result<CommitmentPair, JsError> {
-        Self::deserialize(bytes)
+    pub fn new(random_secret: &RandomSecret, commitment: &Commitment) -> CommitmentPair {
+        let commitment_pair = nimiq_keys::multisig::commitment::CommitmentPair::new(
+            *random_secret.native_ref(),
+            *commitment.native_ref(),
+        );
+        CommitmentPair::from(commitment_pair)
     }
 
     /// Serializes the commitment pair to a byte array.

--- a/web-client/src/multisig/mod.rs
+++ b/web-client/src/multisig/mod.rs
@@ -1,0 +1,4 @@
+pub mod commitment;
+pub mod commitment_pair;
+pub mod partial_signature;
+pub mod random_secret;

--- a/web-client/src/multisig/partial_signature.rs
+++ b/web-client/src/multisig/partial_signature.rs
@@ -1,0 +1,179 @@
+use nimiq_keys::multisig::{CommitmentsBuilder, MUSIG2_PARAMETER_V};
+use nimiq_serde::Deserialize;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_derive::TryFromJsValue;
+
+use super::{
+    commitment::{Commitment, CommitmentAnyArrayArrayType},
+    commitment_pair::{CommitmentPair, CommitmentPairAnyArrayType},
+};
+use crate::primitives::{
+    private_key::PrivateKey,
+    public_key::{PublicKey, PublicKeyAnyArrayType},
+};
+
+/// A partial signature is a signature of one of the co-signers in a multisig.
+/// Combining all partial signatures yields the full signature (combining is done through summation).
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct PartialSignature {
+    inner: nimiq_keys::multisig::partial_signature::PartialSignature,
+}
+
+#[wasm_bindgen]
+impl PartialSignature {
+    #[wasm_bindgen(getter = SIZE)]
+    pub fn size() -> usize {
+        nimiq_keys::multisig::partial_signature::PartialSignature::SIZE
+    }
+
+    #[wasm_bindgen(getter = serializedSize)]
+    pub fn serialized_size(&self) -> usize {
+        PartialSignature::size()
+    }
+
+    /// Parses a partial signature from a {@link PartialSignature} instance, a hex string representation, or a byte array.
+    ///
+    /// Throws when a PartialSignature cannot be parsed from the argument.
+    #[wasm_bindgen(js_name = fromAny)]
+    pub fn from_any(secret: &PartialSignatureAnyType) -> Result<PartialSignature, JsError> {
+        let js_value: &JsValue = secret.unchecked_ref();
+
+        if let Ok(secret) = PartialSignature::try_from(js_value) {
+            return Ok(secret);
+        }
+
+        if let Ok(string) = serde_wasm_bindgen::from_value::<String>(js_value.to_owned()) {
+            Ok(PartialSignature::from_hex(&string)?)
+        } else if let Ok(bytes) = serde_wasm_bindgen::from_value::<Vec<u8>>(js_value.to_owned()) {
+            Ok(PartialSignature::deserialize(&bytes)?)
+        } else {
+            Err(JsError::new("Could not parse partial signature"))
+        }
+    }
+
+    /// Deserializes a partial signature from a byte array.
+    ///
+    /// Throws when the byte array contains less than 32 bytes.
+    pub fn deserialize(bytes: &[u8]) -> Result<PartialSignature, JsError> {
+        let buf: [u8; nimiq_keys::multisig::partial_signature::PartialSignature::SIZE] =
+            nimiq_serde::FixedSizeByteArray::deserialize_from_vec(bytes)?.into_inner();
+        let signature = nimiq_keys::multisig::partial_signature::PartialSignature::from(buf);
+        Ok(PartialSignature::from(signature))
+    }
+
+    /// Creates a new partial signature from a byte array.
+    ///
+    /// Throws when the byte array is not exactly 32 bytes long.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: &[u8]) -> Result<PartialSignature, JsError> {
+        Self::deserialize(bytes)
+    }
+
+    pub fn create(
+        own_private_key: &PrivateKey,
+        own_public_key: &PublicKey,
+        own_commitment_pairs: &CommitmentPairAnyArrayType,
+        other_public_keys: &PublicKeyAnyArrayType,
+        other_commitments: &CommitmentAnyArrayArrayType,
+        data: &[u8],
+    ) -> Result<PartialSignature, JsError> {
+        let own_private_key = own_private_key.native_ref();
+        let own_public_key = own_public_key.native_ref();
+        let own_commitment_pairs = CommitmentPair::unpack_commitment_pairs(own_commitment_pairs)?;
+        let other_public_keys = PublicKey::unpack_public_keys(other_public_keys)?;
+        let other_commitments = Commitment::unpack_commitments_list(other_commitments)?;
+
+        // Sanity checks
+        if own_commitment_pairs.len() != MUSIG2_PARAMETER_V {
+            return Err(JsError::new(&format!(
+                "Number of own commitment pairs must be {}",
+                MUSIG2_PARAMETER_V
+            )));
+        }
+        if other_public_keys.len() != other_commitments.len() {
+            return Err(JsError::new(
+                "Number of other public keys and other commitment groups must match",
+            ));
+        }
+        if other_commitments
+            .iter()
+            .any(|commitments| commitments.len() != MUSIG2_PARAMETER_V)
+        {
+            return Err(JsError::new(&format!(
+                "Number of commitments in each group must be {}",
+                MUSIG2_PARAMETER_V
+            )));
+        }
+
+        let own_keypair = nimiq_keys::KeyPair {
+            private: own_private_key.clone(),
+            public: *own_public_key,
+        };
+
+        let mut commitment_pairs =
+            [nimiq_keys::multisig::commitment::CommitmentPair::default(); MUSIG2_PARAMETER_V];
+        commitment_pairs.copy_from_slice(&own_commitment_pairs);
+        let mut commitments_data =
+            CommitmentsBuilder::with_private_commitments(*own_public_key, commitment_pairs);
+
+        for i in 0..other_public_keys.len() {
+            let mut commitments =
+                [nimiq_keys::multisig::commitment::Commitment::default(); MUSIG2_PARAMETER_V];
+            commitments.copy_from_slice(&other_commitments[i]);
+            commitments_data.push_signer(other_public_keys[i], commitments);
+        }
+
+        let signature = own_keypair.partial_sign(&commitments_data.build(data), data)?;
+
+        Ok(PartialSignature::from(signature))
+    }
+
+    /// Serializes the partial signature to a byte array.
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.as_bytes().to_vec()
+    }
+
+    /// Parses a partial signature from its hex representation.
+    ///
+    /// Throws when the string is not valid hex format or when it represents less than 32 bytes.
+    #[wasm_bindgen(js_name = fromHex)]
+    pub fn from_hex(hex: &str) -> Result<PartialSignature, JsError> {
+        let bytes = hex::decode(hex)?;
+        Self::deserialize(&bytes)
+    }
+
+    /// Formats the partial signature into a hex string.
+    #[wasm_bindgen(js_name = toHex)]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.serialize())
+    }
+
+    /// Returns if this partial signature is equal to the other partial signature.
+    pub fn equals(&self, other: &PartialSignature) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl From<nimiq_keys::multisig::partial_signature::PartialSignature> for PartialSignature {
+    fn from(secret: nimiq_keys::multisig::partial_signature::PartialSignature) -> PartialSignature {
+        PartialSignature { inner: secret }
+    }
+}
+
+impl PartialSignature {
+    pub fn native_ref(&self) -> &nimiq_keys::multisig::partial_signature::PartialSignature {
+        &self.inner
+    }
+
+    pub fn take_native(self) -> nimiq_keys::multisig::partial_signature::PartialSignature {
+        self.inner
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "PartialSignature | string | Uint8Array")]
+    pub type PartialSignatureAnyType;
+}

--- a/web-client/src/multisig/random_secret.rs
+++ b/web-client/src/multisig/random_secret.rs
@@ -1,0 +1,108 @@
+use nimiq_serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_derive::TryFromJsValue;
+
+/// A random secret that proves a {@link Commitment} for signing multisignature transactions.
+/// It is supposed to be kept secret (similar to a private key).
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct RandomSecret {
+    inner: nimiq_keys::multisig::commitment::Nonce,
+}
+
+#[wasm_bindgen]
+impl RandomSecret {
+    #[wasm_bindgen(getter = SIZE)]
+    pub fn size() -> usize {
+        nimiq_keys::multisig::commitment::Nonce::SIZE
+    }
+
+    #[wasm_bindgen(getter = serializedSize)]
+    pub fn serialized_size(&self) -> usize {
+        RandomSecret::size()
+    }
+
+    /// Parses a random secret from a {@link RandomSecret} instance, a hex string representation, or a byte array.
+    ///
+    /// Throws when a RandomSecret cannot be parsed from the argument.
+    #[wasm_bindgen(js_name = fromAny)]
+    pub fn from_any(secret: &RandomSecretAnyType) -> Result<RandomSecret, JsError> {
+        let js_value: &JsValue = secret.unchecked_ref();
+
+        if let Ok(secret) = RandomSecret::try_from(js_value) {
+            return Ok(secret);
+        }
+
+        if let Ok(string) = serde_wasm_bindgen::from_value::<String>(js_value.to_owned()) {
+            Ok(RandomSecret::from_hex(&string)?)
+        } else if let Ok(bytes) = serde_wasm_bindgen::from_value::<Vec<u8>>(js_value.to_owned()) {
+            Ok(RandomSecret::deserialize(&bytes)?)
+        } else {
+            Err(JsError::new("Could not parse random secret"))
+        }
+    }
+
+    /// Deserializes a random secret from a byte array.
+    ///
+    /// Throws when the byte array contains less than 32 bytes.
+    pub fn deserialize(bytes: &[u8]) -> Result<RandomSecret, JsError> {
+        let secret = nimiq_keys::multisig::commitment::Nonce::deserialize_from_vec(bytes)?;
+        Ok(RandomSecret::from(secret))
+    }
+
+    /// Creates a new random secret from a byte array.
+    ///
+    /// Throws when the byte array is not exactly 32 bytes long.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: &[u8]) -> Result<RandomSecret, JsError> {
+        Self::deserialize(bytes)
+    }
+
+    /// Serializes the random secret to a byte array.
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.serialize_to_vec()
+    }
+
+    /// Parses a random secret from its hex representation.
+    ///
+    /// Throws when the string is not valid hex format or when it represents less than 32 bytes.
+    #[wasm_bindgen(js_name = fromHex)]
+    pub fn from_hex(hex: &str) -> Result<RandomSecret, JsError> {
+        let bytes = hex::decode(hex)?;
+        Self::deserialize(&bytes)
+    }
+
+    /// Formats the random secret into a hex string.
+    #[wasm_bindgen(js_name = toHex)]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.serialize())
+    }
+
+    /// Returns if this random secret is equal to the other random secret.
+    pub fn equals(&self, other: &RandomSecret) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl From<nimiq_keys::multisig::commitment::Nonce> for RandomSecret {
+    fn from(secret: nimiq_keys::multisig::commitment::Nonce) -> RandomSecret {
+        RandomSecret { inner: secret }
+    }
+}
+
+impl RandomSecret {
+    pub fn native_ref(&self) -> &nimiq_keys::multisig::commitment::Nonce {
+        &self.inner
+    }
+
+    pub fn take_native(self) -> nimiq_keys::multisig::commitment::Nonce {
+        self.inner
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "RandomSecret | string | Uint8Array")]
+    pub type RandomSecretAnyType;
+}


### PR DESCRIPTION
## What's in this pull request?

Expose basic primitives for multisig operations through the web-client API.

The primitves are:

- RandomSecret
- Commitment
- CommitmentPair
- PartialSignature

Also add a `Address.fromPublicKeys(public_keys, num_signers)` method to calculate a multisig address from the participating public keys.

These primitives enable the client-side operations of the multisig app with the @nimiq/core package alone and thus remove the need for custom Rust-compiled-to-WASM in both the Multisig App and Keyguard.

This PR does not include what are currently server-side operations, such as aggregating commitments, summing partial signatures or calculating merkle paths. That might get added later in a separate PR (tracked by a separate upcoming issue).

#### This fixes #1578.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
