### PR TITLE
rpc-client: Re-export the RPC interface and types

### DIFF
--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -2,6 +2,12 @@ use anyhow::Error;
 use nimiq_jsonrpc_client::{
     websocket::WebsocketClient, ArcClient, Client as RPCclient, Credentials,
 };
+// Re-export the interfaces and types from the RPC interface subcrate
+pub use nimiq_rpc_interface::{
+    blockchain::BlockchainInterface, consensus::ConsensusInterface, mempool::MempoolInterface,
+    network::NetworkInterface, policy::PolicyInterface, types, validator::ValidatorInterface,
+    wallet::WalletInterface, zkp_component::ZKPComponentInterface,
+};
 use nimiq_rpc_interface::{
     blockchain::BlockchainProxy, consensus::ConsensusProxy, mempool::MempoolProxy,
     network::NetworkProxy, policy::PolicyProxy, validator::ValidatorProxy, wallet::WalletProxy,

--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
 use nimiq_keys::{Address, Ed25519PublicKey, Ed25519Signature};
-use nimiq_rpc_interface::{blockchain::BlockchainInterface, wallet::WalletInterface};
+use nimiq_rpc_client::{BlockchainInterface, WalletInterface};
 
 use crate::Client;
 

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -4,7 +4,7 @@ use clap::{ArgGroup, Parser};
 use futures::StreamExt;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_rpc_interface::{blockchain::BlockchainInterface, types::LogType};
+use nimiq_rpc_client::{types::LogType, BlockchainInterface};
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;

--- a/rpc-client/src/subcommands/mempool_subcommands.rs
+++ b/rpc-client/src/subcommands/mempool_subcommands.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-use nimiq_rpc_interface::mempool::MempoolInterface;
+use nimiq_rpc_client::MempoolInterface;
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;

--- a/rpc-client/src/subcommands/network_subcommands.rs
+++ b/rpc-client/src/subcommands/network_subcommands.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-use nimiq_rpc_interface::network::NetworkInterface;
+use nimiq_rpc_client::NetworkInterface;
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;

--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-use nimiq_rpc_interface::policy::PolicyInterface;
+use nimiq_rpc_client::PolicyInterface;
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use clap::{Args, Parser};
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
-use nimiq_rpc_interface::{
-    consensus::ConsensusInterface,
+use nimiq_rpc_client::{
     types::{HashAlgorithm, ValidityStartHeight},
+    ConsensusInterface,
 };
 use nimiq_transaction::account::htlc_contract::{AnyHash, AnyHash32, AnyHash64, PreImage};
 

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
 use nimiq_keys::Address;
-use nimiq_rpc_interface::{consensus::ConsensusInterface, validator::ValidatorInterface};
+use nimiq_rpc_client::{ConsensusInterface, ValidatorInterface};
 
 use super::{
     accounts_subcommands::HandleSubcommand,

--- a/rpc-client/src/subcommands/zkp_component_subcommands.rs
+++ b/rpc-client/src/subcommands/zkp_component_subcommands.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
-use nimiq_rpc_interface::zkp_component::ZKPComponentInterface;
+use nimiq_rpc_client::ZKPComponentInterface;
 
 use super::accounts_subcommands::HandleSubcommand;
 use crate::Client;


### PR DESCRIPTION
Re-export the RPC interface and types in the client to remove an explicit extra dependency for users of the rpc-client library.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
