### PR TITLE
Fix failed to publish asset for OpenRPC workflow

### DIFF
--- a/.github/workflows/publish_openrpc_document.yml
+++ b/.github/workflows/publish_openrpc_document.yml
@@ -1,10 +1,11 @@
 name: Publish OpenRPC document
 
+# This workflow only works with the 'on.release'-trigger.
+# On.release ensures a new release exists when artifacts from this workflow are being uploaded to the release.
+# On.tags can get triggered without the creation of a new release thus causing uploads to fail.
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build_release_binary_and_publish_document:


### PR DESCRIPTION
This commit partially reverts #3333. Specifically the workflow for publishing the OpenRPC document on a new release. The problem now is that with trigger `on.push.tags` there is a possibility that the actual release on Github isn't yet created. Therefore, after generating the JSON file, uploading files to this non-existent release fails.

To mitigate the problem that #3333 tried to solve, I've changed the trigger back to `on.release.types` for the OpenRPC workflow. However, before the PR it was `[created]` and now I set this to `[published]`. This makes sure that even if the release initially was published as a draft, the workflow is still triggered.

## What's in this pull request?

...
#### This fixes #___.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
