### PR TITLE
chore(web-client): added esm import for non-browser environments

### DIFF
--- a/web-client/dist/package.json
+++ b/web-client/dist/package.json
@@ -24,6 +24,7 @@
     },
     "./web": {
       "browser": "./web/index.js",
+      "import": "./web/index.js",
       "types": "./types/web.d.ts"
     }
   },


### PR DESCRIPTION
## What's in this pull request?

After this message: https://github.com/nimiq/core-rs-albatross/issues/3277#issuecomment-2646614887, I need to import the `web` submodule from a non-browser runtime.

I get the following error:

```
[error] Package subpath './web' is not defined by "exports" in ./node_modules/@nimiq/core/package.json imported from ./.nuxt/prerender/index.mjs
```


Not sure if this is right solution but it works in my `pnpm patch` so I think is ok 