### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ keywords = ["nimiq", "cryptocurrency", "blockchain"]
 clippy.assigning_clones = "allow"                                              # false positives: https://github.com/rust-lang/rust-clippy/issues/12709
 clippy.empty_docs = "allow"                                                    # false positives: https://github.com/rust-lang/rust-clippy/issues/12377
 clippy.large_enum_variant = "allow"
+clippy.result_large_err = "allow"
 clippy.too_many_arguments = "allow"
 clippy.type_complexity = "allow"
 rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -157,11 +157,7 @@ impl Blockchain {
     }
 
     pub fn get_account_if_complete(&self, address: &Address) -> Option<Account> {
-        if let Ok(account) = self.state.accounts.get(address, None) {
-            Some(account)
-        } else {
-            None
-        }
+        self.state.accounts.get(address, None).ok()
     }
 
     /// The given account must correspond to the sender of the given transaction.

--- a/bls/src/types/compressed_public_key.rs
+++ b/bls/src/types/compressed_public_key.rs
@@ -1,8 +1,4 @@
-use std::{
-    cmp::Ordering,
-    fmt,
-    io::{Error, ErrorKind},
-};
+use std::{cmp::Ordering, fmt, io};
 
 use ark_ec::AffineRepr;
 use ark_mnt6_753::G2Affine;
