### PR TITLE
Move listening for SIGINT to dedicated thread, don't block tokio worker thread

### DIFF
--- a/lib/src/extras/signal_handling.rs
+++ b/lib/src/extras/signal_handling.rs
@@ -1,18 +1,16 @@
-use std::time::Duration;
+use std::{thread, time::Duration};
 
-use nimiq_time::sleep;
-use nimiq_utils::spawn;
 use signal_hook::{consts::SIGINT, iterator::Signals};
 
 pub fn initialize_signal_handler() {
     let signals = Signals::new([SIGINT]);
 
     if let Ok(mut signals) = signals {
-        spawn(async move {
+        thread::spawn(move || {
             if signals.forever().next().is_some() {
                 log::warn!("Received Ctrl+C. Closing client");
                 // Add some delay for the log message to propagate into loki
-                sleep(Duration::from_millis(200)).await;
+                thread::sleep(Duration::from_millis(200));
                 std::process::exit(0);
             }
         });


### PR DESCRIPTION
The previous implementation always blocked one tokio worker thread with waiting for CTRL+C signals.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
