### PR TITLE
Fix issue when theres nothing new to learn from a peer

### DIFF
--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -24,7 +24,7 @@ use crate::{
             sync::{EpochIds, PeerMacroRequests},
             LightMacroSync,
         },
-        syncer::MacroSync,
+        syncer::{MacroSync, MacroSyncReturn},
     },
 };
 
@@ -180,7 +180,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
     pub(crate) fn request_macro_headers(
         &mut self,
         mut epoch_ids: EpochIds<TNetwork::PeerId>,
-    ) -> Option<TNetwork::PeerId> {
+    ) -> Option<MacroSyncReturn<TNetwork::PeerId>> {
         // Read our current blockchain state.
         let (our_epoch_id, our_epoch_number, our_block_number) = {
             let blockchain = self.blockchain.read();
@@ -204,7 +204,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                     peer = %epoch_ids.sender,
                     "Peer is behind"
                 );
-                return Some(epoch_ids.sender);
+                return Some(MacroSyncReturn::Outdated(epoch_ids.sender));
             } else {
                 // Check that the epoch_id sent by the peer at our current epoch number corresponds to
                 // our accepted state. If it doesn't, the peer is on a "permanent" fork, so we ban it.
@@ -219,7 +219,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                         peer = %epoch_ids.sender,
                         "Peer is on a different chain"
                     );
-                    return Some(epoch_ids.sender);
+                    return Some(MacroSyncReturn::Outdated(epoch_ids.sender));
                 }
 
                 epoch_ids.ids = epoch_ids
@@ -234,6 +234,13 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             if checkpoint.block_number <= our_block_number {
                 epoch_ids.checkpoint = None;
             }
+        }
+
+        // After discarding all epoch_ids & checkpoint prior to our current state
+        // It could happen that we don't have anything new to learn from this peer
+        if epoch_ids.ids.is_empty() && epoch_ids.checkpoint.is_none() {
+            log::debug!("Nothing new to learn from this peer, emit it as good");
+            return Some(MacroSyncReturn::Good(epoch_ids.sender));
         }
 
         let mut peer_requests = PeerMacroRequests::new();

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -261,9 +261,26 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                 }
             }
 
-            // If the macro header process deems a peer useless, it is returned here and we emit it.
-            if let Some(agent) = self.request_macro_headers(epoch_ids) {
-                return Poll::Ready(Some(MacroSyncReturn::Outdated(agent)));
+            // Request the macro headers from the peer or emit it accordingly
+            if let Some(macro_sync_return) = self.request_macro_headers(epoch_ids) {
+                match macro_sync_return {
+                    MacroSyncReturn::Good(peer_id) => {
+                        // We are synced with this peer.
+                        debug!(?peer_id, "Finished macro syncing with peer");
+
+                        if self.blockchain.read().can_enforce_validity_window() {
+                            // We can enforce the validity window, so we are done.
+                            return Poll::Ready(Some(MacroSyncReturn::Good(peer_id)));
+                        } else {
+                            #[cfg(feature = "full")]
+                            self.start_validity_synchronization(peer_id);
+                        }
+                    }
+                    _ => {
+                        // Propagate any other sync result (outdated is the only one that can be emitted by the macro headers process)
+                        return Poll::Ready(Some(macro_sync_return));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
When processing epoch ids it could happen that by the time we requested the epoch ids and the time we received those we no longer have anything new to learn from the peer, so we need to emit the peer as good.
This caused the peer to hang within the macro-sync process, increasing the time to consensus




## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