@@ -34,14 +30,14 @@ impl CompressedPublicKey {
     pub const SIZE: usize = 285;
 
     /// Transforms the compressed form back into the projective form.
-    pub fn uncompress(&self) -> Result<PublicKey, Error> {
+    pub fn uncompress(&self) -> Result<PublicKey, io::Error> {
         log::debug!(
             compressed = &self.to_hex()[..16],
             "decompressing BLS public key",
         );
         let affine_point: G2Affine =
             CanonicalDeserialize::deserialize_compressed(&mut &self.public_key[..])
-                .map_err(|e| Error::new(ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
         Ok(PublicKey {
             public_key: affine_point.into_group(),
         })

--- a/bls/src/types/compressed_signature.rs
+++ b/bls/src/types/compressed_signature.rs
@@ -1,8 +1,4 @@
-use std::{
-    cmp::Ordering,
-    fmt,
-    io::{Error, ErrorKind},
-};
+use std::{cmp::Ordering, fmt, io};
 
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_mnt6_753::{G1Affine, G1Projective};
@@ -33,10 +29,10 @@ pub struct CompressedSignature {
 
 impl CompressedSignature {
     /// Transforms the compressed form back into the projective form.
-    pub fn uncompress(&self) -> Result<Signature, Error> {
+    pub fn uncompress(&self) -> Result<Signature, io::Error> {
         let affine_point: G1Affine =
             CanonicalDeserialize::deserialize_compressed(&mut &self.signature[..])
-                .map_err(|e| Error::new(ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
         let signature = affine_point.into_group();
         Ok(Signature {
             signature,

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -374,7 +374,7 @@ impl FromIterator<usize> for BitSet {
 impl BitSet {
     /// Maximum size in bytes for a single `BitSet` in binary serialization.
     pub const fn max_size(largest_bit_index: usize) -> usize {
-        let num_u64 = (largest_bit_index + 63) / 64;
+        let num_u64 = largest_bit_index.div_ceil(64);
         nimiq_serde::seq_max_size(u64::MAX_SIZE, num_u64)
     }
 }

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -445,12 +445,12 @@ pub struct RequestMissingBlocks {
     /// The direction the responder should take to search.
     ///  - Direction::Forward searches from the best locator to the target on the main chain.
     ///
-    ///     That also implies that any block request using forward direction can only return main chain blocks.
+    ///    That also implies that any block request using forward direction can only return main chain blocks.
     ///
     ///  - Direction::Backward searches from the target hash backwards until a locator (or macro block) is reached.
     ///
-    ///     Using Backward makes retrieving inferior chains possible, but is more expensive for bigger
-    ///     sets of anticipated returned blocks.
+    ///    Using Backward makes retrieving inferior chains possible, but is more expensive for bigger
+    ///    sets of anticipated returned blocks.
     pub direction: Direction,
 }
 

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -42,6 +42,7 @@ impl Address {
         &self.0
     }
 
+    #[allow(clippy::sliced_string_as_bytes)] // TODO: https://github.com/nimiq/core-rs-albatross/issues/3376
     pub fn from_user_friendly_address(friendly_addr: &str) -> Result<Address, AddressParseError> {
         let friendly_addr_wospace = str::replace(friendly_addr, " ", "");
 

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -689,10 +689,10 @@ impl ClientInner {
 /// * `Consensus` - Contains most other objects, such as blockchain, mempool, etc.
 /// * `Blockchain` - The blockchain. Use this to query blocks or transactions
 /// * `Validator` - If the client runs a validator, this exposes access to the validator state,
-///     such as progress of current signature aggregations.
+///   such as progress of current signature aggregations.
 /// * `Database` - This can be stored to store arbitrary byte strings along-side the consensus state
-///     (e.g. the chain info). Make sure you don't collide with database names - e.g. by prefixing
-///     them with something.
+///   (e.g. the chain info). Make sure you don't collide with database names - e.g. by prefixing
+///   them with something.
 /// * ...
 ///
 /// # ToDo

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fs, num::NonZeroU8, sync::Arc};
+use std::{fs, io, num::NonZeroU8, sync::Arc};
 
 use instant::SystemTime;
 use nimiq_block::Block;
@@ -219,12 +219,9 @@ impl ClientInner {
                             "Proving keys missing, please place them in this folder: {:?}.",
                             zk_prover_config.prover_keys_path
                         );
-                        return Err(Error::NanoZKP(NanoZKPError::Filesystem(
-                            std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                "Proving keys do not exist.",
-                            ),
-                        )));
+                        return Err(Error::NanoZKP(NanoZKPError::Filesystem(io::Error::other(
+                            "Proving keys do not exist.",
+                        ))));
                     }
                     _ => {}
                 }
@@ -302,8 +299,8 @@ impl ClientInner {
                     Some(Item::Sec1Key(key)) => Ok(key.secret_sec1_der().to_vec()),
                     Some(Item::Pkcs8Key(key)) => Ok(key.secret_pkcs8_der().to_vec()),
                     Some(Item::Pkcs1Key(key)) => Ok(key.secret_pkcs1_der().to_vec()),
-                    _ => Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
+                    _ => Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
                         "Invalid TLS private key",
                     )),
                 }
@@ -316,8 +313,8 @@ impl ClientInner {
                 rustls_pemfile::read_all(&mut &*certificate_bytes)
                     .map(|item| match item {
                         Ok(Item::X509Certificate(cert)) => Ok(cert.to_vec()),
-                        _ => Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
+                        _ => Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
                             "Invalid TLS certificate(s)",
                         )),
                     })

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -281,11 +281,11 @@ impl Mempool {
     /// During a Blockchain extend event a new block is mined which implies that:
     ///
     /// 1. Existing transactions in the mempool can become invalidated because:
-    ///     A. They are no longer valid at the new block height (aging)
-    ///     B. Some were already mined
+    ///    A. They are no longer valid at the new block height (aging)
+    ///    B. Some were already mined
     ///
     /// 2. A transaction, that we didn't know about, from a known sender could be included in the blockchain, which implies:
-    ///     A. We need to update the sender balances in our mempool because some txns in or mempool could become invalid
+    ///    A. We need to update the sender balances in our mempool because some txns in or mempool could become invalid
     ///
     /// 1.B and 2.A can be iterated over the txs in the adopted blocks, that is, it is not
     /// necessary to iterate all transactions in the mempool.

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -20,6 +20,7 @@ use crate::{
     DeleteStakerReceipt, Log, RetireStakeReceipt, SetActiveStakeReceipt, TransactionLog,
 };
 
+#[allow(clippy::doc_overindented_list_items)] // Used to typeset in monospace.
 /// Struct representing a staker in the staking contract.
 /// The staker's balance is divided into active, inactive and retired stake.
 ///

--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -46,7 +46,7 @@ impl KeyNibbles {
     }
 
     fn bytes_len(&self) -> usize {
-        (self.len() + 1) / 2
+        self.len().div_ceil(2)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -395,7 +395,7 @@ mod serde_derive {
                     &"fewer nibbles",
                 ));
             }
-            if result.bytes.len != (result.len + 1) / 2 {
+            if result.bytes.len != result.len.div_ceil(2) {
                 // bytes length incorrect
                 return Err(D::Error::invalid_length(
                     result.bytes.len as usize,

--- a/primitives/src/trie/trie_node.rs
+++ b/primitives/src/trie/trie_node.rs
@@ -1,4 +1,4 @@
-use std::{mem, ops::RangeFrom, slice};
+use std::{ops::RangeFrom, slice};
 
 use byteorder::WriteBytesExt;
 use log::error;
@@ -240,7 +240,7 @@ impl TrieNode {
         if self.root_data.is_some() {
             return Err(MerkleRadixTrieError::RootCantHaveValue);
         }
-        Ok(mem::replace(&mut self.value, Some(new_value)))
+        Ok(self.value.replace(new_value))
     }
 
     pub fn iter_children(&self) -> Iter {

--- a/primitives/transaction/src/account/htlc_contract.rs
+++ b/primitives/transaction/src/account/htlc_contract.rs
@@ -318,15 +318,15 @@ impl PoWCreationTransactionData {
 ///
 /// The funds can be unlocked by one of three mechanisms:
 /// 1. After a blockchain height called `timeout` is reached, the `sender` can withdraw the funds.
-///     (called `TimeoutResolve`)
+///    (called `TimeoutResolve`)
 /// 2. The contract stores a `hash_root`. The `recipient` can withdraw the funds before the
-///     `timeout` has been reached by presenting a hash that will yield the `hash_root`
-///     when re-hashing it `hash_count` times.
-///     By presenting a hash that will yield the `hash_root` after re-hashing it k < `hash_count`
-///     times, the `recipient` can retrieve 1/k of the funds.
-///     (called `RegularTransfer`)
+///    `timeout` has been reached by presenting a hash that will yield the `hash_root`
+///    when re-hashing it `hash_count` times.
+///    By presenting a hash that will yield the `hash_root` after re-hashing it k < `hash_count`
+///    times, the `recipient` can retrieve 1/k of the funds.
+///    (called `RegularTransfer`)
 /// 3. If both `sender` and `recipient` sign the transaction, the funds can be withdrawn at any time.
-///     (called `EarlyResolve`)
+///    (called `EarlyResolve`)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum OutgoingHTLCTransactionProof {

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -1171,8 +1171,7 @@ pub fn is_of_log_type_and_related_to_addresses(
     log_types: &[LogType],
 ) -> bool {
     let log_type = LogType::from_log(log);
-    let matches_log_types =
-        log_types.is_empty() || log_types.iter().any(|other| log_type == *other);
+    let matches_log_types = log_types.is_empty() || log_types.contains(&log_type);
     let matches_addresses =
         addresses.is_empty() || addresses.iter().any(|addr| log.is_related_to_address(addr));
     matches_log_types && matches_addresses

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -587,7 +587,7 @@ impl BlockchainInterface for BlockchainDispatcher {
                     BlockchainEvent::HistoryAdopted(hash) => Some(hash.into()),
                     BlockchainEvent::Finalized(_) | BlockchainEvent::EpochFinalized(_) => None,
                     BlockchainEvent::Rebranched(_, new_branch) => {
-                        Some(new_branch.into_iter().last().unwrap().0.into())
+                        Some(new_branch.last().unwrap().0.clone().into())
                     }
                     BlockchainEvent::Stored(_block) => None,
                 };

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -272,7 +272,7 @@ pub trait Serialize: serde::Serialize {
         };
         match postcard::serialize_with_flavor(self, wrapper) {
             Ok(()) => Ok(written),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+            Err(e) => Err(io::Error::other(e)),
         }
     }
     fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<usize> {

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -103,6 +103,7 @@ impl<T: SerializedSize> SerializedMaxSize for T {
 
 #[rustfmt::skip]
 #[allow(unused_qualifications)] // Remove with a MSVR >= 1.80
+#[allow(clippy::manual_div_ceil)] // Breaks integer type inference.
 mod integer_impls {
     use super::SerializedFixedSize;
     use super::SerializedMaxSize;
@@ -159,7 +160,7 @@ pub const fn uint_max_size(max_value: u64) -> usize {
         Some(n) => n + 1,
         None => 1,
     };
-    ((bits + 6) / 7) as usize
+    bits.div_ceil(7) as usize
 }
 
 /// Maximum size in bytes for an `Option<T>` value in binary serialization.

--- a/tendermint/src/protocol.rs
+++ b/tendermint/src/protocol.rs
@@ -60,7 +60,7 @@ pub trait AggregationMessage<ProposalHash>: Aggregation<ProposalHash> {
 
 /// A proposal for Tendermint. Signatures for these  proposals are two fold:
 /// * the proposal itself is signed by the Validator proposing it alongside its round and valid_round.
-///     The signing and verification of it is done in Deps::sign_proposal and Deps::verify_proposal.
+///   The signing and verification of it is done in Deps::sign_proposal and Deps::verify_proposal.
 /// * the proposal is signed, potentially using a different signature scheme for the aggregation itself.
 pub trait Proposal<ProposalHash, InherentHash> {
     /// Hash of the proposal. May include parts of the inherent.

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -415,6 +415,9 @@ impl TransactionBuilder {
     }
 }
 
+// `clippy::doc_overindented_list_items` triggers because whitespace is used to typeset in
+// monospace here.
+#[allow(clippy::doc_overindented_list_items)]
 // Convenience functionality.
 impl TransactionBuilder {
     /// Creates a basic transaction from the address of a given `key_pair` to a basic `recipient`.

--- a/transaction-builder/src/recipient/htlc_contract.rs
+++ b/transaction-builder/src/recipient/htlc_contract.rs
@@ -49,15 +49,15 @@ pub enum HtlcRecipientBuilderError {
 ///
 /// The funds can be unlocked by one of three mechanisms:
 /// 1. After a blockchain height called `timeout` is reached, the `sender` can withdraw the funds.
-///     (called `TimeoutResolve`)
+///    (called `TimeoutResolve`)
 /// 2. The contract stores a `hash_root`. The `recipient` can withdraw the funds before the
-///     `timeout` has been reached by presenting a hash that will yield the `hash_root`
-///     when re-hashing it `hash_count` times.
-///     By presenting a hash that will yield the `hash_root` after re-hashing it k < `hash_count`
-///     times, the `recipient` can retrieve 1/k of the funds.
-///     (called `RegularTransfer`)
+///    `timeout` has been reached by presenting a hash that will yield the `hash_root`
+///    when re-hashing it `hash_count` times.
+///    By presenting a hash that will yield the `hash_root` after re-hashing it k < `hash_count`
+///    times, the `recipient` can retrieve 1/k of the funds.
+///    (called `RegularTransfer`)
 /// 3. If both `sender` and `recipient` sign the transaction, the funds can be withdrawn at any time.
-///     (called `EarlyResolve`)
+///    (called `EarlyResolve`)
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct HtlcRecipientBuilder {

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -1156,7 +1156,7 @@ impl Client {
             loop {
                 let details = match network_events.next().await {
                     Some(Ok(NetworkEvent::PeerJoined(peer_id, peer_info))) => {
-                        if subscribed_addresses.borrow().len() > 0 {
+                        if !subscribed_addresses.borrow().is_empty() {
                             // Subscribe to all addresses at the new peer
                             let owned_consensus = consensus.clone();
                             let owned_subscribed_addresses = Rc::clone(&subscribed_addresses);


### PR DESCRIPTION
- `clippy::doc_overindented_list_items`.
- `clippy::double_ended_iterator_last`.
- `clippy::io_other_error`.
- `clippy::len_zero`.
- `clippy::manual_contains`.
- `clippy::manual_div_ceil`.
- `clippy::manual_ok_err`.
- `clippy::mem_replace_option_with_some`
- `clippy::result_large_err`: Ignored similarly to `clippy::large_enum_variant`.
- `clippy::sliced_string_as_bytes`: Ignored because the method has larger problems: https://github.com/nimiq/core-rs-albatross/issues/3376.