### PR TITLE
Fix initialization in NodeJS environments

### DIFF
--- a/web-client/dist/nodejs/worker.js
+++ b/web-client/dist/nodejs/worker.js
@@ -44,9 +44,7 @@ async function init(config) {
     Comlink.expose(client, nodeEndpoint(parentPort));
 };
 
-parentPort.addListener('message', async (event) => {
-    const data = event.data;
-
+parentPort.addListener('message', async (data) => {
     if (data === 'NIMIQ_CHECKREADY') {
         parentPort.postMessage('NIMIQ_READY');
         return;

--- a/web-client/dist/nodejs/worker.mjs
+++ b/web-client/dist/nodejs/worker.mjs
@@ -44,9 +44,7 @@ async function init(config) {
     Comlink.expose(client, nodeEndpoint(parentPort));
 };
 
-parentPort.addListener('message', async (event) => {
-    const data = event.data;
-
+parentPort.addListener('message', async (data) => {
     if (data === 'NIMIQ_CHECKREADY') {
         parentPort.postMessage('NIMIQ_READY');
         return;


### PR DESCRIPTION
In Node, the callback argument _is_ the `data`. The broken state (#3245) is not yet released, so this must go in before the next release.
