### PR TITLE
Pico consensus

### DIFF
--- a/.github/devnet_topologies/validators_stress.toml
+++ b/.github/devnet_topologies/validators_stress.toml
@@ -42,3 +42,7 @@ sync_mode = "history"
 [[node]]
 restartable = false
 sync_mode = "light"
+
+[[node]]
+restartable = false
+sync_mode = "pico"

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -34,7 +34,10 @@ use self::remote_event_dispatcher::RemoteEventDispatcher;
 use crate::{
     consensus::head_requests::{HeadRequests, HeadRequestsResult},
     messages::{RequestBlock, RequestHead, RequestMacroChain, RequestMissingBlocks},
-    sync::{live::block_queue::BlockSource, syncer::LiveSyncPushEvent, syncer_proxy::SyncerProxy},
+    sync::{
+        live::block_queue::BlockSource, sync_interface::LiveSyncPushEvent,
+        syncer_proxy::SyncerProxy,
+    },
 };
 #[cfg(feature = "full")]
 use crate::{

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -119,4 +119,12 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for HistoryMacroSync<TNetwor
         .boxed();
         self.epoch_ids_stream.push(future);
     }
+
+    fn fallback(&mut self, _peers: Vec<TNetwork::PeerId>) {
+        unimplemented!()
+    }
+
+    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+        unimplemented!()
+    }
 }

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -124,7 +124,7 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for HistoryMacroSync<TNetwor
         unimplemented!()
     }
 
-    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+    fn drain_peers(&mut self) -> Vec<TNetwork::PeerId> {
         unimplemented!()
     }
 }

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -15,7 +15,7 @@ use crate::{
     messages::Checkpoint,
     sync::{
         history::cluster::{SyncCluster, SyncClusterResult},
-        syncer::MacroSync,
+        sync_interface::MacroSync,
     },
 };
 

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -20,7 +20,7 @@ use crate::{
             HistoryMacroSync,
         },
         peer_list::PeerList,
-        syncer::MacroSync,
+        sync_interface::MacroSync,
     },
 };
 

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -17,7 +17,7 @@ use crate::sync::{
         sync::Job,
         HistoryMacroSync,
     },
-    syncer::{MacroSync, MacroSyncReturn},
+    sync_interface::{MacroSync, MacroSyncReturn},
 };
 
 impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
@@ -273,7 +273,7 @@ mod tests {
 
     use crate::{
         messages::{RequestBatchSet, RequestHistoryChunk, RequestMacroChain},
-        sync::{history::HistoryMacroSync, syncer::MacroSyncReturn},
+        sync::{history::HistoryMacroSync, sync_interface::MacroSyncReturn},
     };
 
     fn blockchain() -> Arc<RwLock<Blockchain>> {

--- a/consensus/src/sync/light/mod.rs
+++ b/consensus/src/sync/light/mod.rs
@@ -4,4 +4,4 @@ mod sync_stream;
 #[cfg(feature = "full")]
 mod validity_window;
 
-pub use sync::LightMacroSync;
+pub use sync::{EpochIds, LightMacroSync, PeerMacroRequests};

--- a/consensus/src/sync/light/mod.rs
+++ b/consensus/src/sync/light/mod.rs
@@ -4,4 +4,4 @@ mod sync_stream;
 #[cfg(feature = "full")]
 mod validity_window;
 
-pub use sync::{EpochIds, LightMacroSync, PeerMacroRequests};
+pub use sync::LightMacroSync;

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -197,7 +197,7 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for LightMacroSync<TNetwork>
         unimplemented!()
     }
 
-    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+    fn drain_peers(&mut self) -> Vec<TNetwork::PeerId> {
         unimplemented!()
     }
 }

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet},
     sync::Arc,
 };
 
@@ -20,42 +20,14 @@ use nimiq_zkp_component::{
 use parking_lot::RwLock;
 
 use crate::{
-    messages::{BlockError, Checkpoint},
-    sync::syncer::MacroSync,
+    messages::BlockError,
+    sync::sync_interface::{EpochIds, MacroSync, PeerMacroRequests},
 };
 #[cfg(feature = "full")]
 use crate::{
     messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk},
     sync::{peer_list::PeerList, sync_queue::SyncQueue},
 };
-
-#[derive(Clone)]
-/// This struct is used to request Epochs IDs (hashes) from other peers
-/// in order to determine their macro chain state relative to us
-pub struct EpochIds<T> {
-    /// Indicates if the latest epoch id that was queried was found in the peer's chain
-    pub locator_found: bool,
-    /// The most recent epoch ids (hashes)
-    pub ids: Vec<Blake2bHash>,
-    /// The most recent checkpoint block in the latest epoch (if any)
-    pub checkpoint: Option<Checkpoint>,
-    /// Epoch number corresponding to the first hash in ids
-    pub first_epoch_number: usize,
-    /// The sender that created this struct
-    pub sender: T,
-}
-
-impl<T> EpochIds<T> {
-    #[inline]
-    pub(crate) fn checkpoint_epoch_number(&self) -> usize {
-        self.first_epoch_number + self.ids.len()
-    }
-
-    #[inline]
-    pub(crate) fn last_epoch_number(&self) -> usize {
-        self.checkpoint_epoch_number().saturating_sub(1)
-    }
-}
 
 #[cfg(feature = "full")]
 /// Struct used to track the progress of the validity window chunk process.
@@ -70,68 +42,6 @@ pub struct ValidityChunkRequest {
     pub election_in_window: bool,
     /// Number of items in the previous requested chunk (for cases where we adopt a new macro head)
     pub last_chunk_items: Option<usize>,
-}
-
-/// This struct is used to track all the macro requests sent to a particular peer
-pub struct PeerMacroRequests {
-    /// Number of requests that have been fulfilled
-    completed_requests: usize,
-    /// A Queue used to track the requests that have been sent, and their respective result
-    queued_requests: VecDeque<(Blake2bHash, Option<Block>)>,
-}
-
-impl Default for PeerMacroRequests {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-impl PeerMacroRequests {
-    pub fn new() -> Self {
-        Self {
-            completed_requests: 0,
-            queued_requests: VecDeque::new(),
-        }
-    }
-
-    // Pushes a new request into the queue
-    pub fn push_request(&mut self, block_hash: Blake2bHash) {
-        self.queued_requests.push_back((block_hash, None))
-    }
-
-    // Pops a request from the queue
-    pub fn pop_request(&mut self) -> Option<(Blake2bHash, Option<Block>)> {
-        self.queued_requests.pop_front()
-    }
-
-    // Returns true if the request was updated, false in case the request was not found
-    pub fn update_request(&mut self, mut block: Block) -> bool {
-        let position = self
-            .queued_requests
-            .iter()
-            .position(|(hash, _)| *hash == block.hash_cached());
-
-        if let Some(position) = position {
-            if self.queued_requests[position].1.is_none() {
-                // A fulfilled request is only count once
-                self.completed_requests += 1;
-            }
-            // We update our block request.
-            // Note: If we receive a response more than once, we use the latest
-            let block_hash = block.hash_cached();
-            log::trace!(%block_hash, "Updating block request");
-            self.queued_requests[position] = (block_hash, Some(block));
-
-            true
-        } else {
-            log::trace!("Received a response for a block that we didn't expect");
-            false
-        }
-    }
-
-    // Returns true if all the requests have been completed
-    pub fn is_ready(&self) -> bool {
-        self.queued_requests.len() == self.completed_requests
-    }
 }
 
 #[cfg(feature = "full")]

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -1,7 +1,5 @@
-#[cfg(feature = "full")]
-use std::collections::HashSet;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
 };
 
