### PR TITLE
Validate and fix web-client type declarations

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -134,6 +134,9 @@ jobs:
     - name: Compile to wasm and generate bindings
       working-directory: ./web-client
       run: ./scripts/build.sh --only nodejs,types
+    - name: Validate type declarations
+      working-directory: ./web-client/extras
+      run: yarn tsc ../dist/types/wasm/bundler.d.ts
     - name: Install dependencies in the web-client/dist folder
       working-directory: ./web-client/dist
       run: yarn install

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -14,8 +14,7 @@ use crate::{
 #[repr(u8)]
 #[cfg_attr(
     feature = "ts-types",
-    derive(tsify::Tsify),
-    serde(rename = "PlainAccountType", rename_all = "lowercase"),
+    serde(rename_all = "lowercase"),
     wasm_bindgen::prelude::wasm_bindgen
 )]
 pub enum AccountType {

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -89,8 +89,7 @@ pub struct TransactionReceipt {
 #[repr(u8)]
 #[cfg_attr(
     feature = "ts-types",
-    derive(tsify::Tsify),
-    serde(rename = "PlainTransactionFormat", rename_all = "lowercase"),
+    serde(rename_all = "lowercase"),
     wasm_bindgen::prelude::wasm_bindgen
 )]
 pub enum TransactionFormat {

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -846,19 +846,19 @@ pub struct PlainTransaction {
     /// any extra data. Basic transactions can be serialized to less bytes, so take up less place on the
     /// blockchain. Extended transactions on the other hand are all other transactions: contract creations
     /// and interactions, staking transactions, transactions with exta data, etc.
-    #[tsify(type = "PlainTransactionFormat")]
+    #[tsify(type = "\"basic\" | \"extended\"")]
     pub format: TransactionFormat,
     /// The transaction's sender address in human-readable IBAN format.
     pub sender: String,
     /// The account type of the transaction's sender. "basic" are regular private-key controlled accounts,
     /// "vesting" and "htlc" are contracts, and "staking" is the staking contract.
-    #[tsify(type = "PlainAccountType")]
+    #[tsify(type = "\"basic\" | \"vesting\" | \"htlc\" | \"staking\"")]
     pub sender_type: AccountType,
     /// The transaction's recipient address in human-readable IBAN format.
     pub recipient: String,
     /// The account type of the transaction's recipient. "basic" are regular private-key controlled accounts,
     /// "vesting" and "htlc" are contracts, and "staking" is the staking contract.
-    #[tsify(type = "PlainAccountType")]
+    #[tsify(type = "\"basic\" | \"vesting\" | \"htlc\" | \"staking\"")]
     pub recipient_type: AccountType,
     // The transaction's value in luna (NIM's smallest unit).
     pub value: u64,


### PR DESCRIPTION
The latest npm release v2.1.0 has broken web-client type declarations. I tracked it down to a [change in the upstream `tsify` update](https://github.com/madonoharu/tsify/pull/44) which was not part of my fork. When we switched to the upstream version from my fork in #3366, this change was included and broke the types.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
