### PR TITLE
Fix clippy warning

### DIFF
--- a/network-libp2p/src/network_metrics.rs
+++ b/network-libp2p/src/network_metrics.rs
@@ -23,7 +23,7 @@ impl Default for NetworkMetrics {
         NetworkMetrics {
             gossipsub_messages_received: Default::default(),
             gossipsub_messages_published: Default::default(),
-            response_times: Histogram::new([0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0].into_iter()),
+            response_times: Histogram::new([0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0]),
         }
     }
 }


### PR DESCRIPTION
Fix clippy warning in the `network-libp2p` metrics implementation.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
