### PR TITLE
web-client: Handle PoW `mined` transaction state

### DIFF
--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -942,6 +942,7 @@ pub enum TransactionState {
     Pending,
     /// The transaction has been included into the blockchain, but not yet finalized by a following
     /// macro block.
+    #[serde(alias = "mined")]
     Included,
     /// The transaction is included in the blockchain and has been finalized by a following macro block.
     Confirmed,


### PR DESCRIPTION
Sometimes, very old PlainTransactionDetails are passed into the web-client for parsing, currently leading to a parsing error when the old state is `mined`.