@@ -34,7 +32,7 @@ use crate::{
 #[derive(Clone)]
 /// This struct is used to request Epochs IDs (hashes) from other peers
 /// in order to determine their macro chain state relative to us
-pub(crate) struct EpochIds<T> {
+pub struct EpochIds<T> {
     /// Indicates if the latest epoch id that was queried was found in the peer's chain
     pub locator_found: bool,
     /// The most recent epoch ids (hashes)
@@ -80,6 +78,12 @@ pub struct PeerMacroRequests {
     completed_requests: usize,
     /// A Queue used to track the requests that have been sent, and their respective result
     queued_requests: VecDeque<(Blake2bHash, Option<Block>)>,
+}
+
+impl Default for PeerMacroRequests {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 impl PeerMacroRequests {
     pub fn new() -> Self {
@@ -275,8 +279,15 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for LightMacroSync<TNetwork>
 
     fn add_peer(&mut self, peer_id: TNetwork::PeerId) {
         info!(%peer_id, "Requesting zkp from peer");
-
         self.zkp_requests
             .push(Self::request_zkps(self.zkp_component_proxy.clone(), peer_id).boxed());
+    }
+
+    fn fallback(&mut self, _peers: Vec<TNetwork::PeerId>) {
+        unimplemented!()
+    }
+
+    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+        unimplemented!()
     }
 }

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -20,11 +20,8 @@ use nimiq_zkp_component::{
 use crate::{
     messages::{BlockError, MacroChain, MacroChainError, RequestBlock, RequestMacroChain},
     sync::{
-        light::{
-            sync::{EpochIds, PeerMacroRequests},
-            LightMacroSync,
-        },
-        syncer::{MacroSync, MacroSyncReturn},
+        light::LightMacroSync,
+        sync_interface::{EpochIds, MacroSync, MacroSyncReturn, PeerMacroRequests},
     },
 };
 

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -293,6 +293,15 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         while let Poll::Ready(Some(result)) = self.block_headers.poll_next_unpin(cx) {
             match result {
                 (Ok(Ok(block)), peer_id) => {
+                    if !block.is_macro() {
+                        // We received a non macro block during the macro sync process.
+                        log::warn!(%peer_id,
+                            "Banning peer due to a non expected response",
+                        );
+                        self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
+                        return Poll::Ready(None);
+                    }
+
                     if let Some(peer_requests) = self.peer_requests.get_mut(&peer_id) {
                         if !peer_requests.update_request(block) {
                             // We received a block we were not expecting from this peer

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -18,7 +18,7 @@ use nimiq_zkp_component::types::ZKPRequestEvent::{OutdatedProof, Proof};
 
 use crate::sync::{
     light::LightMacroSync,
-    syncer::{MacroSync, MacroSyncReturn},
+    sync_interface::{MacroSync, MacroSyncReturn},
 };
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
@@ -483,7 +483,7 @@ mod tests {
 
     use crate::{
         messages::{RequestBlock, RequestHistoryChunk, RequestMacroChain},
-        sync::{light::LightMacroSync, syncer::MacroSyncReturn},
+        sync::{light::LightMacroSync, sync_interface::MacroSyncReturn},
     };
 
     fn blockchain() -> BlockchainProxy {

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -180,7 +180,6 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     peer_id = ?epoch_ids.sender,
                     "Peer is behind or on different chain"
                 );
-
                 return Poll::Ready(Some(MacroSyncReturn::Outdated(epoch_ids.sender)));
             } else if epoch_ids.ids.is_empty() && epoch_ids.checkpoint.is_none() {
                 match self.blockchain {

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -19,7 +19,7 @@ use nimiq_transaction::historic_transaction::HistoricTransaction;
 use super::LightMacroSync;
 use crate::{
     messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk},
-    sync::{light::sync::ValidityChunkRequest, syncer::MacroSyncReturn},
+    sync::{light::sync::ValidityChunkRequest, sync_interface::MacroSyncReturn},
 };
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {

--- a/consensus/src/sync/live/block_queue/live_sync.rs
+++ b/consensus/src/sync/live/block_queue/live_sync.rs
@@ -23,7 +23,7 @@ use crate::{
             block_queue::queue::BlockQueue,
             queue::{self, LiveSyncQueue},
         },
-        syncer::{LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
+        sync_interface::{LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
     },
     BlsCache,
 };

--- a/consensus/src/sync/live/block_queue/proxy.rs
+++ b/consensus/src/sync/live/block_queue/proxy.rs
@@ -29,7 +29,7 @@ use crate::{
             },
             queue::{LiveSyncQueue, QueueConfig},
         },
-        syncer::LiveSyncEvent,
+        sync_interface::LiveSyncEvent,
     },
     BlsCache,
 };

--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     sync::{
         live::{block_queue::live_sync::PushOpResult, queue::LiveSyncQueue},
         peer_list::PeerList,
-        syncer::LiveSyncEvent,
+        sync_interface::LiveSyncEvent,
     },
 };
 

--- a/consensus/src/sync/live/mod.rs
+++ b/consensus/src/sync/live/mod.rs
@@ -16,7 +16,7 @@ use tokio_stream::wrappers::ReceiverStream;
 #[cfg(feature = "full")]
 use self::state_queue::StateQueue;
 use self::{block_queue::BlockQueue, queue::LiveSyncQueue};
-use super::syncer::{LiveSync, LiveSyncEvent};
+use super::sync_interface::{LiveSync, LiveSyncEvent};
 use crate::{
     consensus::ResolveBlockRequest,
     sync::live::block_queue::{BlockAndSource, BlockSource},

--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -29,7 +29,7 @@ use crate::{
     consensus::ResolveBlockRequest,
     sync::{
         live::block_queue::{BlockAndSource, BlockSource},
-        syncer::LiveSyncEvent,
+        sync_interface::LiveSyncEvent,
     },
     BlsCache,
 };

--- a/consensus/src/sync/live/state_queue/live_sync.rs
+++ b/consensus/src/sync/live/state_queue/live_sync.rs
@@ -21,7 +21,7 @@ use crate::{
             block_queue::{live_sync::PushOpResult as BlockPushOpResult, BlockAndSource},
             queue::{self, LiveSyncQueue},
         },
-        syncer::{LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
+        sync_interface::{LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
     },
     BlsCache,
 };

--- a/consensus/src/sync/mod.rs
+++ b/consensus/src/sync/mod.rs
@@ -3,6 +3,7 @@ pub mod history;
 pub mod light;
 pub mod live;
 pub mod peer_list;
+pub mod pico;
 mod sync_queue;
 pub mod syncer;
 pub mod syncer_proxy;

--- a/consensus/src/sync/mod.rs
+++ b/consensus/src/sync/mod.rs
@@ -4,6 +4,7 @@ pub mod light;
 pub mod live;
 pub mod peer_list;
 pub mod pico;
+pub mod sync_interface;
 mod sync_queue;
 pub mod syncer;
 pub mod syncer_proxy;

--- a/consensus/src/sync/pico/mod.rs
+++ b/consensus/src/sync/pico/mod.rs
@@ -1,0 +1,5 @@
+mod sync;
+mod sync_requests;
+mod sync_stream;
+
+pub use sync::PicoMacroSync;

--- a/consensus/src/sync/pico/sync.rs
+++ b/consensus/src/sync/pico/sync.rs
@@ -15,10 +15,7 @@ use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 
 use crate::{
     messages::BlockError,
-    sync::{
-        light::{EpochIds, PeerMacroRequests},
-        syncer::MacroSync,
-    },
+    sync::sync_interface::{EpochIds, MacroSync, PeerMacroRequests},
 };
 
 /// The PicoMacroSync is one type of MacroSync that operates on a per peer basis,

--- a/consensus/src/sync/pico/sync.rs
+++ b/consensus/src/sync/pico/sync.rs
@@ -111,7 +111,7 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for PicoMacroSync<TNetwork> 
         unimplemented!()
     }
 
-    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+    fn drain_peers(&mut self) -> Vec<TNetwork::PeerId> {
         self.syncing_peers.drain().collect()
     }
 }

--- a/consensus/src/sync/pico/sync.rs
+++ b/consensus/src/sync/pico/sync.rs
@@ -1,0 +1,120 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use futures::{future::BoxFuture, FutureExt};
+use nimiq_block::Block;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_network_interface::{
+    network::{CloseReason, Network, SubscribeEvents},
+    request::RequestError,
+};
+use nimiq_utils::{spawn, stream::FuturesUnordered};
+use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
+
+use crate::{
+    messages::BlockError,
+    sync::{
+        light::{EpochIds, PeerMacroRequests},
+        syncer::MacroSync,
+    },
+};
+
+/// The PicoMacroSync is one type of MacroSync that operates on a per peer basis,
+/// emitting peers either as Outdated, Good or Conflicting.
+/// To do this, it will:
+///   1. Request epoch IDs from the peer
+///   2. Request the last (if any) election or checkpoint blocks
+///   3. Apply the latest state, if any discrepancy is found, then it will emit the peer
+///      as conflicting so that we can fallback to other macro sync mechanism.
+pub struct PicoMacroSync<TNetwork: Network> {
+    /// The blockchain
+    pub(crate) blockchain: BlockchainProxy,
+    /// Reference to the network
+    pub(crate) network: Arc<TNetwork>,
+    /// Stream for peer joined and peer left events
+    pub(crate) network_event_rx: SubscribeEvents<TNetwork::PeerId>,
+    /// Used to track the macro requests on a per peer basis
+    pub(crate) peer_requests: HashMap<TNetwork::PeerId, PeerMacroRequests>,
+    /// The stream for epoch ids requests
+    pub(crate) epoch_ids_stream:
+        FuturesUnordered<BoxFuture<'static, Option<EpochIds<TNetwork::PeerId>>>>,
+    /// Block requests
+    pub(crate) block_headers: FuturesUnordered<
+        BoxFuture<
+            'static,
+            (
+                Result<Result<Block, BlockError>, RequestError>,
+                TNetwork::PeerId,
+            ),
+        >,
+    >,
+    /// Collection of peers we are currently pico macro syncing with
+    pub(crate) syncing_peers: HashSet<TNetwork::PeerId>,
+    /// Reference to the ZKP proxy used to interact with the ZKP component
+    /// It is not used by the pico consensus itself, but we need the reference
+    /// as part of the fallback mechanism
+    pub(crate) zkp_component_proxy: ZKPComponentProxy<TNetwork>,
+}
+
+impl<TNetwork: Network> PicoMacroSync<TNetwork> {
+    pub fn new(
+        blockchain: BlockchainProxy,
+        network: Arc<TNetwork>,
+        network_event_rx: SubscribeEvents<TNetwork::PeerId>,
+        zkp_component_proxy: ZKPComponentProxy<TNetwork>,
+    ) -> Self {
+        Self {
+            blockchain,
+            network,
+            network_event_rx,
+            peer_requests: HashMap::new(),
+            epoch_ids_stream: FuturesUnordered::new(),
+            block_headers: Default::default(),
+            syncing_peers: HashSet::new(),
+            zkp_component_proxy,
+        }
+    }
+
+    /// This function is used when a peer disconnects, to remove any outstanding request
+    pub fn remove_peer_requests(&mut self, peer_id: TNetwork::PeerId) {
+        self.peer_requests.remove(&peer_id);
+        self.syncing_peers.remove(&peer_id);
+    }
+
+    /// Performs cleaning and notifies the network when a peer is disconnected
+    pub fn disconnect_peer(&mut self, peer_id: TNetwork::PeerId, reason: CloseReason) {
+        // Remove all pending peer requests (if any)
+        self.remove_peer_requests(peer_id);
+        let network = Arc::clone(&self.network);
+        // We disconnect from this peer
+        spawn(Box::pin({
+            async move {
+                network.disconnect_peer(peer_id, reason).await;
+            }
+        }));
+    }
+}
+
+impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for PicoMacroSync<TNetwork> {
+    const MAX_REQUEST_EPOCHS: u16 = 1000; // TODO: Use other value
+
+    fn add_peer(&mut self, peer_id: TNetwork::PeerId) {
+        info!(%peer_id, "Pico MacroSync: Requesting epoch ids from peer");
+
+        self.syncing_peers.insert(peer_id);
+        let future =
+            Self::request_epoch_ids(self.blockchain.clone(), Arc::clone(&self.network), peer_id)
+                .boxed();
+        self.epoch_ids_stream.push(future);
+    }
+
+    fn fallback(&mut self, _peers: Vec<TNetwork::PeerId>) {
+        unimplemented!()
+    }
+
+    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+        self.syncing_peers.drain().collect()
+    }
+}

--- a/consensus/src/sync/pico/sync_requests.rs
+++ b/consensus/src/sync/pico/sync_requests.rs
@@ -14,9 +14,8 @@ use nimiq_primitives::policy::Policy;
 use crate::{
     messages::{BlockError, MacroChain, MacroChainError, RequestBlock, RequestMacroChain},
     sync::{
-        light::{EpochIds, PeerMacroRequests},
         pico::PicoMacroSync,
-        syncer::MacroSync,
+        sync_interface::{EpochIds, MacroSync, PeerMacroRequests},
     },
 };
 

--- a/consensus/src/sync/pico/sync_requests.rs
+++ b/consensus/src/sync/pico/sync_requests.rs
@@ -15,7 +15,7 @@ use crate::{
     messages::{BlockError, MacroChain, MacroChainError, RequestBlock, RequestMacroChain},
     sync::{
         pico::PicoMacroSync,
-        sync_interface::{EpochIds, MacroSync, PeerMacroRequests},
+        sync_interface::{EpochIds, MacroSync, MacroSyncReturn, PeerMacroRequests},
     },
 };
 
@@ -129,7 +129,7 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
     pub(crate) fn request_macro_headers(
         &mut self,
         mut epoch_ids: EpochIds<TNetwork::PeerId>,
-    ) -> Option<TNetwork::PeerId> {
+    ) -> Option<MacroSyncReturn<TNetwork::PeerId>> {
         // Read our current blockchain state.
         let (our_epoch_id, our_epoch_number, our_block_number) = {
             let blockchain = self.blockchain.read();
@@ -153,7 +153,7 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
                     peer = %epoch_ids.sender,
                     "Peer is behind"
                 );
-                return Some(epoch_ids.sender);
+                return Some(MacroSyncReturn::Outdated(epoch_ids.sender));
             } else {
                 // Check that the epoch_id sent by the peer at our current epoch number corresponds to
                 // our accepted state. If it doesn't, the peer is on a "permanent" fork, so we ban it.
@@ -167,7 +167,7 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
                         peer = %epoch_ids.sender,
                         "Peer is on a different chain"
                     );
-                    return Some(epoch_ids.sender);
+                    return Some(MacroSyncReturn::Outdated(epoch_ids.sender));
                 }
 
                 epoch_ids.ids = epoch_ids
@@ -182,6 +182,13 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
             if checkpoint.block_number <= our_block_number {
                 epoch_ids.checkpoint = None;
             }
+        }
+
+        // After discarding all epoch_ids & checkpoint prior to our current state
+        // It could happen that we don't have anything new to learn from this peer
+        if epoch_ids.ids.is_empty() && epoch_ids.checkpoint.is_none() {
+            log::debug!("Nothing new to learn from this peer, emit it as good");
+            return Some(MacroSyncReturn::Good(epoch_ids.sender));
         }
 
         let mut peer_requests = PeerMacroRequests::new();

--- a/consensus/src/sync/pico/sync_requests.rs
+++ b/consensus/src/sync/pico/sync_requests.rs
@@ -1,0 +1,275 @@
+use std::sync::Arc;
+
+use futures::FutureExt;
+use nimiq_block::Block;
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_hash::Blake2bHash;
+use nimiq_network_interface::{
+    network::{CloseReason, Network},
+    request::RequestError,
+};
+use nimiq_primitives::policy::Policy;
+
+use crate::{
+    messages::{BlockError, MacroChain, MacroChainError, RequestBlock, RequestMacroChain},
+    sync::{
+        light::{EpochIds, PeerMacroRequests},
+        pico::PicoMacroSync,
+        syncer::MacroSync,
+    },
+};
+
+impl<TNetwork: Network> PicoMacroSync<TNetwork> {
+    /// Starts the sync process by requesting epoch ids (Macro chain) to other peers.
+    pub(crate) async fn request_epoch_ids(
+        blockchain: BlockchainProxy,
+        network: Arc<TNetwork>,
+        peer_id: TNetwork::PeerId,
+    ) -> Option<EpochIds<TNetwork::PeerId>> {
+        let (locators, epoch_number) = {
+            // Order matters here. The first hash found by the recipient of the request will be
+            // used, so they need to be in backwards block height order.
+            let blockchain = blockchain.read();
+            let election_head = blockchain.election_head();
+            let macro_head = blockchain.macro_head();
+
+            // So if there is a checkpoint hash that should be included in addition to the election
+            // block hash, it should come first.
+            let mut locators = vec![];
+            if macro_head.hash() != election_head.hash() {
+                locators.push(macro_head.hash());
+            }
+            // The election block is at the end here
+            locators.push(election_head.hash());
+
+            (locators, election_head.epoch_number())
+        };
+
+        let result = Self::request_macro_chain(
+            Arc::clone(&network),
+            peer_id,
+            locators,
+            Self::MAX_REQUEST_EPOCHS,
+        )
+        .await;
+
+        match result {
+            Ok(Err(error)) => {
+                debug!(%error, "Error requesting macro chain");
+                Some(EpochIds {
+                    locator_found: false,
+                    ids: Vec::new(),
+                    checkpoint: None,
+                    first_epoch_number: 0,
+                    sender: peer_id,
+                })
+            }
+            Ok(Ok(macro_chain)) => {
+                // Validate that the maximum number of epochs is not exceeded.
+                if macro_chain.epochs.len() > Self::MAX_REQUEST_EPOCHS as usize {
+                    log::warn!(
+                        num_epochs = macro_chain.epochs.len(),
+                        %peer_id,
+                        "Banning peer because requesting macro chain failed: too many epochs returned"
+                    );
+                    network
+                        .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                        .await;
+                    return None;
+                }
+
+                // Sanity-check checkpoint block number:
+                //  * is in checkpoint epoch
+                //  * is a non-election macro block
+                if let Some(checkpoint) = &macro_chain.checkpoint {
+                    let checkpoint_epoch = epoch_number + macro_chain.epochs.len() as u32 + 1;
+                    if Policy::epoch_at(checkpoint.block_number) != checkpoint_epoch
+                        || !Policy::is_macro_block_at(checkpoint.block_number)
+                        || Policy::is_election_block_at(checkpoint.block_number)
+                    {
+                        // Peer provided an invalid checkpoint block number, close connection.
+                        log::warn!(
+                            block_number = checkpoint.block_number,
+                            checkpoint_epoch,
+                            %peer_id,
+                            "Banning peer because requesting macro chain failed: invalid checkpoint"
+                        );
+                        network
+                            .disconnect_peer(peer_id, CloseReason::MaliciousPeer)
+                            .await;
+                        return None;
+                    }
+                }
+
+                log::debug!(
+                    received_epochs = macro_chain.epochs.len(),
+                    start_epoch = epoch_number + 1,
+                    checkpoint = macro_chain.checkpoint.is_some(),
+                    sender = %peer_id,
+                    "Received epoch_ids"
+                );
+
+                Some(EpochIds {
+                    locator_found: true,
+                    ids: macro_chain.epochs,
+                    checkpoint: macro_chain.checkpoint,
+                    first_epoch_number: epoch_number as usize + 1,
+                    sender: peer_id,
+                })
+            }
+            Err(error) => {
+                log::warn!(%error, %peer_id, "Request macro chain failed");
+                network.disconnect_peer(peer_id, CloseReason::Error).await;
+                None
+            }
+        }
+    }
+
+    /// Requests macro headers to the current syncing peer
+    pub(crate) fn request_macro_headers(
+        &mut self,
+        mut epoch_ids: EpochIds<TNetwork::PeerId>,
+    ) -> Option<TNetwork::PeerId> {
+        // Read our current blockchain state.
+        let (our_epoch_id, our_epoch_number, our_block_number) = {
+            let blockchain = self.blockchain.read();
+            (
+                blockchain.election_head_hash(),
+                blockchain.election_head().epoch_number() as usize,
+                blockchain.block_number(),
+            )
+        };
+
+        // Truncate epoch_ids by epoch_number: Discard all epoch_ids prior to our accepted state.
+        if !epoch_ids.ids.is_empty() && epoch_ids.first_epoch_number <= our_epoch_number {
+            let peers_epoch_number = epoch_ids.last_epoch_number();
+            if peers_epoch_number < our_epoch_number
+                || (peers_epoch_number == our_epoch_number && epoch_ids.checkpoint.is_none())
+            {
+                // Peer is behind, emit it as useless.
+                debug!(
+                    our_epoch_number,
+                    peers_epoch_number,
+                    peer = %epoch_ids.sender,
+                    "Peer is behind"
+                );
+                return Some(epoch_ids.sender);
+            } else {
+                // Check that the epoch_id sent by the peer at our current epoch number corresponds to
+                // our accepted state. If it doesn't, the peer is on a "permanent" fork, so we ban it.
+                let peers_epoch_id =
+                    &epoch_ids.ids[our_epoch_number - epoch_ids.first_epoch_number];
+                if our_epoch_id != *peers_epoch_id {
+                    debug!(
+                        our_epoch_number,
+                        %our_epoch_id,
+                        %peers_epoch_id,
+                        peer = %epoch_ids.sender,
+                        "Peer is on a different chain"
+                    );
+                    return Some(epoch_ids.sender);
+                }
+
+                epoch_ids.ids = epoch_ids
+                    .ids
+                    .split_off(our_epoch_number - epoch_ids.first_epoch_number + 1);
+                epoch_ids.first_epoch_number = our_epoch_number + 1;
+            }
+        }
+
+        // Discard checkpoint block if it is old.
+        if let Some(checkpoint) = &epoch_ids.checkpoint {
+            if checkpoint.block_number <= our_block_number {
+                epoch_ids.checkpoint = None;
+            }
+        }
+
+        let mut peer_requests = PeerMacroRequests::new();
+
+        log::trace!(%epoch_ids.sender,
+            "Creating a new set of requests",
+        );
+
+        // Request the latest election block
+        if let Some(last_election) = epoch_ids.ids.last() {
+            let network = Arc::clone(&self.network);
+            let peer_id = epoch_ids.sender;
+
+            log::debug!(
+                %last_election,
+                "Request latest election block",
+            );
+
+            peer_requests.push_request(last_election.clone());
+            let last_election = last_election.clone();
+
+            self.block_headers.push(
+                async move {
+                    (
+                        Self::request_macro_block(network, peer_id, last_election).await,
+                        peer_id,
+                    )
+                }
+                .boxed(),
+            );
+        }
+
+        // Request the checkpoint (if any)
+        if let Some(checkpoint) = &epoch_ids.checkpoint {
+            let block_hash = checkpoint.clone().hash;
+            let network = Arc::clone(&self.network);
+            let peer_id = epoch_ids.sender;
+            peer_requests.push_request(block_hash.clone());
+            self.block_headers.push(
+                async move {
+                    (
+                        Self::request_macro_block(network, peer_id, block_hash).await,
+                        peer_id,
+                    )
+                }
+                .boxed(),
+            );
+        }
+
+        self.peer_requests.insert(epoch_ids.sender, peer_requests);
+
+        None
+    }
+
+    /// Requests a single macro block to the given peer
+    pub async fn request_macro_block(
+        network: Arc<TNetwork>,
+        peer_id: TNetwork::PeerId,
+        hash: Blake2bHash,
+    ) -> Result<Result<Block, BlockError>, RequestError> {
+        // We will only request macro blocks, so we always need the body
+        network
+            .request::<RequestBlock>(
+                RequestBlock {
+                    hash,
+                    include_body: false,
+                },
+                peer_id,
+            )
+            .await
+    }
+
+    /// Requests the macro chain to the given peer.
+    pub async fn request_macro_chain(
+        network: Arc<TNetwork>,
+        peer_id: TNetwork::PeerId,
+        locators: Vec<Blake2bHash>,
+        max_epochs: u16,
+    ) -> Result<Result<MacroChain, MacroChainError>, RequestError> {
+        network
+            .request::<RequestMacroChain>(
+                RequestMacroChain {
+                    locators,
+                    max_epochs,
+                },
+                peer_id,
+            )
+            .await
+    }
+}

--- a/consensus/src/sync/pico/sync_stream.rs
+++ b/consensus/src/sync/pico/sync_stream.rs
@@ -1,0 +1,260 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{FutureExt, Stream, StreamExt};
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_light_blockchain::LightBlockchain;
+use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent};
+use nimiq_primitives::policy::Policy;
+
+use crate::sync::{
+    pico::PicoMacroSync,
+    syncer::{MacroSync, MacroSyncReturn},
+};
+
+impl<TNetwork: Network> PicoMacroSync<TNetwork> {
+    // This function is the one that starts the PicoMacroSync process,
+    // by adding peers into the MacroSync component.
+    // It also removes peers from the internal data structures, when they leave
+    fn poll_network_events(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<MacroSyncReturn<TNetwork::PeerId>>> {
+        while let Poll::Ready(Some(result)) = self.network_event_rx.poll_next_unpin(cx) {
+            match result {
+                Ok(NetworkEvent::PeerLeft(peer_id)) => {
+                    // Remove the peer from internal data structures.
+                    self.remove_peer_requests(peer_id);
+                }
+                Ok(NetworkEvent::PeerJoined(peer_id, _)) => {
+                    // Query if that peer provides the necessary services for syncing
+                    if self.network.peer_provides_required_services(peer_id) {
+                        // Request zkps and start the macro sync process
+                        self.add_peer(peer_id);
+                    } else {
+                        // We can't sync with this peer as it doesn't provide the services that we need.
+                        // Emit the peer as incompatible.
+                        self.syncing_peers.remove(&peer_id);
+                        return Poll::Ready(Some(MacroSyncReturn::Incompatible(peer_id)));
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => return Poll::Ready(None),
+            }
+        }
+
+        Poll::Pending
+    }
+
+    fn poll_epoch_ids(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<MacroSyncReturn<TNetwork::PeerId>>> {
+        while let Poll::Ready(Some(Some(epoch_ids))) = self.epoch_ids_stream.poll_next_unpin(cx) {
+            // The peer might have disconnected during the request.
+            if !self.network.has_peer(epoch_ids.sender) {
+                continue;
+            }
+
+            // If the peer didn't find any of our locators, we are done with it and emit it.
+            if !epoch_ids.locator_found {
+                debug!(
+                    peer_id = ?epoch_ids.sender,
+                    "Peer is behind or on different chain"
+                );
+                self.syncing_peers.remove(&epoch_ids.sender);
+                return Poll::Ready(Some(MacroSyncReturn::Outdated(epoch_ids.sender)));
+            } else if epoch_ids.ids.is_empty() && epoch_ids.checkpoint.is_none() {
+                // We are synced with this peer.
+                debug!(
+                    peer_id = ?epoch_ids.sender,
+                    "Finished macro syncing with peer");
+                self.syncing_peers.remove(&epoch_ids.sender);
+                return Poll::Ready(Some(MacroSyncReturn::Good(epoch_ids.sender)));
+            }
+
+            // If the macro header process deems a peer useless, it is returned here and we emit it.
+            if let Some(agent) = self.request_macro_headers(epoch_ids) {
+                self.syncing_peers.remove(&agent);
+                return Poll::Ready(Some(MacroSyncReturn::Outdated(agent)));
+            }
+        }
+
+        Poll::Pending
+    }
+
+    fn poll_macro_blocks(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<MacroSyncReturn<TNetwork::PeerId>>> {
+        while let Poll::Ready(Some(result)) = self.block_headers.poll_next_unpin(cx) {
+            match result {
+                (Ok(Ok(block)), peer_id) => {
+                    if let Some(peer_requests) = self.peer_requests.get_mut(&peer_id) {
+                        if !peer_requests.update_request(block) {
+                            // We received a block we were not expecting from this peer
+                            log::warn!(%peer_id,
+                                "Banning peer due to a non expected response",
+                            );
+                            self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
+                            return Poll::Ready(None);
+                        }
+
+                        if peer_requests.is_ready() {
+                            log::trace!(%peer_id, "All pending requests are ready");
+
+                            while let Some((_, block)) = peer_requests.pop_request() {
+                                let block = block.expect("At this point the queue should be ready");
+
+                                if !block.is_macro() {
+                                    log::warn!(%peer_id,
+                                        "Banning peer because it sent us an invalid block type ",
+                                    );
+                                    self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
+                                    return Poll::Ready(None);
+                                }
+
+                                // Check if the block is still valid for us or if it is outdated before trying to apply it
+                                let push_result = match self.blockchain {
+                                    #[cfg(feature = "full")]
+                                    BlockchainProxy::Full(_) => {
+                                        panic!("Pico macro sync is not supported in the full blockchain")
+                                    }
+                                    BlockchainProxy::Light(ref light_blockchain) => {
+                                        let blockchain = light_blockchain.upgradable_read();
+                                        let latest_block_number = blockchain.block_number();
+
+                                        if block.block_number() < latest_block_number {
+                                            // The peer is outdated, so we emit it, and we remove it
+                                            self.peer_requests.remove(&peer_id);
+                                            self.syncing_peers.remove(&peer_id);
+                                            return Poll::Ready(Some(MacroSyncReturn::Outdated(
+                                                peer_id,
+                                            )));
+                                        }
+
+                                        if Policy::is_election_block_at(block.block_number()) {
+                                            if Policy::genesis_block_number() == latest_block_number
+                                            {
+                                                log::info!("PicoSync: Pushing latest election");
+                                                // If we are currently at the genesis block we blindly push the election block we obtained
+                                                LightBlockchain::push_pico_election(
+                                                    blockchain,
+                                                    block.clone(),
+                                                )
+                                            } else {
+                                                // We don't accept other election blocks if we are not in the genesis.
+                                                // Although we could tolerate +/- 1 block differences
+                                                self.syncing_peers.remove(&peer_id);
+                                                return Poll::Ready(Some(
+                                                    MacroSyncReturn::Conflicting(peer_id),
+                                                ));
+                                            }
+                                        } else {
+                                            // We only accept macro blocks from the current epoch
+                                            if blockchain.epoch_number()
+                                                == Policy::epoch_at(latest_block_number)
+                                            {
+                                                LightBlockchain::push_macro(
+                                                    blockchain,
+                                                    block.clone(),
+                                                )
+                                            } else {
+                                                self.syncing_peers.remove(&peer_id);
+                                                return Poll::Ready(Some(
+                                                    MacroSyncReturn::Conflicting(peer_id),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                };
+
+                                match push_result {
+                                    Ok(push_result) => {
+                                        log::debug!(
+                                            block_number = block.block_number(),
+                                            ?push_result,
+                                            "Pushed a macro block",
+                                        );
+                                    }
+                                    Err(error) => {
+                                        log::warn!(
+                                            block_number = block.block_number(),
+                                            ?error,
+                                            %peer_id,
+                                            "Failed to push macro block",
+                                        );
+                                        // Since we cannot differentiate between a malicious peer and someone who's behind and
+                                        // we don't know if the initial state (election block) that we obtained was good
+                                        // then we need to fallback to light macro sync.
+                                        self.syncing_peers.remove(&peer_id);
+                                        return Poll::Ready(Some(MacroSyncReturn::Conflicting(
+                                            peer_id,
+                                        )));
+                                    }
+                                }
+                            }
+                            // At this point we applied all the pending requests from this peer
+                            self.peer_requests.remove(&peer_id);
+
+                            // Re-request epoch ids after applying these blocks in order to know if we are up to date with this peer
+                            // or if there is more to sync
+                            let future = Self::request_epoch_ids(
+                                self.blockchain.clone(),
+                                Arc::clone(&self.network),
+                                peer_id,
+                            )
+                            .boxed();
+                            self.epoch_ids_stream.push(future);
+                        }
+                    } else {
+                        // If we don't have any pending requests from this peer, we proceed requesting epoch ids
+                        let future = Self::request_epoch_ids(
+                            self.blockchain.clone(),
+                            Arc::clone(&self.network),
+                            peer_id,
+                        )
+                        .boxed();
+                        self.epoch_ids_stream.push(future);
+                    }
+                }
+                (Ok(Err(error)), peer_id) => {
+                    trace!(%error, %peer_id, "Received a response for a failed request on the remote side");
+                    // If a block request fails, we disconnect from this peer
+                    self.disconnect_peer(peer_id, CloseReason::Error);
+                }
+                (Err(error), peer_id) => {
+                    trace!(?error, %peer_id, "Failed block request");
+                    // If a block request fails, we disconnect from this peer
+                    self.disconnect_peer(peer_id, CloseReason::Error);
+                }
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<TNetwork: Network> Stream for PicoMacroSync<TNetwork> {
+    type Item = MacroSyncReturn<TNetwork::PeerId>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(o) = self.poll_network_events(cx) {
+            return Poll::Ready(o);
+        }
+
+        if let Poll::Ready(o) = self.poll_epoch_ids(cx) {
+            return Poll::Ready(o);
+        }
+
+        if let Poll::Ready(o) = self.poll_macro_blocks(cx) {
+            return Poll::Ready(o);
+        }
+
+        Poll::Pending
+    }
+}

--- a/consensus/src/sync/pico/sync_stream.rs
+++ b/consensus/src/sync/pico/sync_stream.rs
@@ -55,32 +55,29 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
         cx: &mut Context<'_>,
     ) -> Poll<Option<MacroSyncReturn<TNetwork::PeerId>>> {
         while let Poll::Ready(Some(Some(epoch_ids))) = self.epoch_ids_stream.poll_next_unpin(cx) {
+            let peer_id = epoch_ids.sender;
+
             // The peer might have disconnected during the request.
-            if !self.network.has_peer(epoch_ids.sender) {
+            if !self.network.has_peer(peer_id) {
                 continue;
             }
 
             // If the peer didn't find any of our locators, we are done with it and emit it.
             if !epoch_ids.locator_found {
-                debug!(
-                    peer_id = ?epoch_ids.sender,
-                    "Peer is behind or on different chain"
-                );
-                self.syncing_peers.remove(&epoch_ids.sender);
+                debug!(?peer_id, "Peer is behind or on different chain");
+                self.syncing_peers.remove(&peer_id);
                 return Poll::Ready(Some(MacroSyncReturn::Outdated(epoch_ids.sender)));
             } else if epoch_ids.ids.is_empty() && epoch_ids.checkpoint.is_none() {
                 // We are synced with this peer.
-                debug!(
-                    peer_id = ?epoch_ids.sender,
-                    "Finished macro syncing with peer");
-                self.syncing_peers.remove(&epoch_ids.sender);
+                debug!(?peer_id, "Finished macro syncing with peer");
+                self.syncing_peers.remove(&peer_id);
                 return Poll::Ready(Some(MacroSyncReturn::Good(epoch_ids.sender)));
             }
 
-            // If the macro header process deems a peer useless, it is returned here and we emit it.
-            if let Some(agent) = self.request_macro_headers(epoch_ids) {
-                self.syncing_peers.remove(&agent);
-                return Poll::Ready(Some(MacroSyncReturn::Outdated(agent)));
+            // Request macro headers from this peer
+            if let Some(macro_sync_return) = self.request_macro_headers(epoch_ids) {
+                self.syncing_peers.remove(&peer_id);
+                return Poll::Ready(Some(macro_sync_return));
             }
         }
 

--- a/consensus/src/sync/pico/sync_stream.rs
+++ b/consensus/src/sync/pico/sync_stream.rs
@@ -13,7 +13,7 @@ use nimiq_primitives::policy::Policy;
 
 use crate::sync::{
     pico::PicoMacroSync,
-    syncer::{MacroSync, MacroSyncReturn},
+    sync_interface::{MacroSync, MacroSyncReturn},
 };
 
 impl<TNetwork: Network> PicoMacroSync<TNetwork> {

--- a/consensus/src/sync/pico/sync_stream.rs
+++ b/consensus/src/sync/pico/sync_stream.rs
@@ -91,6 +91,15 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
         while let Poll::Ready(Some(result)) = self.block_headers.poll_next_unpin(cx) {
             match result {
                 (Ok(Ok(block)), peer_id) => {
+                    if !block.is_macro() {
+                        // We received a non macro block during the macro sync process.
+                        log::warn!(%peer_id,
+                            "Banning peer due to a non expected response",
+                        );
+                        self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
+                        return Poll::Ready(None);
+                    }
+
                     if let Some(peer_requests) = self.peer_requests.get_mut(&peer_id) {
                         if !peer_requests.update_request(block) {
                             // We received a block we were not expecting from this peer

--- a/consensus/src/sync/sync_interface.rs
+++ b/consensus/src/sync/sync_interface.rs
@@ -1,0 +1,191 @@
+use std::collections::VecDeque;
+
+use futures::Stream;
+use nimiq_block::Block;
+use nimiq_hash::Blake2bHash;
+use nimiq_network_interface::network::Network;
+
+use super::live::block_queue::BlockSource;
+use crate::{consensus::ResolveBlockRequest, messages::Checkpoint};
+
+/// Trait that defines how a node synchronizes macro blocks
+/// The expected functionality is that there could be different methods of syncing but they
+/// all must synchronize to the latest macro block. An implementation of this trait requests,
+/// process and validates these macro blocks.
+/// The quantity of macro blocks needed or extra metadata associated are defined by each
+/// implementor of these trait.
+pub trait MacroSync<TPeerId>: Stream<Item = MacroSyncReturn<TPeerId>> + Unpin + Send {
+    /// The maximum amount of epochs we request for MacroSync
+    const MAX_REQUEST_EPOCHS: u16;
+    /// Adds a peer to synchronize macro blocks
+    fn add_peer(&mut self, peer_id: TPeerId);
+    /// Gets the list of peers that are being synced with and removes them from the sync process
+    fn collect_peers(&mut self) -> Vec<TPeerId>;
+    /// Fallbacks to other macro syncing mechanism.
+    /// Currently we can only fallback from Pico to Light macro sync.
+    fn fallback(&mut self, peers: Vec<TPeerId>);
+}
+
+/// Trait that defines how a node synchronizes receiving the blocks the peers are currently
+/// processing.
+/// The expected functionality is that there could be different methods of syncing but they
+/// all must synchronize to the latest macro block. Once that happened, an implementation of
+/// this trait comes into play to start receiving or processing the blocks that the peers are
+/// currently processing and/or synchronize micro blocks.
+pub trait LiveSync<N: Network>: Stream<Item = LiveSyncEvent<N::PeerId>> + Unpin + Send {
+    /// This function will be called each time a Block is received or announced by any of the
+    /// peers added into the LiveSync.
+    fn push_block(&mut self, block: Block, block_source: BlockSource<N>);
+    /// Adds a peer to receive or request blocks from it.
+    fn add_peer(&mut self, peer_id: N::PeerId);
+    /// Returns the number of peers that are being synced with
+    fn num_peers(&self) -> usize;
+    /// Returns the list of peers that are being synced with
+    fn peers(&self) -> Vec<N::PeerId>;
+    /// Returns whether the state sync has finished (or `true` if there is no state sync required)
+    fn state_complete(&self) -> bool {
+        true
+    }
+    /// Initiates an attempt to resolve a ResolveBlockRequest.
+    fn resolve_block(&mut self, request: ResolveBlockRequest<N>);
+    /// The maximum number of blocks a peer can be ahead before it is considered out-of-sync.
+    fn acceptance_window_size(&self) -> u32;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// Return type for a `MacroSync`
+pub enum MacroSyncReturn<T> {
+    /// We have synced to this peer's macro state.
+    Good(T),
+    /// The peer is behind our own state.
+    Outdated(T),
+    /// We can't sync with this peer.
+    Incompatible(T),
+    /// Conflicting peer, can only be returned from the Pico Macro sync
+    Conflicting(T),
+}
+
+#[derive(Clone, Debug)]
+/// Enumeration for events emitted by the Live Sync stream
+pub enum LiveSyncEvent<TPeerId> {
+    /// Events related to received/accepted or rejected blocks
+    PushEvent(LiveSyncPushEvent),
+    /// Events related to peer qualifications in the sync
+    PeerEvent(LiveSyncPeerEvent<TPeerId>),
+}
+
+#[derive(Clone, Debug)]
+/// Enumeration for the LiveSync stream events related to blocks
+pub enum LiveSyncPushEvent {
+    /// An announced block has been accepted
+    AcceptedAnnouncedBlock(Blake2bHash),
+    /// A buffered block has been accepted
+    AcceptedBufferedBlock(Blake2bHash, usize),
+    /// Missing blocks were received. The vec of all adopted blocks hashes is given here.
+    ReceivedMissingBlocks(Vec<Blake2bHash>),
+    /// Block was rejected
+    /// (this is only returned in *some* cases blocks were rejected)
+    RejectedBlock(Blake2bHash),
+    /// Chunks have been accepted for the head block
+    /// (note that other accepted chunks won't be announced)
+    AcceptedChunks(Blake2bHash),
+}
+
+#[derive(Clone, Debug)]
+/// Enumeration for the LiveSync stream events related to peers
+pub enum LiveSyncPeerEvent<TPeerId> {
+    /// Peer is in the past (outdated)
+    Behind(TPeerId),
+    /// Peer is in the future (advanced)
+    Ahead(TPeerId),
+}
+
+#[derive(Clone)]
+/// This struct is used to request Epochs IDs (hashes) from other peers
+/// in order to determine their macro chain state relative to us
+pub struct EpochIds<T> {
+    /// Indicates if the latest epoch id that was queried was found in the peer's chain
+    pub locator_found: bool,
+    /// The most recent epoch ids (hashes)
+    pub ids: Vec<Blake2bHash>,
+    /// The most recent checkpoint block in the latest epoch (if any)
+    pub checkpoint: Option<Checkpoint>,
+    /// Epoch number corresponding to the first hash in ids
+    pub first_epoch_number: usize,
+    /// The sender that created this struct
+    pub sender: T,
+}
+
+impl<T> EpochIds<T> {
+    #[inline]
+    pub(crate) fn checkpoint_epoch_number(&self) -> usize {
+        self.first_epoch_number + self.ids.len()
+    }
+
+    #[inline]
+    pub(crate) fn last_epoch_number(&self) -> usize {
+        self.checkpoint_epoch_number().saturating_sub(1)
+    }
+}
+
+/// This struct is used to track all the macro requests sent to a particular peer
+pub struct PeerMacroRequests {
+    /// Number of requests that have been fulfilled
+    completed_requests: usize,
+    /// A Queue used to track the requests that have been sent, and their respective result
+    queued_requests: VecDeque<(Blake2bHash, Option<Block>)>,
+}
+
+impl Default for PeerMacroRequests {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl PeerMacroRequests {
+    pub fn new() -> Self {
+        Self {
+            completed_requests: 0,
+            queued_requests: VecDeque::new(),
+        }
+    }
+
+    // Pushes a new request into the queue
+    pub fn push_request(&mut self, block_hash: Blake2bHash) {
+        self.queued_requests.push_back((block_hash, None))
+    }
+
+    // Pops a request from the queue
+    pub fn pop_request(&mut self) -> Option<(Blake2bHash, Option<Block>)> {
+        self.queued_requests.pop_front()
+    }
+
+    // Returns true if the request was updated, false in case the request was not found
+    pub fn update_request(&mut self, mut block: Block) -> bool {
+        let position = self
+            .queued_requests
+            .iter()
+            .position(|(hash, _)| *hash == block.hash_cached());
+
+        if let Some(position) = position {
+            if self.queued_requests[position].1.is_none() {
+                // A fulfilled request is only count once
+                self.completed_requests += 1;
+            }
+            // We update our block request.
+            // Note: If we receive a response more than once, we use the latest
+            let block_hash = block.hash_cached();
+            log::trace!(%block_hash, "Updating block request");
+            self.queued_requests[position] = (block_hash, Some(block));
+
+            true
+        } else {
+            log::trace!("Received a response for a block that we didn't expect");
+            false
+        }
+    }
+
+    // Returns true if all the requests have been completed
+    pub fn is_ready(&self) -> bool {
+        self.queued_requests.len() == self.completed_requests
+    }
+}

--- a/consensus/src/sync/sync_interface.rs
+++ b/consensus/src/sync/sync_interface.rs
@@ -20,7 +20,7 @@ pub trait MacroSync<TPeerId>: Stream<Item = MacroSyncReturn<TPeerId>> + Unpin + 
     /// Adds a peer to synchronize macro blocks
     fn add_peer(&mut self, peer_id: TPeerId);
     /// Gets the list of peers that are being synced with and removes them from the sync process
-    fn collect_peers(&mut self) -> Vec<TPeerId>;
+    fn drain_peers(&mut self) -> Vec<TPeerId>;
     /// Fallbacks to other macro syncing mechanism.
     /// Currently we can only fallback from Pico to Light macro sync.
     fn fallback(&mut self, peers: Vec<TPeerId>);

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -11,107 +11,17 @@ use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent, SubscribeEvents};
 use nimiq_primitives::policy::Policy;
 use nimiq_time::{interval, Interval};
 use nimiq_utils::stream::FuturesUnordered;
 
+use super::sync_interface::{
+    LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent, MacroSync, MacroSyncReturn,
+};
 use crate::{
     consensus::ResolveBlockRequest, messages::RequestHead, sync::live::block_queue::BlockSource,
 };
-
-/// Trait that defines how a node synchronizes macro blocks
-/// The expected functionality is that there could be different methods of syncing but they
-/// all must synchronize to the latest macro block. An implementation of this trait requests,
-/// process and validates these macro blocks.
-/// The quantity of macro blocks needed or extra metadata associated are defined by each
-/// implementor of these trait.
-pub trait MacroSync<TPeerId>: Stream<Item = MacroSyncReturn<TPeerId>> + Unpin + Send {
-    /// The maximum amount of epochs we request for MacroSync
-    const MAX_REQUEST_EPOCHS: u16;
-    /// Adds a peer to synchronize macro blocks
-    fn add_peer(&mut self, peer_id: TPeerId);
-    /// Gets the list of peers that are being synced with and removes them from the sync process
-    fn collect_peers(&mut self) -> Vec<TPeerId>;
-    /// Fallbacks to other macro syncing mechanism.
-    /// Currently we can only fallback from Pico to Light macro sync.
-    fn fallback(&mut self, peers: Vec<TPeerId>);
-}
-
-/// Trait that defines how a node synchronizes receiving the blocks the peers are currently
-/// processing.
-/// The expected functionality is that there could be different methods of syncing but they
-/// all must synchronize to the latest macro block. Once that happened, an implementation of
-/// this trait comes into play to start receiving or processing the blocks that the peers are
-/// currently processing and/or synchronize micro blocks.
-pub trait LiveSync<N: Network>: Stream<Item = LiveSyncEvent<N::PeerId>> + Unpin + Send {
-    /// This function will be called each time a Block is received or announced by any of the
-    /// peers added into the LiveSync.
-    fn push_block(&mut self, block: Block, block_source: BlockSource<N>);
-    /// Adds a peer to receive or request blocks from it.
-    fn add_peer(&mut self, peer_id: N::PeerId);
-    /// Returns the number of peers that are being synced with
-    fn num_peers(&self) -> usize;
-    /// Returns the list of peers that are being synced with
-    fn peers(&self) -> Vec<N::PeerId>;
-    /// Returns whether the state sync has finished (or `true` if there is no state sync required)
-    fn state_complete(&self) -> bool {
-        true
-    }
-    /// Initiates an attempt to resolve a ResolveBlockRequest.
-    fn resolve_block(&mut self, request: ResolveBlockRequest<N>);
-    /// The maximum number of blocks a peer can be ahead before it is considered out-of-sync.
-    fn acceptance_window_size(&self) -> u32;
-}
-
-#[derive(Debug, PartialEq, Eq)]
-/// Return type for a `MacroSync`
-pub enum MacroSyncReturn<T> {
-    /// We have synced to this peer's macro state.
-    Good(T),
-    /// The peer is behind our own state.
-    Outdated(T),
-    /// We can't sync with this peer.
-    Incompatible(T),
-    /// Conflicting peer, can only be returned from the Pico Macro sync
-    Conflicting(T),
-}
-
-#[derive(Clone, Debug)]
-/// Enumeration for events emitted by the Live Sync stream
-pub enum LiveSyncEvent<TPeerId> {
-    /// Events related to received/accepted or rejected blocks
-    PushEvent(LiveSyncPushEvent),
-    /// Events related to peer qualifications in the sync
-    PeerEvent(LiveSyncPeerEvent<TPeerId>),
-}
-
-#[derive(Clone, Debug)]
-/// Enumeration for the LiveSync stream events related to blocks
-pub enum LiveSyncPushEvent {
-    /// An announced block has been accepted
-    AcceptedAnnouncedBlock(Blake2bHash),
-    /// A buffered block has been accepted
-    AcceptedBufferedBlock(Blake2bHash, usize),
-    /// Missing blocks were received. The vec of all adopted blocks hashes is given here.
-    ReceivedMissingBlocks(Vec<Blake2bHash>),
-    /// Block was rejected
-    /// (this is only returned in *some* cases blocks were rejected)
-    RejectedBlock(Blake2bHash),
-    /// Chunks have been accepted for the head block
-    /// (note that other accepted chunks won't be announced)
-    AcceptedChunks(Blake2bHash),
-}
-
-#[derive(Clone, Debug)]
-/// Enumeration for the LiveSync stream events related to peers
-pub enum LiveSyncPeerEvent<TPeerId> {
-    /// Peer is in the past (outdated)
-    Behind(TPeerId),
-    /// Peer is in the future (advanced)
-    Ahead(TPeerId),
-}
 
 /// Syncer is the main synchronization object inside `Consensus`
 /// It has a reference to the main blockchain and network and has two dynamic

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -32,6 +32,11 @@ pub trait MacroSync<TPeerId>: Stream<Item = MacroSyncReturn<TPeerId>> + Unpin + 
     const MAX_REQUEST_EPOCHS: u16;
     /// Adds a peer to synchronize macro blocks
     fn add_peer(&mut self, peer_id: TPeerId);
+    /// Gets the list of peers that are being synced with and removes them from the sync process
+    fn collect_peers(&mut self) -> Vec<TPeerId>;
+    /// Fallbacks to other macro syncing mechanism.
+    /// Currently we can only fallback from Pico to Light macro sync.
+    fn fallback(&mut self, peers: Vec<TPeerId>);
 }
 
 /// Trait that defines how a node synchronizes receiving the blocks the peers are currently
@@ -69,6 +74,8 @@ pub enum MacroSyncReturn<T> {
     Outdated(T),
     /// We can't sync with this peer.
     Incompatible(T),
+    /// Conflicting peer, can only be returned from the Pico Macro sync
+    Conflicting(T),
 }
 
 #[derive(Clone, Debug)]
@@ -323,6 +330,14 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Stream for Syncer<N, M
                 Some(MacroSyncReturn::Incompatible(peer_id)) => {
                     debug!(%peer_id, "Macro sync returned incompatible peer");
                     self.check_incompatible_peer(peer_id);
+                }
+                Some(MacroSyncReturn::Conflicting(peer_id)) => {
+                    debug!(%peer_id, "Macro sync returned conflicting peer");
+                    let mut syncing_peers = self.live_sync.peers();
+                    syncing_peers.push(peer_id);
+                    syncing_peers.append(&mut self.macro_sync.collect_peers());
+
+                    self.macro_sync.fallback(syncing_peers);
                 }
                 None => {}
             }

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -245,7 +245,7 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Stream for Syncer<N, M
                     debug!(%peer_id, "Macro sync returned conflicting peer");
                     let mut syncing_peers = self.live_sync.peers();
                     syncing_peers.push(peer_id);
-                    syncing_peers.append(&mut self.macro_sync.collect_peers());
+                    syncing_peers.append(&mut self.macro_sync.drain_peers());
 
                     self.macro_sync.fallback(syncing_peers);
                 }

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -20,7 +20,7 @@ use pin_project::pin_project;
 
 use super::{
     pico::PicoMacroSync,
-    syncer::{MacroSync, MacroSyncReturn},
+    sync_interface::{MacroSync, MacroSyncReturn},
 };
 #[cfg(feature = "full")]
 use crate::sync::{
@@ -36,7 +36,8 @@ use crate::{
             queue::QueueConfig,
             BlockLiveSync,
         },
-        syncer::{LiveSyncPushEvent, Syncer},
+        sync_interface::LiveSyncPushEvent,
+        syncer::Syncer,
     },
     BlsCache,
 };

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "full")]
 use std::cmp::max;
 use std::{
+    mem,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -9,6 +10,7 @@ use std::{
 use futures::{Stream, StreamExt};
 use nimiq_block::Block;
 use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
 #[cfg(feature = "full")]
 use nimiq_primitives::policy::Policy;
@@ -16,6 +18,10 @@ use nimiq_zkp_component::zkp_component::ZKPComponentProxy;
 use parking_lot::Mutex;
 use pin_project::pin_project;
 
+use super::{
+    pico::PicoMacroSync,
+    syncer::{MacroSync, MacroSyncReturn},
+};
 #[cfg(feature = "full")]
 use crate::sync::{
     history::HistoryMacroSync,
@@ -43,6 +49,7 @@ macro_rules! gen_syncer_match {
             #[cfg(feature = "full")]
             SyncerProxy::Full(syncer) => syncer.$f($( $arg ),*),
             SyncerProxy::Light(syncer) => syncer.$f($( $arg ),*),
+            SyncerProxy::Pico(syncer) => syncer.$f($( $arg ),*),
         }
     };
 }
@@ -58,6 +65,88 @@ pub enum SyncerProxy<N: Network> {
     Full(Syncer<N, LightMacroSync<N>, StateLiveSync<N>>),
     /// Light Syncer, uses light macro sync for macro sync and block live sync.
     Light(Syncer<N, LightMacroSync<N>, BlockLiveSync<N>>),
+    /// Pico Syncer, uses pico macro sync, light macro sync and block live sync
+    Pico(Syncer<N, EitherSyncer<N>, BlockLiveSync<N>>),
+}
+
+/// Represents one of two possible macro sync mechanisms: LightMacroSync or PicoMacroSync
+/// only one of them can be active at any point in time.
+#[pin_project(project = EitherSyncerProj)]
+pub enum EitherSyncer<N: Network> {
+    Fallback(LightMacroSync<N>),
+    Normal(PicoMacroSync<N>),
+}
+
+impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for EitherSyncer<TNetwork> {
+    const MAX_REQUEST_EPOCHS: u16 = 1000; // TODO: Use other value
+
+    fn add_peer(&mut self, peer_id: TNetwork::PeerId) {
+        match self {
+            EitherSyncer::Fallback(macro_sync) => macro_sync.add_peer(peer_id),
+            EitherSyncer::Normal(macro_sync) => macro_sync.add_peer(peer_id),
+        }
+    }
+
+    fn fallback(&mut self, peers: Vec<TNetwork::PeerId>) {
+        // This functionality is only implemented for switching from Pico to Light macro sync.
+        let EitherSyncer::Normal(pico) = self else {
+            return;
+        };
+
+        log::info!("Falling back to light macro sync");
+
+        // Get all the peers from the pico macro sync move them to light macro sync
+        let network = &pico.network;
+        let network_event_rx = network.subscribe_events();
+        let blockchain = &pico.blockchain;
+
+        match blockchain {
+            #[cfg(feature = "full")]
+            BlockchainProxy::Full(_) => {
+                unimplemented!()
+            }
+            BlockchainProxy::Light(light_blockchain) => {
+                let blockchain = light_blockchain.upgradable_read();
+                // Reset the blockchain state
+                log::info!("Resetting the light blockchain state");
+                LightBlockchain::reset_blockchain(blockchain);
+            }
+        }
+
+        log::info!("Initializing Light Macro Sync");
+        let mut light_macro_sync = LightMacroSync::new(
+            pico.blockchain.clone(),
+            Arc::clone(&pico.network),
+            network_event_rx,
+            pico.zkp_component_proxy.clone(),
+            0, // Since the light sync does not keep state, we ignore the threshold.
+        );
+
+        for peer_id in peers {
+            info!(%peer_id, "Adding peer into fallback macro sync");
+            light_macro_sync.add_peer(peer_id);
+        }
+
+        let _ = mem::replace(self, EitherSyncer::Fallback(light_macro_sync));
+    }
+
+    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+        match self {
+            EitherSyncer::Fallback(macro_sync) => macro_sync.collect_peers(),
+            EitherSyncer::Normal(macro_sync) => macro_sync.collect_peers(),
+        }
+    }
+}
+
+impl<TNetwork: Network> Stream for EitherSyncer<TNetwork> {
+    type Item = MacroSyncReturn<TNetwork::PeerId>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.project() {
+            EitherSyncerProj::Fallback(macro_sync) => macro_sync.poll_next_unpin(cx),
+            EitherSyncerProj::Normal(macro_sync) => macro_sync.poll_next_unpin(cx),
+        }
+    }
 }
 
 impl<N: Network> SyncerProxy<N> {
@@ -207,6 +296,51 @@ impl<N: Network> SyncerProxy<N> {
         ))
     }
 
+    /// Creates a new instance of a `SyncerProxy` for the `Pico` variant
+    pub async fn new_pico(
+        blockchain_proxy: BlockchainProxy,
+        network: Arc<N>,
+        bls_cache: Arc<Mutex<BlsCache>>,
+        zkp_component_proxy: ZKPComponentProxy<N>,
+        network_event_rx: SubscribeEvents<N::PeerId>,
+    ) -> Self {
+        let block_queue_config = QueueConfig {
+            include_body: false,
+            ..Default::default()
+        };
+
+        let block_queue = BlockQueue::new(
+            Arc::clone(&network),
+            blockchain_proxy.clone(),
+            block_queue_config,
+        )
+        .await;
+
+        let live_sync = BlockLiveSync::with_queue(
+            blockchain_proxy.clone(),
+            Arc::clone(&network),
+            block_queue,
+            bls_cache,
+        );
+
+        let pico_macro_sync = PicoMacroSync::new(
+            blockchain_proxy.clone(),
+            Arc::clone(&network),
+            network_event_rx,
+            zkp_component_proxy,
+        );
+
+        // We start with the Pico Macro sync mechanism
+        let normal_syncer = EitherSyncer::Normal(pico_macro_sync);
+
+        Self::Pico(Syncer::new(
+            blockchain_proxy,
+            network,
+            live_sync,
+            normal_syncer,
+        ))
+    }
+
     /// Pushes a block for the live sync method
     pub fn push_block(&mut self, block: Block, block_source: BlockSource<N>) {
         gen_syncer_match!(self, push_block, block, block_source)
@@ -247,6 +381,7 @@ impl<N: Network> Stream for SyncerProxy<N> {
             #[cfg(feature = "full")]
             SyncerProxyProj::Full(syncer) => syncer.poll_next_unpin(cx),
             SyncerProxyProj::Light(syncer) => syncer.poll_next_unpin(cx),
+            SyncerProxyProj::Pico(syncer) => syncer.poll_next_unpin(cx),
         }
     }
 }

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -131,10 +131,10 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for EitherSyncer<TNetwork> {
         let _ = mem::replace(self, EitherSyncer::Fallback(light_macro_sync));
     }
 
-    fn collect_peers(&mut self) -> Vec<TNetwork::PeerId> {
+    fn drain_peers(&mut self) -> Vec<TNetwork::PeerId> {
         match self {
-            EitherSyncer::Fallback(macro_sync) => macro_sync.collect_peers(),
-            EitherSyncer::Normal(macro_sync) => macro_sync.collect_peers(),
+            EitherSyncer::Fallback(macro_sync) => macro_sync.drain_peers(),
+            EitherSyncer::Normal(macro_sync) => macro_sync.drain_peers(),
         }
     }
 }

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -62,7 +62,7 @@ impl MacroSync<MockPeerId> for MockHistorySyncStream {
         self.peers.write().push(peer_id);
     }
 
-    fn collect_peers(&mut self) -> Vec<MockPeerId> {
+    fn drain_peers(&mut self) -> Vec<MockPeerId> {
         unimplemented!()
     }
 

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -60,6 +60,14 @@ impl MacroSync<MockPeerId> for MockHistorySyncStream {
     fn add_peer(&mut self, peer_id: MockPeerId) {
         self.peers.write().push(peer_id);
     }
+
+    fn collect_peers(&mut self) -> Vec<MockPeerId> {
+        unimplemented!()
+    }
+
+    fn fallback(&mut self, _peers: Vec<MockPeerId>) {
+        unimplemented!()
+    }
 }
 
 fn blockchain() -> Arc<RwLock<Blockchain>> {

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -13,7 +13,8 @@ use nimiq_consensus::{
     messages::{RequestMissingBlocks, ResponseBlocks},
     sync::{
         live::{block_queue::BlockQueue, queue::QueueConfig, BlockLiveSync},
-        syncer::{LiveSync, MacroSync, MacroSyncReturn, Syncer},
+        sync_interface::{LiveSync, MacroSync, MacroSyncReturn},
+        syncer::Syncer,
     },
     BlsCache,
 };

--- a/consensus/tests/pico_sync.rs
+++ b/consensus/tests/pico_sync.rs
@@ -1,0 +1,66 @@
+mod sync_utils;
+
+use nimiq_primitives::policy::Policy;
+use nimiq_test_log::test;
+
+use crate::sync_utils::{sync_two_peers, SyncMode};
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_empty_chain() {
+    sync_two_peers(0, 0, SyncMode::Pico).await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_single_batch() {
+    sync_two_peers(1, 0, SyncMode::Pico).await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_two_batches() {
+    sync_two_peers(2, 0, SyncMode::Pico).await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_epoch_minus_batch() {
+    sync_two_peers(
+        (Policy::batches_per_epoch() - 1) as usize,
+        0,
+        SyncMode::Pico,
+    )
+    .await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_epoch_plus_batch() {
+    sync_two_peers(
+        (Policy::batches_per_epoch() + 1) as usize,
+        0,
+        SyncMode::Pico,
+    )
+    .await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_epoch_plus_two_batches() {
+    sync_two_peers(
+        (Policy::batches_per_epoch() + 2) as usize,
+        0,
+        SyncMode::Pico,
+    )
+    .await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_single_epoch() {
+    sync_two_peers(Policy::batches_per_epoch() as usize, 0, SyncMode::Pico).await
+}
+
+#[test(tokio::test)]
+async fn two_peers_can_sync_two_epochs() {
+    sync_two_peers(
+        (Policy::batches_per_epoch() * 2) as usize,
+        0,
+        SyncMode::Pico,
+    )
+    .await
+}

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -16,7 +16,7 @@ use nimiq_consensus::{
             state_queue::{Chunk, ChunkRequestState, RequestChunk, ResponseChunk, StateQueue},
             StateLiveSync,
         },
-        syncer::{LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
+        sync_interface::{LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
     },
     BlsCache,
 };

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -31,6 +31,7 @@ pub enum SyncMode {
     History,
     Full,
     Light,
+    Pico,
 }
 
 async fn syncer(
@@ -62,6 +63,16 @@ async fn syncer(
         }
         SyncMode::Light => {
             SyncerProxy::new_light(
+                blockchain.clone(),
+                Arc::clone(network),
+                Arc::new(Mutex::new(BlsCache::new_test())),
+                zkp_prover.proxy(),
+                network.subscribe_events(),
+            )
+            .await
+        }
+        SyncMode::Pico => {
+            SyncerProxy::new_pico(
                 blockchain.clone(),
                 Arc::clone(network),
                 Arc::new(Mutex::new(BlsCache::new_test())),
@@ -140,6 +151,10 @@ pub async fn sync_two_peers(
             BlockchainProxy::from(blockchain2)
         }
         SyncMode::Light => {
+            let blockchain2 = Arc::new(RwLock::new(LightBlockchain::new(NetworkId::UnitAlbatross)));
+            BlockchainProxy::from(blockchain2)
+        }
+        SyncMode::Pico => {
             let blockchain2 = Arc::new(RwLock::new(LightBlockchain::new(NetworkId::UnitAlbatross)));
             BlockchainProxy::from(blockchain2)
         }

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -180,6 +180,12 @@ pub async fn sync_two_peers(
             syncer.move_peer_into_live_sync(net1.get_local_peer_id());
             macro_sync_result
         }
+        SyncerProxy::Pico(ref mut syncer) => {
+            let macro_sync_result = syncer.macro_sync.next().await;
+            // Now we move the syncing peer to the live sync.
+            syncer.move_peer_into_live_sync(net1.get_local_peer_id());
+            macro_sync_result
+        }
     };
     log::debug!("Macro sync result {:?}", macro_sync_result);
     assert_eq!(

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -7,7 +7,7 @@ use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_consensus::{
     consensus::Consensus,
     messages::{BlockBodyTopic, BlockHeaderMessage, BlockHeaderTopic},
-    sync::{syncer::MacroSyncReturn, syncer_proxy::SyncerProxy},
+    sync::{sync_interface::MacroSyncReturn, syncer_proxy::SyncerProxy},
     BlsCache,
 };
 use nimiq_database::mdbx::MdbxDatabase;

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -135,6 +135,10 @@ pub fn generate_service_flags(sync_mode: SyncMode, index_history: bool) -> (Serv
             log::info!("Client configured as a light node");
             Services::provided(NodeType::Light)
         }
+        SyncMode::Pico => {
+            log::info!("Client configured as a pico node");
+            Services::provided(NodeType::Pico)
+        }
     };
 
     let required_services = match sync_mode {
@@ -144,6 +148,7 @@ pub fn generate_service_flags(sync_mode: SyncMode, index_history: bool) -> (Serv
         SyncMode::Full => Services::required(NodeType::Full),
         // Services required by light nodes
         SyncMode::Light => Services::required(NodeType::Light),
+        SyncMode::Pico => Services::required(NodeType::Pico),
     };
     (provided_services, required_services)
 }
@@ -417,9 +422,9 @@ impl ClientInner {
                 };
                 BlockchainProxy::from(&blockchain)
             }
-            SyncMode::Light => BlockchainProxy::from(&Arc::new(RwLock::new(LightBlockchain::new(
-                config.network_id,
-            )))),
+            SyncMode::Light | SyncMode::Pico => BlockchainProxy::from(&Arc::new(RwLock::new(
+                LightBlockchain::new(config.network_id),
+            ))),
         };
 
         // Create the Dht verifier
@@ -516,6 +521,20 @@ impl ClientInner {
                     ZKPComponent::new(blockchain_proxy.clone(), Arc::clone(&network), zkp_storage)
                         .await;
                 let syncer = SyncerProxy::new_light(
+                    blockchain_proxy.clone(),
+                    Arc::clone(&network),
+                    bls_cache,
+                    zkp_component.proxy(),
+                    network_events,
+                )
+                .await;
+                (syncer, zkp_component)
+            }
+            SyncMode::Pico => {
+                let zkp_component =
+                    ZKPComponent::new(blockchain_proxy.clone(), Arc::clone(&network), zkp_storage)
+                        .await;
+                let syncer = SyncerProxy::new_pico(
                     blockchain_proxy.clone(),
                     Arc::clone(&network),
                     bls_cache,

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -59,6 +59,9 @@ pub enum SyncMode {
     Full,
     /// Light nodes: They use LightMacroSync + BlockLiveSync
     Light,
+    /// Pico nodes: They use PicoMacroSync optimistically
+    /// if something fails, they fallback to LightMacroSync
+    Pico,
 }
 
 impl fmt::Display for SyncMode {
@@ -102,7 +105,7 @@ impl ConsensusConfigBuilder {
     ) -> &mut Self {
         let index_history = should_index_history.unwrap_or(match sync_mode {
             SyncMode::History => true,
-            SyncMode::Full | SyncMode::Light => false,
+            SyncMode::Full | SyncMode::Light | SyncMode::Pico => false,
         });
 
         self.index_history = Some(index_history);
@@ -787,6 +790,15 @@ impl ClientConfigBuilder {
     pub fn light(&mut self) -> &mut Self {
         let consensus_config = ConsensusConfig {
             sync_mode: SyncMode::Light,
+            ..Default::default()
+        };
+        self.consensus(consensus_config)
+    }
+
+    /// Configuration for Pico Client
+    pub fn pico(&mut self) -> &mut Self {
+        let consensus_config = ConsensusConfig {
+            sync_mode: SyncMode::Pico,
             ..Default::default()
         };
         self.consensus(consensus_config)

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -271,6 +271,9 @@ pub enum SyncMode {
     Full,
     /// Light nodes use LightMacroSync + BlockLiveSync to reach consensus
     Light,
+    /// Pico nodes: They use PicoMacroSync optimistically
+    /// if something fails, they fallback to LightMacroSync
+    Pico,
 }
 
 #[derive(Debug, Error)]
@@ -296,6 +299,7 @@ impl From<SyncMode> for config::SyncMode {
             SyncMode::History => Self::History,
             SyncMode::Full => Self::Full,
             SyncMode::Light => Self::Light,
+            SyncMode::Pico => Self::Pico,
         }
     }
 }

--- a/light-blockchain/src/blockchain.rs
+++ b/light-blockchain/src/blockchain.rs
@@ -12,6 +12,7 @@ use nimiq_primitives::{
 };
 use nimiq_utils::time::OffsetTime;
 use nimiq_vrf::VrfEntropy;
+use parking_lot::RwLockUpgradableReadGuard;
 use tokio::sync::broadcast;
 
 use crate::chain_store::ChainStore;
@@ -77,6 +78,23 @@ impl LightBlockchain {
             notifier: broadcast::Sender::new(BROADCAST_MAX_CAPACITY),
             fork_notifier: broadcast::Sender::new(BROADCAST_MAX_CAPACITY),
         }
+    }
+
+    /// Resets the light blockchain to its initial state
+    pub fn reset_blockchain(this: RwLockUpgradableReadGuard<Self>) {
+        // Upgrade lock
+        let genesis_block = this.genesis_block.clone();
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
+
+        let chain_info = ChainInfo::new(genesis_block.clone(), true);
+        this.chain_store = ChainStore::default();
+
+        this.chain_store.put_chain_info(chain_info);
+
+        this.head = genesis_block.clone();
+        this.macro_head = genesis_block.clone().unwrap_macro();
+        this.election_head = genesis_block.clone().unwrap_macro();
+        this.current_validators = genesis_block.validators()
     }
 
     /// Gets the active validators for a given epoch.

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -2,6 +2,7 @@ use nimiq_block::Block;
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, PushError, PushResult,
 };
+use nimiq_primitives::policy::Policy;
 use nimiq_zkp::{verify::verify, NanoProof, ZKP_VERIFYING_DATA};
 use parking_lot::RwLockUpgradableReadGuard;
 
@@ -187,6 +188,73 @@ impl LightBlockchain {
                 .send(BlockchainEvent::Finalized(block_hash))
                 .ok();
         }
+
+        Ok(PushResult::Extended)
+    }
+
+    /// Pushes an election block for the pico sync, bypassing many checks
+    pub fn push_pico_election(
+        this: RwLockUpgradableReadGuard<Self>,
+        mut block: Block,
+    ) -> Result<PushResult, PushError> {
+        // Must be a macro block.
+        assert!(block.is_macro());
+        assert!(Policy::is_election_block_at(block.block_number()));
+
+        let block_hash = block.hash_cached();
+
+        // Check if we already know this block.
+        if this.chain_store.get_chain_info(&block_hash, false).is_ok() {
+            return Ok(PushResult::Known);
+        }
+
+        if block.block_number() <= this.macro_head.block_number() {
+            return Ok(PushResult::Ignored);
+        }
+
+        // We expect blocks without body here. Defensively strip the block body as opposed to
+        // rejecting the block if the body is present as we can still push it just fine.
+        match block {
+            Block::Macro(ref mut block) => block.body = None,
+            Block::Micro(ref mut block) => block.body = None,
+        }
+
+        // Perform block intrinsic checks.
+        block.verify(this.network_id)?;
+
+        // Upgrade the blockchain lock
+        let mut this = RwLockUpgradableReadGuard::upgrade(this);
+
+        // Create the chain info for the new block.
+        let chain_info = ChainInfo::new(block.clone(), true);
+
+        // Remove old blocks from the ChainStore.
+        this.chain_store
+            .clear_old_blocks(chain_info.head.block_number());
+
+        // Store the block chain info.
+        this.chain_store.put_chain_info(chain_info);
+
+        // Update the blockchain.
+        this.head = block.clone();
+
+        this.macro_head = block.clone().unwrap_macro();
+
+        this.notifier
+            .send(BlockchainEvent::Extended(block_hash.clone()))
+            .ok();
+
+        this.election_head = block.unwrap_macro_ref().clone();
+
+        this.current_validators = block.validators();
+
+        // Store the election block header.
+        this.chain_store.put_election(block.unwrap_macro().header);
+
+        // We shouldn't log errors if there are no listeners.
+        this.notifier
+            .send(BlockchainEvent::EpochFinalized(block_hash))
+            .ok();
 
         Ok(PushResult::Extended)
     }

--- a/network-interface/src/peer_info.rs
+++ b/network-interface/src/peer_info.rs
@@ -55,6 +55,8 @@ pub enum NodeType {
     Light,
     /// Full node type
     Full,
+    /// Pico node type
+    Pico,
 }
 
 impl Services {
@@ -71,6 +73,7 @@ impl Services {
             NodeType::Full => {
                 Services::ACCOUNTS_PROOF | Services::FULL_BLOCKS | Services::ACCOUNTS_CHUNKS
             }
+            NodeType::Pico => Services::empty(),
         }
     }
 
@@ -80,6 +83,7 @@ impl Services {
             NodeType::History => Services::HISTORY | Services::FULL_BLOCKS,
             NodeType::Light => Services::ACCOUNTS_PROOF,
             NodeType::Full => Services::FULL_BLOCKS | Services::HISTORY | Services::ACCOUNTS_CHUNKS,
+            NodeType::Pico => Services::ACCOUNTS_PROOF,
         }
     }
 }

--- a/scripts/devnet/topology.py
+++ b/scripts/devnet/topology.py
@@ -105,7 +105,7 @@ class Topology:
             for count, node in enumerate(topology[key]):
                 if 'sync_mode' not in node:
                     raise Exception("Missing sync_mode for a node")
-                elif node['sync_mode'] not in ["full", "history", "light"]:
+                elif node['sync_mode'] not in ["full", "history", "light", "pico"]:
                     raise Exception(
                         "Unexpected sync_mode for a node: "
                         f"{node['sync_mode']}")


### PR DESCRIPTION
Pico Consensus Implementation
    
The PicoMacroSync is a macro sync mechanism that pushes the latest election block
that is obtained from a peer, if subsequent (sufficient) peers also have the same latest election
(and latest checkpoint blocks) then we move all the peers to live sync and we establish consensus.
If some peer has a different state than the initial state we obtained, we need to fallback to the
regular light macro sync.




To use it or try it in the web client:
web-client/src/client/lib.rs

`
let mut config = builder.volatile().pico().build().expect("Build configuration failed");
`


You can also set consensus sync mode to 'pico' if you want to test it in a light client


## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
