### PR TITLE
Switch back to upstream `tsify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,7 +5262,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.0",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
  "tokio",
@@ -6762,7 +6762,7 @@ checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals 0.29.1",
+ "serde_derive_internals",
  "syn 2.0.100",
 ]
 
@@ -6872,17 +6872,6 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
@@ -6906,17 +6895,6 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7788,23 +7766,25 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsify"
-version = "0.4.5"
-source = "git+https://github.com/sisou/tsify?branch=sisou%2Fcomments#e36e55bcf3c9ac7c1d8185e5ad994885f4a2eb46"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
 dependencies = [
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen",
  "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "tsify-macros"
-version = "0.4.5"
-source = "git+https://github.com/sisou/tsify?branch=sisou%2Fcomments#e36e55bcf3c9ac7c1d8185e5ad994885f4a2eb46"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a324606929ad11628a19206d7853807481dcaecd6c08be70a235930b8241955"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals 0.28.0",
+ "serde_derive_internals",
  "syn 2.0.100",
 ]
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 serde_repr = { version = "0.1", optional = true }
 thiserror = { version = "2.0", optional = true }
-tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = [
+tsify = { version = "0.5", default-features = false, features = [
     "js",
 ], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/primitives/transaction/Cargo.toml
+++ b/primitives/transaction/Cargo.toml
@@ -24,7 +24,7 @@ log = { workspace = true }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"
-tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"], optional = true }
+tsify = { version = "0.5", default-features = false, features = ["js"], optional = true }
 url = { version = "2.5", features = ["serde"] }
 wasm-bindgen = { version = "0.2", optional = true }
 

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -35,7 +35,7 @@ serde_bytes = "0.11"
 serde_json = "1.0"
 serde-wasm-bindgen = "0.6"
 tokio = { version = "1.44", features = ["sync"] }
-tsify = { git = "https://github.com/sisou/tsify", branch = "sisou/comments", default-features = false, features = ["js"] }
+tsify = { version = "0.5", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-derive = { version = "0.3", optional = true }


### PR DESCRIPTION
Switch back to upstream `tsify` now that the changes to copy over rust docs to TS are now merged. See
[this PR](https://github.com/madonoharu/tsify/pull/32).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
