### PR TITLE
Fix clippy warnings

### DIFF
--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -161,8 +161,7 @@ impl Blockchain {
         if let Some(accounts_hash) = accounts.get_root_hash(Some(txn)) {
             assert_eq!(
                 block.header.state_root, accounts_hash,
-                "Cannot revert {} - inconsistent state",
-                block,
+                "Cannot revert {block} - inconsistent state",
             );
         }
 

--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -160,9 +160,7 @@ impl Blockchain {
                 assert_eq!(
                     prev_info.head.state_root(),
                     &accounts_hash,
-                    "Inconsistent state after reverting block {} - {:?}",
-                    block,
-                    block,
+                    "Inconsistent state after reverting block {block} - {block:?}",
                 );
             }
 

--- a/blockchain/src/chain_store.rs
+++ b/blockchain/src/chain_store.rs
@@ -422,8 +422,7 @@ impl ChainStore {
                 self.get_block(&block_hash, include_body, Some(&txn))
                     .unwrap_or_else(|_| {
                         panic!(
-                            "Corrupted store: Block {} referenced from index not found",
-                            block_hash
+                            "Corrupted store: Block {block_hash} referenced from index not found"
                         )
                     }),
             );

--- a/blockchain/src/history/validity_store.rs
+++ b/blockchain/src/history/validity_store.rs
@@ -126,9 +126,7 @@ impl ValidityStore {
         let last_bn = self.last_bn(db_txn);
         assert!(
             first_bn <= last_bn,
-            "First block number {} is greater than last block number {}",
-            first_bn,
-            last_bn
+            "First block number {first_bn} is greater than last block number {last_bn}"
         );
         let num_blocks = last_bn - first_bn + 1;
 

--- a/blockchain/tests/push_with_chunks.rs
+++ b/blockchain/tests/push_with_chunks.rs
@@ -503,7 +503,7 @@ fn can_converge_with_changes_in_staking_contract() {
             temp_producer2.push_with_chunks(block, diff, vec![chunk]),
             Ok((PushResult::Extended, Ok(ChunksPushResult::Chunks(1, 0))))
         );
-        println!("{} {:?}", i, chunk_end);
+        println!("{i} {chunk_end:?}");
         i += 1;
         assert_eq!(
             temp_producer2

--- a/bls/tests/tests.rs
+++ b/bls/tests/tests.rs
@@ -14,7 +14,7 @@ fn sign_verify() {
     for i in 0..100 {
         let keypair = KeyPair::generate(rng);
 
-        let message = format!("Message {}", i);
+        let message = format!("Message {i}");
 
         let sig = keypair.sign(&message);
 
@@ -29,7 +29,7 @@ fn compress_uncompress() {
     for i in 0..100 {
         let keypair = KeyPair::generate(rng);
 
-        let message = format!("Message {}", i);
+        let message = format!("Message {i}");
 
         let sig = keypair.sign(&message);
 
@@ -51,7 +51,7 @@ fn serialize_deserialize() {
         let ser_pub_key = keypair.public_key.serialize_to_vec();
         let compress_pub_key = keypair.public_key.compress();
         let ser_comp_pub_key = compress_pub_key.serialize_to_vec();
-        let message = format!("Message {}", i);
+        let message = format!("Message {i}");
 
         let sig = keypair.sign(&message);
         let ser_signature = sig.serialize_to_vec();

--- a/collections/src/bitset.rs
+++ b/collections/src/bitset.rs
@@ -429,16 +429,14 @@ impl<'de> Visitor<'de> for BitSetVisitorHumanReadable {
         let mut result = BitSet::new();
         while let Some(elem) = seq.next_element::<usize>()? {
             if elem > 65536 {
-                return Err(A::Error::custom(format!(
-                    "bitset element {} too large",
-                    elem,
-                )));
+                return Err(A::Error::custom(
+                    format!("bitset element {elem} too large",),
+                ));
             }
             if result.contains(elem) {
-                return Err(A::Error::custom(format!(
-                    "duplicate bitset element {}",
-                    elem,
-                )));
+                return Err(A::Error::custom(
+                    format!("duplicate bitset element {elem}",),
+                ));
             }
             result.insert(elem);
         }

--- a/consensus/src/sync/live/diff_queue/diff_request_component.rs
+++ b/consensus/src/sync/live/diff_queue/diff_request_component.rs
@@ -56,7 +56,7 @@ impl<N: Network> DiffRequestComponent<N> {
 
             let network = Arc::clone(&network);
             let concurrent_requests = Arc::clone(&concurrent_requests);
-            let block_desc = format!("{}", block);
+            let block_desc = format!("{block}");
             let block_hash = block.hash();
             let block_diff_root = block.diff_root().clone();
             let max_backoff = Duration::from_secs(30);

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -558,7 +558,7 @@ impl<N: Network> Stream for StateQueue<N> {
                     // We throw away the remaining incoming chunks if we are complete.
                     // This avoids breaking the state sync invariant new block + no diffs, then no chunks.
                     if !self.start_key.is_complete() {
-                        let key = u32::from_str_radix(&format!("{}00000000", start_key)[..8], 16)
+                        let key = u32::from_str_radix(&format!("{start_key}00000000")[..8], 16)
                             .unwrap_or(0);
 
                         let percentage = (key as f32 / u32::MAX as f32) * 100.0;

--- a/database/benches/hash_keys.rs
+++ b/database/benches/hash_keys.rs
@@ -180,8 +180,7 @@ fn measure_table_insertion<K: Eq + PartialEq + PartialOrd + Ord + Hash + Clone +
 
         group.bench_function(
             format!(
-                "{} |  {ty} | {scenario_str} | preload: {} | writing: {} ",
-                TABLE, preload_size, input_size
+                "{TABLE} |  {ty} | {scenario_str} | preload: {preload_size} | writing: {input_size} "
             ),
             |b| {
                 b.iter_with_setup(setup, execution);

--- a/genesis/build.rs
+++ b/genesis/build.rs
@@ -9,7 +9,7 @@ fn write_genesis_rs(directory: &Path, name: &str, genesis_hash: &Blake2bHash, ha
         let mut hash = String::new();
         write!(&mut hash, "0x{:02x}", genesis_hash.0[0]).unwrap();
         for &byte in &genesis_hash.0[1..] {
-            write!(&mut hash, ", 0x{:02x}", byte).unwrap();
+            write!(&mut hash, ", 0x{byte:02x}").unwrap();
         }
         hash
     };

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -107,7 +107,7 @@ impl Level {
                     let level = Level::new(i, Identity::NOBODY);
                     levels.push(level);
                 }
-                Err(e) => panic!("Partitioning error: {}", e),
+                Err(e) => panic!("Partitioning error: {e}"),
             }
         }
 

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -193,7 +193,7 @@ where
             // Merge individual signature into multisig
             contribution
                 .combine(individual)
-                .unwrap_or_else(|e| panic!("Individual contribution from id={:?} can't be added to aggregate contributions: {:?}", id, e));
+                .unwrap_or_else(|e| panic!("Individual contribution from id={id:?} can't be added to aggregate contributions: {e:?}"));
             contributors.combine(&id, false);
         }
 

--- a/hash/tests/hmac.rs
+++ b/hash/tests/hmac.rs
@@ -69,13 +69,12 @@ fn it_correctly_computes_hmac_sha512() {
             // Simulate truncated output.
             let mut hash = hash.to_string();
             hash.truncate(32);
-            assert_eq!(hash, vector.hash, "Invalid hmac sha512 in test case {}", i);
+            assert_eq!(hash, vector.hash, "Invalid hmac sha512 in test case {i}");
         } else {
             assert_eq!(
                 hash,
                 vector.get_hash(),
-                "Invalid hmac sha512 in test case {}",
-                i
+                "Invalid hmac sha512 in test case {i}"
             );
         }
     }

--- a/hash/tests/pbkdf2.rs
+++ b/hash/tests/pbkdf2.rs
@@ -75,8 +75,7 @@ fn it_correctly_computes_hmac_sha512() {
         assert_eq!(
             derived_key.unwrap(),
             vector.get_derived_key(),
-            "Invalid pbkdf2 in test case {}",
-            i
+            "Invalid pbkdf2 in test case {i}"
         );
     }
 }

--- a/key-derivation/tests/mod.rs
+++ b/key-derivation/tests/mod.rs
@@ -124,34 +124,26 @@ fn it_correctly_derives_keys() {
             let key = key.derive_path(vector.path);
             assert!(
                 key.is_some(),
-                "Could not derive path for seed {} in test case {}",
-                i,
-                j
+                "Could not derive path for seed {i} in test case {j}"
             );
             let key = key.unwrap();
 
             assert_eq!(
                 key.get_chain_code(),
                 &vector.get_chain_code(),
-                "Invalid chain code for seed {} in test case {}",
-                i,
-                j
+                "Invalid chain code for seed {i} in test case {j}"
             );
 
             assert_eq!(
                 &key.to_public_key(),
                 &vector.get_public_key(),
-                "Invalid public key for seed {} in test case {}",
-                i,
-                j
+                "Invalid public key for seed {i} in test case {j}"
             );
 
             assert_eq!(
                 &key.into_private_key(),
                 &vector.get_private_key(),
-                "Invalid private key for seed {} in test case {}",
-                i,
-                j
+                "Invalid private key for seed {i} in test case {j}"
             );
         }
     }

--- a/keys/tests/multisig.rs
+++ b/keys/tests/multisig.rs
@@ -172,8 +172,7 @@ fn it_can_create_signatures() {
                 key_pair
                     .public
                     .verify_partial(&data, &partial_sig, &test.message),
-                "cannot verify {}",
-                i
+                "cannot verify {i}"
             );
 
             if i > 0 {

--- a/lib/src/extras/dht_fallback.rs
+++ b/lib/src/extras/dht_fallback.rs
@@ -44,7 +44,7 @@ impl DhtFallback {
 
         let client = Client::builder(TokioExecutor::new()).build(https);
         let uri = url.as_str().parse().map_err(|_| {
-            io::Error::new(io::ErrorKind::InvalidInput, format!("invalid URI: {}", url))
+            io::Error::new(io::ErrorKind::InvalidInput, format!("invalid URI: {url}"))
         })?;
         Ok(DhtFallback { client, uri })
     }

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -1159,8 +1159,7 @@ async fn mempool_update() {
         prev_txn = updated_txns[i].clone();
         assert_eq!(
             expected_txns[i], updated_txns[i],
-            "Transaction at position {} is not expected",
-            i
+            "Transaction at position {i} is not expected"
         );
     }
 }

--- a/mnemonic/src/lib.rs
+++ b/mnemonic/src/lib.rs
@@ -100,7 +100,7 @@ impl Entropy {
             &salt,
             Algorithm::Argon2d,
         )
-        .map_err(|err| format!("{:?}", err))?;
+        .map_err(|err| format!("{err:?}"))?;
 
         let mut buf = Vec::with_capacity(
             /*version*/ 1 + /*kdf rounds*/ 1 + salt.len() + ciphertext.len(),
@@ -119,7 +119,7 @@ impl Entropy {
         let version = buf[0];
         let rounds_log = buf[1];
         if rounds_log > 32 {
-            return Err(format!("Rounds out-of-bounds: 2^{}", rounds_log));
+            return Err(format!("Rounds out-of-bounds: 2^{rounds_log}"));
         }
         let rounds = 2u32.pow(rounds_log as u32);
 
@@ -127,7 +127,7 @@ impl Entropy {
             1 => unimplemented!(),
             2 => unimplemented!(),
             3 => Entropy::decrypt_v3(&buf[2..], key, rounds),
-            _ => Err(format!("Unknown version: {}", version)),
+            _ => Err(format!("Unknown version: {version}")),
         }
     }
 
@@ -140,7 +140,7 @@ impl Entropy {
             ..Entropy::ENCRYPTION_SALT_SIZE + Entropy::ENCRYPTION_CHECKSUM_SIZE_V3 + /*purposeId*/ 4 + Entropy::SIZE];
 
         let plaintext = otp(ciphertext, key, rounds, salt, Algorithm::Argon2d)
-            .map_err(|err| format!("{:?}", err))?;
+            .map_err(|err| format!("{err:?}"))?;
 
         let check = &plaintext[..Entropy::ENCRYPTION_CHECKSUM_SIZE_V3];
         let payload = &plaintext[Entropy::ENCRYPTION_CHECKSUM_SIZE_V3..];
@@ -155,7 +155,7 @@ impl Entropy {
 
         let purpose_id = u32::from_be_bytes(payload[..4].try_into().unwrap());
         if purpose_id != Entropy::PURPOSE_ID {
-            return Err(format!("Invalid secret type (Purpose ID) {}", purpose_id));
+            return Err(format!("Invalid secret type (Purpose ID) {purpose_id}"));
         }
 
         let secret = &payload[4..];

--- a/mnemonic/tests/mod.rs
+++ b/mnemonic/tests/mod.rs
@@ -163,20 +163,17 @@ fn it_correctly_computes_mnemonics() {
         assert_eq!(
             entropy.to_mnemonic(WORDLIST_EN),
             mnemonic,
-            "Invalid entropy.to_mnemonic in test case {}",
-            i
+            "Invalid entropy.to_mnemonic in test case {i}"
         );
         let computed_entropy = mnemonic.to_entropy(WORDLIST_EN);
         assert!(
             computed_entropy.is_some(),
-            "mnemonic.to_entropy yields None in test case {}",
-            i
+            "mnemonic.to_entropy yields None in test case {i}"
         );
         assert_eq!(
             mnemonic.to_entropy(WORDLIST_EN).unwrap(),
             entropy,
-            "Invalid mnemonic.to_entropy in test case {}",
-            i
+            "Invalid mnemonic.to_entropy in test case {i}"
         );
         if vector.seed.is_some() {
             assert_eq!(mnemonic.to_seed(Some("TREZOR")).unwrap(), vector.get_seed());

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -740,7 +740,7 @@ impl Behaviour {
                             TransportError::Other(e) => e.to_string(),
                         };
 
-                        format!("{} => {}", address, err)
+                        format!("{address} => {err}")
                     })
                     .collect::<Vec<String>>()
                     .join(", ")

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -126,7 +126,7 @@ fn random_peer_contact(n: usize, services: Services) -> SignedPeerContact {
 
     let peer_contact = PeerContact::new(
         Some(
-            format!("/dns/test{}.local/tcp/443/wss", n)
+            format!("/dns/test{n}.local/tcp/443/wss")
                 .parse()
                 .expect("Must be able to parse Mutltiaddr"),
         ),

--- a/network-libp2p/tests/helper/mod.rs
+++ b/network-libp2p/tests/helper/mod.rs
@@ -6,7 +6,7 @@ pub fn assert_peer_joined(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId)
     if let NetworkEvent::PeerJoined(peer_id, _) = event {
         assert_eq!(peer_id, wanted_peer_id);
     } else {
-        panic!("Event is not a NetworkEvent::PeerJoined: {:?}", event);
+        panic!("Event is not a NetworkEvent::PeerJoined: {event:?}");
     }
 }
 
@@ -15,7 +15,7 @@ pub fn assert_peer_left(event: &NetworkEvent<PeerId>, wanted_peer_id: &PeerId) {
     if let NetworkEvent::PeerLeft(peer_id) = event {
         assert_eq!(peer_id, wanted_peer_id);
     } else {
-        panic!("Event is not a NetworkEvent::PeerLeft: {:?}", event);
+        panic!("Event is not a NetworkEvent::PeerLeft: {event:?}");
     }
 }
 

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -316,7 +316,7 @@ async fn test_valid_request_valid_response() {
         Ok(response) => {
             assert_eq!(response, test_response);
         }
-        Err(e) => assert!(false, "Response received with error: {:?}", e),
+        Err(e) => assert!(false, "Response received with error: {e:?}"),
     };
 }
 
@@ -368,7 +368,7 @@ async fn test_multiple_valid_requests_valid_responses() {
             Ok(response) => {
                 assert_eq!(response, test_response_2);
             }
-            Err(e) => assert!(false, "Response received with error: {:?}", e),
+            Err(e) => assert!(false, "Response received with error: {e:?}"),
         };
     }
 }
@@ -404,7 +404,7 @@ async fn test_valid_request_no_response() {
 
     match received_response {
         Ok(response) => {
-            assert!(false, "Received unexpected valid response: {:?}", response)
+            assert!(false, "Received unexpected valid response: {response:?}")
         }
         Err(e) => assert_eq!(
             e,
@@ -452,7 +452,7 @@ async fn test_valid_request_no_response_close_connection() {
 
     match received_response {
         Ok(response) => {
-            assert!(false, "Received unexpected valid response: {:?}", response)
+            assert!(false, "Received unexpected valid response: {response:?}")
         }
         Err(e) => assert_eq!(
             e,
@@ -483,7 +483,7 @@ async fn test_valid_request_no_response_no_receiver() {
     // Check the received response
     match received_response {
         Ok(response) => {
-            assert!(false, "Received unexpected valid response: {:?}", response)
+            assert!(false, "Received unexpected valid response: {response:?}")
         }
         Err(e) => assert_eq!(
             e,
@@ -563,7 +563,7 @@ async fn send_n_request_to_succeed(net1: &Arc<Network>, net2: &Arc<Network>, n: 
                     "First requests must return Ok Result"
                 );
             }
-            Err(e) => assert!(false, "Response received with error: {:?}", e),
+            Err(e) => assert!(false, "Response received with error: {e:?}"),
         };
     }
 }

--- a/pow-migration/build.rs
+++ b/pow-migration/build.rs
@@ -4,7 +4,7 @@ fn main() {
     } else {
         format!("v{}", env!("CARGO_PKG_VERSION"))
     };
-    println!("cargo::rustc-env=NIMIQ_POW_MIGRATION_VERSION={}", version);
+    println!("cargo::rustc-env=NIMIQ_POW_MIGRATION_VERSION={version}");
     println!("cargo::rerun-if-changed=../.git/index");
     println!("cargo::rerun-if-changed=../.git/logs/HEAD");
 }

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -492,7 +492,7 @@ fn accounts_performance() {
     );
     match result {
         Ok(_) => assert!(true),
-        Err(err) => assert!(false, "Received {}", err),
+        Err(err) => assert!(false, "Received {err}"),
     };
     let duration = start.elapsed();
     println!(
@@ -621,7 +621,7 @@ fn accounts_performance_history_sync_batches_single_sender() {
             );
             match result {
                 Ok(_) => assert!(true),
-                Err(err) => assert!(false, "Received {}", err),
+                Err(err) => assert!(false, "Received {err}"),
             };
             block_index += 1;
         }
@@ -748,7 +748,7 @@ fn accounts_performance_history_sync_batches_many_to_many() {
             );
             match result {
                 Ok(_) => assert!(true),
-                Err(err) => assert!(false, "Received {}", err),
+                Err(err) => assert!(false, "Received {err}"),
             };
             block_index += 1;
         }

--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -625,13 +625,7 @@ mod tests {
             }
         }
         for key in &keys {
-            assert_eq!(
-                key.post_order_cmp(key),
-                Ordering::Equal,
-                "{} == {}",
-                key,
-                key
-            );
+            assert_eq!(key.post_order_cmp(key), Ordering::Equal, "{key} == {key}");
         }
     }
 }

--- a/primitives/tests/coin/mod.rs
+++ b/primitives/tests/coin/mod.rs
@@ -46,7 +46,7 @@ fn test_deserialize_out_of_bounds() {
     use nimiq_serde::DeserializeError;
 
     match Coin::deserialize_from_vec(&hex::decode("0020000000000000").unwrap()) {
-        Ok(coin) => panic!("Instead of failing, got {}", coin),
+        Ok(coin) => panic!("Instead of failing, got {coin}"),
         Err(err) => assert_eq!(err, DeserializeError::serde_custom()),
     }
 }

--- a/primitives/transaction/src/account/htlc_contract.rs
+++ b/primitives/transaction/src/account/htlc_contract.rs
@@ -841,8 +841,7 @@ mod serde_derive {
                 }
                 _ => {
                     return Err(Error::custom(format!(
-                        "Invalid hash algorithm type: {}",
-                        hash_algorithm
+                        "Invalid hash algorithm type: {hash_algorithm}"
                     )))
                 }
             };

--- a/primitives/transaction/src/signature_proof.rs
+++ b/primitives/transaction/src/signature_proof.rs
@@ -175,7 +175,7 @@ impl SignatureProof {
         let algorithm = match type_byte {
             0 => SignatureProofAlgorithm::Ed25519,
             1 => SignatureProofAlgorithm::ES256,
-            _ => return Err(format!("Invalid signature proof algorithm: {}", type_byte)),
+            _ => return Err(format!("Invalid signature proof algorithm: {type_byte}")),
         };
         // The flags are encoded in the upper 4 bits
         let flags = SignatureProofFlags::from_bits_truncate(byte >> 4);
@@ -573,6 +573,6 @@ impl Error for SerializationError {
 
 impl From<url::ParseError> for SerializationError {
     fn from(err: url::ParseError) -> Self {
-        SerializationError::new(&format!("Failed to parse URL: {}", err))
+        SerializationError::new(&format!("Failed to parse URL: {err}"))
     }
 }

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -165,7 +165,7 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         let node = if let Some(node) = self.get_node(txn, key) {
             node
         } else {
-            println!("{}-> MISSING", prefix);
+            println!("{prefix}-> MISSING");
             return;
         };
 
@@ -174,7 +174,7 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
             if let Ok(subkey) = child.key(key, missing_range) {
                 self.debug_print_subtrie(txn, &subkey, missing_range, depth + 2);
             } else {
-                println!("{}  -> MISSING", prefix);
+                println!("{prefix}  -> MISSING");
             }
         }
     }

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -525,7 +525,7 @@ impl HandleSubcommand for TransactionCommand {
                 retire_stake,
                 tx_commons,
             } => {
-                eprintln! {"a {:?}\n{:?}\n{:?}\n{:?}",sender_wallet,staker_wallet,retire_stake,tx_commons};
+                eprintln! {"a {sender_wallet:?}\n{staker_wallet:?}\n{retire_stake:?}\n{tx_commons:?}"};
                 if tx_commons.dry {
                     let tx = client
                         .consensus

--- a/rpc-interface/src/types.rs
+++ b/rpc-interface/src/types.rs
@@ -95,8 +95,7 @@ impl<'de> Deserialize<'de> for ValidityStartHeight {
             StrOrU32::Number(height) => Ok(Self::Absolute(height)),
             StrOrU32::String(height) => Self::from_str(&height).map_err(|e| {
                 Error::custom(format!(
-                    "ValidityStartHeight cannot be converted into a `u32`: {}",
-                    e
+                    "ValidityStartHeight cannot be converted into a `u32`: {e}"
                 ))
             }),
         }

--- a/test-utils/src/performance/accounts-tree/main.rs
+++ b/test-utils/src/performance/accounts-tree/main.rs
@@ -102,7 +102,7 @@ fn accounts_tree_populate(
     println!("Done adding accounts to genesis");
 
     for loop_number in 1..loops + 1 {
-        println!("Starting loop: {}", loop_number);
+        println!("Starting loop: {loop_number}");
         println!("-----------------");
         println!("Generating transactions...");
         // Generate recipients accounts
@@ -129,7 +129,7 @@ fn accounts_tree_populate(
             txns_per_block.push(txns);
         }
 
-        println!("Done generating {} transactions", txn_index);
+        println!("Done generating {txn_index} transactions");
 
         let mut block_index = 0;
 

--- a/test-utils/src/performance/history-store/main.rs
+++ b/test-utils/src/performance/history-store/main.rs
@@ -96,8 +96,7 @@ fn history_store_populate(
     let batches_per_round = batches / rounds;
     let blocks_per_round = number_of_blocks / rounds;
     println!(
-        " Number of rounds: {}, batches per round {} blocks per round {}",
-        rounds, batches_per_round, blocks_per_round
+        " Number of rounds: {rounds}, batches per round {batches_per_round} blocks per round {blocks_per_round}"
     );
 
     for round in 0..rounds {
@@ -180,7 +179,7 @@ fn main() {
     let loops = args.loops.unwrap_or(1);
 
     for loop_number in 1..(1 + loops) {
-        println!("Current loop {}", loop_number);
+        println!("Current loop {loop_number}");
 
         history_store_populate(
             &*history_store,

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -555,7 +555,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 IncomingType::Basic | IncomingType::CreateVesting | IncomingType::CreateHTLC
             )
         {
-            panic!("Cannot fail a {:?} account recipient", incoming_type);
+            panic!("Cannot fail a {incoming_type:?} account recipient");
         }
 
         match incoming_type {

--- a/tools/src/rpc-schema/openrpc/document.rs
+++ b/tools/src/rpc-schema/openrpc/document.rs
@@ -628,6 +628,6 @@ mod tests {
             ContentDescriptorOrReference::new_content_descriptor::<MyRet>("ret".to_string(), None);
         document.add_object_method(method);
         let j = serde_json::to_string_pretty(&document).unwrap();
-        println!("{}", j);
+        println!("{j}");
     }
 }

--- a/tools/src/trim-genesis-config/main.rs
+++ b/tools/src/trim-genesis-config/main.rs
@@ -68,7 +68,7 @@ fn main() {
         if hash_trimmed == hash {
             log!("hashes match");
         } else {
-            eprintln!("hash mismatch, {} != {}", hash_trimmed, hash);
+            eprintln!("hash mismatch, {hash_trimmed} != {hash}");
             eprintln!("aborting");
             process::exit(1);
         }

--- a/utils/tests/merkle/incremental.rs
+++ b/utils/tests/merkle/incremental.rs
@@ -337,10 +337,7 @@ fn it_correctly_computes_more_complex_proofs() {
                 assert_eq!(
                     proof_result.next_index(),
                     end_i,
-                    "Invalid next index for size {}, chunk_size {}, chunk #{}",
-                    end,
-                    chunk_size,
-                    chunk_i
+                    "Invalid next index for size {end}, chunk_size {chunk_size}, chunk #{chunk_i}"
                 );
                 prev_proof = Some(proof_result);
             }
@@ -413,7 +410,7 @@ fn it_discards_invalid_proofs() {
     let proof_result = chunks[1].compute_root_from_values(&values[2..], None);
     match proof_result {
         Err(IncrementalMerkleProofError::InvalidProof) => {}
-        _ => assert!(false, "Case 2 gave invalid response: {:?}", proof_result),
+        _ => assert!(false, "Case 2 gave invalid response: {proof_result:?}"),
     }
 
     // Case 3: Invalid previous proof.
@@ -430,13 +427,13 @@ fn it_discards_invalid_proofs() {
     let proof_result = chunks[1].compute_root_from_values(&values[2..], Some(&proof_result));
     match proof_result {
         Err(_) => {}
-        _ => assert!(false, "Case 3 gave invalid response: {:?}", proof_result),
+        _ => assert!(false, "Case 3 gave invalid response: {proof_result:?}"),
     }
 
     // Case 4: Invalid chunk size.
     let builder = IncrementalMerkleProofBuilder::<Blake2bHash>::new(0);
     match builder {
         Err(IncrementalMerkleProofError::InvalidChunkSize) => {}
-        _ => assert!(false, "Case 4 gave invalid response: {:?}", proof_result),
+        _ => assert!(false, "Case 4 gave invalid response: {proof_result:?}"),
     }
 }

--- a/utils/tests/merkle/partial.rs
+++ b/utils/tests/merkle/partial.rs
@@ -378,18 +378,12 @@ fn it_correctly_computes_more_complex_proofs() {
                 assert_eq!(
                     proof_result.root(),
                     &root,
-                    "Invalid root for size {}, chunk_size {}, chunk #{}",
-                    end,
-                    chunk_size,
-                    chunk_i
+                    "Invalid root for size {end}, chunk_size {chunk_size}, chunk #{chunk_i}"
                 );
                 assert_eq!(
                     proof_result.next_index(),
                     end_i,
-                    "Invalid next index for size {}, chunk_size {}, chunk #{}",
-                    end,
-                    chunk_size,
-                    chunk_i
+                    "Invalid next index for size {end}, chunk_size {chunk_size}, chunk #{chunk_i}"
                 );
                 prev_proof = Some(proof_result);
             }
@@ -435,7 +429,7 @@ fn it_discards_invalid_proofs() {
     let proof_result = chunks[1].compute_root_from_values(&values[2..], None);
     match proof_result {
         Err(PartialMerkleProofError::InvalidProof) => {}
-        _ => assert!(false, "Case 2 gave invalid response: {:?}", proof_result),
+        _ => assert!(false, "Case 2 gave invalid response: {proof_result:?}"),
     }
 
     // Case 3: Invalid previous proof.
@@ -458,13 +452,13 @@ fn it_discards_invalid_proofs() {
     let proof_result = chunks[1].compute_root_from_values(&values[2..], Some(&proof_result));
     match proof_result {
         Err(_) => {}
-        _ => assert!(false, "Case 3 gave invalid response: {:?}", proof_result),
+        _ => assert!(false, "Case 3 gave invalid response: {proof_result:?}"),
     }
 
     // Case 4: Invalid chunk size.
     let chunks = PartialMerkleProofBuilder::from_values::<Blake2bHash, &str>(&values, 0);
     match chunks {
         Err(PartialMerkleProofError::InvalidChunkSize) => {}
-        _ => assert!(false, "Case 4 gave invalid response: {:?}", proof_result),
+        _ => assert!(false, "Case 4 gave invalid response: {proof_result:?}"),
     }
 }

--- a/utils/tests/otp/mod.rs
+++ b/utils/tests/otp/mod.rs
@@ -31,7 +31,7 @@ fn create_unlocked_checked() {
 
     let lock = match OtpLock::unlocked_with_defaults(secret.clone(), password.as_bytes()) {
         Ok(l) => l,
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
 
     assert!(lock.is_unlocked());
@@ -63,7 +63,7 @@ fn create_locked_unchecked() {
 
     let lock = match OtpLock::locked_with_defaults(secret, password.as_bytes()) {
         Ok(l) => l,
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
 
     assert!(lock.is_locked());

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -714,7 +714,7 @@ where
         }
 
         spawn(async move {
-            let block_id = format!("{}", block);
+            let block_id = format!("{block}");
 
             let (header, body) = BlockHeaderMessage::split_block(block);
 

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -39,7 +39,7 @@ fn test_serialize_deserialize() {
             assert_eq!(wallet, deserialized);
         }
         Err(e) => {
-            panic!("Error: {}", e);
+            panic!("Error: {e}");
         }
     }
 }

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -1375,8 +1375,7 @@ impl Client {
                 accounts
                     .get(address)
                     .ok_or(JsError::new(&format!(
-                        "Missing trie proof node for {}",
-                        address
+                        "Missing trie proof node for {address}"
                     )))?
                     .as_ref()
                     .unwrap_or(&default),
@@ -1403,8 +1402,7 @@ impl Client {
                 stakers
                     .get(address)
                     .ok_or(JsError::new(&format!(
-                        "Missing trie proof node for {}",
-                        address
+                        "Missing trie proof node for {address}"
                     )))?
                     .as_ref()
                     .map(PlainStaker::from),
@@ -1431,8 +1429,7 @@ impl Client {
                 validators
                     .get(address)
                     .ok_or(JsError::new(&format!(
-                        "Missing trie proof node for {}",
-                        address
+                        "Missing trie proof node for {address}"
                     )))?
                     .as_ref()
                     .map(PlainValidator::from),

--- a/web-client/src/common/client_configuration.rs
+++ b/web-client/src/common/client_configuration.rs
@@ -222,7 +222,7 @@ impl TryFrom<PlainClientConfiguration> for ClientConfiguration {
 
         if let Some(network_id) = config.network_id {
             client_config.network_id = NetworkId::from_str(&network_id)
-                .map_err(|err| JsError::new(&format!("Invalid network ID: {}", err)))?;
+                .map_err(|err| JsError::new(&format!("Invalid network ID: {err}")))?;
         }
 
         if let Some(seed_nodes) = config.seed_nodes {
@@ -256,7 +256,7 @@ impl TryFrom<PlainClientConfiguration> for ClientConfiguration {
         if let Some(sync_mode) = config.sync_mode {
             // Only "pico" and "light" sync modes are supported for web clients
             if !(sync_mode == "pico" || sync_mode == "light") {
-                return Err(JsError::new(&format!("Invalid sync mode: {}", sync_mode)));
+                return Err(JsError::new(&format!("Invalid sync mode: {sync_mode}")));
             }
 
             client_config.sync_mode = sync_mode;

--- a/web-client/src/crypto_utils/mod.rs
+++ b/web-client/src/crypto_utils/mod.rs
@@ -41,7 +41,7 @@ impl CryptoUtils {
         derived_key_length: usize,
     ) -> Result<Vec<u8>, JsError> {
         compute_pbkdf2_sha512(password, salt, iterations, derived_key_length)
-            .map_err(|err| JsError::new(&format!("{:?}", err)))
+            .map_err(|err| JsError::new(&format!("{err:?}")))
     }
 
     #[cfg(feature = "crypto")]
@@ -59,7 +59,7 @@ impl CryptoUtils {
     ) -> Result<Uint8Array, JsError> {
         Ok(Uint8Array::from(
             otp(message, key, iterations, salt, Algorithm::Argon2d)
-                .map_err(|err| JsError::new(&format!("{:?}", err)))?
+                .map_err(|err| JsError::new(&format!("{err:?}")))?
                 .as_slice(),
         ))
     }

--- a/web-client/src/multisig/partial_signature.rs
+++ b/web-client/src/multisig/partial_signature.rs
@@ -88,8 +88,7 @@ impl PartialSignature {
         // Sanity checks
         if own_commitment_pairs.len() != MUSIG2_PARAMETER_V {
             return Err(JsError::new(&format!(
-                "Number of own commitment pairs must be {}",
-                MUSIG2_PARAMETER_V
+                "Number of own commitment pairs must be {MUSIG2_PARAMETER_V}"
             )));
         }
         if other_public_keys.len() != other_commitments.len() {
@@ -102,8 +101,7 @@ impl PartialSignature {
             .any(|commitments| commitments.len() != MUSIG2_PARAMETER_V)
         {
             return Err(JsError::new(&format!(
-                "Number of commitments in each group must be {}",
-                MUSIG2_PARAMETER_V
+                "Number of commitments in each group must be {MUSIG2_PARAMETER_V}"
             )));
         }
 

--- a/zkp-circuits/src/gadgets/serialize.rs
+++ b/zkp-circuits/src/gadgets/serialize.rs
@@ -192,8 +192,7 @@ mod tests_mnt4 {
             assert_eq!(
                 primitive_bytes[i],
                 gadget_bytes[i].value().unwrap(),
-                "Mismatch in byte {}",
-                i
+                "Mismatch in byte {i}"
             );
         }
     }
@@ -306,8 +305,7 @@ mod tests_mnt6 {
             assert_eq!(
                 primitive_bytes[i],
                 gadget_bytes[i].value().unwrap(),
-                "Mismatch in byte {}",
-                i
+                "Mismatch in byte {i}"
             );
         }
     }

--- a/zkp-component/src/types.rs
+++ b/zkp-component/src/types.rs
@@ -348,7 +348,7 @@ mod serde_derive {
                     ark_serialize::Compress::Yes,
                 ));
                 CanonicalSerialize::serialize_compressed(latest_proof, writer.by_ref())
-                    .map_err(|e| S::Error::custom(format!("Could not serialize proof: {}", e)))?;
+                    .map_err(|e| S::Error::custom(format!("Could not serialize proof: {e}")))?;
                 Some(writer)
             } else {
                 None
@@ -420,7 +420,7 @@ mod serde_derive {
                     ark_serialize::Compress::No,
                 ));
                 CanonicalSerialize::serialize_uncompressed(latest_proof, writer.by_ref())
-                    .map_err(|e| S::Error::custom(format!("Could not serialize proof: {}", e)))?;
+                    .map_err(|e| S::Error::custom(format!("Could not serialize proof: {e}")))?;
                 Some(writer)
             } else {
                 None
@@ -505,7 +505,7 @@ mod serde_derive {
                     ark_serialize::Compress::No,
                 ));
                 CanonicalSerialize::serialize_uncompressed(previous_proof, writer.by_ref())
-                    .map_err(|e| S::Error::custom(format!("Could not serialize proof: {}", e)))?;
+                    .map_err(|e| S::Error::custom(format!("Could not serialize proof: {e}")))?;
                 Some(writer)
             } else {
                 None

--- a/zkp/src/proof_system/prove.rs
+++ b/zkp/src/proof_system/prove.rs
@@ -288,7 +288,7 @@ fn prove_pk_tree_node_mnt4<R: CryptoRng + Rng>(
 ) -> Result<([u8; 32], [u8; 32]), NanoZKPError> {
     assert_eq!(pks.len(), signer_bitmap.len());
 
-    let name = format!("pk_tree_{}", tree_level);
+    let name = format!("pk_tree_{tree_level}");
     let vk_file = format!("pk_tree_{}", tree_level + 1);
 
     let l_pks = &pks[..pks.len() / 2];
@@ -469,7 +469,7 @@ fn prove_pk_tree_node_mnt6<R: CryptoRng + Rng>(
 ) -> Result<[u8; 32], NanoZKPError> {
     assert_eq!(pks.len(), signer_bitmap.len());
 
-    let name = format!("pk_tree_{}", tree_level);
+    let name = format!("pk_tree_{tree_level}");
     let vk_file = format!("pk_tree_{}", tree_level + 1);
 
     let l_pks = &pks[..pks.len() / 2];

--- a/zkp/src/verifying_key.rs
+++ b/zkp/src/verifying_key.rs
@@ -69,7 +69,7 @@ impl ZKPVerifyingKey {
                     "/../.zkp_tests/meta_data.json"
                 )),
             ),
-            _ => panic!("Network id {:?} does not have a verifying key!", network_id),
+            _ => panic!("Network id {network_id:?} does not have a verifying key!"),
         };
         let metadata: VerifyingKeyMetadata = serde_json::from_str(metadata_bytes)
             .expect("Invalid metadata. Please rebuild the ZKP keys.");


### PR DESCRIPTION
Fix clippy warnings related to unaligned format arguments as documented [here](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
