### PR TITLE
Omit autonat and kad features from the web-client

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -125,6 +125,7 @@ full-consensus = [
     "nimiq-blockchain",
     "nimiq-consensus/full",
     "nimiq-dht",
+    "nimiq-network-libp2p/autonat",
     "nimiq-network-libp2p/kad",
 ]
 logging = ["nimiq-log", "serde_json", "tokio", "tracing-subscriber"]

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -55,9 +55,7 @@ nimiq-validator-network = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 libp2p = { version = "0.56", default-features = false, features = [
-    "autonat",
     "gossipsub",
-    "kad",
     "macros",
     "noise",
     "ping",
@@ -69,9 +67,7 @@ libp2p = { version = "0.56", default-features = false, features = [
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 libp2p = { version = "0.56", default-features = false, features = [
-    "autonat",
     "gossipsub",
-    "kad",
     "macros",
     "noise",
     "ping",
@@ -90,6 +86,7 @@ nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }
 
 [features]
-kad = []
+autonat = ["libp2p/autonat"]
+kad = ["libp2p/kad"]
 metrics = ["prometheus-client"]
 tokio-websocket = ["libp2p/dns", "libp2p/tcp", "libp2p/tokio", "libp2p/websocket"]

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -1,7 +1,8 @@
 use std::{iter, sync::Arc};
 
+#[cfg(feature = "autonat")]
+use libp2p::autonat::v2::{self as autonat, client::Config as AutonatConfig};
 use libp2p::{
-    autonat::v2::{self as autonat, client::Config as AutonatConfig},
     connection_limits, gossipsub,
     kad::{self, store::MemoryStore},
     ping, request_response,
@@ -34,7 +35,9 @@ pub struct Behaviour {
     pub connection_limits: connection_limits::Behaviour,
     pub pool: connection_pool::Behaviour,
     pub discovery: discovery::Behaviour,
+    #[cfg(feature = "autonat")]
     pub autonat_server: autonat::server::Behaviour,
+    #[cfg(feature = "autonat")]
     pub autonat_client: autonat::client::Behaviour,
     #[cfg(feature = "kad")]
     pub dht: kad::Behaviour<MemoryStore>,
@@ -113,9 +116,11 @@ impl Behaviour {
         );
 
         // AutoNAT server behaviour
+        #[cfg(feature = "autonat")]
         let autonat_server = autonat::server::Behaviour::new(Default::default());
 
         // AutoNAT client behaviour
+        #[cfg(feature = "autonat")]
         let autonat_client =
             autonat::client::Behaviour::new(Default::default(), AutonatConfig::default());
 
@@ -136,7 +141,9 @@ impl Behaviour {
             ping,
             pool,
             request_response,
+            #[cfg(feature = "autonat")]
             autonat_client,
+            #[cfg(feature = "autonat")]
             autonat_server,
             connection_limits,
         }

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -2,12 +2,11 @@ use std::{iter, sync::Arc};
 
 #[cfg(feature = "autonat")]
 use libp2p::autonat::v2::{self as autonat, client::Config as AutonatConfig};
+#[cfg(feature = "kad")]
+use libp2p::kad::{self, store::MemoryStore};
 use libp2p::{
-    connection_limits, gossipsub,
-    kad::{self, store::MemoryStore},
-    ping, request_response,
-    swarm::NetworkBehaviour,
-    Multiaddr, PeerId, StreamProtocol,
+    connection_limits, gossipsub, ping, request_response, swarm::NetworkBehaviour, Multiaddr,
+    PeerId, StreamProtocol,
 };
 use parking_lot::RwLock;
 
@@ -56,6 +55,7 @@ impl Behaviour {
         let public_key = config.keypair.public();
         let peer_id = public_key.to_peer_id();
 
+        #[cfg(feature = "kad")]
         // DHT behaviour
         let store = MemoryStore::new(peer_id);
         #[cfg(feature = "kad")]

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -1,6 +1,8 @@
 use std::{num::NonZeroU8, time::Duration};
 
-use libp2p::{gossipsub, identity::Keypair, kad, Multiaddr, StreamProtocol};
+#[cfg(feature = "kad")]
+use libp2p::kad;
+use libp2p::{gossipsub, identity::Keypair, Multiaddr, StreamProtocol};
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::MIN_SUPPORTED_MSG_SIZE, peer_info::Services};
 use sha2::{Digest, Sha256};
@@ -25,6 +27,7 @@ pub struct Config {
     pub peer_contact: PeerContact,
     pub seeds: Vec<Multiaddr>,
     pub discovery: discovery::Config,
+    #[cfg(feature = "kad")]
     pub kademlia: kad::Config,
     pub gossipsub: gossipsub::Config,
     pub memory_transport: bool,
@@ -82,14 +85,23 @@ impl Config {
             .build()
             .expect("Invalid Gossipsub config");
 
+        #[cfg(feature = "kad")]
         let mut kademlia = kad::Config::new(StreamProtocol::new(DHT_PROTOCOL));
+        #[cfg(feature = "kad")]
         kademlia.set_kbucket_inserts(kad::BucketInserts::OnConnected);
+        #[cfg(feature = "kad")]
         kademlia.set_record_ttl(Some(Duration::from_secs(2 * 60 * 60))); // 2h
+        #[cfg(feature = "kad")]
         kademlia.set_publication_interval(Some(Duration::from_secs(10 * 60))); // 10 min
+        #[cfg(feature = "kad")]
         kademlia.set_replication_interval(Some(Duration::from_secs(60))); // 1 min
+        #[cfg(feature = "kad")]
         kademlia.set_provider_record_ttl(Some(Duration::from_secs(60 * 60))); // 1h
+        #[cfg(feature = "kad")]
         kademlia.set_provider_publication_interval(Some(Duration::from_secs(5 * 60))); // 5 min
+        #[cfg(feature = "kad")]
         kademlia.set_query_timeout(Duration::from_secs(10));
+        #[cfg(feature = "kad")]
         kademlia.set_record_filtering(kad::StoreInserts::FilterBoth);
 
         Self {
@@ -101,6 +113,7 @@ impl Config {
                 required_services,
                 only_secure_ws_connections,
             ),
+            #[cfg(feature = "kad")]
             kademlia,
             gossipsub,
             memory_transport,

--- a/network-libp2p/src/dht.rs
+++ b/network-libp2p/src/dht.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "kad")]
 use libp2p::{kad::Record, PeerId};
 use nimiq_keys::Address;
 use nimiq_network_interface::network::Network as NetworkInterface;
 use nimiq_serde::DeserializeError;
+#[cfg(feature = "kad")]
 use nimiq_validator_network::validator_record::ValidatorRecord;
 
+#[cfg(feature = "kad")]
 pub use crate::network_types::DhtRecord;
 use crate::Network;
 
@@ -24,11 +27,13 @@ pub enum DhtVerifierError {
     InvalidSignature,
 }
 
+#[cfg(feature = "kad")]
 pub trait Verifier: Send + Sync {
     fn verify(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError>;
 }
 
 /// Dummy implementation for testcases
+#[cfg(feature = "kad")]
 impl Verifier for () {
     fn verify(&self, record: &Record) -> Result<DhtRecord, DhtVerifierError> {
         let peer_id = PeerId::random();

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -36,6 +36,7 @@ use super::{
     peer_contacts::{PeerContactBook, SignedPeerContact},
     protocol::{ChallengeNonce, DiscoveryMessage, DiscoveryProtocol},
 };
+#[cfg(feature = "autonat")]
 use crate::{AUTONAT_DIAL_BACK_PROTOCOL, AUTONAT_DIAL_REQUEST_PROTOCOL};
 
 #[derive(Debug)]
@@ -256,6 +257,7 @@ impl Handler {
     }
 
     /// Report to all the ConnectionHandlers that the remote peer supports the AutoNAT V2 client and server protocols
+    #[cfg(feature = "autonat")]
     fn report_remote_autonat_support(&mut self) {
         let mut stream_protocols = HashSet::new();
         stream_protocols.insert(StreamProtocol::new(AUTONAT_DIAL_REQUEST_PROTOCOL));
@@ -310,6 +312,7 @@ impl ConnectionHandler for Handler {
                 }
                 self.inbound = Some(protocol);
                 self.check_initialized();
+                #[cfg(feature = "autonat")]
                 self.report_remote_autonat_support();
             }
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
@@ -323,6 +326,7 @@ impl ConnectionHandler for Handler {
                 }
                 self.outbound = Some(protocol);
                 self.check_initialized();
+                #[cfg(feature = "autonat")]
                 self.report_remote_autonat_support();
             }
             ConnectionEvent::DialUpgradeError(DialUpgradeError { error, .. }) => {

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -19,12 +19,15 @@ pub enum NetworkError {
     #[error("Serialization error: {0}")]
     Serialization(#[from] nimiq_serde::DeserializeError),
 
+    #[cfg(feature = "kad")]
     #[error("DHT store error: {0:?}")]
     DhtStore(libp2p::kad::store::Error),
 
+    #[cfg(feature = "kad")]
     #[error("DHT GetRecord error: {0:?}")]
     DhtGetRecord(libp2p::kad::GetRecordError),
 
+    #[cfg(feature = "kad")]
     #[error("DHT PutRecord error: {0:?}")]
     DhtPutRecord(libp2p::kad::PutRecordError),
 
@@ -67,18 +70,21 @@ impl From<tokio::sync::oneshot::error::RecvError> for NetworkError {
     }
 }
 
+#[cfg(feature = "kad")]
 impl From<libp2p::kad::store::Error> for NetworkError {
     fn from(e: libp2p::kad::store::Error) -> Self {
         Self::DhtStore(e)
     }
 }
 
+#[cfg(feature = "kad")]
 impl From<libp2p::kad::GetRecordError> for NetworkError {
     fn from(e: libp2p::kad::GetRecordError) -> Self {
         Self::DhtGetRecord(e)
     }
 }
 
+#[cfg(feature = "kad")]
 impl From<libp2p::kad::PutRecordError> for NetworkError {
     fn from(e: libp2p::kad::PutRecordError) -> Self {
         Self::DhtPutRecord(e)

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "autonat")]
 mod autonat;
 mod behaviour;
 mod config;
@@ -20,7 +21,9 @@ mod utils;
 
 pub const DISCOVERY_PROTOCOL: &str = "/nimiq/discovery/0.0.1";
 pub const DHT_PROTOCOL: &str = "/nimiq/kad/0.0.1";
+#[cfg(feature = "autonat")]
 pub const AUTONAT_DIAL_REQUEST_PROTOCOL: &str = "/libp2p/autonat/2/dial-request";
+#[cfg(feature = "autonat")]
 pub const AUTONAT_DIAL_BACK_PROTOCOL: &str = "/libp2p/autonat/2/dial-back";
 
 pub use config::{Config, TlsConfig};

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 use bytes::Bytes;
 #[cfg(feature = "metrics")]
 use instant::Instant;
+#[cfg(feature = "kad")]
+use libp2p::kad::{QueryId, Record};
 use libp2p::{
     gossipsub,
-    kad::{QueryId, Record},
     request_response::{InboundRequestId, OutboundRequestId, ResponseChannel},
     swarm::NetworkInfo,
     Multiaddr, PeerId,
@@ -140,6 +141,7 @@ pub(crate) enum DhtBootStrapState {
 }
 
 /// Enum over all of the possible DHT records values
+#[cfg(feature = "kad")]
 #[derive(Clone, PartialEq)]
 pub enum DhtRecord {
     /// Validator record with its publisher Peer ID,
@@ -147,6 +149,7 @@ pub enum DhtRecord {
     Validator(PeerId, ValidatorRecord<PeerId>, Record),
 }
 
+#[cfg(feature = "kad")]
 impl DhtRecord {
     pub(crate) fn get_signed_record(self) -> Record {
         match self {
@@ -167,6 +170,7 @@ impl DhtRecord {
     }
 }
 
+#[cfg(feature = "kad")]
 impl PartialOrd for DhtRecord {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.get_timestamp().partial_cmp(&other.get_timestamp())
@@ -174,6 +178,7 @@ impl PartialOrd for DhtRecord {
 }
 
 /// DHT record decoding errors
+#[cfg(feature = "kad")]
 #[derive(Debug, Error)]
 pub enum DhtRecordError {
     /// Tag is unknown
@@ -184,6 +189,7 @@ pub enum DhtRecordError {
     DeserializeError(#[from] DeserializeError),
 }
 
+#[cfg(feature = "kad")]
 impl TryFrom<&Record> for DhtRecord {
     type Error = DhtRecordError;
     fn try_from(record: &Record) -> Result<Self, Self::Error> {
@@ -212,6 +218,7 @@ impl TryFrom<&Record> for DhtRecord {
 }
 
 /// DHT results obtained for a specific query ID
+#[cfg(feature = "kad")]
 pub(crate) struct DhtResults {
     /// Number of records obtained
     pub(crate) count: u8,
@@ -230,16 +237,21 @@ pub(crate) struct GossipsubTopicInfo {
 #[derive(Default)]
 pub(crate) struct TaskState {
     /// Senders for DHT (kad) put operations
+    #[cfg(feature = "kad")]
     pub(crate) dht_puts: HashMap<QueryId, oneshot::Sender<Result<(), NetworkError>>>,
     /// Senders for DHT (kad) get operations
+    #[cfg(feature = "kad")]
     pub(crate) dht_gets: HashMap<QueryId, oneshot::Sender<Result<Vec<u8>, NetworkError>>>,
     /// Get results for DHT (kad) get operation
+    #[cfg(feature = "kad")]
     pub(crate) dht_get_results: HashMap<QueryId, DhtResults>,
     /// Senders per Gossibsub topic
     pub(crate) gossip_topics: HashMap<gossipsub::TopicHash, GossipsubTopicInfo>,
     /// DHT (kad) has been bootstrapped
+    #[cfg(feature = "kad")]
     pub(crate) dht_bootstrap_state: DhtBootStrapState,
     /// DHT (kad) is in server mode
+    #[cfg(feature = "kad")]
     pub(crate) dht_server_mode: bool,
     /// The NAT status of the local peer
     #[cfg(feature = "autonat")]

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -22,8 +22,9 @@ use nimiq_validator_network::validator_record::ValidatorRecord;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
+#[cfg(feature = "autonat")]
+use crate::autonat::NatState;
 use crate::{
-    autonat::NatState,
     dispatch::codecs::{IncomingRequest, OutgoingResponse},
     rate_limiting::RateLimitConfig,
     NetworkError,
@@ -241,6 +242,7 @@ pub(crate) struct TaskState {
     /// DHT (kad) is in server mode
     pub(crate) dht_server_mode: bool,
     /// The NAT status of the local peer
+    #[cfg(feature = "autonat")]
     pub(crate) nat_status: NatState,
     /// Senders per `OutboundRequestId` for request-response
     pub(crate) requests: HashMap<OutboundRequestId, oneshot::Sender<Result<Bytes, RequestError>>>,

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -5,6 +5,12 @@ use futures::StreamExt;
 use instant::Instant;
 #[cfg(feature = "autonat")]
 use libp2p::autonat::{self, InboundFailure, OutboundFailure};
+#[cfg(feature = "kad")]
+use libp2p::kad::{
+    self, store::RecordStore, BootstrapError, BootstrapOk, GetRecordError, GetRecordOk,
+    InboundRequest, Mode, ProgressStep, PutRecordError, PutRecordOk, QueryId, QueryResult,
+    QueryStats, Quorum, Record,
+};
 #[cfg(all(target_family = "wasm", not(feature = "tokio-websocket")))]
 use libp2p::websocket_websys;
 use libp2p::{
@@ -15,11 +21,6 @@ use libp2p::{
     },
     gossipsub,
     identity::Keypair,
-    kad::{
-        self, store::RecordStore, BootstrapError, BootstrapOk, GetRecordError, GetRecordOk,
-        InboundRequest, Mode, ProgressStep, PutRecordError, PutRecordOk, QueryId, QueryResult,
-        QueryStats, Quorum, Record,
-    },
     noise, ping,
     request_response::{self, InboundRequestId, OutboundRequestId, ResponseChannel},
     swarm::{
@@ -46,14 +47,16 @@ use crate::autonat::NatStatus;
 #[cfg(feature = "metrics")]
 use crate::network_metrics::NetworkMetrics;
 use crate::{
-    behaviour, dht,
+    behaviour,
     discovery::{self, peer_contacts::PeerContactBook},
-    network_types::{
-        DhtBootStrapState, DhtRecord, DhtResults, GossipsubTopicInfo, NetworkAction, TaskState,
-        ValidateMessage,
-    },
+    network_types::{GossipsubTopicInfo, NetworkAction, TaskState, ValidateMessage},
     rate_limiting::{RateLimitId, RateLimits},
     Config, NetworkError, TlsConfig,
+};
+#[cfg(feature = "kad")]
+use crate::{
+    dht,
+    network_types::{DhtBootStrapState, DhtRecord, DhtResults},
 };
 
 type NimiqSwarm = Swarm<behaviour::Behaviour>;
@@ -122,6 +125,7 @@ pub(crate) async fn swarm_task(
     #[cfg(feature = "metrics")] metrics: Arc<NetworkMetrics>,
 ) {
     let mut task_state = TaskState {
+        #[cfg(feature = "kad")]
         dht_server_mode: force_dht_server_mode,
         dht_quorum: dht_quorum.into(),
         ..Default::default()
@@ -1069,12 +1073,14 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
             let result = swarm.dial(dial_opts).map_err(Into::into);
             output.send(result).ok();
         }
+        #[cfg(feature = "kad")]
         NetworkAction::DhtGet { key, output } => {
-            #[cfg(feature = "kad")]
             let query_id = swarm.behaviour_mut().dht.get_record(key.into());
-            #[cfg(feature = "kad")]
             state.dht_gets.insert(query_id, output);
         }
+        #[cfg(not(feature = "kad"))]
+        NetworkAction::DhtGet { .. } => {}
+        #[cfg(feature = "kad")]
         NetworkAction::DhtPut { key, value, output } => {
             let local_peer_id = Swarm::local_peer_id(swarm);
 
@@ -1085,7 +1091,6 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
                 expires: None, // This only affects local storage. Records are replicated with configured TTL.
             };
 
-            #[cfg(feature = "kad")]
             match swarm.behaviour_mut().dht.put_record(record, Quorum::One) {
                 Ok(query_id) => {
                     // Remember put operation to resolve when we receive a `QueryResult::PutRecord`
@@ -1096,6 +1101,8 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
                 }
             }
         }
+        #[cfg(not(feature = "kad"))]
+        NetworkAction::DhtPut { .. } => {}
         NetworkAction::Subscribe {
             topic_name,
             buffer_size,

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -3,10 +3,11 @@ use std::{collections::HashMap, num::NonZeroU8, sync::Arc, time::Duration};
 use futures::StreamExt;
 #[cfg(feature = "metrics")]
 use instant::Instant;
+#[cfg(feature = "autonat")]
+use libp2p::autonat::{self, InboundFailure, OutboundFailure};
 #[cfg(all(target_family = "wasm", not(feature = "tokio-websocket")))]
 use libp2p::websocket_websys;
 use libp2p::{
-    autonat::{self, InboundFailure, OutboundFailure},
     core::{
         self,
         muxing::StreamMuxerBox,
@@ -40,10 +41,11 @@ use nimiq_time::Interval;
 use parking_lot::RwLock;
 use tokio::sync::{broadcast, mpsc};
 
+#[cfg(feature = "autonat")]
+use crate::autonat::NatStatus;
 #[cfg(feature = "metrics")]
 use crate::network_metrics::NetworkMetrics;
 use crate::{
-    autonat::NatStatus,
     behaviour, dht,
     discovery::{self, peer_contacts::PeerContactBook},
     network_types::{
@@ -400,11 +402,13 @@ fn handle_event(event: SwarmEvent<behaviour::BehaviourEvent>, event_info: EventI
                 .behaviour_mut()
                 .discovery
                 .add_own_addresses([address.clone()].to_vec());
+            #[cfg(feature = "autonat")]
             if event_info.swarm.behaviour().is_address_dialable(&address) {
                 event_info.state.nat_status.add_address(address);
             }
         }
 
+        #[cfg(feature = "autonat")]
         SwarmEvent::ListenerClosed {
             listener_id: _,
             addresses,
@@ -415,11 +419,13 @@ fn handle_event(event: SwarmEvent<behaviour::BehaviourEvent>, event_info: EventI
             });
         }
 
+        #[cfg(feature = "autonat")]
         SwarmEvent::ExternalAddrConfirmed { address } => {
             log::trace!(%address, "Address is confirmed and externally reachable");
             event_info.state.nat_status.add_confirmed_address(address);
         }
 
+        #[cfg(feature = "autonat")]
         SwarmEvent::ExternalAddrExpired { address } => {
             log::trace!(%address, "External address is expired and no longer externally reachable");
             event_info
@@ -436,9 +442,11 @@ fn handle_event(event: SwarmEvent<behaviour::BehaviourEvent>, event_info: EventI
 
 fn handle_behaviour_event(event: behaviour::BehaviourEvent, event_info: EventInfo) {
     match event {
+        #[cfg(feature = "autonat")]
         behaviour::BehaviourEvent::AutonatClient(event) => {
             handle_autonat_client_event(event, event_info)
         }
+        #[cfg(feature = "autonat")]
         behaviour::BehaviourEvent::AutonatServer(event) => {
             handle_autonat_server_event(event, event_info)
         }
@@ -455,6 +463,7 @@ fn handle_behaviour_event(event: behaviour::BehaviourEvent, event_info: EventInf
     }
 }
 
+#[cfg(feature = "autonat")]
 fn handle_autonat_client_event(event: autonat::v2::client::Event, event_info: EventInfo) {
     log::trace!(?event, "AutoNAT outbound probe");
     match event.result {
@@ -469,6 +478,7 @@ fn handle_autonat_client_event(event: autonat::v2::client::Event, event_info: Ev
     }
 }
 
+#[cfg(feature = "autonat")]
 fn handle_autonat_server_event(event: autonat::v2::server::Event, _event_info: EventInfo) {
     log::trace!(?event, "AutoNAT inbound probe");
 }
@@ -856,6 +866,7 @@ fn handle_request_response_event(
                 event_info,
             ),
         },
+        #[cfg(feature = "autonat")]
         request_response::Event::OutboundFailure {
             peer: peer_id,
             connection_id,
@@ -868,6 +879,9 @@ fn handle_request_response_event(
             error,
             event_info,
         ),
+        #[cfg(not(feature = "autonat"))]
+        request_response::Event::OutboundFailure { .. } => {}
+        #[cfg(feature = "autonat")]
         request_response::Event::InboundFailure {
             peer: peer_id,
             connection_id,
@@ -880,6 +894,8 @@ fn handle_request_response_event(
             error,
             event_info,
         ),
+        #[cfg(not(feature = "autonat"))]
+        request_response::Event::InboundFailure { .. } => {}
         request_response::Event::ResponseSent { .. } => {}
     }
 }
@@ -1006,6 +1022,7 @@ fn handle_request_response_response(
     }
 }
 
+#[cfg(feature = "autonat")]
 fn handle_request_response_outbound_failure(
     peer_id: PeerId,
     connection_id: ConnectionId,
@@ -1025,6 +1042,7 @@ fn handle_request_response_outbound_failure(
     channel.send(Err(to_response_error(error))).ok();
 }
 
+#[cfg(feature = "autonat")]
 fn handle_request_response_inbound_failure(
     peer_id: PeerId,
     connection_id: ConnectionId,
@@ -1264,6 +1282,7 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
     }
 }
 
+#[cfg(feature = "autonat")]
 fn to_response_error(error: OutboundFailure) -> RequestError {
     match error {
         OutboundFailure::ConnectionClosed => {


### PR DESCRIPTION
## What's in this pull request?

Improve usage of feature flags throughout different crates to avoid bundling `autonat` and parts of `kad` functionality into the web-client (and I believe thus light client, too)

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
