### PR TITLE
chore(web-client): fix default comlink import in node

### DIFF
--- a/web-client/dist/nodejs/crypto.mjs
+++ b/web-client/dist/nodejs/crypto.mjs
@@ -2,7 +2,7 @@
 // global scope. We import the generated JS file to make `wasm_bindgen`
 // available which we need to initialize our WASM code.
 import { parentPort } from 'node:worker_threads';
-import Comlink from 'comlink';
+import * as Comlink from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import { CryptoUtils } from './crypto-wasm/index.js';
 

--- a/web-client/dist/nodejs/index.mjs
+++ b/web-client/dist/nodejs/index.mjs
@@ -1,6 +1,6 @@
 import { webcrypto } from 'node:crypto';
 import { Worker } from 'node:worker_threads';
-import Comlink from 'comlink';
+import * as Comlink from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.min.mjs';
 import { Address, CryptoUtils, Transaction } from './main-wasm/index.js';
 import { clientFactory } from '../launcher/node/client-proxy.mjs';

--- a/web-client/dist/nodejs/worker.mjs
+++ b/web-client/dist/nodejs/worker.mjs
@@ -2,7 +2,7 @@
 // global scope. We import the generated JS file to make `wasm_bindgen`
 // available which we need to initialize our WASM code.
 import { parentPort } from 'node:worker_threads';
-import Comlink from 'comlink';
+import * as Comlink from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import websocket from 'websocket';
 import { Client } from './worker-wasm/index.js';


### PR DESCRIPTION
## Summary
@nimiq/core Node.js build uses incorrect default imports for comlink in 3 files. Comlink has no default export, violating ESM spec.

## Live Demo

**Bug Demo:** https://nimiq-core-3278-bug.vercel.app

**Instructions:**
1. Open the demo page
2. Press F12 to open browser DevTools console
3. Click "Import @nimiq/core" button
4. Watch console for runtime import errors

The page imports @nimiq/core@2.2.1 via esm.sh CDN, which will show the comlink import error in browser console.

## Verify Bug Locally

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nimiq-core-3278 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nimiq-core-3278
cd nimiq-core-3278 && pnpm i

# Show 3 files with incorrect default import
grep "import Comlink from" node_modules/@nimiq/core/nodejs/*.mjs

# Verify comlink has no default export
tail -5 node_modules/.pnpm/comlink@*/node_modules/comlink/dist/esm/comlink.mjs
# Shows: export { createEndpoint, expose, ... } - NO default
```

## Verify Fix

```bash
git sparse-checkout add nimiq-core-3278-fixed
cd ../nimiq-core-3278-fixed && pnpm i

# Verify correct namespace import
grep "import \* as Comlink from" node_modules/@nimiq/core/nodejs/*.mjs
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Real-World Impact

Production apps need patches to work around this:
- [nimiq/starter patches/@nimiq__core@2.2.0.patch](https://github.com/nimiq/starter/blob/main/patches/%40nimiq__core%402.2.0.patch) - Cloudflare D1 example requires patching
- Correct pattern already used in bundler build: [bundler/crypto.js:4](https://github.com/nimiq/core-rs-albatross/blob/albatross/web-client/dist/bundler/crypto.js#L4)

## Changes
3 files updated to use namespace imports:
- `nodejs/crypto.mjs`
- `nodejs/index.mjs`
- `nodejs/worker.mjs`
