### PR TITLE
docs(consensus): add Rustdoc and inline comments

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -1,3 +1,7 @@
+//! Interface for sending requests to the consensus component.
+//!
+//! Used by other modules to resolve blocks or subscribe to consensus events.
+
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::{
@@ -36,7 +40,11 @@ use crate::{
     },
     ConsensusEvent,
 };
-
+/// Implements the logic for handling consensus-related requests.
+///
+/// The consensus proxy provides methods for interacting with peers, syncing nodes,
+/// retrieving blockchain data, and managing subscriptions.
+/// Used as an external interface to the internal consensus logic.
 pub struct ConsensusProxy<N: Network> {
     pub blockchain: BlockchainProxy,
     pub network: Arc<N>,
@@ -58,7 +66,6 @@ impl<N: Network> Clone for ConsensusProxy<N> {
         }
     }
 }
-
 impl<N: Network> ConsensusProxy<N> {
     pub async fn send_transaction(&self, tx: Transaction) -> Result<(), N::Error> {
         match ControlTransaction::try_from(tx) {
@@ -71,6 +78,7 @@ impl<N: Network> ConsensusProxy<N> {
         }
     }
 
+    /// Returns true if consensus is established.
     pub fn is_established(&self) -> bool {
         self.established_flag.load(Ordering::Acquire)
     }
@@ -81,6 +89,7 @@ impl<N: Network> ConsensusProxy<N> {
             && self.synced_validity_window_flag.load(Ordering::Acquire)
     }
 
+    /// Subsribes to consensus events: Established or Lost.
     pub fn subscribe_events(&self) -> BroadcastStream<ConsensusEvent> {
         BroadcastStream::new(self.events.subscribe())
     }
@@ -99,6 +108,15 @@ impl<N: Network> ConsensusProxy<N> {
         txn_stream.unwrap()
     }
 
+    /// Requests transaction receipts for a given address from multiple peers.
+    ///
+    /// The request can be limited by a maximum number of receipts (`max`),
+    /// a starting point (`start_at`, hash), and whether to include pre-genesis data.
+    ///
+    /// Fails if not enough peers are available to satisfy `min_peers`,
+    /// or if no valid response is received after contacting multiple peers.
+    ///
+    /// See [`RequestError`] and its variants for possible failure causes.
     pub async fn request_transaction_receipts_by_address(
         &self,
         address: Address,
@@ -156,6 +174,7 @@ impl<N: Network> ConsensusProxy<N> {
         Ok(receipts)
     }
 
+    /// Requests a transaction by hash and block number from multiple peers.
     pub async fn request_transaction_by_hash_and_block_number(
         &self,
         tx_hash: Blake2bHash,
@@ -174,6 +193,7 @@ impl<N: Network> ConsensusProxy<N> {
         }
     }
 
+    /// Requests a transaction by hash from multiple peers.
     pub async fn request_transaction_by_hash(
         &self,
         tx_hash: Blake2bHash,
@@ -191,6 +211,7 @@ impl<N: Network> ConsensusProxy<N> {
         }
     }
 
+    /// Returns peers that support all requested services (e.g. full blocks, history, mempool).
     async fn get_peers_for_service(
         &self,
         services: Services,
@@ -211,6 +232,8 @@ impl<N: Network> ConsensusProxy<N> {
             })
     }
 
+    /// Requests and verifies historic transactions from peers based on receipt data, and returns a list of verified transactions,
+    /// sorted by block number in descending order.
     pub async fn prove_transactions_from_receipts(
         &self,
         receipts: Vec<(Blake2bHash, Option<u32>)>,
@@ -512,6 +535,7 @@ impl<N: Network> ConsensusProxy<N> {
         remote_ds.get_stakers(addresses).await
     }
 
+    /// Subscribes to the given addresses on one or more peers.
     pub async fn subscribe_to_addresses(
         &self,
         addresses: Vec<Address>,
@@ -577,14 +601,15 @@ impl<N: Network> ConsensusProxy<N> {
         }
     }
 
+    /// Unsubscribes to the given addresses on one or more peers.
     pub async fn unsubscribe_from_addresses(
         &self,
         addresses: Vec<Address>,
         min_peers: usize,
     ) -> Result<(), RequestError> {
         // Unsubscribe given addresses from all peers
-        // Note: this does not mean that we will fully unsubscribe  from a peer,
-        // we will unsubscribe  only from the addresses that were supplied to this function
+        // Note: this does not mean that we will fully unsubscribe from a peer,
+        // we will unsubscribe only from the addresses that were supplied to this function
         for peer_id in self
             .get_peers_for_service(Services::FULL_BLOCKS, min_peers)
             .await?

--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -42,7 +42,8 @@ pub struct HeadRequests<TNetwork: Network + 'static> {
     unknown_blocks: Vec<(Block, TNetwork::PeerId)>,
     include_body: bool,
 }
-
+/// Contains the number of known and unknown blocks,
+/// and a list of unknown blocks paired with the peer they came from.
 pub struct HeadRequestsResult<TNetwork: Network + 'static> {
     pub num_known_blocks: usize,
     pub num_unknown_blocks: usize,
@@ -50,6 +51,7 @@ pub struct HeadRequestsResult<TNetwork: Network + 'static> {
 }
 
 impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
+    /// Creates a new `HeadRequest` instance for a given set of peers.
     pub fn new(
         peers: Vec<TNetwork::PeerId>,
         network: Arc<TNetwork>,
@@ -84,10 +86,12 @@ impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
         }
     }
 
+    /// Returns `true` if all head and block requests have been processed.
     pub fn is_finished(&self) -> bool {
         self.head_hashes.is_empty() && self.head_blocks.is_empty()
     }
 
+    /// Used to retrieve the peer's current head block information.
     async fn request_head(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,
@@ -97,6 +101,9 @@ impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
             .await
     }
 
+    /// Requests a block by hash from the specified peer, optionally including the body.
+    ///
+    /// Verifies that the returned block matches the requested hash.
     async fn request_block(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,
@@ -127,6 +134,11 @@ impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
 impl<TNetwork: Network + 'static> Future for HeadRequests<TNetwork> {
     type Output = HeadRequestsResult<TNetwork>;
 
+    /// Polls the future for head requests. First collects head hashes from peers,
+    /// checks if each hash is known or unknown, and schedules a block request if unknown.
+    /// Then polls for block responses, collecting valid ones and banning peers that respond
+    /// with mismatched data. When all requests have been processed, the future returns with the result;
+    /// otherwise, it remains pending.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // We poll the hashes first.
         while let Poll::Ready(Some((i, result))) = self.head_hashes.poll_next_unpin(cx) {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -1,3 +1,10 @@
+//! Core implementation of the Albatross consensus protocol.
+//!
+//! This module manages the consensus state, and facilitates synchronization with peers.
+//!
+//! It serves as the control center of the blockchain's
+//! agreement mechanism, ensuring all nodes converge on a single chain state.
+
 use std::{
     future::Future,
     pin::Pin,
@@ -125,7 +132,9 @@ pub struct ResolveBlockRequest<N: Network> {
 pub enum ConsensusRequest<N: Network> {
     ResolveBlock(ResolveBlockRequest<N>),
 }
-
+/// Coordinates synchronization between the blockchain and the network.
+/// Tracks peers, handles event notifications, and manages requests for chain data.
+/// Provides channels and flags for other components to maintain chain state.
 pub struct Consensus<N: Network> {
     pub blockchain: BlockchainProxy,
     pub network: Arc<N>,

--- a/consensus/src/consensus/remote_data_store.rs
+++ b/consensus/src/consensus/remote_data_store.rs
@@ -223,6 +223,8 @@ impl<N: Network> RemoteDataStore<N> {
         self.exec(RemoteDataStoreOps::Tombstone(addresses)).await
     }
 
+    /// Executes a remote data store operation by converting addresses into trie keys,
+    /// querying remote peers for their values, and returning a map of addresses to their stored items.
     async fn exec<T: Deserialize + Clone>(
         &self,
         op: RemoteDataStoreOps,

--- a/consensus/src/consensus/remote_event_dispatcher.rs
+++ b/consensus/src/consensus/remote_event_dispatcher.rs
@@ -192,6 +192,9 @@ pub struct RemoteEventDispatcher<N: Network> {
 }
 
 impl<N: Network> RemoteEventDispatcher<N> {
+    /// Creates a new `RemoteEventDispatcher` instance and sets up the necessary
+    /// event streams to handle incoming address subscription requests and
+    /// observe blockchain and network events.
     pub fn new(network: Arc<N>, blockchain: Arc<RwLock<Blockchain>>) -> Self {
         let state = Arc::new(RwLock::new(RemoteEventDispatcherState::new()));
 

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -1,13 +1,16 @@
+//! Defines error types used across the consensus layer.
+
 use nimiq_blockchain_interface::BlockchainError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Errors that can occur in the consensus layer.
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Blockchain error: {0}")]
     BlockchainError(#[from] BlockchainError),
 }
-
+/// Errors returned during synchronization.
 #[derive(Debug, Error)]
 pub enum SyncError {
     #[error("Other")]

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,3 +1,13 @@
+//! The `consensus` crate implements the Albatross consensus protocol.
+//! It coordinates synchronization and peer-to-peer communication.
+//!
+//! The main modules are:
+//! - `consensus`: manages the consensus state.
+//! - `sync`: handles synchronization across different modes.
+//! - `messages`: defines the network message formats.
+//! - `error`: defines errors related to consensus and communication.
+//! - `bls_cache`: internal LRU cache for optimizing BLS key usage.
+
 #[macro_use]
 extern crate log;
 

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -1,3 +1,9 @@
+//! Contains implementations of request handlers for consensus-related message types.
+//!
+//! Each handler defines how to respond to a specific request (e.g., block, head, macro chain,
+//! missing blocks, history chunk) by interacting with the local blockchain state.
+//! These handlers are registered to process incoming network requests during consensus and syncing operations.
+
 #[cfg(feature = "full")]
 use std::sync::Arc;
 use std::{cmp, collections::HashSet};
@@ -106,16 +112,23 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestBatchSet {
     ) -> Result<BatchSetInfo, BatchSetError> {
         let blockchain = blockchain.read();
 
+        // Fetch the block corresponding to the given hash and ensure it is a macro block.
+        // Return an error if it is a micro block or the hash is not found.
         let block = match blockchain.get_block(&self.hash, true, None) {
             Ok(Block::Macro(block)) => block,
             Ok(Block::Micro(_)) => return Err(BatchSetError::MicroBlockGiven),
             Err(_) => return Err(BatchSetError::TargetHashNotFound),
         };
-
+        // Try to get the epoch chunk hashes following the given macro block.
+        // For each hash, fetch the macro block and its history length, and build a batch set.
+        // If there are no chunks, create a single batch set with the provided block.
         let batch_sets = if let Ok(macro_hashes) = blockchain
             .chain_store
             .get_epoch_chunks(block.block_number(), None)
         {
+            // Build a list of batch sets for the given macro blocks.
+            // For each macro block in the current epoch, retrieve the full block and its associated history length.
+            // These are bundled into `BatchSet` items and collected into a vector.
             let mut batch_sets = vec![];
             for macro_hash in macro_hashes {
                 let macro_block = blockchain
@@ -135,6 +148,7 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestBatchSet {
             }
             batch_sets
         } else {
+            // If there are no epoch chunks, create a single batch set from the given macro block.
             let history_len = blockchain
                 .history_store
                 .prove_num_leaves(block.block_number(), None)
@@ -168,6 +182,7 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestHistoryChunk {
         _peer_id: N::PeerId,
         blockchain: &Arc<RwLock<Blockchain>>,
     ) -> Result<HistoryChunk, HistoryChunkError> {
+        // Attempt to retrieve a proof for the requested history chunk.
         if let Some(chunk) = blockchain.read().history_store.prove_chunk(
             self.epoch_number,
             self.block_number,
@@ -175,8 +190,10 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestHistoryChunk {
             self.chunk_index as usize,
             None,
         ) {
+            // Return the chunk if the proof was successfully generated.
             Ok(HistoryChunk { chunk })
         } else {
+            // Return an error if the proof could not be produced.
             Err(HistoryChunkError::CouldntProduceProof)
         }
     }
@@ -188,6 +205,9 @@ impl<N: Network> Handle<N, BlockchainProxy> for RequestBlock {
         _peer_id: N::PeerId,
         blockchain: &BlockchainProxy,
     ) -> Result<Block, BlockError> {
+        // Attempt to retrieve the requested block from the blockchain.
+        // The block body is included if `include_body` is true.
+        // If the block is not found, return an error.
         blockchain
             .read()
             .get_block(&self.hash, self.include_body)
@@ -356,6 +376,7 @@ impl RequestMissingBlocks {
 impl<N: Network> Handle<N, BlockchainProxy> for RequestHead {
     fn handle(&self, _peer_id: N::PeerId, blockchain: &BlockchainProxy) -> ResponseHead {
         let blockchain = blockchain.read();
+        // Read blockchain state and return the current head information
         ResponseHead {
             block_number: blockchain.block_number(),
             block_hash: blockchain.head_hash(),
@@ -376,6 +397,8 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestChunk {
             return ResponseChunk::IncompleteState;
         }
 
+        // Request a chunk of the accounts state starting at the specified key,
+        // up to the defined limit (bounded by the protocol maximum).
         let chunk = blockchain_rg.state.accounts.get_chunk(
             self.start_key.clone(),
             cmp::min(self.limit, Policy::state_chunks_max_size()) as usize,
@@ -414,6 +437,7 @@ impl RequestTransactionsProof {
     const MAX_TRANSACTIONS: usize = 255;
 
     #[cfg(feature = "full")]
+    /// Proves inclusion of transactions for a specific block number.
     fn prove_txns_with_block_number(
         blockchain: &Arc<RwLock<Blockchain>>,
         transactions: &[Blake2bHash],
@@ -539,6 +563,7 @@ impl RequestTransactionsProof {
     }
 
     #[cfg(feature = "full")]
+    /// Attempts to prove inclusion of a single transaction by hash.
     fn prove_transaction(
         blockchain: &Arc<RwLock<Blockchain>>,
         transaction: &Blake2bHash,
@@ -621,6 +646,7 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTransactionsProof
     ) -> Result<ResponseTransactionsProof, ResponseTransactionProofError> {
         // Validate request.
         if self.hashes.len() > Self::MAX_TRANSACTIONS {
+            // Reject request that exceed the tx limit
             return Err(ResponseTransactionProofError::TooManyTransactionsProvided);
         }
 

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -1,3 +1,10 @@
+//! Contains the message types and request/response handlers used for peer-to-peer communication during consensus and sync.
+//!
+//! This module groups together:
+//! - Request types that a node can send to peers.
+//! - Response types for the corresponding requests.
+//! - Handler implementations for processing incoming requests.
+
 use std::{
     fmt::{Debug, Display, Formatter},
     io::Write,
@@ -29,6 +36,8 @@ use crate::error::SubscribeToAddressesError;
 
 mod handlers;
 
+/// Message containing the header and justification of either a macro or micro block.
+/// Used when broadcasting block headers over the network.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum BlockHeaderMessage {
     Macro {
@@ -56,6 +65,7 @@ impl BlockHeaderMessage {
         }
     }
 
+    /// Splits a block into its header and body messages for transmission.
     pub fn split_block(block: Block) -> (BlockHeaderMessage, BlockBodyMessage) {
         match block {
             Block::Macro(block) => {
@@ -122,6 +132,7 @@ impl From<BlockHeaderMessage> for Block {
     }
 }
 
+/// Message containing the body of a block, paired with the hash of its header message.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockBodyMessage {
     /// Hash of the corresponding [`BlockHeaderMessage`].
@@ -130,6 +141,7 @@ pub struct BlockBodyMessage {
     /// [`MacroHeader`]/[`MicroHeader`] since the header hash wouldn't capture
     /// the justification.
     pub header_message_hash: Blake2bHash,
+    /// The block body of either a micro or macro block.
     pub body: BlockBody,
 }
 
@@ -146,6 +158,7 @@ impl Topic for BlockHeaderTopic {
     const MAX_MESSAGES: u32 = 20;
 }
 
+/// GossipSub topic for broadcasting block body messages.
 #[derive(Clone, Debug, Default)]
 pub struct BlockBodyTopic;
 
@@ -232,6 +245,7 @@ impl RequestCommon for RequestMacroChain {
     const MAX_REQUESTS: u32 = 20;
 }
 
+/// Request a batch set for the given macro block hash.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestBatchSet {
     /// The hash of the macro block.
@@ -245,6 +259,7 @@ impl RequestCommon for RequestBatchSet {
     const MAX_REQUESTS: u32 = 100;
 }
 
+/// A batch set containing a macro block and the total history length at its height.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BatchSet {
     /// Verifying macro block
@@ -253,6 +268,7 @@ pub struct BatchSet {
     pub history_len: SizeProof<Blake2bHash, HistoricTransaction>,
 }
 
+/// Errors that can occur when processing a [`RequestBatchSet`].
 #[derive(Clone, Debug, Deserialize, Error, Serialize)]
 pub enum BatchSetError {
     #[error("target hash not found")]
@@ -306,7 +322,7 @@ impl Debug for BatchSetInfo {
 }
 
 #[cfg(feature = "full")]
-/// This message contains a chunk of the history.
+/// Request to get a specific chunk of the history for a given block and epoch.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestHistoryChunk {
     pub epoch_number: u32,
@@ -329,6 +345,7 @@ pub struct HistoryChunk {
     pub chunk: HistoryTreeChunk,
 }
 
+/// Error returned when [`RequestHistoryChunk`] fails.
 #[cfg(feature = "full")]
 #[derive(Clone, Debug, Deserialize, Error, Serialize)]
 pub enum HistoryChunkError {
@@ -437,9 +454,9 @@ pub struct RequestMissingBlocks {
     ///
     /// The locator ordering should be from newest to oldest block.
     ///
-    /// For requests with `Direction::Forward`, if not ordered that way any response may include blocks which are
-    /// not necessary as they answer with respect to an older locator than they could have.
-    /// For `Direction::Backward` it does have no effect.
+    /// For `Direction::Forward`, locators must be ordered from newest to oldest.
+    /// Otherwise, the responder may select an older locator as the starting point, returning unnecessary blocks.
+    /// The order does not matter for `Direction::Backward`.
     pub locators: Vec<Blake2bHash>,
 
     /// The direction the responder should take to search.
@@ -465,6 +482,7 @@ impl RequestCommon for RequestMissingBlocks {
 #[derive(Clone, Debug, Deserialize, Serialize, SerializedMaxSize)]
 pub struct RequestHead {}
 
+/// Indicates the responder’s latest known state.
 #[derive(Clone, Debug, Deserialize, Serialize, SerializedMaxSize)]
 pub struct ResponseHead {
     pub block_number: u32,
@@ -481,12 +499,19 @@ impl RequestCommon for RequestHead {
 }
 test_max_req_size!(RequestHead, request_head_req_size, request_head_resp_size);
 
+/// Response containing a proof of transaction inclusion.
 #[derive(Serialize, Deserialize)]
 pub struct ResponseTransactionsProof {
+    /// The history MMR proof
     pub proof: HistoryTreeProof,
+    /// Block used to generate the history tree proof.
+    ///
+    /// The block is determined by internal logic (see the `prove_txns_with_block_number`
+    /// function in the implementation of [`RequestTransactionsProof`])
     pub block: Block,
 }
 
+/// Errors returned when generating a transaction inclusion proof in response to a [`RequestTransactionsProof`].
 #[derive(Clone, Debug, Deserialize, Error, Serialize)]
 pub enum ResponseTransactionProofError {
     #[error("empty list of transactions given")]
@@ -510,6 +535,7 @@ pub enum ResponseTransactionProofError {
     Other,
 }
 
+/// Request a proof of inclusion for one or more transactions.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestTransactionsProof {
     pub hashes: Vec<Blake2bHash>,
@@ -543,6 +569,7 @@ impl RequestCommon for RequestTransactionReceiptsByAddress {
     const MAX_REQUESTS: u32 = 20;
 }
 
+/// Response containing a list of transactions related to a specific address.
 #[derive(Serialize, Deserialize)]
 pub struct ResponseTransactionReceiptsByAddress {
     /// Tuples of `(transaction_hash, block_number)`
@@ -572,6 +599,7 @@ pub struct ResponseTrieProof {
     pub block_hash: Blake2bHash,
 }
 
+/// Errors returned in response to a [`RequestTrieProof`].
 #[derive(Clone, Debug, Deserialize, Error, Serialize)]
 pub enum ResponseTrieProofError {
     #[error("incomplete trie")]
@@ -583,17 +611,20 @@ pub enum ResponseTrieProofError {
     Other,
 }
 
+/// Request a block inclusion proof for a set of block numbers relative to a given election head.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestBlocksProof {
     pub election_head: u32,
     pub blocks: Vec<u32>,
 }
 
+/// Response containing a proof of inclusion for a set of blocks.
 #[derive(Serialize, Deserialize)]
 pub struct ResponseBlocksProof {
     pub proof: BlockInclusionProof,
 }
 
+/// Errors returned when generating a blocks proof in response to a [`RequestBlocksProof`].
 #[derive(Clone, Debug, Deserialize, Error, Serialize)]
 pub enum ResponseBlocksProofError {
     #[error("bad block number {0}")]

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -1,3 +1,5 @@
+//! Handles the logic for syncing historical blockchain data in clustered epochs.
+
 use std::{
     collections::VecDeque,
     fmt::Formatter,
@@ -69,18 +71,26 @@ struct PendingBatchSet {
 }
 
 impl PendingBatchSet {
+    /// Returns `true` if all expected history transactions for this batch set
+    /// have been received.
     fn is_complete(&self) -> bool {
         self.history_len == self.history.len() as u64
     }
 
+    /// Returns the epoch number associated with the macro block of this batch set.
     fn epoch_number(&self) -> u32 {
         self.macro_block.epoch_number()
     }
 }
 
+/// Represents a single batch set of historic transactions for a macro block during synchronization.
+/// Multiple `BatchSet`s are managed and ordered by a sync cluster to reconstruct the full history of an epoch.
 pub struct BatchSet {
+    /// Macro block that proves this batch set
     pub block: MacroBlock,
+    /// The list of history items
     pub history: Vec<HistoricTransaction>,
+    /// Identifies the position of this batch set within the epoch.
     pub batch_index: usize,
 }
 
@@ -88,7 +98,6 @@ impl std::fmt::Debug for BatchSet {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("BatchSet");
         dbg.field("epoch_number", &self.block.epoch_number());
-        dbg.field("", &self.block.epoch_number());
         dbg.field("history_len", &self.history.len());
         dbg.field("batch_index", &self.batch_index);
         dbg.finish()
@@ -96,6 +105,7 @@ impl std::fmt::Debug for BatchSet {
 }
 
 impl From<PendingBatchSet> for BatchSet {
+    // Converts a completed `PendingBatchSet` into a `BatchSet` by reusing its data.
     fn from(batch_set: PendingBatchSet) -> Self {
         Self {
             block: batch_set.macro_block,
@@ -105,12 +115,14 @@ impl From<PendingBatchSet> for BatchSet {
     }
 }
 
+/// Keeps track of verification context for validating batch sets.
 pub struct BatchSetVerifyState {
     network: NetworkId,
     predecessor: Block,
     validators: Validators,
 }
 
+/// Represents a request for a specific chunk of the history for a macro block.
 #[derive(Clone, Debug)]
 pub struct HistoryChunkRequest {
     epoch_number: u32,
@@ -132,6 +144,8 @@ impl HistoryChunkRequest {
 
 static SYNC_CLUSTER_ID: AtomicUsize = AtomicUsize::new(0);
 
+/// Manages synchronization of a specific set of epochs. Coordinates the download and verification of macro blocks
+/// and their corresponding history chunks for a range of epochs.
 pub struct SyncCluster<TNetwork: Network> {
     pub id: usize,
     pub epoch_ids: Vec<Blake2bHash>,
@@ -160,6 +174,9 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
     const NUM_PENDING_BATCH_SETS: usize = 5;
     const NUM_PENDING_CHUNKS: usize = 12;
 
+    /// This is used when a history node needs to sync full epochs (including their macro blocks
+    /// and historic transactions) from other peers. The `epoch_ids` parameter identifies the macro blocks
+    /// to request, and the cluster will sequentially download them.
     pub(crate) fn for_epoch(
         blockchain: Arc<RwLock<Blockchain>>,
         network: Arc<TNetwork>,
@@ -178,6 +195,9 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         )
     }
 
+    /// This is used when syncing from a specific checkpoint block,
+    /// instead of an entire epoch. It starts the cluster with a single checkpoint block hash
+    /// and the corresponding epoch.
     pub(crate) fn for_checkpoint(
         blockchain: Arc<RwLock<Blockchain>>,
         network: Arc<TNetwork>,
@@ -204,8 +224,10 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         first_epoch_number: usize,
         first_block_number: usize,
     ) -> Self {
+        // Assigns a unique ID for the the cluster.
         let id = SYNC_CLUSTER_ID.fetch_add(1, Ordering::SeqCst);
 
+        // Verifies the current state.
         let batch_verify_state = {
             let blockchain = blockchain.read();
             BatchSetVerifyState {
@@ -214,10 +236,12 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
                 validators: blockchain.election_head().get_validators().unwrap(),
             }
         };
+        // Prepare the queue of epoch IDs.
         let epoch_ids_queue = epoch_ids
             .iter()
             .map(|epoch_id| (epoch_id.clone(), None))
             .collect();
+        // Create a SyncQueue to fetch and verify BatchSetInfo for each epoch.
         let batch_set_queue = SyncQueue::with_verification(
             Arc::clone(&network),
             epoch_ids_queue,
@@ -256,6 +280,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             batch_verify_state,
         );
 
+        // Create a SyncQueue for downloading history chunks
         let history_queue = SyncQueue::new(
             Arc::clone(&network),
             Vec::<(HistoryChunkRequest, Option<_>)>::new(),
@@ -284,6 +309,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         }
     }
 
+    // Verifies macro block and returns an error in case any of the checks fail.
     fn verify_macro_block(
         block: &Block,
         network: NetworkId,
@@ -308,6 +334,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         Ok(())
     }
 
+    // Verifies the validity of the `batch_set_info`
     fn verify_batch_set_info(
         network: NetworkId,
         batch_set_info: &BatchSetInfo,
@@ -352,6 +379,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         Ok(())
     }
 
+    // Processes a newly received epoch
     fn on_epoch_received(&mut self, epoch: BatchSetInfo) -> Result<(), SyncClusterResult> {
         let block = epoch.final_macro_block();
         let epoch_number = block.epoch_number();
@@ -454,6 +482,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         Ok(())
     }
 
+    // Handles an incoming verified history chunk and updates the corresponding pending batch set.
     fn on_history_chunk_received(
         &mut self,
         epoch_number: u32,
@@ -506,6 +535,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         self.batch_set_queue.peers.read().peers().to_vec()
     }
 
+    /// Splits the current cluster at the given index and returns a new cluster with the remaining epochs.
     pub(crate) fn split_off(&mut self, at: usize) -> Self {
         assert!(
             self.num_epochs_finished() <= at,
@@ -535,6 +565,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         *self = self.split_off(usize::min(num_items, self.len()));
     }
 
+    /// Compares this cluster with another to determine which should be prioritized for syncing.
     pub(crate) fn compare(&self, other: &Self, current_epoch: usize) -> std::cmp::Ordering {
         let this_epoch_number = self.first_epoch_number.max(current_epoch);
         let other_epoch_number = other.first_epoch_number.max(current_epoch);
@@ -565,18 +596,23 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             .then_with(|| self.epoch_ids.cmp(&other.epoch_ids))
     }
 
+    /// Returns the number of remaining epoch IDs in this cluster.
     pub(crate) fn len(&self) -> usize {
         self.epoch_ids.len()
     }
 
+    /// Returns `true` if there are no more epoch IDs to process.
     pub(crate) fn is_empty(&self) -> bool {
         self.epoch_ids.is_empty()
     }
 
+    /// Returns the number of epochs that have been fully processed in this cluster.
     pub(crate) fn num_epochs_finished(&self) -> usize {
         self.num_epochs_finished
     }
 
+    /// Resets the batch set verification state using the current election head and validator set
+    /// from the blockchain.
     pub(crate) fn reset_verify_state(&mut self) {
         let blockchain = self.blockchain.read();
         let verify_state = BatchSetVerifyState {
@@ -587,6 +623,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         self.batch_set_queue.set_verify_state(verify_state);
     }
 
+    /// Sends a request to a peer to retrieve the BatchSetInfo for a given epoch.
     pub async fn request_epoch(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,
@@ -611,6 +648,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         Ok(batch_set_info)
     }
 
+    /// Sends a request to a peer for a specific history chunk and verifies its validity.
     pub async fn request_history_chunk(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,
@@ -642,6 +680,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         Ok(chunk)
     }
 
+    // Pops and returns the next completed batch set from the front of the queue.
     fn pop_complete_epoch(&mut self) -> Option<PendingBatchSet> {
         if !self.pending_batch_sets.is_empty() && self.pending_batch_sets[0].is_complete() {
             self.num_epochs_finished += 1;
@@ -652,6 +691,9 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
     }
 }
 
+// Implements a `Stream` trait for `SyncCluster`, enabling it to produce verified
+// and complete batch sets as they become available.
+// Coordinates epoch-level history sync.
 impl<TNetwork: Network + 'static> Stream for SyncCluster<TNetwork> {
     type Item = Result<BatchSet, SyncClusterResult>;
 
@@ -748,6 +790,7 @@ impl<TNetwork: Network + 'static> std::fmt::Debug for SyncCluster<TNetwork> {
     }
 }
 
+/// Result type returned by a `SyncCluster` after attempting to sync
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SyncClusterResult {
     EpochSuccessful,

--- a/consensus/src/sync/history/mod.rs
+++ b/consensus/src/sync/history/mod.rs
@@ -1,3 +1,5 @@
+//! Handles the logic of syncing for history nodes.
+
 pub mod cluster;
 mod sync;
 mod sync_clustering;

--- a/consensus/src/sync/history/sync.rs
+++ b/consensus/src/sync/history/sync.rs
@@ -19,9 +19,10 @@ use crate::{
     },
 };
 
+/// A set of epoch unique IDs.
 #[derive(Clone)]
 pub(crate) struct EpochIds<T> {
-    pub locator_found: bool,
+    pub locator_found: bool, // Whether the locator was successfully found in the peer's chain.
     pub ids: Vec<Blake2bHash>,
     pub checkpoint: Option<Checkpoint>, // The most recent checkpoint block in the latest epoch.
     pub first_epoch_number: usize,
@@ -45,6 +46,7 @@ pub(crate) enum Job<TNetwork: Network> {
     FinishCluster(SyncCluster<TNetwork>, SyncClusterResult),
 }
 
+/// Handles history synchronization for macro blocks in history nodes.
 pub struct HistoryMacroSync<TNetwork: Network> {
     pub(crate) blockchain: Arc<RwLock<Blockchain>>,
     pub(crate) network: Arc<TNetwork>,

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -1,3 +1,8 @@
+//! This module coordinates multiple `SyncCluster`s used for history macro syncing.
+//! It handles clusters, their prioritization, and polling behavior.
+//! Only one cluster is active at a time; the rest are queued and managed based on
+//! sync progress and peer availability.
+
 use std::{collections::VecDeque, sync::Arc};
 
 use nimiq_blockchain::Blockchain;

--- a/consensus/src/sync/history/sync_stream.rs
+++ b/consensus/src/sync/history/sync_stream.rs
@@ -20,6 +20,9 @@ use crate::sync::{
     sync_interface::{MacroSync, MacroSyncReturn},
 };
 
+// Implements the `Stream` trait for `HistoryMacroSync`.
+// Polls in sequence network events, epoch ID responses, active cluster processing and job queue.
+// Produces `MacroSyncReturn` events that signal sync progress.
 impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
     fn poll_network_events(
         &mut self,

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -26,6 +26,8 @@ use crate::{
 };
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
+    /// Sends a ZKP request to a specific peer.
+    /// Returns the result and the peer ID, handling any communication errors.
     pub(crate) async fn request_zkps(
         zkp_component: ZKPComponentProxy<TNetwork>,
         peer_id: TNetwork::PeerId,
@@ -46,6 +48,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         (zkp_result, peer_id)
     }
 
+    /// Requests epoch IDs from a peer by sending a macro chain request.
+    /// Performs basic validation on the result and may ban the peer on invalid responses.
     pub(crate) async fn request_epoch_ids(
         blockchain: BlockchainProxy,
         network: Arc<TNetwork>,
@@ -150,6 +154,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         }
     }
 
+    /// Adds a request for a single macro block to the block headers queue.
+    /// This is useful for fetching a specific block during sync when the latest zkp is not ready yet.
     #[cfg(feature = "full")]
     pub(crate) fn request_single_macro_block(
         &mut self,
@@ -174,6 +180,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         self.peer_requests.insert(peer_id, peer_requests);
     }
 
+    /// Creates block header requests for election blocks and an optional checkpoint
+    /// received from a peer.
     pub(crate) fn request_macro_headers(
         &mut self,
         mut epoch_ids: EpochIds<TNetwork::PeerId>,
@@ -291,6 +299,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         None
     }
 
+    /// Sends a macro block request to a peer.
     pub async fn request_macro_block(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,
@@ -308,6 +317,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             .await
     }
 
+    /// Sends a macro chain request to a peer, using the provided locators and maximum number of epochs.
     pub async fn request_macro_chain(
         network: Arc<TNetwork>,
         peer_id: TNetwork::PeerId,

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -164,6 +164,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         Poll::Pending
     }
 
+    /// Polls for results from epoch ID requests made to peers.
     fn poll_epoch_ids(
         &mut self,
         cx: &mut Context<'_>,
@@ -286,6 +287,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         Poll::Pending
     }
 
+    /// Polls for macro block headers received in response to previous requests.
     fn poll_macro_blocks(
         &mut self,
         cx: &mut Context<'_>,
@@ -439,6 +441,15 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
 impl<TNetwork: Network> Stream for LightMacroSync<TNetwork> {
     type Item = MacroSyncReturn<TNetwork::PeerId>;
 
+    /// Polls all syncing stages in order and returns the result of the first completed stage.
+    ///
+    /// This function implements the `Stream` trait for `LightMacroSync`, making it a driver that
+    /// progresses syncing in steps. It checks for:
+    /// - Peer join/leave events
+    /// - ZKP proofs
+    /// - Epoch ID responses
+    /// - Macro block headers
+    /// - Validity window chunks
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Poll::Ready(o) = self.poll_network_events(cx) {
             return Poll::Ready(o);

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -43,6 +43,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             .await
     }
 
+    /// Determines the correct epoch and chunk index to begin syncing from, based on the current state of
+    /// the local history store. Sets up internal state to track progress and sends the first request.
     fn start_validity_chunk_request(
         &mut self,
         peer_id: TNetwork::PeerId,
@@ -149,6 +151,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         self.validity_queue.add_ids(vec![(request, None)]);
     }
 
+    /// Begins the validity window sync process with the given peer from a specific starting point
     pub fn start_validity_synchronization(&mut self, peer_id: TNetwork::PeerId) {
         if self.validity_requests.is_some() {
             // We already have a synchoronization in progress, so we just add the peer

--- a/consensus/src/sync/live/block_queue/assembler.rs
+++ b/consensus/src/sync/live/block_queue/assembler.rs
@@ -29,6 +29,7 @@ struct CachedBodyKey {
     header_message_hash: Blake2bHash,
 }
 
+/// Collects blocks headers and bodies and tries to assemble full blocks.
 pub struct BlockAssembler<N: Network> {
     network: Arc<N>,
     header_stream: BoxStream<'static, PubsubHeader<N>>,
@@ -54,6 +55,7 @@ impl<N: Network> BlockAssembler<N> {
         }
     }
 
+    /// Combines a block header and body into a full block; retuns either a micro or macro block
     fn assemble_block(header: BlockHeaderMessage, body: BlockBody) -> Block {
         match header {
             BlockHeaderMessage::Macro {
@@ -75,6 +77,7 @@ impl<N: Network> BlockAssembler<N> {
         }
     }
 
+    /// Marks the given messages as invalid and disconnects the respective peers.
     fn reject_messages(&self, pubsub_id_header: N::PubsubId, pubsub_id_body: N::PubsubId) {
         let network = Arc::clone(&self.network);
         let peer_id_header = pubsub_id_header.propagation_source();
@@ -100,6 +103,7 @@ impl<N: Network> BlockAssembler<N> {
 impl<N: Network> Stream for BlockAssembler<N> {
     type Item = (Block, BlockSource<N>);
 
+    /// a stream that assembles full blocks from separate header and body messages.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         while let Poll::Ready(item) = self.header_stream.poll_next_unpin(cx) {
             let Some((header_message, header_id)) = item else {
@@ -237,14 +241,17 @@ impl<K: Eq + std::hash::Hash + Clone, V> TimeLimitedCache<K, V> {
         evicted_entries
     }
 
+    /// Retrieves a reference to the value for the given key, if it exists and is not expired.
     fn get(&self, k: &K) -> Option<&V> {
         self.map.get(k).map(|v| &v.0)
     }
 
+    /// Inserts a key-value pair into the cache
     fn insert(&mut self, k: K, v: V) -> Option<V> {
         self.map.insert(k, (v, Instant::now())).map(|v| v.0)
     }
 
+    /// Removes the entry associated with the given key and returns it
     fn remove(&mut self, k: &K) -> Option<V> {
         self.map.remove(k).map(|v| v.0)
     }
@@ -263,6 +270,8 @@ impl<K: Eq + std::hash::Hash + Clone, V> TimeLimitedCache<K, V> {
 impl<K: Eq + std::hash::Hash + Unpin + Clone, V: Unpin> Stream for TimeLimitedCache<K, V> {
     type Item = Vec<(K, V)>;
 
+    /// Periodically polls the cache and returns any entries that have expired since the last poll.
+    /// Each poll returns a `Vec` of all expired entries at that moment.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         while self.interval.poll_next_unpin(cx).is_ready() {
             let evicted_entries = self.evict_expired_entries();

--- a/consensus/src/sync/live/block_queue/block_request_component.rs
+++ b/consensus/src/sync/live/block_queue/block_request_component.rs
@@ -1,3 +1,7 @@
+//! Defines the `BlockRequestComponent`, which handles requesting missing blocks
+//! from peers during synchronization. It maintains a list of active peers, manages a queue
+//! of block requests, and verifies the integrity of responses.
+
 use std::{
     collections::BTreeSet,
     fmt::{Debug, Formatter},
@@ -24,6 +28,7 @@ use crate::{
     sync::{peer_list::PeerList, sync_queue::SyncQueue},
 };
 
+/// Result of a successful missing block request.
 #[derive(Debug)]
 pub struct BlockRequestResult<N: Network> {
     pub target_block_number: u32,
@@ -33,6 +38,7 @@ pub struct BlockRequestResult<N: Network> {
     pub sender: N::PeerId,
 }
 
+/// Request for a sequence of missing blocks from a peer.
 #[derive(Clone)]
 pub struct MissingBlockRequest {
     /// The block number of the requested block.
@@ -62,6 +68,7 @@ impl Debug for MissingBlockRequest {
     }
 }
 
+/// Response to a missing block request from a peer.
 #[derive(Debug, Clone)]
 pub struct MissingBlockResponse<N: Network> {
     pub target_block_number: u32,
@@ -71,6 +78,7 @@ pub struct MissingBlockResponse<N: Network> {
     pub sender: N::PeerId,
 }
 
+/// Error type for missing block requests during sync
 #[derive(Clone, Debug, Error)]
 pub enum MissingBlockError {
     #[error("request: {0}")]
@@ -79,6 +87,7 @@ pub enum MissingBlockError {
     Response(ResponseBlocksError),
 }
 
+/// Error returned when a block request fails within the sync queue.
 #[derive(Debug, Error)]
 #[error("Sync queue error. Target block hash: {target_block_hash}, target block number {target_block_number}")]
 pub struct SyncQueueError {
@@ -349,7 +358,9 @@ impl<N: Network> Stream for BlockRequestComponent<N> {
         // Poll self.sync_queue, return results.
         while let Poll::Ready(result) = self.sync_queue.poll_next_unpin(cx) {
             match result {
+                // A valid response was received with blocks from a peer.
                 Some(Ok(response)) => {
+                    // Remove this request from the pending set.
                     self.pending_requests.remove(&response.target_block_hash);
                     return Poll::Ready(Some(Ok(BlockRequestResult {
                         target_block_number: response.target_block_number,
@@ -359,6 +370,7 @@ impl<N: Network> Stream for BlockRequestComponent<N> {
                         sender: response.sender,
                     })));
                 }
+                // The request failed
                 Some(Err(request)) => {
                     self.pending_requests.remove(&request.target_block_hash);
                     debug!(

--- a/consensus/src/sync/live/block_queue/live_sync.rs
+++ b/consensus/src/sync/live/block_queue/live_sync.rs
@@ -1,3 +1,6 @@
+//! Defines how queued blocks are pushed to the blockchain during live sync
+//! and how the results are processed into higher-level sync events.
+
 use std::{
     collections::{HashSet, VecDeque},
     mem,
@@ -28,6 +31,7 @@ use crate::{
     BlsCache,
 };
 
+/// Represents the result of pushing blocks to the blockchain during live sync.
 pub enum PushOpResult<N: Network> {
     Head(Result<PushResult, PushError>, Blake2bHash),
     Buffered(Result<PushResult, PushError>, Blake2bHash),
@@ -49,6 +53,7 @@ impl<N: Network> LiveSyncQueue<N> for BlockQueue<N> {
         bls_cache: Arc<Mutex<BlsCache>>,
         result: Self::QueueResult,
     ) -> VecDeque<BoxFuture<'static, Self::PushResult>> {
+        // Queue of push operation futures to be executed in order.
         let mut future_results = VecDeque::new();
         match result {
             QueuedBlock::Head((block, block_source)) => {

--- a/consensus/src/sync/live/block_queue/mod.rs
+++ b/consensus/src/sync/live/block_queue/mod.rs
@@ -1,3 +1,5 @@
+//! Block queue auxiliary structures.
+
 use futures::stream::BoxStream;
 use nimiq_block::Block;
 use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
@@ -22,6 +24,7 @@ pub type BlockAndSource<N> = (Block, BlockSource<N>);
 
 pub type ResolveBlockSender<N> = oneshot::Sender<Result<Block, ResolveBlockError<N>>>;
 
+/// Represents the block queue events.
 pub enum QueuedBlock<N: Network> {
     Head(BlockAndSource<N>),
     Buffered(Vec<BlockAndSource<N>>),
@@ -30,6 +33,7 @@ pub enum QueuedBlock<N: Network> {
     TooFarBehind(N::PeerId),
 }
 
+/// Describes the origin of a block
 #[derive(Debug)]
 pub enum BlockSource<N: Network> {
     Announced {
@@ -42,14 +46,17 @@ pub enum BlockSource<N: Network> {
 }
 
 impl<N: Network> BlockSource<N> {
+    /// Creates a `BlockSource` for an announced block
     pub fn announced(header_id: N::PubsubId, body_id: Option<N::PubsubId>) -> Self {
         Self::Announced { header_id, body_id }
     }
 
+    /// From a specific peer
     pub fn requested(id: N::PeerId) -> Self {
         Self::Requested { id }
     }
 
+    /// Returns the peer ID associated with the `BlockSource`
     pub fn peer_id(&self) -> N::PeerId {
         match self {
             BlockSource::Announced { header_id, .. } => header_id.propagation_source(),
@@ -57,26 +64,33 @@ impl<N: Network> BlockSource<N> {
         }
     }
 
+    /// Returns true if the block was received via announcement.
     pub fn is_announced(&self) -> bool {
         matches!(self, BlockSource::Announced { .. })
     }
 
+    /// Returns true if the block was received as a direct response to a request.
     pub fn is_requested(&self) -> bool {
         matches!(self, BlockSource::Requested { .. })
     }
 
+    /// Marks the block as accepted.
     pub fn accept_block(&self, network: &N) {
         self.validate_block(network, MsgAcceptance::Accept);
     }
 
+    /// Marks the block as rejected
     pub fn reject_block(&self, network: &N) {
         self.validate_block(network, MsgAcceptance::Reject);
     }
 
+    /// Marks the block as ignored.
     pub fn ignore_block(&self, network: &N) {
         self.validate_block(network, MsgAcceptance::Ignore);
     }
 
+    /// Applies the given acceptance decision to the associated network messages
+    /// for blocks received via gossip.
     pub fn validate_block(&self, network: &N, acceptance: MsgAcceptance) {
         match self {
             BlockSource::Announced { header_id, body_id } => {

--- a/consensus/src/sync/live/block_queue/proxy.rs
+++ b/consensus/src/sync/live/block_queue/proxy.rs
@@ -34,8 +34,11 @@ use crate::{
     BlsCache,
 };
 
+/// A proxy to interact with `BlockQueue` running on its independent task.
 pub struct BlockQueueProxy<N: Network> {
+    /// Shared reference to the underlying block queue.
     queue: Arc<Mutex<BlockQueue<N>>>,
+    /// Channel used to receive queued blocks from the internal background task.
     receiver: UnboundedReceiver<QueuedBlock<N>>,
 }
 
@@ -45,6 +48,7 @@ impl<N: Network> BlockQueueProxy<N> {
         Self::with_queue(queue)
     }
 
+    /// Starts the internal queue with a stream of blocks received via gossip sub.
     pub fn with_gossipsub_block_stream(
         blockchain: BlockchainProxy,
         network: Arc<N>,
@@ -56,6 +60,7 @@ impl<N: Network> BlockQueueProxy<N> {
         Self::with_queue(queue)
     }
 
+    /// Uses a specific block stream
     pub fn with_block_stream(
         blockchain: BlockchainProxy,
         network: Arc<N>,
@@ -66,6 +71,7 @@ impl<N: Network> BlockQueueProxy<N> {
         Self::with_queue(queue)
     }
 
+    /// Spawns the block queue as another task and opens the communication channel to forward block queue results to the current task.
     pub fn with_queue(queue: BlockQueue<N>) -> Self {
         let queue = Arc::new(Mutex::new(queue));
 
@@ -80,22 +86,27 @@ impl<N: Network> BlockQueueProxy<N> {
         Self { queue, receiver }
     }
 
+    /// Marks the given block as processed in the queue.
     pub fn on_block_processed(&mut self, block_hash: &Blake2bHash) {
         self.queue.lock().on_block_processed(block_hash);
     }
 
+    /// Marks invalid blocks from the queue.
     pub fn remove_invalid_blocks(&mut self, invalid_blocks: &mut HashSet<Blake2bHash>) {
         self.queue.lock().remove_invalid_blocks(invalid_blocks);
     }
 
+    /// Returns the blocks currently buffered in the queue.
     pub fn buffered_blocks(&self) -> Vec<(u32, Vec<Block>)> {
         self.queue.lock().buffered_blocks()
     }
 
+    /// Returns the total number of buffered blocks.
     pub fn num_buffered_blocks(&self) -> usize {
         self.queue.lock().num_buffered_blocks()
     }
 
+    /// Returns the peer list used by the queue
     #[cfg(feature = "full")]
     pub(crate) fn peer_list(&self) -> Arc<RwLock<PeerList<N>>> {
         self.queue.lock().peer_list()
@@ -159,6 +170,7 @@ impl<N: Network> Stream for BlockQueueProxy<N> {
     }
 }
 
+/// Background future that continuously polls the internal `BlockQueue` for new queued blocks.
 struct BlockQueueFuture<N: Network> {
     queue: Weak<Mutex<BlockQueue<N>>>,
     sender: UnboundedSender<QueuedBlock<N>>,
@@ -167,6 +179,8 @@ struct BlockQueueFuture<N: Network> {
 impl<N: Network> Future for BlockQueueFuture<N> {
     type Output = ();
 
+    /// Continuously polls the BlockQueue. If a new queued block is available,
+    /// it sends it to the proxy. Stops if the queue is dropped or the stream ends.
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let queue = match self.queue.upgrade() {
             Some(queue) => queue,

--- a/consensus/src/sync/live/diff_queue/diff_request_component.rs
+++ b/consensus/src/sync/live/diff_queue/diff_request_component.rs
@@ -13,6 +13,7 @@ use crate::sync::{
     peer_list::{PeerList, PeerListIndex},
 };
 
+/// Handles requesting `TrieDiff` for blocks from peers during live sync.
 pub struct DiffRequestComponent<N: Network> {
     network: Arc<N>,
     peers: Arc<RwLock<PeerList<N>>>,
@@ -23,6 +24,7 @@ pub struct DiffRequestComponent<N: Network> {
 impl<N: Network> DiffRequestComponent<N> {
     const NUM_PENDING_DIFFS: usize = 5;
 
+    /// Creates a new `DiffRequestComponent` with a limit on concurrent diff requests.
     pub fn new(network: Arc<N>, peers: Arc<RwLock<PeerList<N>>>) -> Self {
         DiffRequestComponent {
             network,
@@ -62,15 +64,18 @@ impl<N: Network> DiffRequestComponent<N> {
             let max_backoff = Duration::from_secs(30);
 
             Box::pin(async move {
+                // Controls the number of concurrent diff requests.
                 let _request_permit = concurrent_requests.acquire().await.unwrap();
                 let mut num_tries = 0;
                 let mut backoff_delay = Duration::from_secs(1);
 
                 loop {
+                    // Get the current peer based on the index.
                     let peer_id = peers.read().get(&current_peer_index);
                     let peer_id = match peer_id {
                         Some(peer_id) => peer_id,
                         None => {
+                            // If no peer is available, wait and retry.
                             error!("couldn't fetch diff: no peers");
                             sleep(Duration::from_secs(5)).await;
                             continue;
@@ -78,6 +83,7 @@ impl<N: Network> DiffRequestComponent<N> {
                     };
                     current_peer_index.increment();
 
+                    // Send the diff request to the selected peer.
                     let result = network
                         .request(
                             RequestTrieDiff {
@@ -91,8 +97,11 @@ impl<N: Network> DiffRequestComponent<N> {
                     let max_tries = peers.read().len();
 
                     match result {
+                        // If the peer returns a partial diff, validate it.
                         Ok(ResponseTrieDiff::PartialDiff(diff)) => {
+                            // Verify that the returned diff matches the block’s expected diff root.
                             if TreeProof::new(diff.0.iter()).root_hash() == block_diff_root {
+                                // If valid, return the diff.
                                 return Ok(diff);
                             }
                             warn!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: invalid diff");
@@ -121,6 +130,7 @@ impl<N: Network> DiffRequestComponent<N> {
         }
     }
 
+    /// Returns the current peer list used for diff requests.
     pub fn peer_list(&self) -> Arc<RwLock<PeerList<N>>> {
         Arc::clone(&self.peers)
     }

--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -1,3 +1,5 @@
+//! Provides a queuing component that augments blocks with state trie diffs during live sync.
+
 use std::{
     collections::HashSet,
     future,
@@ -56,6 +58,7 @@ impl RequestCommon for RequestTrieDiff {
     const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_TRIE_DIFFS;
 }
 
+/// Represents a block or set of blocks classified by how they should be processed.
 pub enum QueuedDiff<N: Network> {
     Head(BlockAndSource<N>, Option<TrieDiff>),
     Buffered(Vec<(BlockAndSource<N>, Option<TrieDiff>)>),
@@ -158,6 +161,7 @@ pub struct DiffQueue<N: Network> {
 }
 
 impl<N: Network> DiffQueue<N> {
+    /// Creates a new DiffQueue using an existing BlockQueue.
     pub fn with_block_queue(network: Arc<N>, block_queue: BlockQueue<N>) -> Self {
         let diff_request_component =
             DiffRequestComponent::new(Arc::clone(&network), block_queue.peer_list());
@@ -169,6 +173,7 @@ impl<N: Network> DiffQueue<N> {
         }
     }
 
+    /// Removes blocks marked as invalid from the BlockQueue.
     pub(crate) fn remove_invalid_blocks(&mut self, invalid_blocks: &mut HashSet<Blake2bHash>) {
         // We remove invalid blocks from the block queue.
         self.block_queue.remove_invalid_blocks(invalid_blocks);
@@ -209,6 +214,7 @@ impl<N: Network> DiffQueue<N> {
         self.block_queue.num_buffered_blocks()
     }
 
+    /// Sets whether diffs should be fetched for incoming blocks.
     pub(crate) fn set_diff_needed(&mut self, diff_needed: bool) {
         self.diff_needed = diff_needed;
     }

--- a/consensus/src/sync/live/mod.rs
+++ b/consensus/src/sync/live/mod.rs
@@ -30,13 +30,17 @@ pub mod queue;
 #[cfg(feature = "full")]
 pub mod state_queue;
 
+/// Live sync stream using `BlockQueue`.
 pub type BlockLiveSync<N> = LiveSyncer<N, BlockQueue<N>>;
+/// Live sync stream using `StateQueue`.
 #[cfg(feature = "full")]
 pub type StateLiveSync<N> = LiveSyncer<N, StateQueue<N>>;
 
 /// The maximum capacity of the external block stream passed into the block queue.
 const MAX_BLOCK_STREAM_BUFFER: usize = 256;
 
+/// The `LiveSyncer` manages the live sync process by coordinating block and chunk
+/// processing through a `LiveSyncQueue`.
 pub struct LiveSyncer<N: Network, Q: LiveSyncQueue<N>> {
     blockchain: BlockchainProxy,
 
@@ -57,6 +61,7 @@ pub struct LiveSyncer<N: Network, Q: LiveSyncQueue<N>> {
 }
 
 impl<N: Network, Q: LiveSyncQueue<N>> LiveSyncer<N, Q> {
+    // Sets up an internal channel to receive blocks and connects it to the queue
     pub fn with_queue(
         blockchain: BlockchainProxy,
         network: Arc<N>,
@@ -115,6 +120,8 @@ impl<N: Network, Q: LiveSyncQueue<N>> LiveSync<N> for LiveSyncer<N, Q> {
 impl<N: Network, Q: LiveSyncQueue<N>> Stream for LiveSyncer<N, Q> {
     type Item = LiveSyncEvent<N::PeerId>;
 
+    // Stream that polls for completed block push operations and new sync items from the queue.
+    // Completed operations produce events. New items are turned into push tasks.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         Poll::Ready(loop {
             if let Some(p) = self.pending.front_mut() {

--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -1,3 +1,5 @@
+//! Implements utilities and logic for pushing blocks and state chunks during live sync.
+
 use std::{
     collections::{HashSet, VecDeque},
     fmt,
@@ -46,6 +48,8 @@ async fn spawn_blocking<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(f:
     }
 }
 
+/// Used during state live sync to track which peer provided which chunk,
+/// and to locate the chunk's position in the trie.
 pub struct ChunkAndSource<N: Network> {
     pub chunk: TrieChunk,
     pub start_key: KeyNibbles,
@@ -63,6 +67,7 @@ impl<N: Network> fmt::Debug for ChunkAndSource<N> {
 }
 
 impl<N: Network> ChunkAndSource<N> {
+    /// Creates a new instance given chunk, start key, and peer ID
     pub fn new(chunk: TrieChunk, start_key: KeyNibbles, peer_id: N::PeerId) -> Self {
         Self {
             chunk,
@@ -71,6 +76,7 @@ impl<N: Network> ChunkAndSource<N> {
         }
     }
 
+    /// Converts this struct into a pair consisting of a `TrieChunkWithStart` and its source peer ID.
     pub fn into_pair(self) -> (TrieChunkWithStart, N::PeerId) {
         (
             TrieChunkWithStart {
@@ -82,10 +88,13 @@ impl<N: Network> ChunkAndSource<N> {
     }
 }
 
+/// Trait defining the behavior of a live sync queue; manages incoming blocks, tracks peers,
+/// and coordinates the integration of blocks into the blockchain.
 pub trait LiveSyncQueue<N: Network>: Stream<Item = Self::QueueResult> + Send + Unpin {
     type QueueResult: Send;
     type PushResult;
 
+    /// Converts a queue result into a list of push operations to be run in order.
     fn push_queue_result(
         network: Arc<N>,
         blockchain: BlockchainProxy,
@@ -93,12 +102,16 @@ pub trait LiveSyncQueue<N: Network>: Stream<Item = Self::QueueResult> + Send + U
         result: Self::QueueResult,
     ) -> VecDeque<BoxFuture<'static, Self::PushResult>>;
 
+    /// Called once a push operation completes, to process its outcome and emit a sync event.
     fn process_push_result(&mut self, item: Self::PushResult) -> Option<LiveSyncEvent<N::PeerId>>;
 
+    /// Returns a list of peer IDs currently tracked by the queue.
     fn peers(&self) -> Vec<N::PeerId>;
 
+    /// Returns the number of tracked peers.
     fn num_peers(&self) -> usize;
 
+    /// Adds a peer to the sync queue.
     fn add_peer(&self, peer_id: N::PeerId);
 
     /// Adds a block stream by replacing the current block stream with a `select` of both streams.
@@ -106,8 +119,10 @@ pub trait LiveSyncQueue<N: Network>: Stream<Item = Self::QueueResult> + Send + U
     where
         S: Stream<Item = BlockAndSource<N>> + Send + 'static;
 
+    /// Returns whether this queue expects blocks to include bodies.
     fn include_body(&self) -> bool;
 
+    /// Returns `true` if the state sync is complete.
     fn state_complete(&self) -> bool {
         true
     }
@@ -119,6 +134,7 @@ pub trait LiveSyncQueue<N: Network>: Stream<Item = Self::QueueResult> + Send + U
     fn acceptance_window_size(&self) -> u32;
 }
 
+/// Parameters for any of the syncing queues (`BlockQueue` or `StateQueue`).
 #[derive(Clone, Debug)]
 pub struct QueueConfig {
     /// Buffer size limit
@@ -154,6 +170,7 @@ struct BlockchainPushResult<N: Network> {
 }
 
 impl<N: Network> BlockchainPushResult<N> {
+    /// Creates a push result based on the result of pushing a block without associated chunks.
     fn with_light_block_result(
         push_result: Result<PushResult, PushError>,
         block_hash: Blake2bHash,
@@ -166,6 +183,7 @@ impl<N: Network> BlockchainPushResult<N> {
         }
     }
 
+    /// Creates a push result based on the result of pushing a block and its associated chunks.
     #[cfg(feature = "full")]
     fn with_block_result(
         push_result: Result<(PushResult, Result<ChunksPushResult, ChunksPushError>), PushError>,
@@ -191,6 +209,7 @@ impl<N: Network> BlockchainPushResult<N> {
         }
     }
 
+    /// Creates a push result that only involves chunk processing.
     #[cfg(feature = "full")]
     fn with_chunks_result(
         push_chunks_result: Result<ChunksPushResult, ChunksPushError>,
@@ -364,6 +383,7 @@ pub async fn push_multiple_blocks_impl<N: Network>(
     )
 }
 
+/// Pushes a sequence of blocks along with their associated state diffs and chunks into the blockchain.
 pub async fn push_multiple_blocks_with_chunks<N: Network>(
     blockchain: BlockchainProxy,
     bls_cache: Arc<Mutex<BlsCache>>,
@@ -418,11 +438,14 @@ pub async fn push_chunks_only<N: Network>(
 
 pub struct MessageValidator<N: Network> {
     network: Arc<N>,
+    /// Whether annouced or requested
     block_source: BlockSource<N>,
 }
 
 #[cfg(feature = "full")]
 impl<N: Network> PostValidationHook for MessageValidator<N> {
+    /// Called after a block has been validated and pushed to the blockchain.
+    /// Communicates the acceptance result to the peer that sent the block.
     fn post_validation(&self, push_result: Result<&PushResult, &PushError>) {
         let acceptance = match push_result {
             Ok(result) => match result {
@@ -441,6 +464,7 @@ impl<N: Network> PostValidationHook for MessageValidator<N> {
     }
 }
 
+/// Caches the BLS public keys from the given macro block’s validator list.
 fn update_cache(block: &Block, bls_cache: &mut BlsCache) {
     let Block::Macro(block) = block else {
         return;

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -1,3 +1,5 @@
+//! Implements the state sync queue for live syncing accounts state.
+
 pub mod chunk_request_component;
 pub mod live_sync;
 
@@ -63,6 +65,7 @@ impl Display for Chunk {
     }
 }
 
+/// Returns a `Chunk` or a `IncompleteState` indicating the peer does not yet have the complete state
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ResponseChunk {
@@ -89,6 +92,8 @@ impl RequestCommon for RequestChunk {
     const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_CHUNKS;
 }
 
+/// Used during state synchronization to track the push result of blocks and their corresponding trie diffs
+/// and chunks
 pub enum QueuedStateChunks<N: Network> {
     Head(BlockAndSource<N>, Option<TrieDiff>, Vec<ChunkAndSource<N>>),
     Buffered(Vec<(BlockAndSource<N>, Option<TrieDiff>, Vec<ChunkAndSource<N>>)>),

--- a/consensus/src/sync/mod.rs
+++ b/consensus/src/sync/mod.rs
@@ -1,3 +1,5 @@
+//! Synchronization logic for different types of sync in the consensus layer.
+
 #[cfg(feature = "full")]
 pub mod history;
 pub mod light;

--- a/consensus/src/sync/peer_list.rs
+++ b/consensus/src/sync/peer_list.rs
@@ -1,3 +1,8 @@
+//! Peer list management for synchronization.
+//!
+//! This module provides the [`PeerList`] and [`PeerListIndex`] types, which are used to manage
+//! and iterate over peers involved in the sync process.
+
 use std::{collections::HashSet, fmt, ops::Index, slice::SliceIndex, sync::Arc};
 
 use futures::future::BoxFuture;

--- a/consensus/src/sync/pico/mod.rs
+++ b/consensus/src/sync/pico/mod.rs
@@ -1,3 +1,5 @@
+//! Pico node macro sync logic.
+
 mod sync;
 mod sync_requests;
 mod sync_stream;

--- a/consensus/src/sync/sync_interface.rs
+++ b/consensus/src/sync/sync_interface.rs
@@ -1,3 +1,5 @@
+//! Defines the sync interface used by both live and macro syncing modes.
+
 use std::collections::VecDeque;
 
 use futures::Stream;

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -18,6 +18,7 @@ use pin_project::pin_project;
 use super::peer_list::PeerList;
 use crate::sync::peer_list::PeerListIndex;
 
+/// A wrapper struct that tracks metadata for each in-flight request.
 #[pin_project]
 #[derive(Debug)]
 struct OrderWrapper<TId, TOutput> {
@@ -97,6 +98,7 @@ pub struct SyncQueue<
     ids_to_request: VecDeque<(TId, Option<TNetwork::PeerId>)>,
     pending_futures:
         FuturesUnordered<OrderWrapper<TId, BoxFuture<'static, Option<Result<TOutput, TError>>>>>,
+    // outputs received but not yet yielded.
     queued_outputs: BinaryHeap<OrderWrapper<TId, Option<TOutput>>>,
     next_incoming_index: usize,
     next_outgoing_index: usize,
@@ -254,6 +256,7 @@ where
         }
     }
 
+    // Handles re-requesting failed items from a different peer.
     fn retry_request(
         &mut self,
         id: TId,
@@ -330,20 +333,24 @@ where
             .truncate(len.saturating_sub(self.next_incoming_index));
     }
 
+    /// Returns the current number of peers in the peer list.
     #[cfg(feature = "full")]
     pub fn num_peers(&self) -> usize {
         self.peers.read().len()
     }
 
+    /// Returns the total number of unresolved requested items.
     pub fn len(&self) -> usize {
         self.ids_to_request.len() + self.pending_futures.len() + self.queued_outputs.len()
     }
 
+    /// Checks if there are no more items to request and all request responses have been processed and returned.
     #[cfg(feature = "full")]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Sets the internal verification state for the incoming responses' verification.
     #[cfg(feature = "full")]
     pub fn set_verify_state(&mut self, verify_state: TVerifyState) {
         self.verify_state = verify_state;
@@ -361,6 +368,7 @@ where
 {
     type Item = Result<TOutput, TId>;
 
+    // The stream implementation that returns items in order as they become available and pass verification.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.waker.store_waker(cx);
 

--- a/consensus/src/sync/syncer.rs
+++ b/consensus/src/sync/syncer.rs
@@ -1,3 +1,5 @@
+//! Syncer component coordinating macro and live synchronization modes.
+
 use std::{
     collections::HashSet,
     mem,
@@ -69,6 +71,11 @@ pub struct Syncer<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> {
 impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
     const CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
+    /// Creates a new `Syncer` instance with the given blockchain proxy, network,
+    /// live sync component, and macro sync component.
+    ///
+    /// Also subscribes to network events and initializes internal state used
+    /// for peer tracking and periodic checks.
     pub fn new(
         blockchain: BlockchainProxy,
         network: Arc<N>,
@@ -90,32 +97,39 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
         }
     }
 
+    /// Pushes a block to the live sync component.
     pub fn push_block(&mut self, block: Block, block_source: BlockSource<N>) {
         self.live_sync.push_block(block, block_source);
     }
 
+    // Moves a peer into macro sync
     fn move_peer_into_macro_sync(&mut self, peer_id: N::PeerId) {
         debug!(%peer_id, "Adding peer to macro sync");
         self.macro_sync.add_peer(peer_id);
     }
 
+    /// Moves a peer into live sync
     pub fn move_peer_into_live_sync(&mut self, peer_id: N::PeerId) {
         debug!(%peer_id, "Adding peer to live sync");
         self.live_sync.add_peer(peer_id);
     }
 
+    /// Returns the number of peers currently participating in live sync.
     pub fn num_peers(&self) -> usize {
         self.live_sync.num_peers()
     }
 
+    /// Returns the list of peer IDs currently in live sync.
     pub fn peers(&self) -> Vec<N::PeerId> {
         self.live_sync.peers()
     }
 
+    /// Returns the number of accepted block announcements.
     pub fn accepted_block_announcements(&self) -> usize {
         self.accepted_announcements
     }
 
+    /// Indicates whether the live sync state has been fully synchronized.
     pub fn state_complete(&self) -> bool {
         self.live_sync.state_complete()
     }
@@ -125,18 +139,22 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
         self.live_sync.resolve_block(request)
     }
 
+    // Moves all peers marked as outdated into macro sync.
     fn check_outdated_peers(&mut self) {
         for peer_id in mem::take(&mut self.outdated_peers) {
             self.move_peer_into_macro_sync(peer_id);
         }
     }
 
+    // Triggers a compatibility check for all peers marked as incompatible.
     fn check_incompatible_peers(&mut self) {
         for peer_id in mem::take(&mut self.incompatible_peers) {
             self.check_incompatible_peer(peer_id);
         }
     }
 
+    // Initiates an asynchronous check to determine if a previously incompatible peer
+    // has caught up and is now in sync within the `acceptance_window_size`.
     fn check_incompatible_peer(&mut self, peer_id: N::PeerId) {
         let blockchain = self.blockchain.clone();
         let network = Arc::clone(&self.network);
@@ -154,6 +172,7 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
         self.pending_checks.push(future);
     }
 
+    /// Checks whether the given peer is considered in sync with the local blockchain state.
     async fn is_peer_synced(
         blockchain: BlockchainProxy,
         network: Arc<N>,
@@ -212,8 +231,10 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Syncer<N, M, L> {
 impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Stream for Syncer<N, M, L> {
     type Item = LiveSyncPushEvent;
 
+    // Polls internal components and handles network, macro sync, and live sync events.
+    // Also manages peer states by removing incompatible peers and assigning
+    // compatible ones to macro or live sync based on the current sync phase.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        // Poll network events and remove disconnected peers.
         while let Poll::Ready(event) = self.network_events.poll_next_unpin(cx) {
             let event = match event {
                 Some(event) => event,
@@ -290,6 +311,7 @@ impl<N: Network, M: MacroSync<N::PeerId>, L: LiveSync<N>> Stream for Syncer<N, M
                     self.incompatible_peers.insert(peer_id);
                 }
             } else {
+                // Peer is still not in sync.
                 self.incompatible_peers.insert(peer_id);
             }
         }

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -1,3 +1,11 @@
+//! The `syncer_proxy` module provides an abstraction layer over multiple syncing mechanisms
+//! used in Nimiq nodes. Each variant corresponds to a different type of node configuration.
+//!
+//! - `History`: History node syncs all the historical data.
+//! - `Full`: Full node focused on state sync.
+//! - `Light`: Light node using macro light sync.
+//! - `Pico`: Pico node using minimal sync logic, with fallback.
+
 #[cfg(feature = "full")]
 use std::cmp::max;
 use std::{
@@ -131,6 +139,7 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for EitherSyncer<TNetwork> {
         let _ = mem::replace(self, EitherSyncer::Fallback(light_macro_sync));
     }
 
+    /// Removes all peers from the macro sync and returns their IDs.
     fn drain_peers(&mut self) -> Vec<TNetwork::PeerId> {
         match self {
             EitherSyncer::Fallback(macro_sync) => macro_sync.drain_peers(),
@@ -142,6 +151,10 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for EitherSyncer<TNetwork> {
 impl<TNetwork: Network> Stream for EitherSyncer<TNetwork> {
     type Item = MacroSyncReturn<TNetwork::PeerId>;
 
+    /// Polls the underlying macro sync variant for the next macro sync result.
+    ///
+    /// This delegates to the currently active macro sync implementation (either `LightMacroSync`
+    /// or `PicoMacroSync`), allowing `EitherSyncer` to behave as a single stream interface.
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.project() {
             EitherSyncerProj::Fallback(macro_sync) => macro_sync.poll_next_unpin(cx),
@@ -164,11 +177,13 @@ impl<N: Network> SyncerProxy<N> {
             "History Syncer can only be created for a full blockchain"
         );
 
+        // Extract the full blockchain from the proxy.
         let blockchain = match &blockchain_proxy {
             BlockchainProxy::Full(blockchain) => Arc::clone(blockchain),
             BlockchainProxy::Light(_) => unreachable!(),
         };
 
+        // Initialize the block queue for pending blocks to be processed during sync
         let block_queue = BlockQueue::new(
             Arc::clone(&network),
             blockchain_proxy.clone(),
@@ -176,6 +191,7 @@ impl<N: Network> SyncerProxy<N> {
         )
         .await;
 
+        // Set up the live sync component using the block queue
         let live_sync = BlockLiveSync::with_queue(
             blockchain_proxy.clone(),
             Arc::clone(&network),
@@ -183,6 +199,7 @@ impl<N: Network> SyncerProxy<N> {
             bls_cache,
         );
 
+        // Set up the macro sync component for historical sync.
         let macro_sync = HistoryMacroSync::new(blockchain, Arc::clone(&network), network_event_rx);
 
         Self::History(Syncer::new(
@@ -203,11 +220,14 @@ impl<N: Network> SyncerProxy<N> {
         network_event_rx: SubscribeEvents<N::PeerId>,
         full_sync_threshold: u32,
     ) -> Self {
+        // Start from the default configuration for the block queue.
         let mut queue_config = QueueConfig::default();
+        // Ensure the queue size is large enough for full sync, based on the given threshold.
         let min_queue_size = full_sync_threshold + Policy::blocks_per_batch() * 2;
         queue_config.window_ahead_max = max(min_queue_size, queue_config.window_ahead_max);
         queue_config.buffer_max = max(min_queue_size as usize, queue_config.buffer_max);
 
+        // Create the block queue used to buffer and manage incoming blocks.
         let block_queue = BlockQueue::new(
             Arc::clone(&network),
             blockchain_proxy.clone(),
@@ -215,13 +235,16 @@ impl<N: Network> SyncerProxy<N> {
         )
         .await;
 
+        // Extract the full blockchain reference from the proxy.
         let blockchain = match &blockchain_proxy {
             BlockchainProxy::Full(blockchain) => Arc::clone(blockchain),
             BlockchainProxy::Light(_) => unreachable!(),
         };
 
+        // Create the diff queue, which buffers block differences before applying state changes.
         let diff_queue = DiffQueue::with_block_queue(Arc::clone(&network), block_queue);
 
+        // Create the state queue, which applies state updates based on the diff queue.
         let state_queue = StateQueue::with_diff_queue(
             Arc::clone(&network),
             Arc::clone(&blockchain),
@@ -229,6 +252,7 @@ impl<N: Network> SyncerProxy<N> {
             queue_config,
         );
 
+        // Set up live sync with state queue.
         let live_sync = StateLiveSync::with_queue(
             blockchain_proxy.clone(),
             Arc::clone(&network),
@@ -246,6 +270,7 @@ impl<N: Network> SyncerProxy<N> {
             full_sync_threshold,
         );
 
+        // Return the Full node variant of the SyncerProxy.
         Self::Full(Syncer::new(
             blockchain_proxy,
             network,
@@ -262,11 +287,13 @@ impl<N: Network> SyncerProxy<N> {
         zkp_component_proxy: ZKPComponentProxy<N>,
         network_event_rx: SubscribeEvents<N::PeerId>,
     ) -> Self {
+        // Light sync does not require full block bodies, only headers and metadata.
         let block_queue_config = QueueConfig {
             include_body: false,
             ..Default::default()
         };
 
+        // Create a block queue to manage block announcements and requests.
         let block_queue = BlockQueue::new(
             Arc::clone(&network),
             blockchain_proxy.clone(),
@@ -274,6 +301,7 @@ impl<N: Network> SyncerProxy<N> {
         )
         .await;
 
+        // Live sync is responsible for syncing micro blocks using the block queue.
         let live_sync = BlockLiveSync::with_queue(
             blockchain_proxy.clone(),
             Arc::clone(&network),
@@ -281,6 +309,7 @@ impl<N: Network> SyncerProxy<N> {
             bls_cache,
         );
 
+        // Set up LightMacroSync, which uses ZKPs to sync the light node to the latest macro block.
         let macro_sync = LightMacroSync::new(
             blockchain_proxy.clone(),
             Arc::clone(&network),
@@ -289,6 +318,7 @@ impl<N: Network> SyncerProxy<N> {
             0, // Since the light sync does not keep state, we ignore the threshold.
         );
 
+        // Return the constructed Light node variant of the SyncerProxy.
         Self::Light(Syncer::new(
             blockchain_proxy,
             network,
@@ -305,11 +335,13 @@ impl<N: Network> SyncerProxy<N> {
         zkp_component_proxy: ZKPComponentProxy<N>,
         network_event_rx: SubscribeEvents<N::PeerId>,
     ) -> Self {
+        // Configure the block queue to exclude block bodies
         let block_queue_config = QueueConfig {
             include_body: false,
             ..Default::default()
         };
 
+        // Set up a block queue to be used by the live sync process.
         let block_queue = BlockQueue::new(
             Arc::clone(&network),
             blockchain_proxy.clone(),
@@ -317,6 +349,7 @@ impl<N: Network> SyncerProxy<N> {
         )
         .await;
 
+        // Create a live sync instance using the configured block queue.
         let live_sync = BlockLiveSync::with_queue(
             blockchain_proxy.clone(),
             Arc::clone(&network),
@@ -324,6 +357,7 @@ impl<N: Network> SyncerProxy<N> {
             bls_cache,
         );
 
+        // Set up PicoMacroSync
         let pico_macro_sync = PicoMacroSync::new(
             blockchain_proxy.clone(),
             Arc::clone(&network),
@@ -331,9 +365,10 @@ impl<N: Network> SyncerProxy<N> {
             zkp_component_proxy,
         );
 
-        // We start with the Pico Macro sync mechanism
+        // We start with the Pico Macro sync mechanism; can later fall back to LightMacroSync
         let normal_syncer = EitherSyncer::Normal(pico_macro_sync);
 
+        // Return the SyncerProxy in the Pico node variant.
         Self::Pico(Syncer::new(
             blockchain_proxy,
             network,
@@ -366,7 +401,7 @@ impl<N: Network> SyncerProxy<N> {
     pub fn state_complete(&self) -> bool {
         gen_syncer_match!(self, state_complete)
     }
-
+    /// Triggers resolution of a block.
     pub fn resolve_block(&mut self, request: ResolveBlockRequest<N>) {
         gen_syncer_match!(self, resolve_block, request)
     }


### PR DESCRIPTION
## What's in this pull request?
Adds inline comments and Rustdoc documentation to several modules in the `consensus` crate.

#### This fixes #___.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
