### PR TITLE
Update to Rust Edition 2024

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -127,7 +127,7 @@ jobs:
         tool-cache: true
         large-packages: false
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@1.86.0
       with:
         targets: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.83.0 # Also test our Rust MSRV here.
+    - uses: dtolnay/rust-toolchain@1.85.0 # Also test our Rust MSRV here.
     - uses: Swatinem/rust-cache@v2
     - run: cargo check --all-features --tests --benches
 

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86.0
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ ark-r1cs-std = { git = "https://github.com/paberr/r1cs-std", branch = "pb/fix-pe
 [workspace.package]
 version = "1.1.0"
 authors = ["The Nimiq Core Development Team <info@nimiq.com>"]
-edition = "2021"
+edition = "2024"
 homepage = "https://nimiq.com"
 repository = "https://github.com/nimiq/core-rs-albatross"
 license = "Apache-2.0"

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -19,8 +19,8 @@ macro_rules! gen_blockchain_match {
     ($self: ident, $t: ident, $f: ident $(, $arg:expr )*) => {
         match $self {
             #[cfg(feature = "full")]
-            $t::Full(ref blockchain) => AbstractBlockchain::$f(&**blockchain, $( $arg ),*),
-            $t::Light(ref light_blockchain) => AbstractBlockchain::$f(&**light_blockchain, $( $arg ),*),
+            $t::Full(blockchain) => AbstractBlockchain::$f(&**blockchain, $( $arg ),*),
+            $t::Light(light_blockchain) => AbstractBlockchain::$f(&**light_blockchain, $( $arg ),*),
         }
     };
 }

--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -40,7 +40,7 @@ impl Blockchain {
 
         // Check the type of the block.
         match block {
-            Block::Macro(ref macro_block) => {
+            Block::Macro(macro_block) => {
                 // Initialize a vector to store the inherents.
                 let inherents = self.create_macro_block_inherents(macro_block);
 
@@ -61,7 +61,7 @@ impl Blockchain {
 
                 Ok(total_tx_size)
             }
-            Block::Micro(ref micro_block) => {
+            Block::Micro(micro_block) => {
                 // Get the body of the block.
                 let body = micro_block
                     .body

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -93,7 +93,7 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
             cluster.remove_peer(&peer_id);
         }
         for job in self.job_queue.iter_mut() {
-            if let Job::FinishCluster(ref mut cluster, _) = job {
+            if let Job::FinishCluster(cluster, _) = job {
                 cluster.remove_peer(&peer_id);
             }
         }

--- a/consensus/src/sync/live/diff_queue/diff_request_component.rs
+++ b/consensus/src/sync/live/diff_queue/diff_request_component.rs
@@ -34,7 +34,7 @@ impl<N: Network> DiffRequestComponent<N> {
 
     pub fn request_diff(
         &mut self,
-    ) -> impl FnMut(&BlockAndSource<N>) -> BoxFuture<'static, Result<TrieDiff, ()>> {
+    ) -> impl FnMut(&BlockAndSource<N>) -> BoxFuture<'static, Result<TrieDiff, ()>> + use<N> {
         let mut starting_peer_index = self.current_peer_index.clone();
         self.current_peer_index.increment();
 

--- a/consensus/src/sync/live/state_queue/chunk_request_component.rs
+++ b/consensus/src/sync/live/state_queue/chunk_request_component.rs
@@ -20,7 +20,7 @@ use crate::sync::{peer_list::PeerList, sync_queue::SyncQueue};
 ///
 /// - The sync queue which manages the requests and responses.
 /// - The peers list.
-/// - The network stream of events used to remove the peers that have left.  
+/// - The network stream of events used to remove the peers that have left.
 ///
 /// The public interface allows to request chunks, which are not immediately returned.
 /// The chunks instead are returned by polling the component.
@@ -50,7 +50,7 @@ impl<N: Network> ChunkRequestComponent<N> {
             },
             |request, (response, _, peer_id), _| {
                 // Verifies the response chunk size.
-                if let ResponseChunk::Chunk(ref chunk) = response {
+                if let ResponseChunk::Chunk(chunk) = response {
                     if chunk.chunk.items.len() > request.limit as usize {
                         debug!(
                                 "Peer[{}] Chunk size exceeded the request limit. Req: {:?} Chunk size: {}",

--- a/database/database-value-derive/src/lib.rs
+++ b/database/database-value-derive/src/lib.rs
@@ -12,7 +12,7 @@ fn impl_db_serialize(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
-    let gen = quote! {
+    let generated = quote! {
         impl #impl_generics ::nimiq_database_value::AsDatabaseBytes for #name #ty_generics where #name #ty_generics: ::nimiq_hash::nimiq_serde::Serialize {
             fn as_key_bytes(&self) -> std::borrow::Cow<[u8]> {
                 std::borrow::Cow::Owned(::nimiq_hash::nimiq_serde::Serialize::serialize_to_vec(&self))
@@ -35,5 +35,5 @@ fn impl_db_serialize(ast: &DeriveInput) -> TokenStream {
             }
         }
     };
-    gen
+    generated
 }

--- a/database/src/mdbx/transaction/proxy.rs
+++ b/database/src/mdbx/transaction/proxy.rs
@@ -33,21 +33,21 @@ where
     fn get<T: Table>(&self, table: &T, key: &T::Key) -> Option<T::Value> {
         match self {
             TransactionProxy::Read(txn) => txn.get(table, key),
-            TransactionProxy::OwnedRead(ref txn) => txn.get(table, key),
+            TransactionProxy::OwnedRead(txn) => txn.get(table, key),
         }
     }
 
     fn cursor<'txn, T: RegularTable>(&'txn self, table: &T) -> Self::Cursor<'txn, T> {
         match self {
             TransactionProxy::Read(txn) => txn.cursor(table),
-            TransactionProxy::OwnedRead(ref txn) => txn.cursor(table),
+            TransactionProxy::OwnedRead(txn) => txn.cursor(table),
         }
     }
 
     fn dup_cursor<'txn, T: DupTable>(&'txn self, table: &T) -> Self::DupCursor<'txn, T> {
         match self {
             TransactionProxy::Read(txn) => txn.dup_cursor(table),
-            TransactionProxy::OwnedRead(ref txn) => txn.dup_cursor(table),
+            TransactionProxy::OwnedRead(txn) => txn.dup_cursor(table),
         }
     }
 }
@@ -61,7 +61,7 @@ where
     fn deref(&self) -> &Self::Target {
         match self {
             TransactionProxy::Read(txn) => txn,
-            TransactionProxy::OwnedRead(ref txn) => txn,
+            TransactionProxy::OwnedRead(txn) => txn,
         }
     }
 }
@@ -73,7 +73,7 @@ where
     fn as_ref(&self) -> &MdbxReadTransaction<'db> {
         match self {
             TransactionProxy::Read(txn) => txn,
-            TransactionProxy::OwnedRead(ref txn) => txn,
+            TransactionProxy::OwnedRead(txn) => txn,
         }
     }
 }

--- a/database/src/mdbx/transaction/wrapper.rs
+++ b/database/src/mdbx/transaction/wrapper.rs
@@ -41,15 +41,15 @@ impl<'db> ReadTransaction<'db> for MdbxReadTransaction<'db> {
 
     fn get<T: Table>(&self, table: &T, key: &T::Key) -> Option<T::Value> {
         match self {
-            MdbxReadTransaction::Read(ref txn) => txn.get(table, key),
-            MdbxReadTransaction::Write(ref txn) => txn.get(table, key),
+            MdbxReadTransaction::Read(txn) => txn.get(table, key),
+            MdbxReadTransaction::Write(txn) => txn.get(table, key),
         }
     }
 
     fn cursor<'txn, T: RegularTable>(&'txn self, table: &T) -> Self::Cursor<'txn, T> {
         match self {
-            MdbxReadTransaction::Read(ref txn) => CursorProxy::Read(txn.cursor(table)),
-            MdbxReadTransaction::Write(ref txn) => {
+            MdbxReadTransaction::Read(txn) => CursorProxy::Read(txn.cursor(table)),
+            MdbxReadTransaction::Write(txn) => {
                 CursorProxy::Write(ReadTransaction::cursor(txn, table))
             }
         }
@@ -57,8 +57,8 @@ impl<'db> ReadTransaction<'db> for MdbxReadTransaction<'db> {
 
     fn dup_cursor<'txn, T: DupTable>(&'txn self, table: &T) -> Self::DupCursor<'txn, T> {
         match self {
-            MdbxReadTransaction::Read(ref txn) => CursorProxy::Read(txn.dup_cursor(table)),
-            MdbxReadTransaction::Write(ref txn) => {
+            MdbxReadTransaction::Read(txn) => CursorProxy::Read(txn.dup_cursor(table)),
+            MdbxReadTransaction::Write(txn) => {
                 CursorProxy::Write(ReadTransaction::dup_cursor(txn, table))
             }
         }

--- a/hash/hash_derive/src/lib.rs
+++ b/hash/hash_derive/src/lib.rs
@@ -12,7 +12,7 @@ fn impl_serialize_content(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
-    let gen = quote! {
+    let generated = quote! {
         impl #impl_generics ::nimiq_hash::SerializeContent for #name #ty_generics where #name #ty_generics: ::nimiq_hash::nimiq_serde::Serialize {
             #[allow(unused_mut, unused_variables)]
             fn serialize_content<W: ::std::io::Write, H>(&self, writer: &mut W) -> ::std::io::Result<()> {
@@ -21,5 +21,5 @@ fn impl_serialize_content(ast: &DeriveInput) -> TokenStream {
             }
         }
     };
-    gen
+    generated
 }

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -75,11 +75,11 @@ impl ChainStore {
         // - Micro blocks: Headers and Justifications
         // - Macro blocks: Headers
         match &mut chain_info.head {
-            Block::Macro(ref mut block) => {
+            Block::Macro(block) => {
                 block.body = None;
                 block.justification = None;
             }
-            Block::Micro(ref mut block) => {
+            Block::Micro(block) => {
                 block.body = None;
             }
         }

--- a/network-interface/src/request/mod.rs
+++ b/network-interface/src/request/mod.rs
@@ -223,7 +223,7 @@ pub fn request_handler<T: Send + Sync + Clone + 'static, Req: Handle<N, T>, N: N
     network: &Arc<N>,
     stream: BoxStream<'static, (Req, N::RequestId, N::PeerId)>,
     req_environment: &T,
-) -> impl Future<Output = ()> {
+) -> impl Future<Output = ()> + use<T, Req, N> {
     let req_environment = req_environment.clone();
     let network = Arc::clone(network);
     async move {

--- a/primitives/account/src/account/staking_contract/store.rs
+++ b/primitives/account/src/account/staking_contract/store.rs
@@ -69,14 +69,14 @@ impl<T: DataStoreReadOps> StakingContractStoreReadOps for StakingContractStoreRe
 }
 
 impl<T: DataStoreReadOps + DataStoreIterOps> StakingContractStoreRead<'_, T> {
-    pub(crate) fn iter_stakers(&self) -> impl Iterator<Item = Staker> {
+    pub(crate) fn iter_stakers(&self) -> impl Iterator<Item = Staker> + use<T> {
         self.0.iter(
             &StakingContractStore::staker_key(&Address::START_ADDRESS),
             &StakingContractStore::staker_key(&Address::END_ADDRESS),
         )
     }
 
-    pub(crate) fn iter_validators(&self) -> impl Iterator<Item = Validator> {
+    pub(crate) fn iter_validators(&self) -> impl Iterator<Item = Validator> + use<T> {
         self.0.iter(
             &StakingContractStore::validator_key(&Address::START_ADDRESS),
             &StakingContractStore::validator_key(&Address::END_ADDRESS),

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -559,19 +559,16 @@ impl BlockLog {
 
     pub fn transaction_logs(&self) -> &[TransactionLog] {
         match self {
-            BlockLog::AppliedBlock { ref tx_logs, .. }
-            | BlockLog::RevertedBlock { ref tx_logs, .. } => tx_logs,
+            BlockLog::AppliedBlock { tx_logs, .. } | BlockLog::RevertedBlock { tx_logs, .. } => {
+                tx_logs
+            }
         }
     }
 
     pub fn inherent_logs(&self) -> &[Log] {
         match self {
-            BlockLog::AppliedBlock {
-                ref inherent_logs, ..
-            }
-            | BlockLog::RevertedBlock {
-                ref inherent_logs, ..
-            } => inherent_logs,
+            BlockLog::AppliedBlock { inherent_logs, .. }
+            | BlockLog::RevertedBlock { inherent_logs, .. } => inherent_logs,
         }
     }
 }

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -49,7 +49,7 @@ fn revert_penalize_inherent(
         .expect("Failed to revert inherent");
 
     let mut offense_event_block = block_state.number;
-    if let Inherent::Penalize { ref slot } = inherent {
+    if let Inherent::Penalize { slot } = inherent {
         offense_event_block = slot.offense_event_block;
     }
 

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -53,24 +53,24 @@ impl Block {
     /// Returns the network ID of the block.
     pub fn network(&self) -> NetworkId {
         match self {
-            Block::Macro(ref block) => block.header.network,
-            Block::Micro(ref block) => block.header.network,
+            Block::Macro(block) => block.header.network,
+            Block::Micro(block) => block.header.network,
         }
     }
 
     /// Returns the version number of the block.
     pub fn version(&self) -> u16 {
         match self {
-            Block::Macro(ref block) => block.header.version,
-            Block::Micro(ref block) => block.header.version,
+            Block::Macro(block) => block.header.version,
+            Block::Micro(block) => block.header.version,
         }
     }
 
     /// Returns the block number of the block.
     pub fn block_number(&self) -> u32 {
         match self {
-            Block::Macro(ref block) => block.header.block_number,
-            Block::Micro(ref block) => block.header.block_number,
+            Block::Macro(block) => block.header.block_number,
+            Block::Micro(block) => block.header.block_number,
         }
     }
 
@@ -87,8 +87,8 @@ impl Block {
     /// Returns the timestamp of the block.
     pub fn timestamp(&self) -> u64 {
         match self {
-            Block::Macro(ref block) => block.header.timestamp,
-            Block::Micro(ref block) => block.header.timestamp,
+            Block::Macro(block) => block.header.timestamp,
+            Block::Micro(block) => block.header.timestamp,
         }
     }
 
@@ -96,8 +96,8 @@ impl Block {
     /// immediately preceding block.
     pub fn parent_hash(&self) -> &Blake2bHash {
         match self {
-            Block::Macro(ref block) => &block.header.parent_hash,
-            Block::Micro(ref block) => &block.header.parent_hash,
+            Block::Macro(block) => &block.header.parent_hash,
+            Block::Micro(block) => &block.header.parent_hash,
         }
     }
 
@@ -105,48 +105,48 @@ impl Block {
     /// header of the preceding election macro block.
     pub fn parent_election_hash(&self) -> Option<&Blake2bHash> {
         match self {
-            Block::Macro(ref block) => Some(&block.header.parent_election_hash),
-            Block::Micro(ref _block) => None,
+            Block::Macro(block) => Some(&block.header.parent_election_hash),
+            Block::Micro(_block) => None,
         }
     }
 
     /// Returns the seed of the block.
     pub fn seed(&self) -> &VrfSeed {
         match self {
-            Block::Macro(ref block) => &block.header.seed,
-            Block::Micro(ref block) => &block.header.seed,
+            Block::Macro(block) => &block.header.seed,
+            Block::Micro(block) => &block.header.seed,
         }
     }
 
     /// Returns the extra data of the block.
     pub fn extra_data(&self) -> &[u8] {
         match self {
-            Block::Macro(ref block) => &block.header.extra_data,
-            Block::Micro(ref block) => &block.header.extra_data,
+            Block::Macro(block) => &block.header.extra_data,
+            Block::Micro(block) => &block.header.extra_data,
         }
     }
 
     /// Returns the state root of the block.
     pub fn state_root(&self) -> &Blake2bHash {
         match self {
-            Block::Macro(ref block) => &block.header.state_root,
-            Block::Micro(ref block) => &block.header.state_root,
+            Block::Macro(block) => &block.header.state_root,
+            Block::Micro(block) => &block.header.state_root,
         }
     }
 
     /// Returns the body root of the block.
     pub fn body_root(&self) -> &Blake2sHash {
         match self {
-            Block::Macro(ref block) => &block.header.body_root,
-            Block::Micro(ref block) => &block.header.body_root,
+            Block::Macro(block) => &block.header.body_root,
+            Block::Micro(block) => &block.header.body_root,
         }
     }
 
     /// Returns the history root of the block.
     pub fn history_root(&self) -> &Blake2bHash {
         match self {
-            Block::Macro(ref block) => &block.header.history_root,
-            Block::Micro(ref block) => &block.header.history_root,
+            Block::Macro(block) => &block.header.history_root,
+            Block::Micro(block) => &block.header.history_root,
         }
     }
 
@@ -161,8 +161,8 @@ impl Block {
     /// Returns the Blake2b hash of the block header.
     pub fn hash(&self) -> Blake2bHash {
         match self {
-            Block::Macro(ref block) => block.header.hash(),
-            Block::Micro(ref block) => block.header.hash(),
+            Block::Macro(block) => block.header.hash(),
+            Block::Micro(block) => block.header.hash(),
         }
     }
 
@@ -203,8 +203,8 @@ impl Block {
     /// Returns true if this block contains a body.
     pub fn has_body(&self) -> bool {
         match self {
-            Block::Macro(ref block) => block.body.is_some(),
-            Block::Micro(ref block) => block.body.is_some(),
+            Block::Macro(block) => block.body.is_some(),
+            Block::Micro(block) => block.body.is_some(),
         }
     }
 
@@ -213,7 +213,7 @@ impl Block {
     pub fn transactions(&self) -> Option<&[ExecutedTransaction]> {
         match self {
             Block::Macro(_) => None,
-            Block::Micro(ref block) => block.body.as_ref().map(|ex| &ex.transactions[..]),
+            Block::Micro(block) => block.body.as_ref().map(|ex| &ex.transactions[..]),
         }
     }
 
@@ -222,7 +222,7 @@ impl Block {
     pub fn transactions_mut(&mut self) -> Option<&mut Vec<ExecutedTransaction>> {
         match self {
             Block::Macro(_) => None,
-            Block::Micro(ref mut block) => block.body.as_mut().map(|ex| &mut ex.transactions),
+            Block::Micro(block) => block.body.as_mut().map(|ex| &mut ex.transactions),
         }
     }
 
@@ -237,7 +237,7 @@ impl Block {
     pub fn sum_transaction_fees(&self) -> Coin {
         match self {
             Block::Macro(_) => Coin::ZERO,
-            Block::Micro(ref block) => block
+            Block::Micro(block) => block
                 .body
                 .as_ref()
                 .map(|ex| {
@@ -252,7 +252,7 @@ impl Block {
 
     /// Unwraps the block and returns a reference to the underlying Macro block.
     pub fn unwrap_macro_ref(&self) -> &MacroBlock {
-        if let Block::Macro(ref block) = self {
+        if let Block::Macro(block) = self {
             block
         } else {
             unreachable!()
@@ -261,7 +261,7 @@ impl Block {
 
     /// Unwraps the block and returns a reference to the underlying Micro block.
     pub fn unwrap_micro_ref(&self) -> &MicroBlock {
-        if let Block::Micro(ref block) = self {
+        if let Block::Micro(block) = self {
             block
         } else {
             unreachable!()
@@ -270,7 +270,7 @@ impl Block {
 
     /// Unwraps the block and returns a mutable reference to the underlying Macro block.
     pub fn unwrap_macro_ref_mut(&mut self) -> &mut MacroBlock {
-        if let Block::Macro(ref mut block) = self {
+        if let Block::Macro(block) = self {
             block
         } else {
             unreachable!()
@@ -279,7 +279,7 @@ impl Block {
 
     /// Unwraps the block and returns a mutable reference to the underlying Micro block.
     pub fn unwrap_micro_ref_mut(&mut self) -> &mut MicroBlock {
-        if let Block::Micro(ref mut block) = self {
+        if let Block::Micro(block) = self {
             block
         } else {
             unreachable!()

--- a/test-log/proc-macro/Cargo.toml
+++ b/test-log/proc-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nimiq-test-log-proc-macro"
 version.workspace = true
 authors = ["Daniel Mueller <deso@posteo.net>"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 include = ["src/lib.rs", "LICENSE-*", "README.md", "CHANGELOG.md"]

--- a/tools/src/rpc-schema/openrpc/document.rs
+++ b/tools/src/rpc-schema/openrpc/document.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use nimiq_serde::{Deserialize, Serialize};
-use schemars::{gen::SchemaSettings, schema::RootSchema, JsonSchema};
+use schemars::{r#gen::SchemaSettings, schema::RootSchema, JsonSchema};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum Openrpc {
@@ -562,7 +562,7 @@ impl ContentDescriptorOrReference {
     ) -> Self {
         let mut setting = SchemaSettings::draft07();
         setting.inline_subschemas = true;
-        let schema = schemars::gen::SchemaGenerator::new(setting).into_root_schema_for::<T>();
+        let schema = schemars::r#gen::SchemaGenerator::new(setting).into_root_schema_for::<T>();
         let json_schema = JSONSchema::JsonSchemaObject(schema);
         ContentDescriptorOrReference::ContentDescriptorObject(ContentDescriptorObject {
             name,

--- a/zkp-circuits/src/circuits/mnt4/pk_tree_node.rs
+++ b/zkp-circuits/src/circuits/mnt4/pk_tree_node.rs
@@ -122,7 +122,7 @@ impl PKTreeNodeCircuit {
         let mut signer_bitmap_chunk =
             Vec::with_capacity(Policy::SLOTS as usize / 2_usize.pow(tree_level as u32));
         for _ in 0..Policy::SLOTS as usize / 2_usize.pow(tree_level as u32) {
-            signer_bitmap_chunk.push(rng.gen());
+            signer_bitmap_chunk.push(rng.r#gen());
         }
 
         let keys = VerifyingKeys::rand(rng);

--- a/zkp-circuits/src/circuits/mnt6/pk_tree_leaf.rs
+++ b/zkp-circuits/src/circuits/mnt6/pk_tree_leaf.rs
@@ -139,7 +139,7 @@ impl Distribution<PKTreeLeafCircuit> for Standard {
 
         let mut signer_bitmap = Vec::with_capacity(Policy::SLOTS as usize / PK_TREE_BREADTH);
         for _ in 0..Policy::SLOTS as usize / PK_TREE_BREADTH {
-            signer_bitmap.push(rng.gen());
+            signer_bitmap.push(rng.r#gen());
         }
 
         // Create parameters for our circuit

--- a/zkp-circuits/src/circuits/mnt6/pk_tree_node.rs
+++ b/zkp-circuits/src/circuits/mnt6/pk_tree_node.rs
@@ -148,7 +148,7 @@ impl PKTreeNodeCircuit {
         let mut signer_bitmap =
             Vec::with_capacity(Policy::SLOTS as usize / 2_usize.pow(tree_level as u32));
         for _ in 0..Policy::SLOTS as usize / 2_usize.pow(tree_level as u32) {
-            signer_bitmap.push(rng.gen());
+            signer_bitmap.push(rng.r#gen());
         }
 
         let keys = VerifyingKeys::rand(rng);

--- a/zkp-circuits/src/setup.rs
+++ b/zkp-circuits/src/setup.rs
@@ -152,7 +152,7 @@ fn setup_pk_tree_leaf<R: Rng + CryptoRng>(
         return Ok(());
     }
 
-    let circuit: LeafMNT6 = rng.gen();
+    let circuit: LeafMNT6 = rng.r#gen();
 
     let (pk, vk) = Groth16::<MNT4_753>::setup(circuit, rng)?;
 

--- a/zkp-circuits/zkp-constraints/main.rs
+++ b/zkp-circuits/zkp-constraints/main.rs
@@ -44,7 +44,7 @@ fn main() {
     let start = Instant::now();
     let mut rng = &mut rand_core_compat::Rng09(rand::rng());
 
-    let circuit: mnt6::PKTreeLeafCircuit = rng.gen();
+    let circuit: mnt6::PKTreeLeafCircuit = rng.r#gen();
     evaluate_circuit(circuit, "pk_tree_leaf mnt6");
 
     let circuit = mnt4::PKTreeNodeCircuit::rand(0, &mut rng);

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -165,7 +165,7 @@ impl<N: Network> ZKPComponent<N> {
 
         // Activates the prover based on the configuration provided.
         zkp_component.zk_prover = match (is_prover_active, &zkp_component.blockchain) {
-            (true, BlockchainProxy::Full(ref blockchain)) => Some(
+            (true, BlockchainProxy::Full(blockchain)) => Some(
                 ZKProver::new(
                     Arc::clone(blockchain),
                     Arc::clone(&zkp_component.network),


### PR DESCRIPTION
Requires Rust v1.85.0, so can only be merged when that version is 2 versions old, as per MSRV policy (this PR sets the MSRV in the CI test to 1.85.0).

## What's in this pull request?

- Remove now unnecessary `ref` and `ref mut` keywords in `match` patterns
- Makes sure the new keyword `gen` is properly escaped where unavoidable
- Satisfy new lifetime declaration rules

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
