### PR TITLE
More initial seed node connections

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -345,6 +345,7 @@ impl ClientInner {
             config.network.peer_count_per_ip_max,
             config.network.peer_count_per_subnet_max,
             config.network.only_secure_ws_connections,
+            config.network.num_initial_connections,
             config.network.allow_loopback_addresses,
             config
                 .network

--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -182,6 +182,10 @@ pub struct NetworkConfig {
     /// Optional, quorum value for the network DHT.
     #[builder(default)]
     pub dht_quorum: Option<NonZeroU8>,
+
+    /// Optional, number of peers connected to at startup.
+    #[builder(default = "4")]
+    pub num_initial_connections: usize,
 }
 
 /// Configuration for setting TLS for secure WebSocket
@@ -871,6 +875,7 @@ impl ClientConfigBuilder {
             only_secure_ws_connections: false,
             allow_loopback_addresses: config_file.network.allow_loopback_addresses,
             dht_quorum: config_file.network.dht_quorum,
+            num_initial_connections: config_file.network.num_initial_connections,
         });
 
         // Configure consensus

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -97,6 +97,12 @@ seed_nodes = [
 # Default: 20
 #peer_count_per_subnet_max = 20
 
+# The amount of connections initially attempted at startup. 
+# This must be a number bigger than 0 or no connections at all will be attempted.
+# The default is one more than the default of consensus.min_peers.
+# Default: 4 
+#num_initial_connections = 4
+
 ##############################################################################
 #
 # TLS network configuration:

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -190,6 +190,8 @@ pub struct NetworkSettings {
     pub allow_loopback_addresses: bool,
     #[serde(default)]
     pub dht_quorum: Option<NonZeroU8>,
+    #[serde(default = "NetworkSettings::default_num_initial_connections")]
+    pub num_initial_connections: usize,
 }
 
 impl NetworkSettings {
@@ -207,6 +209,10 @@ impl NetworkSettings {
 
     pub fn peer_count_per_subnet_max() -> usize {
         20
+    }
+
+    pub fn default_num_initial_connections() -> usize {
+        4
     }
 }
 

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -92,6 +92,7 @@ impl Behaviour {
             peer_count_max: config.peer_count_max,
             peer_count_per_ip_max: config.peer_count_per_ip_max,
             peer_count_per_subnet_max: config.peer_count_per_subnet_max,
+            num_initial_connections: config.num_initial_connections,
             ..Default::default()
         };
 

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub required_services: Services,
     pub tls: Option<TlsConfig>,
     pub desired_peer_count: usize,
+    pub num_initial_connections: usize,
 
     /// Max number of peer connections.
     pub peer_count_max: usize,
@@ -58,6 +59,7 @@ impl Config {
         peer_count_per_ip_max: usize,
         peer_count_per_subnet_max: usize,
         only_secure_ws_connections: bool,
+        num_initial_connections: usize,
         allow_loopback_addresses: bool,
         dht_quorum: NonZeroU8,
     ) -> Self {
@@ -109,6 +111,7 @@ impl Config {
             peer_count_per_ip_max,
             peer_count_per_subnet_max,
             only_secure_ws_connections,
+            num_initial_connections,
             allow_loopback_addresses,
             dht_quorum,
         }

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -46,6 +46,8 @@ struct Limits {
 pub(crate) struct Config {
     /// Desired count of peers
     pub desired_peer_count: usize,
+    /// The number of initial attempted connections. These will connect to seed nodes.
+    pub num_initial_connections: usize,
     /// Maximum count of peers
     pub peer_count_max: usize,
     /// Maximum peer count per IP
@@ -83,6 +85,7 @@ impl Default for Config {
             ipv4_subnet_prefix_len: 24,
             ipv6_subnet_prefix_len: 96,
             dialing_count_max: 3,
+            num_initial_connections: 1,
             retry_down_after: Duration::from_secs(60 * 10), // 10 minutes
             housekeeping_interval: Duration::from_secs(60 * 2), // 2 minutes
         }
@@ -584,7 +587,7 @@ impl Behaviour {
             return vec![];
         }
 
-        let num_seeds = 1;
+        let num_seeds = self.config.num_initial_connections;
         let contacts = self.contacts.read();
         let own_contact = contacts.get_own_contact();
         let own_addresses: HashSet<&Multiaddr> = own_contact.addresses().collect();

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -73,6 +73,7 @@ fn network_config(address: Multiaddr) -> Config {
         required_services: Services::all(),
         tls: None,
         desired_peer_count: 3,
+        num_initial_connections: 1,
         peer_count_max: 4000,
         peer_count_per_ip_max: 20,
         peer_count_per_subnet_max: 20,

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -247,6 +247,7 @@ fn network_config(address: Multiaddr) -> Config {
         required_services: Services::all(),
         tls: None,
         desired_peer_count: 3,
+        num_initial_connections: 1,
         peer_count_max: 4000,
         peer_count_per_ip_max: 20,
         peer_count_per_subnet_max: 20,

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -79,6 +79,7 @@ impl TestNetwork for Network {
             20,
             20,
             false,
+            1,
             true,
             NonZeroU8::new(1).unwrap(),
         );


### PR DESCRIPTION
Previous to this PR the client will only attempt one single seed node connection in order to have a better discovered peer set as the next connections. With this PR a new configuration parameter is introduced to set a specific count. 
The default is set to the default of the required peers to establish consensus + 1 such that consensus should be established easier and more quickly.