### PR TITLE
Fixes #3415

### DIFF
--- a/rpc-interface/src/blockchain.rs
+++ b/rpc-interface/src/blockchain.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
+use nimiq_primitives::networks::NetworkId;
 
 use crate::types::{
     Account, Block, BlockLog, BlockchainState, ExecutedTransaction, Inherent, LogType,
@@ -12,6 +13,9 @@ use crate::types::{
 #[async_trait]
 pub trait BlockchainInterface {
     type Error;
+
+    /// Returns the network ID.
+    async fn get_network_id(&self) -> RPCResult<NetworkId, (), Self::Error>;
 
     /// Returns the block number for the current head.
     async fn get_block_number(&self) -> RPCResult<u32, (), Self::Error>;

--- a/rpc-server/src/dispatchers/blockchain.rs
+++ b/rpc-server/src/dispatchers/blockchain.rs
@@ -6,7 +6,7 @@ use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent};
 use nimiq_blockchain_proxy::{BlockchainProxy, BlockchainReadProxy};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_primitives::{key_nibbles::KeyNibbles, policy::Policy};
+use nimiq_primitives::{key_nibbles::KeyNibbles, networks::NetworkId, policy::Policy};
 use nimiq_rpc_interface::{
     blockchain::BlockchainInterface,
     types::{
@@ -80,6 +80,9 @@ impl BlockchainInterface for BlockchainDispatcher {
         Ok(self.blockchain.read().block_number().into())
     }
 
+    async fn get_network_id(&self) -> RPCResult<NetworkId, (), Self::Error> {
+        Ok(self.blockchain.read().network_id().into())
+    }
     async fn get_batch_number(&self) -> RPCResult<u32, (), Self::Error> {
         Ok(Policy::batch_at(self.blockchain.read().block_number()).into())
     }


### PR DESCRIPTION
Directly exposes the network-id via RPC
Note: In the current albatross code the network-id is stored as one of the blockchain properties. This commit does not change that.

...
#### This fixes #3415 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
