### PR TITLE
policy: Initialize the default policy to the mainnet values

### DIFF
--- a/primitives/block/tests/block_proof.rs
+++ b/primitives/block/tests/block_proof.rs
@@ -8,11 +8,11 @@ fn test_interlink_hops_to_block() {
     fn assert_interlink_hops(target: u32, election_head: u32, hops: Vec<u32>) {
         assert_eq!(
             BlockInclusionProof::get_interlink_hops(
-                target * Policy::blocks_per_epoch(),
-                election_head * Policy::blocks_per_epoch()
+                target * Policy::blocks_per_epoch() + Policy::genesis_block_number(),
+                election_head * Policy::blocks_per_epoch() + Policy::genesis_block_number()
             ),
             hops.into_iter()
-                .map(|i| i * Policy::blocks_per_epoch())
+                .map(|i| i * Policy::blocks_per_epoch() + Policy::genesis_block_number())
                 .collect::<Vec<u32>>()
         );
     }
@@ -37,7 +37,7 @@ fn test_is_block_proven() {
         1,
         MacroBlock {
             header: MacroHeader {
-                block_number: Policy::blocks_per_epoch(),
+                block_number: Policy::blocks_per_epoch() + Policy::genesis_block_number(),
                 interlink: Some(vec![]),
                 ..Default::default()
             },
@@ -50,7 +50,7 @@ fn test_is_block_proven() {
             i,
             MacroBlock {
                 header: MacroHeader {
-                    block_number: Policy::blocks_per_epoch() * i,
+                    block_number: Policy::blocks_per_epoch() * i + Policy::genesis_block_number(),
                     interlink: Some(interlink),
                     parent_election_hash: blocks[&(i - 1)].hash(),
                     ..Default::default()

--- a/primitives/block/tests/macro_block.rs
+++ b/primitives/block/tests/macro_block.rs
@@ -7,7 +7,8 @@ fn test_next_interlink() {
     fn create_interlink_macro_block(election_number: u32, interlink: &[Blake2bHash]) -> MacroBlock {
         MacroBlock {
             header: MacroHeader {
-                block_number: Policy::blocks_per_epoch() * election_number,
+                block_number: Policy::blocks_per_epoch() * election_number
+                    + Policy::genesis_block_number(),
                 interlink: Some(interlink.to_vec()),
                 ..Default::default()
             },

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
 
+/// Policy constants
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "ts-types", cfg_eval::cfg_eval, wasm_bindgen)]
 pub struct Policy {
@@ -644,16 +645,31 @@ impl Policy {
 
 impl Default for Policy {
     fn default() -> Self {
-        Policy {
-            blocks_per_batch: 60,
-            batches_per_epoch: 720,
-            state_chunks_max_size: 1000,
-            transaction_validity_window: 120,
-            genesis_block_number: 0,
-        }
+        MAINNET_POLICY
     }
 }
 
+/// Policy constants for MainNet
+pub const MAINNET_POLICY: Policy = Policy {
+    blocks_per_batch: 60,
+    batches_per_epoch: 720,
+    state_chunks_max_size: 1000,
+    transaction_validity_window: 120,
+    // As defined in the `main` network genesis file
+    genesis_block_number: 3456000,
+};
+
+/// Policy constants for TestNet
+pub const TESTNET_POLICY: Policy = Policy {
+    blocks_per_batch: 60,
+    batches_per_epoch: 720,
+    state_chunks_max_size: 1000,
+    transaction_validity_window: 120,
+    // As defined in the `test` network genesis file
+    genesis_block_number: 3032010,
+};
+
+/// Policy constants used for testing purposes
 pub const TEST_POLICY: Policy = Policy {
     blocks_per_batch: 32,
     batches_per_epoch: 4,

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -7,6 +7,7 @@ use nimiq_genesis::NetworkId;
 use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{Network, Topic};
 use nimiq_network_mock::MockHub;
+use nimiq_primitives::policy;
 use nimiq_zkp_component::ZKPComponent;
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,8 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
 #[wasm_bindgen_test]
 pub async fn it_can_initialize_with_mock_network() {
+    let _ = policy::Policy::get_or_init(policy::TEST_POLICY);
+
     let mut hub = MockHub::new();
 
     let mock_network = Arc::new(hub.new_network());


### PR DESCRIPTION
- Initialize the default policy to the mainnet values.
- Add the testnet `Policy` `struct` to facilitate setting these constants for this network.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
