### PR TITLE
Update some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "build-data"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23084982b6264a75acfd469b97ce0ef9301e154e7af51fec388e695eedf01bc1"
+checksum = "fc81c325bfc4db4af7aaa5b2da9cf7c7fa866b6d6756108aadd77eb9bc319a9c"
 dependencies = [
  "chrono",
  "safe-regex",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -48,7 +48,7 @@ log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
 parking_lot = "0.12"
 rand = "0.9"
 rand_chacha = "0.9"
-rustls = { version = "0.23", default-features = false, optional = true }
+rustls = { version = "0.23.18", default-features = false, optional = true }
 rustls-pemfile = "2.2"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -68,7 +68,7 @@ toml = "0.8"
 url = "2.5"
 
 [build-dependencies]
-build-data = "0.2"
+build-data = "0.3"
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
- Update the `buld-data` dependency in the `pow-migration` subcrate as for some reason it wasn't picked up by GH dependabot.
- Update the minimum version for `rustls` in the `lib` subcrate to avoid the potential insecure warning.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
