### PR TITLE
Dont request zkp when in pico mode

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -417,8 +417,15 @@ impl<N: Network> Consensus<N> {
                     self.head_requests = None;
                     self.head_requests_time = None;
 
-                    self.zkp_proxy
-                        .request_zkp_from_peers(self.sync.peers(), false);
+                    match self.sync {
+                        SyncerProxy::Pico(_) => {
+                            // Dont request zkps for pico consensus
+                        }
+                        _ => {
+                            self.zkp_proxy
+                                .request_zkp_from_peers(self.sync.peers(), false);
+                        }
+                    }
 
                     let (synced_validity_window, _) = self.check_validity_window();
                     return Some(ConsensusEvent::Established {
@@ -435,8 +442,15 @@ impl<N: Network> Consensus<N> {
                             info!("Consensus established, 2/3 of heads known.");
                             self.established_flag.swap(true, Ordering::Release);
 
-                            self.zkp_proxy
-                                .request_zkp_from_peers(self.sync.peers(), false);
+                            match self.sync {
+                                SyncerProxy::Pico(_) => {
+                                    // Dont request zkps for pico consensus
+                                }
+                                _ => {
+                                    self.zkp_proxy
+                                        .request_zkp_from_peers(self.sync.peers(), false);
+                                }
+                            }
 
                             let (synced_validity_window, _) = self.check_validity_window();
                             return Some(ConsensusEvent::Established {


### PR DESCRIPTION
When we reach consensus, we request ZKP proofs to our peers.
This is not necessary for Pico nodes since the Pico syncing mechanism
does not rely on ZKP proofs.
This could cause problems since the Pico nodes do not always have
the election block associated to the latest ZKP proof

...
#### This fixes #___.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
