### PR TITLE
rpc: Make the RPC interface methods to not require `&mut self`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4230,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-client"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f251102c037c9357604098a821e6de70a91aa446284836595c6446ffc9ee54dd"
+checksum = "b3ec069e1475e9cdee66a8312449a7fdd62003e73f9fa0ecf464009d20623008"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4252,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844ff8c10decca1ba306e650d3fca09e15e184d07735cd9a1980cb9f1d86f1cf"
+checksum = "83faa30f372f9b11fc6a88fbfe7260e6485317685ab92064632cc07add64b6bd"
 dependencies = [
  "log",
  "serde",
@@ -4264,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-derive"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58a9567ff158ce2420f78a97bf3ce9811c7c921280d8ee4e2aaea19024f6606"
+checksum = "2a0cd4c23d56aa34ab2315c7d37557d81797a584207aac3f9327b3f098ffbae6"
 dependencies = [
  "darling",
  "heck",
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "nimiq-jsonrpc-server"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0e7b400e3f552cb649342c40007263ed59e811459cea721c1144cef0ace89d"
+checksum = "c715d29b502b39b7f1b982f2283d9232549f810f60712098f77d681dc7642257"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -7496,7 +7496,9 @@ checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -7800,6 +7802,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "sha1",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,10 +196,10 @@ nimiq-genesis-builder = { path = "genesis-builder", default-features = false }
 nimiq-handel = { path = "handel", default-features = false }
 nimiq-hash = { path = "hash", default-features = false }
 nimiq-hash_derive = { path = "hash/hash_derive", default-features = false }
-nimiq-jsonrpc-client = { version = "0.2.2", default-features = false }
-nimiq-jsonrpc-core = { version = "0.2.2", default-features = false }
-nimiq-jsonrpc-derive = { version = "0.2.2", default-features = false }
-nimiq-jsonrpc-server = { version = "0.2.2", default-features = false }
+nimiq-jsonrpc-client = { version = "0.3.0", default-features = false }
+nimiq-jsonrpc-core = { version = "0.3.0", default-features = false }
+nimiq-jsonrpc-derive = { version = "0.3.0", default-features = false }
+nimiq-jsonrpc-server = { version = "0.3.0", default-features = false }
 nimiq-key-derivation = { path = "key-derivation", default-features = false }
 nimiq-keys = { path = "keys", default-features = false }
 nimiq-light-blockchain = { path = "light-blockchain", default-features = false }

--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -8,7 +8,7 @@ use crate::Client;
 
 #[async_trait]
 pub trait HandleSubcommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error>;
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error>;
 }
 
 #[derive(Debug, Parser)]
@@ -104,7 +104,7 @@ pub enum AccountCommand {
 
 #[async_trait]
 impl HandleSubcommand for AccountCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             AccountCommand::List { short } => {
                 let accounts = client.wallet.list_accounts().await?.data;

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -177,7 +177,7 @@ pub enum BlockchainCommand {
 
 #[async_trait]
 impl HandleSubcommand for BlockchainCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             BlockchainCommand::Block {
                 block_hash,

--- a/rpc-client/src/subcommands/mempool_subcommands.rs
+++ b/rpc-client/src/subcommands/mempool_subcommands.rs
@@ -34,7 +34,7 @@ pub enum MempoolCommand {
 
 #[async_trait]
 impl HandleSubcommand for MempoolCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             MempoolCommand::PushTransaction {
                 raw_tx,

--- a/rpc-client/src/subcommands/network_subcommands.rs
+++ b/rpc-client/src/subcommands/network_subcommands.rs
@@ -21,7 +21,7 @@ pub enum NetworkCommand {
 
 #[async_trait]
 impl HandleSubcommand for NetworkCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             NetworkCommand::PeerId {} => {
                 println!("{:#?}", client.network.get_peer_id().await?);

--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -146,7 +146,7 @@ pub enum PolicyCommand {
 
 #[async_trait]
 impl HandleSubcommand for PolicyCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             PolicyCommand::PolicyConstants {} => {
                 println!("{:#?}", client.policy.get_policy_constants().await?);

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -354,7 +354,7 @@ impl TransactionCommand {
 
 #[async_trait]
 impl HandleSubcommand for TransactionCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             TransactionCommand::Basic {
                 sender_wallet,

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -121,7 +121,7 @@ pub enum ValidatorCommand {
 
 #[async_trait]
 impl HandleSubcommand for ValidatorCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             ValidatorCommand::ValidatorAddress {} => {
                 println!("{:#?}", client.validator.get_address().await?);

--- a/rpc-client/src/subcommands/zkp_component_subcommands.rs
+++ b/rpc-client/src/subcommands/zkp_component_subcommands.rs
@@ -14,7 +14,7 @@ pub enum ZKPComponentCommand {
 
 #[async_trait]
 impl HandleSubcommand for ZKPComponentCommand {
-    async fn handle_subcommand(self, mut client: Client) -> Result<Client, Error> {
+    async fn handle_subcommand(self, client: Client) -> Result<Client, Error> {
         match self {
             ZKPComponentCommand::ZkpState {} => {
                 println!("{:?}", client.zkp_component.get_zkp_state().await?);

--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -14,18 +14,18 @@ pub trait BlockchainInterface {
     type Error;
 
     /// Returns the block number for the current head.
-    async fn get_block_number(&mut self) -> RPCResult<u32, (), Self::Error>;
+    async fn get_block_number(&self) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the batch number for the current head.
-    async fn get_batch_number(&mut self) -> RPCResult<u32, (), Self::Error>;
+    async fn get_batch_number(&self) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the epoch number for the current head.
-    async fn get_epoch_number(&mut self) -> RPCResult<u32, (), Self::Error>;
+    async fn get_epoch_number(&self) -> RPCResult<u32, (), Self::Error>;
 
     /// Tries to fetch a block given its hash. It has an option to include the transactions in the
     /// block, which defaults to false.
     async fn get_block_by_hash(
-        &mut self,
+        &self,
         hash: Blake2bHash,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
@@ -34,7 +34,7 @@ pub trait BlockchainInterface {
     /// block, which defaults to false. Note that this function will only fetch blocks that are part
     /// of the main chain.
     async fn get_block_by_number(
-        &mut self,
+        &self,
         block_number: u32,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
@@ -42,7 +42,7 @@ pub trait BlockchainInterface {
     /// Returns the block at the head of the main chain. It has an option to include the
     /// transactions in the block, which defaults to false.
     async fn get_latest_block(
-        &mut self,
+        &self,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error>;
 
@@ -51,42 +51,42 @@ pub trait BlockchainInterface {
     /// at the given height.
     /// We only have this information available for the last 2 batches at most.
     async fn get_slot_at(
-        &mut self,
+        &self,
         block_number: u32,
         offset_opt: Option<u32>,
     ) -> RPCResult<Slot, BlockchainState, Self::Error>;
 
     /// Tries to fetch a transaction (including reward transactions) given its hash.
     async fn get_transaction_by_hash(
-        &mut self,
+        &self,
         hash: Blake2bHash,
     ) -> RPCResult<ExecutedTransaction, (), Self::Error>;
 
     /// Returns all the transactions (including reward transactions) for the given block number. Note
     /// that this only considers blocks in the main chain.
     async fn get_transactions_by_block_number(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     /// Returns all the inherents (including reward inherents) for the given block number. Note
     /// that this only considers blocks in the main chain.
     async fn get_inherents_by_block_number(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error>;
 
     /// Returns all the transactions (including reward transactions) for the given batch number. Note
     /// that this only considers blocks in the main chain.
     async fn get_transactions_by_batch_number(
-        &mut self,
+        &self,
         batch_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error>;
 
     /// Returns all the inherents (including reward inherents) for the given batch number. Note
     /// that this only considers blocks in the main chain.
     async fn get_inherents_by_batch_number(
-        &mut self,
+        &self,
         batch_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error>;
 
@@ -97,7 +97,7 @@ pub trait BlockchainInterface {
     /// transaction hash (exclusive). If this hash is not found or does not belong to this address, it will return an empty list.
     /// The transaction hashes are returned in descending order, meaning the latest transaction is the first.
     async fn get_transaction_hashes_by_address(
-        &mut self,
+        &self,
         address: Address,
         max: Option<u16>,
         start_at: Option<Blake2bHash>,
@@ -110,7 +110,7 @@ pub trait BlockchainInterface {
     /// transaction hash (exclusive). If this hash is not found or does not belong to this address, it will return an empty list.
     /// The transactions are returned in descending order, meaning the latest transaction is the first.
     async fn get_transactions_by_address(
-        &mut self,
+        &self,
         address: Address,
         max: Option<u16>,
         start_at: Option<Blake2bHash>,
@@ -118,74 +118,74 @@ pub trait BlockchainInterface {
 
     /// Tries to fetch the account at the given address.
     async fn get_account_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Account, BlockchainState, Self::Error>;
 
     /// Fetches all accounts in the accounts tree.
     /// IMPORTANT: This operation iterates over all accounts in the accounts tree
     /// and thus is extremely computationally expensive.
-    async fn get_accounts(&mut self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error>;
+    async fn get_accounts(&self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error>;
 
     /// Returns a collection of the currently active validator's addresses and balances.
     async fn get_active_validators(
-        &mut self,
+        &self,
     ) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;
 
     /// Returns information about the currently penalized slots. This includes slots that lost rewards
     /// and that were disabled.
     async fn get_current_penalized_slots(
-        &mut self,
+        &self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error>;
 
     /// Returns information about the penalized slots of the previous batch. This includes slots that
     /// lost rewards and that were disabled.
     async fn get_previous_penalized_slots(
-        &mut self,
+        &self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error>;
 
     /// Tries to fetch a validator information given its address.
     async fn get_validator_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Validator, BlockchainState, Self::Error>;
 
     /// Fetches all validators in the staking contract.
     /// IMPORTANT: This operation iterates over all validators in the staking contract
     /// and thus is extremely computationally expensive.
-    async fn get_validators(&mut self) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;
+    async fn get_validators(&self) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error>;
 
     /// Fetches all stakers for a given validator.
     /// IMPORTANT: This operation iterates over all stakers of the staking contract
     /// and thus is extremely computationally expensive.
     async fn get_stakers_by_validator_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Vec<Staker>, BlockchainState, Self::Error>;
 
     /// Tries to fetch a staker information given its address.
     async fn get_staker_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Staker, BlockchainState, Self::Error>;
 
     /// Subscribes to new block events (retrieves the full block).
     #[stream]
     async fn subscribe_for_head_block(
-        &mut self,
+        &self,
         include_body: Option<bool>,
     ) -> Result<BoxStream<'static, RPCData<Block, ()>>, Self::Error>;
 
     /// Subscribes to new block events (only retrieves the block hash).
     #[stream]
     async fn subscribe_for_head_block_hash(
-        &mut self,
+        &self,
     ) -> Result<BoxStream<'static, RPCData<Blake2bHash, ()>>, Self::Error>;
 
     /// Subscribes to pre epoch validators events.
     #[stream]
     async fn subscribe_for_validator_election_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> Result<BoxStream<'static, RPCData<Validator, BlockchainState>>, Self::Error>;
 
@@ -194,7 +194,7 @@ pub trait BlockchainInterface {
     /// Thus the behavior is to assume all addresses or log_types are to be provided if the corresponding vec is empty.
     #[stream]
     async fn subscribe_for_logs_by_addresses_and_types(
-        &mut self,
+        &self,
         addresses: Vec<Address>,
         log_types: Vec<LogType>,
     ) -> Result<BoxStream<'static, RPCData<BlockLog, BlockchainState>>, Self::Error>;

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -14,23 +14,21 @@ pub trait ConsensusInterface {
     /// Returns a boolean specifying if we have established consensus with the network.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
-    async fn is_consensus_established(&mut self) -> RPCResult<bool, (), Self::Error>;
+    async fn is_consensus_established(&self) -> RPCResult<bool, (), Self::Error>;
 
     /// Given a serialized transaction, it will return the corresponding transaction struct.
     async fn get_raw_transaction_info(
-        &mut self,
+        &self,
         raw_tx: String,
     ) -> RPCResult<Transaction, (), Self::Error>;
 
     /// Sends the given serialized transaction to the network.
-    async fn send_raw_transaction(
-        &mut self,
-        raw_tx: String,
-    ) -> RPCResult<Blake2bHash, (), Self::Error>;
+    async fn send_raw_transaction(&self, raw_tx: String)
+        -> RPCResult<Blake2bHash, (), Self::Error>;
 
     /// Returns a serialized basic transaction.
     async fn create_basic_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         value: Coin,
@@ -40,7 +38,7 @@ pub trait ConsensusInterface {
 
     /// Sends a basic transaction to the network.
     async fn send_basic_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         value: Coin,
@@ -50,7 +48,7 @@ pub trait ConsensusInterface {
 
     /// Returns a serialized basic transaction with an arbitrary data field.
     async fn create_basic_transaction_with_data(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         data: String,
@@ -61,7 +59,7 @@ pub trait ConsensusInterface {
 
     /// Sends a basic transaction, with an arbitrary data field, to the network.
     async fn send_basic_transaction_with_data(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         data: String,
@@ -72,7 +70,7 @@ pub trait ConsensusInterface {
 
     /// Returns a serialized transaction creating a new vesting contract.
     async fn create_new_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         owner: Address,
         start_time: u64,
@@ -85,7 +83,7 @@ pub trait ConsensusInterface {
 
     /// Sends a transaction creating a new vesting contract to the network.
     async fn send_new_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         owner: Address,
         start_time: u64,
@@ -98,7 +96,7 @@ pub trait ConsensusInterface {
 
     /// Returns a serialized transaction redeeming a vesting contract.
     async fn create_redeem_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -109,7 +107,7 @@ pub trait ConsensusInterface {
 
     /// Sends a transaction redeeming a vesting contract to the network.
     async fn send_redeem_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -120,7 +118,7 @@ pub trait ConsensusInterface {
 
     /// Returns a serialized transaction creating a new HTLC contract.
     async fn create_new_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         htlc_sender: Address,
         htlc_recipient: Address,
@@ -134,7 +132,7 @@ pub trait ConsensusInterface {
 
     /// Sends a transaction creating a new HTLC contract to the network.
     async fn send_new_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         htlc_sender: Address,
         htlc_recipient: Address,
@@ -149,7 +147,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized transaction redeeming a HTLC contract
     /// using the `RegularTransfer` method.
     async fn create_redeem_regular_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -164,7 +162,7 @@ pub trait ConsensusInterface {
     /// Sends a transaction redeeming a HTLC contract, using the `RegularTransfer` method, to the
     /// network.
     async fn send_redeem_regular_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -179,7 +177,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized transaction redeeming a HTLC contract using the `TimeoutResolve`
     /// method.
     async fn create_redeem_timeout_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -191,7 +189,7 @@ pub trait ConsensusInterface {
     /// Sends a transaction redeeming a HTLC contract, using the `TimeoutResolve` method, to the
     /// network.
     async fn send_redeem_timeout_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -203,7 +201,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized transaction redeeming a HTLC contract using the `EarlyResolve`
     /// method.
     async fn create_redeem_early_htlc_transaction(
-        &mut self,
+        &self,
         contract_address: Address,
         recipient: Address,
         htlc_sender_signature: String,
@@ -216,7 +214,7 @@ pub trait ConsensusInterface {
     /// Sends a transaction redeeming a HTLC contract, using the `EarlyResolve` method, to the
     /// network.
     async fn send_redeem_early_htlc_transaction(
-        &mut self,
+        &self,
         contract_address: Address,
         recipient: Address,
         htlc_sender_signature: String,
@@ -229,7 +227,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized signature that can be used to redeem funds from a HTLC contract using
     /// the `EarlyResolve` method.
     async fn sign_redeem_early_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -241,7 +239,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized `new_staker` transaction. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn create_new_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_wallet: Address,
         delegation: Option<Address>,
@@ -253,7 +251,7 @@ pub trait ConsensusInterface {
     /// Sends a `new_staker` transaction to the network. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn send_new_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_wallet: Address,
         delegation: Option<Address>,
@@ -265,7 +263,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized `stake` transaction. The funds to be staked and the transaction fee will
     /// be paid from the `sender_wallet`.
     async fn create_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_address: Address,
         value: Coin,
@@ -276,7 +274,7 @@ pub trait ConsensusInterface {
     /// Sends a `stake` transaction to the network. The funds to be staked and the transaction fee will
     /// be paid from the `sender_wallet`.
     async fn send_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_address: Address,
         value: Coin,
@@ -288,7 +286,7 @@ pub trait ConsensusInterface {
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
     async fn create_update_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
@@ -301,7 +299,7 @@ pub trait ConsensusInterface {
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
     async fn send_update_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
@@ -314,7 +312,7 @@ pub trait ConsensusInterface {
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
     async fn create_set_active_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_active_balance: Coin,
@@ -326,7 +324,7 @@ pub trait ConsensusInterface {
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
     async fn send_set_active_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_active_balance: Coin,
@@ -338,7 +336,7 @@ pub trait ConsensusInterface {
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
     async fn create_retire_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         retire_stake: Coin,
@@ -350,7 +348,7 @@ pub trait ConsensusInterface {
     /// account (by providing the sender wallet) or from the staker account's balance (by not
     /// providing a sender wallet).
     async fn send_retire_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         retire_stake: Coin,
@@ -361,7 +359,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized `remove_stake` transaction. The transaction fee will be paid from the funds
     /// being removed.
     async fn create_remove_stake_transaction(
-        &mut self,
+        &self,
         staker_wallet: Address,
         recipient: Address,
         value: Coin,
@@ -372,7 +370,7 @@ pub trait ConsensusInterface {
     /// Sends a `remove_stake` transaction to the network. The transaction fee will be paid from the funds
     /// being removed.
     async fn send_remove_stake_transaction(
-        &mut self,
+        &self,
         staker_wallet: Address,
         recipient: Address,
         value: Coin,
@@ -387,7 +385,7 @@ pub trait ConsensusInterface {
     /// "" = Set the signal data field to None.
     /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn create_new_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         signing_secret_key: String,
@@ -405,7 +403,7 @@ pub trait ConsensusInterface {
     /// "" = Set the signal data field to None.
     /// "0x29a4b..." = Set the signal data field to Some(0x29a4b...).
     async fn send_new_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         signing_secret_key: String,
@@ -424,7 +422,7 @@ pub trait ConsensusInterface {
     /// "" = Change the signal data field to None.
     /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn create_update_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         new_signing_secret_key: Option<String>,
@@ -443,7 +441,7 @@ pub trait ConsensusInterface {
     /// "" = Change the signal data field to None.
     /// "0x29a4b..." = Change the signal data field to Some(0x29a4b...).
     async fn send_update_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         new_signing_secret_key: Option<String>,
@@ -457,7 +455,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized `deactivate_validator` transaction. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn create_deactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -468,7 +466,7 @@ pub trait ConsensusInterface {
     /// Sends a `deactivate_validator` transaction to the network. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn send_deactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -479,7 +477,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized `reactivate_validator` transaction. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn create_reactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -490,7 +488,7 @@ pub trait ConsensusInterface {
     /// Sends a `reactivate_validator` transaction to the network. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn send_reactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -501,7 +499,7 @@ pub trait ConsensusInterface {
     /// Returns a serialized `retire_validator` transaction. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn create_retire_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         fee: Coin,
@@ -511,7 +509,7 @@ pub trait ConsensusInterface {
     /// Sends a `retire_validator` transaction to the network. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
     async fn send_retire_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         fee: Coin,
@@ -523,7 +521,7 @@ pub trait ConsensusInterface {
     /// Note in order for this transaction to be accepted fee + value should be equal to the validator deposit, which is not a fixed value:
     /// Failed delete validator transactions can diminish the validator deposit
     async fn create_delete_validator_transaction(
-        &mut self,
+        &self,
         validator_wallet: Address,
         recipient: Address,
         fee: Coin,
@@ -534,7 +532,7 @@ pub trait ConsensusInterface {
     /// Sends a `delete_validator` transaction to the network. The transaction fee will be paid from the
     /// validator deposit that is being returned.
     async fn send_delete_validator_transaction(
-        &mut self,
+        &self,
         validator_wallet: Address,
         recipient: Address,
         fee: Coin,

--- a/rpc-interface/src/mempool.rs
+++ b/rpc-interface/src/mempool.rs
@@ -10,30 +10,29 @@ pub trait MempoolInterface {
     type Error;
 
     /// Pushes a raw transaction with a default priority assigned into the mempool and broadcast it to the network.
-    async fn push_transaction(&mut self, raw_tx: String)
-        -> RPCResult<Blake2bHash, (), Self::Error>;
+    async fn push_transaction(&self, raw_tx: String) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     /// Pushes a raw transaction with a high priority assigned into the mempool and broadcast it to the network.
     async fn push_high_priority_transaction(
-        &mut self,
+        &self,
         raw_tx: String,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     /// Obtains the list of transactions that are currently in the mempool.
     async fn mempool_content(
-        &mut self,
+        &self,
         include_transactions: bool,
     ) -> RPCResult<Vec<HashOrTx>, (), Self::Error>;
 
     /// Obtains the mempool content in fee per byte buckets.
-    async fn mempool(&mut self) -> RPCResult<MempoolInfo, (), Self::Error>;
+    async fn mempool(&self) -> RPCResult<MempoolInfo, (), Self::Error>;
 
     /// Obtains the minimum fee per byte as per mempool configuration.
-    async fn get_min_fee_per_byte(&mut self) -> RPCResult<f64, (), Self::Error>;
+    async fn get_min_fee_per_byte(&self) -> RPCResult<f64, (), Self::Error>;
 
     /// Tries to obtain the given transaction (using its hash) from the mempool.
     async fn get_transaction_from_mempool(
-        &mut self,
+        &self,
         hash: Blake2bHash,
     ) -> RPCResult<Transaction, (), Self::Error>;
 }

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -8,11 +8,11 @@ pub trait NetworkInterface {
     type Error;
 
     /// Returns the peer ID for our local peer.
-    async fn get_peer_id(&mut self) -> RPCResult<String, (), Self::Error>;
+    async fn get_peer_id(&self) -> RPCResult<String, (), Self::Error>;
 
     /// Returns the number of peers.
-    async fn get_peer_count(&mut self) -> RPCResult<usize, (), Self::Error>;
+    async fn get_peer_count(&self) -> RPCResult<usize, (), Self::Error>;
 
     /// Returns a list with the IDs of all our peers.
-    async fn get_peer_list(&mut self) -> RPCResult<Vec<String>, (), Self::Error>;
+    async fn get_peer_list(&self) -> RPCResult<Vec<String>, (), Self::Error>;
 }

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -8,95 +8,80 @@ pub trait PolicyInterface {
     type Error;
 
     /// Returns a bundle of policy constants.
-    async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error>;
+    async fn get_policy_constants(&self) -> RPCResult<PolicyConstants, (), Self::Error>;
 
     /// Returns the epoch number at a given block number (height).
-    async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_epoch_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the epoch index at a given block number. The epoch index is the number of a block relative
     /// to the epoch it is in. For example, the first block of any epoch always has an epoch index of 0.
-    async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_epoch_index_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the batch number at a given `block_number` (height).
-    async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_batch_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the batch index at a given block number. The batch index is the number of a block relative
     /// to the batch it is in. For example, the first block of any batch always has an batch index of 0.
-    async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_batch_index_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the number (height) of the next election macro block after a given block number (height).
-    async fn get_election_block_after(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error>;
+    async fn get_election_block_after(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the number block (height) of the preceding election macro block before a given block number (height).
     /// If the given block number is an election macro block, it returns the election macro block before it.
-    async fn get_election_block_before(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error>;
+    async fn get_election_block_before(&self, block_number: u32)
+        -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the block number (height) of the last election macro block at a given block number (height).
     /// If the given block number is an election macro block, then it returns that block number.
-    async fn get_last_election_block(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error>;
+    async fn get_last_election_block(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns a boolean expressing if the block at a given block number (height) is an election macro block.
-    async fn is_election_block_at(&mut self, block_number: u32)
-        -> RPCResult<bool, (), Self::Error>;
+    async fn is_election_block_at(&self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
     /// Returns the block number (height) of the next macro block after a given block number (height).
-    async fn get_macro_block_after(&mut self, block_number: u32)
-        -> RPCResult<u32, (), Self::Error>;
+    async fn get_macro_block_after(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the block number (height) of the preceding macro block before a given block number (height).
     /// If the given block number is a macro block, it returns the macro block before it.
-    async fn get_macro_block_before(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error>;
+    async fn get_macro_block_before(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns block the number (height) of the last macro block at a given block number (height).
     /// If the given block number is a macro block, then it returns that block number.
-    async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_last_macro_block(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns a boolean expressing if the block at a given block number (height) is a macro block.
-    async fn is_macro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
+    async fn is_macro_block_at(&self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
     /// Returns a boolean expressing if the block at a given block number (height) is a micro block.
-    async fn is_micro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
+    async fn is_micro_block_at(&self, block_number: u32) -> RPCResult<bool, (), Self::Error>;
 
     /// Returns the block number of the first block of the given epoch (which is always a micro block).
-    async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_first_block_of(&self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the block number of the first block of the given batch (which is always a micro block).
-    async fn get_first_block_of_batch(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_first_block_of_batch(&self, batch: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the block number of the election macro block of the given epoch (which is always the last block).
-    async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_election_block_of(&self, epoch: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the block number of the macro block (checkpoint or election) of the given batch (which
     /// is always the last block).
-    async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_macro_block_of(&self, batch: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns a boolean expressing if the batch at a given block number (height) is the first batch
     /// of the epoch.
-    async fn get_first_batch_of_epoch(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error>;
+    async fn get_first_batch_of_epoch(&self, block_number: u32)
+        -> RPCResult<bool, (), Self::Error>;
 
     /// Returns the first block after the reporting window of a given block number has ended.
     async fn get_block_after_reporting_window(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the first block after the jail period of a given block number has ended.
-    async fn get_block_after_jail(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
+    async fn get_block_after_jail(&self, block_number: u32) -> RPCResult<u32, (), Self::Error>;
 
     /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
     /// calculated using the following formula:
@@ -106,7 +91,7 @@ pub trait PolicyInterface {
     /// Where t is the time in milliseconds since the PoS genesis block and `genesis_supply` is the supply at
     /// the genesis of the Nimiq 2.0 chain.
     async fn get_supply_at(
-        &mut self,
+        &self,
         genesis_supply: u64,
         genesis_time: u64,
         current_time: u64,

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -9,29 +9,29 @@ pub trait ValidatorInterface {
     type Error;
 
     /// Returns our validator address.
-    async fn get_address(&mut self) -> RPCResult<Address, (), Self::Error>;
+    async fn get_address(&self) -> RPCResult<Address, (), Self::Error>;
 
     /// Returns our validator signing key.
-    async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error>;
+    async fn get_signing_key(&self) -> RPCResult<String, (), Self::Error>;
 
     /// Returns our current validator voting key.
-    async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error>;
+    async fn get_voting_key(&self) -> RPCResult<String, (), Self::Error>;
 
     /// Returns all available voting keys.
-    async fn get_voting_keys(&mut self) -> RPCResult<Vec<String>, (), Self::Error>;
+    async fn get_voting_keys(&self) -> RPCResult<Vec<String>, (), Self::Error>;
 
     // Adds a voting key that will be used when the key expected by the chain changes
-    async fn add_voting_key(&mut self, secret_key: String) -> RPCResult<(), (), Self::Error>;
+    async fn add_voting_key(&self, secret_key: String) -> RPCResult<(), (), Self::Error>;
 
     /// Updates the configuration setting to automatically reactivate our validator.
     async fn set_automatic_reactivation(
-        &mut self,
+        &self,
         automatic_reactivate: bool,
     ) -> RPCResult<(), (), Self::Error>;
 
     /// Returns if our validator is currently elected.
-    async fn is_validator_elected(&mut self) -> RPCResult<bool, (), Self::Error>;
+    async fn is_validator_elected(&self) -> RPCResult<bool, (), Self::Error>;
 
     /// Returns if our validator is currently synced.
-    async fn is_validator_synced(&mut self) -> RPCResult<bool, (), Self::Error>;
+    async fn is_validator_synced(&self) -> RPCResult<bool, (), Self::Error>;
 }

--- a/rpc-interface/src/wallet.rs
+++ b/rpc-interface/src/wallet.rs
@@ -10,7 +10,7 @@ pub trait WalletInterface {
 
     /// Import an account by its private key, in hexadecimal format, and lock it with the passphrase.
     async fn import_raw_key(
-        &mut self,
+        &self,
         key_data: String,
         passphrase: Option<String>,
     ) -> RPCResult<Address, (), Self::Error>;
@@ -18,23 +18,23 @@ pub trait WalletInterface {
     /// Returns if an account has been imported.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
-    async fn is_account_imported(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
+    async fn is_account_imported(&self, address: Address) -> RPCResult<bool, (), Self::Error>;
 
     /// Returns the accounts that have been imported.
-    async fn list_accounts(&mut self) -> RPCResult<Vec<Address>, (), Self::Error>;
+    async fn list_accounts(&self) -> RPCResult<Vec<Address>, (), Self::Error>;
 
     /// Locks the account to prevent further usage.
-    async fn lock_account(&mut self, address: Address) -> RPCResult<(), (), Self::Error>;
+    async fn lock_account(&self, address: Address) -> RPCResult<(), (), Self::Error>;
 
     /// Generates a new account and store it.
     async fn create_account(
-        &mut self,
+        &self,
         passphrase: Option<String>,
     ) -> RPCResult<ReturnAccount, (), Self::Error>;
 
     /// Unlocks the account.
     async fn unlock_account(
-        &mut self,
+        &self,
         address: Address,
         passphrase: Option<String>,
         duration: Option<u64>,
@@ -42,15 +42,15 @@ pub trait WalletInterface {
 
     /// Removes an imported account.
     /// IMPORTANT: This action is irreversible, and the account can only be recovered with its private key.
-    async fn remove_account(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
+    async fn remove_account(&self, address: Address) -> RPCResult<bool, (), Self::Error>;
 
     /// Returns if the account currently is unlocked.
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
-    async fn is_account_unlocked(&mut self, address: Address) -> RPCResult<bool, (), Self::Error>;
+    async fn is_account_unlocked(&self, address: Address) -> RPCResult<bool, (), Self::Error>;
 
     async fn sign(
-        &mut self,
+        &self,
         message: String,
         address: Address,
         passphrase: Option<String>,
@@ -59,7 +59,7 @@ pub trait WalletInterface {
 
     /// Verifies the signature based on the provided public key and message.
     async fn verify_signature(
-        &mut self,
+        &self,
         message: String,
         public_key: Ed25519PublicKey,
         signature: Ed25519Signature,

--- a/rpc-interface/src/zkp_component.rs
+++ b/rpc-interface/src/zkp_component.rs
@@ -8,5 +8,5 @@ pub trait ZKPComponentInterface {
     type Error;
 
     /// Returns the current ZKP state (proof with its related block hash and block number).
-    async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error>;
+    async fn get_zkp_state(&self) -> RPCResult<ZKPState, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -76,20 +76,20 @@ fn get_validator_by_address(
 impl BlockchainInterface for BlockchainDispatcher {
     type Error = Error;
 
-    async fn get_block_number(&mut self) -> RPCResult<u32, (), Self::Error> {
+    async fn get_block_number(&self) -> RPCResult<u32, (), Self::Error> {
         Ok(self.blockchain.read().block_number().into())
     }
 
-    async fn get_batch_number(&mut self) -> RPCResult<u32, (), Self::Error> {
+    async fn get_batch_number(&self) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_at(self.blockchain.read().block_number()).into())
     }
 
-    async fn get_epoch_number(&mut self) -> RPCResult<u32, (), Self::Error> {
+    async fn get_epoch_number(&self) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::epoch_at(self.blockchain.read().block_number()).into())
     }
 
     async fn get_block_by_hash(
-        &mut self,
+        &self,
         hash: Blake2bHash,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error> {
@@ -97,7 +97,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_block_by_number(
-        &mut self,
+        &self,
         block_number: u32,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error> {
@@ -116,7 +116,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_latest_block(
-        &mut self,
+        &self,
         include_body: Option<bool>,
     ) -> RPCResult<Block, (), Self::Error> {
         let blockchain = self.blockchain.read();
@@ -130,7 +130,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_slot_at(
-        &mut self,
+        &self,
         block_number: u32,
         offset_opt: Option<u32>,
     ) -> RPCResult<Slot, BlockchainState, Self::Error> {
@@ -152,7 +152,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_transaction_by_hash(
-        &mut self,
+        &self,
         hash: Blake2bHash,
     ) -> RPCResult<ExecutedTransaction, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
@@ -178,7 +178,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_transactions_by_block_number(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
@@ -204,7 +204,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_inherents_by_block_number(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
@@ -229,7 +229,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_transactions_by_batch_number(
-        &mut self,
+        &self,
         batch_number: u32,
     ) -> RPCResult<Vec<ExecutedTransaction>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
@@ -262,7 +262,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_inherents_by_batch_number(
-        &mut self,
+        &self,
         batch_number: u32,
     ) -> RPCResult<Vec<Inherent>, (), Self::Error> {
         if let BlockchainReadProxy::Full(blockchain) = self.blockchain.read() {
@@ -304,7 +304,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_transaction_hashes_by_address(
-        &mut self,
+        &self,
         address: Address,
         max: Option<u16>,
         start_at: Option<Blake2bHash>,
@@ -323,7 +323,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_transactions_by_address(
-        &mut self,
+        &self,
         address: Address,
         max: Option<u16>,
         start_at: Option<Blake2bHash>,
@@ -365,7 +365,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_account_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Account, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
@@ -383,7 +383,7 @@ impl BlockchainInterface for BlockchainDispatcher {
         }
     }
 
-    async fn get_accounts(&mut self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error> {
+    async fn get_accounts(&self) -> RPCResult<Vec<Account>, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
             let db_txn = blockchain.read_transaction();
@@ -403,7 +403,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_active_validators(
-        &mut self,
+        &self,
     ) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
@@ -429,7 +429,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_current_penalized_slots(
-        &mut self,
+        &self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
@@ -453,7 +453,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_previous_penalized_slots(
-        &mut self,
+        &self,
     ) -> RPCResult<PenalizedSlots, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
@@ -477,13 +477,13 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_validator_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Validator, BlockchainState, Self::Error> {
         get_validator_by_address(&self.blockchain.read(), &address)
     }
 
-    async fn get_validators(&mut self) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error> {
+    async fn get_validators(&self) -> RPCResult<Vec<Validator>, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
 
         if let BlockchainReadProxy::Full(ref blockchain) = blockchain_proxy {
@@ -504,7 +504,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_stakers_by_validator_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Vec<Staker>, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
@@ -528,7 +528,7 @@ impl BlockchainInterface for BlockchainDispatcher {
     }
 
     async fn get_staker_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> RPCResult<Staker, BlockchainState, Self::Error> {
         let blockchain_proxy = self.blockchain.read();
@@ -553,7 +553,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     #[stream]
     async fn subscribe_for_head_block(
-        &mut self,
+        &self,
         include_body: Option<bool>,
     ) -> Result<BoxStream<'static, RPCData<Block, ()>>, Self::Error> {
         let blockchain = self.blockchain.clone();
@@ -577,7 +577,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     #[stream]
     async fn subscribe_for_head_block_hash(
-        &mut self,
+        &self,
     ) -> Result<BoxStream<'static, RPCData<Blake2bHash, ()>>, Self::Error> {
         let stream = self.blockchain.read().notifier_as_stream();
         Ok(stream
@@ -598,7 +598,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     #[stream]
     async fn subscribe_for_validator_election_by_address(
-        &mut self,
+        &self,
         address: Address,
     ) -> Result<BoxStream<'static, RPCData<Validator, BlockchainState>>, Self::Error> {
         let blockchain = self.blockchain.clone();
@@ -620,7 +620,7 @@ impl BlockchainInterface for BlockchainDispatcher {
 
     #[stream]
     async fn subscribe_for_logs_by_addresses_and_types(
-        &mut self,
+        &self,
         addresses: Vec<Address>,
         log_types: Vec<LogType>,
     ) -> Result<BoxStream<'static, RPCData<BlockLog, BlockchainState>>, Self::Error> {

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -73,12 +73,12 @@ fn transaction_to_hex_string(transaction: &Transaction) -> String {
 impl ConsensusInterface for ConsensusDispatcher {
     type Error = Error;
 
-    async fn is_consensus_established(&mut self) -> RPCResult<bool, (), Self::Error> {
+    async fn is_consensus_established(&self) -> RPCResult<bool, (), Self::Error> {
         Ok(self.consensus.is_established().into())
     }
 
     async fn get_raw_transaction_info(
-        &mut self,
+        &self,
         raw_tx: String,
     ) -> RPCResult<RPCTransaction, (), Self::Error> {
         let transaction = Transaction::deserialize_from_vec(&hex::decode(raw_tx)?)?;
@@ -86,7 +86,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_raw_transaction(
-        &mut self,
+        &self,
         raw_tx: String,
     ) -> RPCResult<Blake2bHash, (), Self::Error> {
         let tx = Transaction::deserialize_from_vec(&hex::decode(&raw_tx)?)?;
@@ -99,7 +99,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_basic_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         value: Coin,
@@ -119,7 +119,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_basic_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         value: Coin,
@@ -134,7 +134,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_basic_transaction_with_data(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         data: String,
@@ -156,7 +156,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_basic_transaction_with_data(
-        &mut self,
+        &self,
         wallet: Address,
         recipient: Address,
         data: String,
@@ -179,7 +179,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_new_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         owner: Address,
         start_time: u64,
@@ -205,7 +205,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_new_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         owner: Address,
         start_time: u64,
@@ -232,7 +232,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_redeem_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -254,7 +254,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_redeem_vesting_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -277,7 +277,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_new_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         htlc_sender: Address,
         htlc_recipient: Address,
@@ -305,7 +305,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_new_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         htlc_sender: Address,
         htlc_recipient: Address,
@@ -334,7 +334,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_redeem_regular_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -362,7 +362,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_redeem_regular_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -391,7 +391,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_redeem_timeout_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -413,7 +413,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_redeem_timeout_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -436,7 +436,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_redeem_early_htlc_transaction(
-        &mut self,
+        &self,
         contract_address: Address,
         recipient: Address,
         htlc_sender_signature: String,
@@ -467,7 +467,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_redeem_early_htlc_transaction(
-        &mut self,
+        &self,
         contract_address: Address,
         recipient: Address,
         htlc_sender_signature: String,
@@ -492,7 +492,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn sign_redeem_early_htlc_transaction(
-        &mut self,
+        &self,
         wallet: Address,
         contract_address: Address,
         recipient: Address,
@@ -514,7 +514,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_new_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_wallet: Address,
         delegation: Option<Address>,
@@ -536,7 +536,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_new_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_wallet: Address,
         delegation: Option<Address>,
@@ -559,7 +559,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_address: Address,
         value: Coin,
@@ -579,7 +579,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         staker_address: Address,
         value: Coin,
@@ -601,7 +601,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_update_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
@@ -628,7 +628,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_update_staker_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_delegation: Option<Address>,
@@ -651,7 +651,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_set_active_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_active_balance: Coin,
@@ -676,7 +676,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_set_active_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         new_active_balance: Coin,
@@ -697,7 +697,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_retire_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         retire_stake: Coin,
@@ -722,7 +722,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_retire_stake_transaction(
-        &mut self,
+        &self,
         sender_wallet: Option<Address>,
         staker_wallet: Address,
         retire_stake: Coin,
@@ -743,7 +743,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_remove_stake_transaction(
-        &mut self,
+        &self,
         staker_wallet: Address,
         recipient: Address,
         value: Coin,
@@ -763,7 +763,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_remove_stake_transaction(
-        &mut self,
+        &self,
         staker_wallet: Address,
         recipient: Address,
         value: Coin,
@@ -784,7 +784,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_new_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         signing_secret_key: String,
@@ -835,7 +835,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_new_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         signing_secret_key: String,
@@ -862,7 +862,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_update_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         new_signing_secret_key: Option<String>,
@@ -926,7 +926,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_update_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         new_signing_secret_key: Option<String>,
@@ -953,7 +953,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_deactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -978,7 +978,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_deactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -999,7 +999,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_reactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -1023,7 +1023,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_reactivate_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
@@ -1068,7 +1068,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_retire_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         fee: Coin,
@@ -1086,7 +1086,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_retire_validator_transaction(
-        &mut self,
+        &self,
         sender_wallet: Address,
         validator_wallet: Address,
         fee: Coin,
@@ -1127,7 +1127,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn create_delete_validator_transaction(
-        &mut self,
+        &self,
         validator_wallet: Address,
         recipient: Address,
         fee: Coin,
@@ -1147,7 +1147,7 @@ impl ConsensusInterface for ConsensusDispatcher {
     }
 
     async fn send_delete_validator_transaction(
-        &mut self,
+        &self,
         validator_wallet: Address,
         recipient: Address,
         fee: Coin,

--- a/rpc-server/src/dispatchers/mempool.rs
+++ b/rpc-server/src/dispatchers/mempool.rs
@@ -31,10 +31,7 @@ impl MempoolDispatcher {
 impl MempoolInterface for MempoolDispatcher {
     type Error = Error;
 
-    async fn push_transaction(
-        &mut self,
-        raw_tx: String,
-    ) -> RPCResult<Blake2bHash, (), Self::Error> {
+    async fn push_transaction(&self, raw_tx: String) -> RPCResult<Blake2bHash, (), Self::Error> {
         let tx = Transaction::deserialize_from_vec(&hex::decode(&raw_tx)?)?;
         let txid = tx.hash::<Blake2bHash>();
 
@@ -50,7 +47,7 @@ impl MempoolInterface for MempoolDispatcher {
     }
 
     async fn push_high_priority_transaction(
-        &mut self,
+        &self,
         raw_tx: String,
     ) -> RPCResult<Blake2bHash, (), Self::Error> {
         let tx = Transaction::deserialize_from_vec(&hex::decode(&raw_tx)?)?;
@@ -71,7 +68,7 @@ impl MempoolInterface for MempoolDispatcher {
     }
 
     async fn mempool_content(
-        &mut self,
+        &self,
         include_transactions: bool,
     ) -> RPCResult<Vec<HashOrTx>, (), Self::Error> {
         return match include_transactions {
@@ -92,16 +89,16 @@ impl MempoolInterface for MempoolDispatcher {
         };
     }
 
-    async fn mempool(&mut self) -> RPCResult<MempoolInfo, (), Self::Error> {
+    async fn mempool(&self) -> RPCResult<MempoolInfo, (), Self::Error> {
         Ok(MempoolInfo::from_txs(self.mempool.get_transactions()).into())
     }
 
-    async fn get_min_fee_per_byte(&mut self) -> RPCResult<f64, (), Self::Error> {
+    async fn get_min_fee_per_byte(&self) -> RPCResult<f64, (), Self::Error> {
         Ok(self.mempool.get_rules().tx_fee_per_byte.into())
     }
 
     async fn get_transaction_from_mempool(
-        &mut self,
+        &self,
         hash: Blake2bHash,
     ) -> RPCResult<Transaction, (), Self::Error> {
         if let Some(tx) = self.mempool.get_transaction_by_hash(&hash) {

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -22,15 +22,15 @@ impl NetworkDispatcher {
 impl NetworkInterface for NetworkDispatcher {
     type Error = Error;
 
-    async fn get_peer_id(&mut self) -> RPCResult<String, (), Self::Error> {
+    async fn get_peer_id(&self) -> RPCResult<String, (), Self::Error> {
         Ok(self.network.local_peer_id().to_string().into())
     }
 
-    async fn get_peer_count(&mut self) -> RPCResult<usize, (), Self::Error> {
+    async fn get_peer_count(&self) -> RPCResult<usize, (), Self::Error> {
         Ok(self.network.get_peers().len().into())
     }
 
-    async fn get_peer_list(&mut self) -> RPCResult<Vec<String>, (), Self::Error> {
+    async fn get_peer_list(&self) -> RPCResult<Vec<String>, (), Self::Error> {
         Ok(self
             .network
             .get_peers()

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -14,7 +14,7 @@ pub struct PolicyDispatcher {}
 impl PolicyInterface for PolicyDispatcher {
     type Error = Error;
 
-    async fn get_policy_constants(&mut self) -> RPCResult<PolicyConstants, (), Self::Error> {
+    async fn get_policy_constants(&self) -> RPCResult<PolicyConstants, (), Self::Error> {
         Ok(PolicyConstants {
             staking_contract_address: Policy::STAKING_CONTRACT_ADDRESS.to_string(),
             coinbase_address: Policy::COINBASE_ADDRESS.to_string(),
@@ -35,31 +35,28 @@ impl PolicyInterface for PolicyDispatcher {
         .into())
     }
 
-    async fn get_epoch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_epoch_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::epoch_at(block_number).into())
     }
 
-    async fn get_epoch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_epoch_index_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::epoch_index_at(block_number).into())
     }
 
-    async fn get_batch_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_batch_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_at(block_number).into())
     }
 
-    async fn get_batch_index_at(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_batch_index_at(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_index_at(block_number).into())
     }
 
-    async fn get_election_block_after(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error> {
+    async fn get_election_block_after(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::election_block_after(block_number).into())
     }
 
     async fn get_election_block_before(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error> {
         if block_number < Policy::genesis_block_number() {
@@ -68,77 +65,65 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::election_block_before(block_number).into())
     }
 
-    async fn get_last_election_block(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error> {
+    async fn get_last_election_block(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         if block_number < Policy::genesis_block_number() {
             return Err(Error::BlockNumberBeforeGenesis);
         }
         Ok(Policy::last_election_block(block_number).into())
     }
 
-    async fn is_election_block_at(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<bool, (), Self::Error> {
+    async fn is_election_block_at(&self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_election_block_at(block_number).into())
     }
 
-    async fn get_macro_block_after(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error> {
+    async fn get_macro_block_after(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::macro_block_after(block_number).into())
     }
 
-    async fn get_macro_block_before(
-        &mut self,
-        block_number: u32,
-    ) -> RPCResult<u32, (), Self::Error> {
+    async fn get_macro_block_before(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         if block_number < Policy::genesis_block_number() {
             return Err(Error::BlockNumberBeforeGenesis);
         }
         Ok(Policy::macro_block_before(block_number).into())
     }
 
-    async fn get_last_macro_block(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_last_macro_block(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         if block_number < Policy::genesis_block_number() {
             return Err(Error::BlockNumberBeforeGenesis);
         }
         Ok(Policy::last_macro_block(block_number).into())
     }
 
-    async fn is_macro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
+    async fn is_macro_block_at(&self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_macro_block_at(block_number).into())
     }
 
-    async fn is_micro_block_at(&mut self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
+    async fn is_micro_block_at(&self, block_number: u32) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::is_micro_block_at(block_number).into())
     }
 
-    async fn get_first_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_first_block_of(&self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::first_block_of(epoch) {
             Some(block_number) => Ok(block_number.into()),
             None => Err(Error::InvalidArgument("epoch".to_string())),
         }
     }
 
-    async fn get_first_block_of_batch(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_first_block_of_batch(&self, batch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::first_block_of_batch(batch) {
             Some(block_number) => Ok(block_number.into()),
             None => Err(Error::InvalidArgument("batch".to_string())),
         }
     }
 
-    async fn get_election_block_of(&mut self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_election_block_of(&self, epoch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::election_block_of(epoch) {
             Some(block_number) => Ok(block_number.into()),
             None => Err(Error::InvalidArgument("epoch".to_string())),
         }
     }
 
-    async fn get_macro_block_of(&mut self, batch: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_macro_block_of(&self, batch: u32) -> RPCResult<u32, (), Self::Error> {
         match Policy::macro_block_of(batch) {
             Some(block_number) => Ok(block_number.into()),
             None => Err(Error::InvalidArgument("batch".to_string())),
@@ -146,25 +131,25 @@ impl PolicyInterface for PolicyDispatcher {
     }
 
     async fn get_first_batch_of_epoch(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<bool, (), Self::Error> {
         Ok(Policy::first_batch_of_epoch(block_number).into())
     }
 
     async fn get_block_after_reporting_window(
-        &mut self,
+        &self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::block_after_reporting_window(block_number).into())
     }
 
-    async fn get_block_after_jail(&mut self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
+    async fn get_block_after_jail(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::block_after_jail(block_number).into())
     }
 
     async fn get_supply_at(
-        &mut self,
+        &self,
         genesis_supply: u64,
         genesis_time: u64,
         current_time: u64,

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -31,16 +31,16 @@ impl ValidatorDispatcher {
 impl ValidatorInterface for ValidatorDispatcher {
     type Error = Error;
 
-    async fn get_address(&mut self) -> RPCResult<Address, (), Self::Error> {
+    async fn get_address(&self) -> RPCResult<Address, (), Self::Error> {
         Ok(self.validator.read().validator_address.clone().into())
     }
 
     // TODO: why do we give out secret keys via RPC?
-    async fn get_signing_key(&mut self) -> RPCResult<String, (), Self::Error> {
+    async fn get_signing_key(&self) -> RPCResult<String, (), Self::Error> {
         Ok(hex::encode(self.validator.read().signing_key.private.serialize_to_vec()).into())
     }
 
-    async fn get_voting_key(&mut self) -> RPCResult<String, (), Self::Error> {
+    async fn get_voting_key(&self) -> RPCResult<String, (), Self::Error> {
         Ok(hex::encode(
             self.validator
                 .read()
@@ -52,7 +52,7 @@ impl ValidatorInterface for ValidatorDispatcher {
         .into())
     }
 
-    async fn get_voting_keys(&mut self) -> RPCResult<Vec<String>, (), Self::Error> {
+    async fn get_voting_keys(&self) -> RPCResult<Vec<String>, (), Self::Error> {
         Ok(self
             .validator
             .read()
@@ -64,7 +64,7 @@ impl ValidatorInterface for ValidatorDispatcher {
             .into())
     }
 
-    async fn add_voting_key(&mut self, secret_key: String) -> RPCResult<(), (), Self::Error> {
+    async fn add_voting_key(&self, secret_key: String) -> RPCResult<(), (), Self::Error> {
         self.validator.write().voting_keys.add_key(BlsKeyPair::from(
             BlsSecretKey::deserialize_from_vec(&hex::decode(secret_key)?)?,
         ));
@@ -72,13 +72,11 @@ impl ValidatorInterface for ValidatorDispatcher {
     }
 
     async fn set_automatic_reactivation(
-        &mut self,
+        &self,
         automatic_reactivate: bool,
     ) -> RPCResult<(), (), Self::Error> {
-        let old = mem::replace(
-            &mut self.validator.write().automatic_reactivate,
-            automatic_reactivate,
-        );
+        let validator = self.validator.write();
+        let old = mem::replace(&mut &validator.automatic_reactivate, &automatic_reactivate);
 
         log::debug!(
             "Automatic reactivation set to {} (from {}).",
@@ -88,12 +86,12 @@ impl ValidatorInterface for ValidatorDispatcher {
         Ok(().into())
     }
 
-    async fn is_validator_elected(&mut self) -> RPCResult<bool, (), Self::Error> {
+    async fn is_validator_elected(&self) -> RPCResult<bool, (), Self::Error> {
         let is_elected = self.validator.read().slot_band.is_some();
         Ok(is_elected.into())
     }
 
-    async fn is_validator_synced(&mut self) -> RPCResult<bool, (), Self::Error> {
+    async fn is_validator_synced(&self) -> RPCResult<bool, (), Self::Error> {
         let is_synced = self.consensus.is_ready_for_validation();
         Ok(is_synced.into())
     }

--- a/rpc-server/src/dispatchers/wallet.rs
+++ b/rpc-server/src/dispatchers/wallet.rs
@@ -42,7 +42,7 @@ impl WalletInterface for WalletDispatcher {
     type Error = Error;
 
     async fn import_raw_key(
-        &mut self,
+        &self,
         key_data: String,
         passphrase: Option<String>,
     ) -> RPCResult<Address, (), Self::Error> {
@@ -63,23 +63,23 @@ impl WalletInterface for WalletDispatcher {
         Ok(address.into())
     }
 
-    async fn is_account_imported(&mut self, address: Address) -> RPCResult<bool, (), Self::Error> {
+    async fn is_account_imported(&self, address: Address) -> RPCResult<bool, (), Self::Error> {
         let is_imported = self.wallet_store.get(&address, None).is_some();
 
         Ok(is_imported.into())
     }
 
-    async fn list_accounts(&mut self) -> RPCResult<Vec<Address>, (), Self::Error> {
+    async fn list_accounts(&self) -> RPCResult<Vec<Address>, (), Self::Error> {
         Ok(self.wallet_store.list(None).into())
     }
 
-    async fn lock_account(&mut self, address: Address) -> RPCResult<(), (), Self::Error> {
+    async fn lock_account(&self, address: Address) -> RPCResult<(), (), Self::Error> {
         self.unlocked_wallets.write().remove(&address);
         Ok(().into())
     }
 
     async fn create_account(
-        &mut self,
+        &self,
         passphrase: Option<String>,
     ) -> RPCResult<ReturnAccount, (), Self::Error> {
         let passphrase = passphrase.unwrap_or_default();
@@ -101,7 +101,7 @@ impl WalletInterface for WalletDispatcher {
 
     // # TODO The duration parameter is ignored.
     async fn unlock_account(
-        &mut self,
+        &self,
         address: Address,
         passphrase: Option<String>,
         _duration: Option<u64>,
@@ -121,14 +121,14 @@ impl WalletInterface for WalletDispatcher {
         Ok(true.into())
     }
 
-    async fn is_account_unlocked(&mut self, address: Address) -> RPCResult<bool, (), Self::Error> {
+    async fn is_account_unlocked(&self, address: Address) -> RPCResult<bool, (), Self::Error> {
         let unlocked_wallets = self.unlocked_wallets.read();
         let is_unlocked = unlocked_wallets.get(&address).is_some();
 
         Ok(is_unlocked.into())
     }
 
-    async fn remove_account(&mut self, address: Address) -> RPCResult<bool, (), Self::Error> {
+    async fn remove_account(&self, address: Address) -> RPCResult<bool, (), Self::Error> {
         let _account = self
             .wallet_store
             .get(&address, None)
@@ -142,7 +142,7 @@ impl WalletInterface for WalletDispatcher {
     }
 
     async fn sign(
-        &mut self,
+        &self,
         message: String,
         address: Address,
         passphrase: Option<String>,
@@ -180,7 +180,7 @@ impl WalletInterface for WalletDispatcher {
     }
 
     async fn verify_signature(
-        &mut self,
+        &self,
         message: String,
         public_key: Ed25519PublicKey,
         signature: Ed25519Signature,

--- a/rpc-server/src/dispatchers/zkp_component.rs
+++ b/rpc-server/src/dispatchers/zkp_component.rs
@@ -23,7 +23,7 @@ impl ZKPComponentDispatcher {
 impl ZKPComponentInterface for ZKPComponentDispatcher {
     type Error = Error;
 
-    async fn get_zkp_state(&mut self) -> RPCResult<ZKPState, (), Self::Error> {
+    async fn get_zkp_state(&self) -> RPCResult<ZKPState, (), Self::Error> {
         Ok(ZKPState::with_zkp_state(&self.zkp_component.get_zkp_state()).into())
     }
 }


### PR DESCRIPTION
Now that the `nimiq-jsonrpc` dependencies support deriving methods without `&mut self` (see [this PR](https://github.com/nimiq/jsonrpc/pull/43)), change the RPC interface, its implemented methods in the server and client to also avoid `&mut self`.

Depends on nimiq/jsonrpc#43 (and a proper release from these crates).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
