### PR TITLE
bls: Decrease log level of public key decompression

### DIFF
--- a/bls/src/types/compressed_public_key.rs
+++ b/bls/src/types/compressed_public_key.rs
@@ -35,7 +35,7 @@ impl CompressedPublicKey {
 
     /// Transforms the compressed form back into the projective form.
     pub fn uncompress(&self) -> Result<PublicKey, Error> {
-        log::info!(
+        log::debug!(
             compressed = &self.to_hex()[..16],
             "decompressing BLS public key",
         );


### PR DESCRIPTION
Decrease log level (from info to debug) of the BLS public key decompression.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
