### PR TITLE
Make the `nimiq-client` version available via RPC and as CLI argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,6 +4179,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-transaction",
  "nimiq-trie",
+ "nimiq-utils",
  "nimiq-vrf",
  "serde",
  "thiserror 2.0.18",
@@ -4755,6 +4756,7 @@ dependencies = [
  "nimiq-primitives",
  "nimiq-rpc-interface",
  "nimiq-transaction",
+ "nimiq-utils",
  "tokio",
  "tracing-subscriber 0.3.23",
  "url",
@@ -5105,6 +5107,7 @@ dependencies = [
 name = "nimiq-utils"
 version = "1.6.1"
 dependencies = [
+ "build-data",
  "clear_on_drop",
  "futures-util",
  "hex",
@@ -5361,6 +5364,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-test-utils",
  "nimiq-transaction",
+ "nimiq-utils",
  "nimiq-zkp-primitives",
  "rand 0.10.1",
  "rand_chacha 0.10.0",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -15,7 +15,7 @@ pub use nimiq::{
     },
 };
 use nimiq_time::interval;
-use nimiq_utils::spawn;
+use nimiq_utils::{spawn, CLIENT_VERSION};
 
 async fn main_inner() -> Result<(), Error> {
     // Keep for potential future reactivation
@@ -38,6 +38,12 @@ async fn main_inner() -> Result<(), Error> {
             Some(&config_file.log)
         },
     )?;
+
+    // Simply log the Cargo package version a.k.a version of the client and return early
+    if command_line.version {
+        log::info!("Client version {}", CLIENT_VERSION);
+        return Ok(());
+    }
 
     // Initialize panic hook.
     initialize_panic_reporting();

--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -32,4 +32,5 @@ nimiq-primitives = { workspace = true, features = ["serde-derive", "slots", "tre
 nimiq-serde = { workspace = true }
 nimiq-transaction = { workspace = true }
 nimiq-trie = { workspace = true }
+nimiq-utils = { workspace = true }
 nimiq-vrf = { workspace = true, features = ["serde-derive"] }

--- a/genesis-builder/src/main.rs
+++ b/genesis-builder/src/main.rs
@@ -12,13 +12,19 @@ fn usage(args: Vec<String>) -> ! {
 }
 
 fn main() {
+    let args = env::args().collect::<Vec<String>>();
+
+    if matches!(args.get(1).map(String::as_str), Some("--version" | "-V")) {
+        println!("nimiq-genesis-builder {}", nimiq_utils::CARGO_VERSION);
+        return;
+    }
+
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
     let db =
         MdbxDatabase::new_volatile(Default::default()).expect("Could not open a volatile database");
-    let args = env::args().collect::<Vec<String>>();
 
     if let Some(file) = args.get(1) {
         let GenesisInfo {

--- a/lib/src/config/command_line.rs
+++ b/lib/src/config/command_line.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 use crate::config::config_file::SyncMode;
 
 #[derive(Debug, Parser)]
+#[command(name = "nimiq-client", version = nimiq_utils::CARGO_VERSION)]
 pub struct CommandLine {
     /// Use a custom configuration file.
     ///

--- a/lib/src/config/command_line.rs
+++ b/lib/src/config/command_line.rs
@@ -67,6 +67,10 @@ pub struct CommandLine {
     /// Internally used flag to start a zero-knowledge prover process.
     #[clap(long, action)]
     pub prove: bool,
+
+    /// Output the version of the client and exit immediately afterwards.
+    #[clap(long, short = 'v')]
+    pub version: bool,
 }
 
 impl CommandLine {

--- a/lib/src/config/user_agent.rs
+++ b/lib/src/config/user_agent.rs
@@ -1,5 +1,7 @@
 use std::{env, fmt, str::FromStr};
 
+use nimiq_utils::CARGO_VERSION;
+
 /// A user agent string.
 ///
 /// Although you can use custom ones, it's recommended to use one provided by default:
@@ -42,10 +44,9 @@ impl From<UserAgent> for String {
 
 impl Default for UserAgent {
     fn default() -> Self {
-        let nimiq_version = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
         format!(
             "core-rs-albatross/{} (native; {} {})",
-            nimiq_version,
+            CARGO_VERSION,
             env::consts::OS,
             env::consts::ARCH
         )

--- a/lib/src/config/user_agent.rs
+++ b/lib/src/config/user_agent.rs
@@ -1,5 +1,7 @@
 use std::{env, fmt, str::FromStr};
 
+use nimiq_utils::CLIENT_VERSION;
+
 /// A user agent string.
 ///
 /// Although you can use custom ones, it's recommended to use one provided by default:
@@ -42,10 +44,9 @@ impl From<UserAgent> for String {
 
 impl Default for UserAgent {
     fn default() -> Self {
-        let nimiq_version = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
         format!(
             "core-rs-albatross/{} (native; {} {})",
-            nimiq_version,
+            CLIENT_VERSION,
             env::consts::OS,
             env::consts::ARCH
         )

--- a/pow-migration/src/main.rs
+++ b/pow-migration/src/main.rs
@@ -31,7 +31,7 @@ const ONLINE_CHECK_BLOCKS: u32 = 10;
 
 /// Command line arguments for the binary
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = nimiq_utils::CARGO_VERSION, about, long_about = None)]
 struct Args {
     /// Path to the PoS configuration file
     #[arg(short, long)]

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -46,3 +46,4 @@ nimiq-keys = { workspace = true }
 nimiq-primitives = { workspace = true }
 nimiq-rpc-interface = { workspace = true }
 nimiq-transaction = { workspace = true }
+nimiq-utils = { workspace = true }

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -8,6 +8,7 @@ pub mod subcommands;
 use crate::subcommands::*;
 
 #[derive(Debug, Parser)]
+#[command(name = "nimiq-rpc", version = nimiq_utils::CARGO_VERSION)]
 struct Opt {
     #[clap(short)]
     url: Option<String>,

--- a/rpc-client/src/subcommands/network_subcommands.rs
+++ b/rpc-client/src/subcommands/network_subcommands.rs
@@ -20,6 +20,9 @@ pub enum NetworkCommand {
 
     /// Returns a list of known peers (peer ID and its stored information).
     AddressBook {},
+
+    /// Returns the version of the client the RPC server is running.
+    Version {},
 }
 
 #[async_trait]
@@ -38,6 +41,9 @@ impl HandleSubcommand for NetworkCommand {
             }
             NetworkCommand::AddressBook {} => {
                 println!("{:#?}", client.network.get_address_book().await?);
+            }
+            NetworkCommand::Version {} => {
+                println!("{:#?}", client.network.get_client_version().await?);
             }
         }
         Ok(client)

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -18,4 +18,7 @@ pub trait NetworkInterface {
 
     /// Returns the address book
     async fn get_address_book(&self) -> RPCResult<Vec<(String, PeerType)>, (), Self::Error>;
+
+    /// Returns the version of the client the RPC server is running.
+    async fn get_client_version(&self) -> RPCResult<String, (), Self::Error>;
 }

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -15,4 +15,7 @@ pub trait NetworkInterface {
 
     /// Returns a list with the IDs of all our peers.
     async fn get_peer_list(&self) -> RPCResult<Vec<String>, (), Self::Error>;
+
+    /// Returns the version of the local client.
+    async fn get_client_version(&self) -> RPCResult<String, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -10,6 +10,7 @@ use nimiq_rpc_interface::{
     network::NetworkInterface,
     types::{PeerType, RPCResult},
 };
+use nimiq_utils::CARGO_VERSION;
 
 use crate::error::Error;
 
@@ -70,5 +71,9 @@ impl NetworkInterface for NetworkDispatcher {
         }
 
         Ok(rpc_address_book.into())
+    }
+
+    async fn get_client_version(&self) -> RPCResult<String, (), Self::Error> {
+        Ok(String::from(CARGO_VERSION).into())
     }
 }

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use nimiq_network_interface::network::Network as InterfaceNetwork;
 use nimiq_network_libp2p::Network;
 use nimiq_rpc_interface::{network::NetworkInterface, types::RPCResult};
+use nimiq_utils::CLIENT_VERSION;
 
 use crate::error::Error;
 
@@ -38,5 +39,9 @@ impl NetworkInterface for NetworkDispatcher {
             .map(|peer_id| peer_id.to_string())
             .collect::<Vec<_>>()
             .into())
+    }
+
+    async fn get_client_version(&self) -> RPCResult<String, (), Self::Error> {
+        Ok(String::from(CLIENT_VERSION).into())
     }
 }

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -36,6 +36,7 @@ use rand::{
 use serde::Deserialize;
 
 #[derive(Debug, Parser)]
+#[command(name = "nimiq-spammer", version = nimiq_utils::CARGO_VERSION)]
 pub struct SpammerCommandLine {
     /// Use a custom configuration file.
     ///

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -151,6 +151,7 @@ async fn main_inner() -> Result<(), Error> {
         sync_mode: None,
         network: None,
         prove: false,
+        version: false,
     };
 
     // Parse config file - this will obey the `--config` command line option.

--- a/test-utils/src/performance/accounts-tree/main.rs
+++ b/test-utils/src/performance/accounts-tree/main.rs
@@ -20,7 +20,7 @@ use tempfile::tempdir;
 
 /// Command line arguments for the binary
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(name = "nimiq-performance-accounts-tree", author, version = nimiq_utils::CARGO_VERSION, about, long_about = None)]
 struct Args {
     /// Number of batches to add
     #[arg(short, long)]

--- a/test-utils/src/performance/blockchain-push/main.rs
+++ b/test-utils/src/performance/blockchain-push/main.rs
@@ -22,7 +22,7 @@ use tracing_subscriber::{
 
 /// Command line arguments for the binary
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(name = "nimiq-performance-blockchain-push", author, version = nimiq_utils::CARGO_VERSION, about, long_about = None)]
 struct Args {
     /// Number of batches to add
     #[arg(short, long)]

--- a/test-utils/src/performance/history-store/main.rs
+++ b/test-utils/src/performance/history-store/main.rs
@@ -17,7 +17,7 @@ use tempfile::tempdir;
 
 /// Command line arguments for the binary
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(name = "nimiq-performance-history-store", author, version = nimiq_utils::CARGO_VERSION, about, long_about = None)]
 struct Args {
     /// Number of batches to add
     #[arg(short, long)]

--- a/tools/src/address/main.rs
+++ b/tools/src/address/main.rs
@@ -10,6 +10,7 @@ fn parse_private_key(s: &str) -> Result<PrivateKey, Box<dyn Error>> {
 
 fn main() {
     let matches = Command::new("nimiq-address")
+        .version(nimiq_utils::CARGO_VERSION)
         .about("Displays address etc. of a random or specified key")
         .arg(Arg::new("private").value_name("PRIVATE"))
         .get_matches();

--- a/tools/src/bls/main.rs
+++ b/tools/src/bls/main.rs
@@ -1,8 +1,16 @@
+use clap::Parser;
 use nimiq_bls::{PublicKey, SecretKey};
 use nimiq_serde::Serialize;
 use nimiq_utils::key_rng::SecureGenerate;
 
+/// Generates a random BLS keypair and its proof of knowledge.
+#[derive(Debug, Parser)]
+#[command(name = "nimiq-bls", version = nimiq_utils::CARGO_VERSION)]
+struct Args {}
+
 fn main() {
+    Args::parse();
+
     let secret_key = SecretKey::generate_default_csprng();
     let public_key = PublicKey::from_secret(&secret_key);
 

--- a/tools/src/rpc-schema/main.rs
+++ b/tools/src/rpc-schema/main.rs
@@ -4,15 +4,15 @@ mod parser;
 use std::{env, fs};
 
 use anyhow::Error;
-use clap::{crate_authors, crate_description, crate_version, Arg, Command};
+use clap::{crate_authors, crate_description, Arg, Command};
 use syn::parse_file;
 use thiserror::Error;
 
 use crate::openrpc::OpenRpcBuilder;
 
 fn main() -> Result<(), Error> {
-    let matches = Command::new("RPC schema generator")
-        .version(crate_version!())
+    let matches = Command::new("nimiq-rpc-schema")
+        .version(nimiq_utils::CARGO_VERSION)
         .author(crate_authors!())
         .about(crate_description!())
         .arg(

--- a/tools/src/signtx/main.rs
+++ b/tools/src/signtx/main.rs
@@ -1,9 +1,7 @@
 use std::{io::stdin, process::exit, str::FromStr};
 
 use anyhow::Error;
-use clap::{
-    crate_authors, crate_description, crate_version, value_parser, Arg, ArgAction, Command,
-};
+use clap::{crate_authors, crate_description, value_parser, Arg, ArgAction, Command};
 use nimiq_keys::{Address, KeyPair, PrivateKey};
 use nimiq_primitives::{coin::Coin, networks::NetworkId};
 use nimiq_serde::{Deserialize, Serialize};
@@ -11,8 +9,8 @@ use nimiq_transaction::Transaction;
 use thiserror::Error;
 
 fn run_app() -> Result<(), Error> {
-    let matches = Command::new("Sign transaction")
-        .version(crate_version!())
+    let matches = Command::new("nimiq-signtx")
+        .version(nimiq_utils::CARGO_VERSION)
         .author(crate_authors!())
         .about(crate_description!())
         .arg(

--- a/tools/src/trim-genesis-config/main.rs
+++ b/tools/src/trim-genesis-config/main.rs
@@ -14,6 +14,7 @@ fn db() -> MdbxDatabase {
 
 fn main() {
     let matches = Command::new("nimiq-trim-genesis-config")
+        .version(nimiq_utils::CARGO_VERSION)
         .about("Trims genesis config to not contain the state")
         .arg(
             Arg::new("genesis-config")

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -45,6 +45,9 @@ tokio = { version = "1.52.3", optional = true }
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-futures = { version = "0.4", optional = true }
 
+[build-dependencies]
+build-data = "0.3"
+
 [dev-dependencies]
 nimiq-keys = { workspace = true }
 nimiq-serde = { workspace = true }

--- a/utils/build.rs
+++ b/utils/build.rs
@@ -1,0 +1,22 @@
+fn main() {
+    let version = env!("CARGO_PKG_VERSION");
+
+    // When building from a work tree with uncommitted changes, append a
+    // `+dirty` SemVer build-metadata identifier (e.g. `1.6.0+dirty`). Build
+    // metadata is ignored for version precedence, so the dirty build still
+    // compares equal to the released version it is based on.
+    //
+    // `build_data::get_git_dirty()` returns `Err` when Git is unavailable or we
+    // are not inside a work tree (e.g. building from a published crate or a
+    // source tarball), in which case no dirty marker is appended.
+    let version = match build_data::get_git_dirty() {
+        Ok(true) => format!("{version}+dirty"),
+        Ok(false) | Err(_) => version.to_string(),
+    };
+    println!("cargo::rustc-env=NIMIQ_VERSION={version}");
+
+    // Re-run the build script when the checked-out commit or branch changes so
+    // the marker stays in sync. Best-effort: ignore the error when not inside a
+    // Git work tree.
+    let _ = build_data::rerun_if_git_commit_or_branch_changed();
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -32,3 +32,8 @@ pub use self::credentials::Credentials;
 #[cfg(feature = "spawn")]
 pub use self::spawn::{spawn, spawn_local};
 pub use self::{sensitive::Sensitive, waker::WakerExt};
+
+/// The version of the Cargo workspace package, with a `+dirty` build-metadata
+/// suffix appended when built from a Git work tree that has uncommitted changes
+/// (see `build.rs`).
+pub const CARGO_VERSION: &str = env!("NIMIQ_VERSION");

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -28,3 +28,6 @@ mod waker;
 #[cfg(feature = "spawn")]
 pub use self::spawn::{spawn, spawn_local};
 pub use self::{sensitive::Sensitive, waker::WakerExt};
+
+/// The version of the client based on the Cargo workspace package
+pub const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -57,6 +57,7 @@ nimiq-primitives = { workspace = true, features = ["policy", "tendermint"] }
 nimiq-serde = { workspace = true }
 nimiq-zkp-primitives = { workspace = true }
 nimiq-keys = { workspace = true }
+nimiq-utils = { workspace = true }
 
 [dev-dependencies]
 nimiq-collections = { workspace = true }

--- a/zkp-circuits/zkp-constraints/main.rs
+++ b/zkp-circuits/zkp-constraints/main.rs
@@ -4,6 +4,7 @@ use ark_ff::{FftField, Field};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, OptimizationGoal};
 use ark_std::rand::Rng as _;
+use clap::Parser;
 use log::{info, level_filters::LevelFilter};
 use nimiq_log::TargetsExt;
 use nimiq_zkp_circuits::circuits::{mnt4, mnt6};
@@ -27,7 +28,14 @@ fn evaluate_circuit<F: Field + FftField, C: ConstraintSynthesizer<F> + Clone>(
     );
 }
 
+/// Estimates the number of constraints for each ZKP circuit.
+#[derive(Debug, Parser)]
+#[command(name = "nimiq-zkp-constraints", version = nimiq_utils::CARGO_VERSION)]
+struct Args {}
+
 fn main() {
+    Args::parse();
+
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_writer(io::stderr))
         .with(

--- a/zkp-circuits/zkp-keys-setup/main.rs
+++ b/zkp-circuits/zkp-keys-setup/main.rs
@@ -19,6 +19,7 @@ use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::Subscriber
 
 /// Create the zkp keys for Devnet or Unit test.
 #[derive(Debug, Parser)]
+#[command(name = "nimiq-zkp-keys-setup", version = nimiq_utils::CARGO_VERSION)]
 struct Setup {
     /// Network ID to generate ZKP keys for.
     /// Only supports Albatross network ids.

--- a/zkp-component/zkp-prove/src/main.rs
+++ b/zkp-component/zkp-prove/src/main.rs
@@ -30,6 +30,7 @@ use tracing_subscriber::{filter::Targets, prelude::*};
 
 /// Run the zk proof generation.
 #[derive(Debug, Parser)]
+#[command(version = nimiq_utils::CARGO_VERSION)]
 struct TestProving {
     /// Network ID to utilize.
     /// Only Albatross network ids are supported.


### PR DESCRIPTION
#### This fixes #3390.

Retrieving the version now becomes available as:
- `nimiq-client --version`
- `getClientVersion` RPC method

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
