### PR TITLE
Make release workflows able to run when a tag is pushed

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,7 +1,8 @@
 name: Publish web-client to npm
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish_openrpc_document.yml
+++ b/.github/workflows/publish_openrpc_document.yml
@@ -1,8 +1,10 @@
 name: Publish OpenRPC document
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   build_release_binary_and_publish_document:


### PR DESCRIPTION
Make release workflows able to run when a tag is pushed instead of when the GH release is created. The creation event as it was before is not performed for instance when a draft release is published.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
