### PR TITLE
tools/rpc-schema: Fix clippy warning

### DIFF
--- a/tools/src/rpc-schema/parser.rs
+++ b/tools/src/rpc-schema/parser.rs
@@ -361,7 +361,7 @@ impl ParsedTraitItemFn {
                     let final_inner_type = if inner_json_type == "array" {
                         "string"
                     } else {
-                        &inner_json_type
+                        inner_json_type
                     };
                     json_schema!({
                         "type": "array",


### PR DESCRIPTION
Fix clippy warning in the rpc-schema tool related to a needless borrow introduced in #3426.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
