### PR TITLE
Fix compilation and clippy warnings

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.85.0 # Also test our Rust MSRV here.
+    - uses: dtolnay/rust-toolchain@1.88.0 # Also test our Rust MSRV here.
     - uses: Swatinem/rust-cache@v2
     - run: cargo check --all-features --tests --benches
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -481,7 +481,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -583,11 +583,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core 0.5.5",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -603,15 +603,14 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -640,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
@@ -651,7 +650,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -660,12 +658,12 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum 0.8.4",
- "axum-core 0.5.2",
+ "axum 0.8.6",
+ "axum-core 0.5.5",
  "bytes",
  "futures-util",
  "headers",
@@ -675,17 +673,17 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "serde",
- "tower 0.5.2",
+ "serde_core",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -693,7 +691,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -707,6 +705,16 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
 
 [[package]]
 name = "base64"
@@ -843,9 +851,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -870,9 +878,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -895,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -1003,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1013,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1025,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1037,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clear_on_drop"
@@ -1131,6 +1139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
@@ -1453,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1492,12 +1506,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1614,7 +1628,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1796,7 +1810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1844,9 +1858,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "findshlibs"
@@ -1868,9 +1882,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2050,24 +2064,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -2100,15 +2100,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2190,12 +2190,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2532,7 +2533,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2552,7 +2553,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2721,7 +2722,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows 0.53.0",
+ "windows",
 ]
 
 [[package]]
@@ -2805,17 +2806,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -3019,9 +3009,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -3502,7 +3492,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.6",
+ "yamux 0.13.7",
 ]
 
 [[package]]
@@ -3563,19 +3553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber 0.3.20",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3566,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "match-lookup"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1265724d8cb29dbbc2b0f06fffb8bf1a8c0cf73a78eede9ba73a4a66c52a981e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "matchers"
@@ -3624,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
@@ -3666,6 +3654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3681,20 +3670,19 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
- "loom",
+ "equivalent",
  "parking_lot",
  "portable-atomic",
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -3719,11 +3707,12 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
 dependencies = [
  "base-x",
+ "base256emoji",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -4240,7 +4229,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "url",
 ]
 
@@ -4279,7 +4268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c715d29b502b39b7f1b982f2283d9232549f810f60712098f77d681dc7642257"
 dependencies = [
  "async-trait",
- "axum 0.8.4",
+ "axum 0.8.6",
  "axum-extra",
  "blake2",
  "futures",
@@ -5230,7 +5219,7 @@ version = "1.1.1"
 dependencies = [
  "ark-serialize",
  "futures-util",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "hex",
  "idb",
  "js-sys",
@@ -5502,11 +5491,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5623,9 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -5669,9 +5658,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -5701,9 +5690,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
@@ -5769,12 +5758,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5898,7 +5887,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6131,7 +6120,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6145,7 +6134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -6168,7 +6157,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6259,7 +6248,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -6308,9 +6297,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -6328,18 +6317,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6348,9 +6337,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6360,9 +6349,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6371,15 +6360,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6524,7 +6513,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6544,14 +6533,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.0",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -6588,7 +6577,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.0",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -6602,9 +6591,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6696,7 +6685,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6735,12 +6724,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6789,9 +6772,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
@@ -7058,6 +7041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7104,12 +7093,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7148,9 +7137,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -7281,10 +7270,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7405,29 +7394,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "tokio-macros",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7458,9 +7444,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -7489,7 +7475,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -7767,9 +7765,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsify"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -7779,9 +7777,9 @@ dependencies = [
 
 [[package]]
 name = "tsify-macros"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a324606929ad11628a19206d7853807481dcaecd6c08be70a235930b8241955"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7808,10 +7806,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
+name = "tungstenite"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uint"
@@ -7916,7 +7931,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -7969,15 +7984,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"
@@ -8132,14 +8138,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.2",
+ "webpki-root-certs 1.0.3",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+checksum = "05d651ec480de84b762e7be71e6efa7461699c19d9e2c272c8d93455f567786e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8150,23 +8156,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.3",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "widestring"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -8190,7 +8196,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8210,28 +8216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8243,46 +8227,22 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.2.1",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8291,9 +8251,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8311,16 +8271,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-registry"
@@ -8353,9 +8303,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8371,9 +8321,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8420,14 +8370,14 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8480,28 +8430,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8524,9 +8465,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8548,9 +8489,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8572,9 +8513,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -8584,9 +8525,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8608,9 +8549,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8632,9 +8573,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8656,9 +8597,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8680,9 +8621,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -8788,9 +8729,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2dd50a6d6115feb3e5d7d0efd45e8ca364b6c83722c1e9c602f5764e0e9597"
+checksum = "6927cfe0edfae4b26a369df6bad49cd0ef088c0ec48f4045b2084bcaedc10246"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
@@ -66,15 +66,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-vec"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
 ]
@@ -100,12 +100,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -133,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -148,36 +142,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -461,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -473,32 +468,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.41",
+ "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -555,20 +538,21 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "http 0.2.12",
+ "base64 0.22.1",
+ "http",
  "log",
  "url",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -580,7 +564,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "itoa",
@@ -599,16 +583,16 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core 0.5.2",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -643,7 +627,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -656,13 +640,13 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.3.1",
+ "futures-core",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -676,20 +660,21 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
- "axum 0.8.1",
- "axum-core 0.5.0",
+ "axum 0.8.4",
+ "axum-core 0.5.2",
  "bytes",
  "futures-util",
  "headers",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "tower 0.5.2",
  "tower-layer",
@@ -698,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -737,9 +722,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bencher"
@@ -749,14 +734,14 @@ checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
 
 [[package]]
 name = "bindgen"
-version = "0.72.0"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -813,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -852,15 +837,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -885,10 +870,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -909,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -956,15 +942,14 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1052,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clear_on_drop"
@@ -1076,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1106,8 +1091,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
 dependencies = [
  "futures-core",
- "prost 0.13.3",
- "prost-types 0.13.3",
+ "prost",
+ "prost-types",
  "tonic",
  "tracing-core",
 ]
@@ -1126,8 +1111,8 @@ dependencies = [
  "humantime",
  "hyper-util",
  "parking_lot",
- "prost 0.13.3",
- "prost-types 0.13.3",
+ "prost",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
@@ -1184,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1218,18 +1203,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1287,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1306,15 +1291,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1453,9 +1438,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1463,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
@@ -1482,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1629,7 +1614,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1651,15 +1636,15 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1689,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1709,7 +1694,7 @@ checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
  "pkcs8",
  "rand_core 0.6.4",
  "serde",
@@ -1720,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -1780,18 +1765,18 @@ dependencies = [
 
 [[package]]
 name = "equator"
-version = "0.2.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
 dependencies = [
  "equator-macro",
 ]
 
 [[package]]
 name = "equator-macro"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1800,25 +1785,25 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1827,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1837,15 +1822,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1856,6 +1841,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "findshlibs"
@@ -1877,9 +1868,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1893,9 +1884,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1988,9 +1979,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2060,15 +2051,16 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -2095,14 +2087,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2116,7 +2108,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2138,9 +2130,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -2179,16 +2171,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.11.4",
  "slab",
  "tokio",
@@ -2198,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -2232,14 +2224,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hashlink"
@@ -2256,7 +2254,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2274,14 +2272,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.3.1",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2293,7 +2291,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -2304,15 +2302,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2342,9 +2334,9 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.0",
+ "rand 0.9.2",
  "ring",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tinyvec",
  "tokio",
@@ -2365,7 +2357,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.17",
@@ -2393,33 +2385,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2440,7 +2410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -2451,16 +2421,16 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -2485,7 +2455,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -2503,7 +2473,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http",
  "hyper",
  "hyper-util",
  "log",
@@ -2550,33 +2520,39 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -2590,21 +2566,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2614,30 +2591,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2645,65 +2602,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -2739,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2782,20 +2726,20 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06464e726471718db9ad3fefc020529fabcde03313a0fc3967510e2db5add12"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
  "futures",
- "http 1.3.1",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.0",
+ "rand 0.9.2",
  "tokio",
  "url",
  "xmltree",
@@ -2819,7 +2763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -2844,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -2865,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -2886,7 +2830,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -2894,19 +2838,29 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2926,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2944,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -2982,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.7"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
+checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -3000,7 +2954,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
@@ -3042,7 +2996,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
 dependencies = [
- "http 1.3.1",
+ "http",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3065,18 +3019,18 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3105,7 +3059,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libp2p-allow-block-list",
  "libp2p-autonat",
  "libp2p-connection-limits",
@@ -3222,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.0"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba535a5d960cc39c3621cee2941ff570a9476679a4c7ca80982412b14f4a88fd"
+checksum = "c7f58e37d8d6848e5c4c9e3c35c6f61133235bff2960c9c00a663b0849301221"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -3235,7 +3189,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "hashlink 0.9.1",
  "hex_fmt",
  "libp2p-core",
@@ -3312,7 +3266,7 @@ dependencies = [
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -3390,7 +3344,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustls",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3423,7 +3377,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
@@ -3459,7 +3413,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -3548,14 +3502,14 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.4",
+ "yamux 0.13.6",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
@@ -3563,21 +3517,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -3590,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "log-panics"
@@ -3606,12 +3554,12 @@ dependencies = [
 
 [[package]]
 name = "loki-api"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674883a98273598ac3aad4301724c56734bea90574c5033af067e8f9fb5eb399"
+checksum = "bdc38a304f59a03e6efa3876766a48c70a766a93f88341c3fff4212834b8e327"
 dependencies = [
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -3633,14 +3581,14 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3676,15 +3624,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
 ]
@@ -3713,22 +3661,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3782,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
@@ -3807,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -3861,24 +3809,23 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.69",
- "tokio",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
  "futures",
@@ -3910,7 +3857,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-vrf",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "tempfile",
  "thiserror 2.0.17",
@@ -3979,7 +3926,7 @@ dependencies = [
  "nimiq-zkp-primitives",
  "parking_lot",
  "prometheus-client 0.24.0",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "serde",
  "tempfile",
@@ -4046,7 +3993,7 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-utils",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_core_compat",
  "serde",
  "thiserror 2.0.17",
@@ -4115,7 +4062,7 @@ dependencies = [
  "nimiq-zkp-component",
  "parking_lot",
  "pin-project",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -4131,7 +4078,7 @@ dependencies = [
  "libmdbx",
  "nimiq-database-value",
  "pprof",
- "rand 0.9.0",
+ "rand 0.9.2",
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
@@ -4241,7 +4188,7 @@ dependencies = [
  "nimiq-time",
  "nimiq-utils",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -4285,7 +4232,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "futures",
- "http 1.3.1",
+ "http",
  "log",
  "nimiq-jsonrpc-core",
  "reqwest",
@@ -4332,7 +4279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c715d29b502b39b7f1b982f2283d9232549f810f60712098f77d681dc7642257"
 dependencies = [
  "async-trait",
- "axum 0.8.1",
+ "axum 0.8.4",
  "axum-extra",
  "blake2",
  "futures",
@@ -4378,7 +4325,7 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-utils",
  "p256",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_core_compat",
  "serde",
  "sha2",
@@ -4396,7 +4343,7 @@ dependencies = [
  "directories",
  "futures-util",
  "hex",
- "http 1.3.1",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -4437,7 +4384,7 @@ dependencies = [
  "nimiq-zkp-component",
  "nimiq-zkp-primitives",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rustls",
  "rustls-pemfile",
@@ -4474,7 +4421,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-zkp",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -4604,7 +4551,7 @@ dependencies = [
  "nimiq-macros",
  "nimiq-test-log",
  "nimiq-utils",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "unicode-normalization",
 ]
@@ -4652,7 +4599,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "prometheus-client 0.24.0",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "sha2",
  "thiserror 2.0.17",
@@ -4698,7 +4645,7 @@ dependencies = [
  "hex",
  "nimiq-hash",
  "nimiq-primitives",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core_compat",
 ]
@@ -4729,7 +4676,7 @@ dependencies = [
  "nimiq-web-client",
  "nimiq_rpc",
  "percentage",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4912,7 +4859,7 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-transaction-builder",
  "nimiq-utils",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "tokio",
  "tokio-metrics",
@@ -4946,7 +4893,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-time",
  "nimiq-utils",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "tokio",
  "tokio-stream",
@@ -5023,7 +4970,7 @@ dependencies = [
  "nimiq-zkp-primitives",
  "parking_lot",
  "paste",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core_compat",
  "serde",
@@ -5154,7 +5101,7 @@ dependencies = [
  "nimiq-test-utils",
  "parking_lot",
  "pin-project",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_core 0.9.3",
  "serde",
  "thiserror 2.0.17",
@@ -5206,7 +5153,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-zkp-component",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rayon",
  "serde",
  "tokio",
@@ -5250,7 +5197,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "sha2",
  "tracing",
@@ -5308,7 +5255,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-zkp-component",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -5351,7 +5298,7 @@ dependencies = [
  "nimiq-zkp-primitives",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core_compat",
  "serde",
@@ -5393,7 +5340,7 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-transaction",
  "nimiq-zkp-primitives",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core_compat",
  "rayon",
@@ -5666,19 +5613,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -5703,10 +5650,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.4"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -5716,9 +5669,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -5742,15 +5695,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -5805,7 +5758,7 @@ dependencies = [
  "petgraph",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5816,9 +5769,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -5902,9 +5855,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -5936,17 +5889,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.41",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5974,9 +5926,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "postcard-bytes"
@@ -5988,6 +5940,15 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -6021,11 +5982,11 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6095,45 +6056,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
-dependencies = [
- "bytes",
- "prost-derive 0.13.3",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -6141,27 +6079,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
-
-[[package]]
-name = "prost-types"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
-dependencies = [
- "prost 0.13.3",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -6196,32 +6119,35 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6235,16 +6161,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.9",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6258,9 +6184,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -6281,13 +6207,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -6325,7 +6250,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -6383,20 +6308,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.17",
 ]
@@ -6446,62 +6371,55 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
-]
+checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 
 [[package]]
 name = "rfc6979"
@@ -6515,9 +6433,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
  "bytemuck",
 ]
@@ -6530,7 +6448,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -6568,15 +6486,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -6598,28 +6516,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
-dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys 0.9.2",
- "windows-sys 0.59.0",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6646,7 +6551,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.5.0",
 ]
 
 [[package]]
@@ -6670,11 +6575,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -6683,9 +6588,9 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.0.1",
+ "security-framework 3.5.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -6708,9 +6613,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rw-stream-sink"
@@ -6725,24 +6630,24 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe-proc-macro2"
-version = "1.0.67"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd85be67db87168aa3c13fd0da99f48f2ab005dccad5af5626138dc1df20eb6"
+checksum = "492d1a72624b0bd5b7f0193ea5834a1905534a517573a117e949e895f342906c"
 dependencies = [
- "unicode-ident",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "safe-quote"
-version = "1.0.15"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
+checksum = "bcaa9a650f2f98ba4da0190623210c85945cb78b262709f606c57655eda173e1"
 dependencies = [
  "safe-proc-macro2",
 ]
@@ -6787,11 +6692,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6884,12 +6789,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6897,9 +6802,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6907,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "send_wrapper"
@@ -7004,12 +6909,13 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7134,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -7153,18 +7059,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snap"
@@ -7191,9 +7094,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -7275,9 +7178,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.12.3"
+version = "12.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ba5365997a4e375660bed52f5b42766475d5bc8ceb1bb13fea09c469ea0f49"
+checksum = "d03f433c9befeea460a01d750e698aa86caf86dcfbd77d552885cd6c89d52f50"
 dependencies = [
  "debugid",
  "memmap2",
@@ -7287,9 +7190,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.12.3"
+version = "12.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beff338b2788519120f38c59ff4bb15174f52a183e547bac3d6072c2c0aa48aa"
+checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -7329,9 +7232,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7380,8 +7283,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.1",
- "windows-sys 0.59.0",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -7426,12 +7329,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -7468,9 +7370,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7488,9 +7390,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7556,12 +7458,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -7579,9 +7480,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -7655,7 +7556,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -7663,8 +7564,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.3",
- "socket2 0.5.9",
+ "prost",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -7711,16 +7612,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.4",
  "bytes",
- "http 1.3.1",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
  "mime",
  "pin-project-lite",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -7751,9 +7656,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7804,9 +7709,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -7886,18 +7791,17 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http",
  "httparse",
  "log",
  "native-tls",
- "rand 0.8.5",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
@@ -7905,9 +7809,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uint"
@@ -7923,9 +7827,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -7995,12 +7899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8014,18 +7912,20 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -8066,17 +7966,26 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -8219,9 +8128,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.2",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8232,23 +8150,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"
@@ -8268,11 +8186,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8293,21 +8211,24 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-collections"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8322,22 +8243,46 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8346,9 +8291,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8357,19 +8302,35 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
+name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -8383,21 +8344,38 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8434,6 +8412,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8475,11 +8471,37 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8501,6 +8523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8517,6 +8545,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8537,10 +8571,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8561,6 +8607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8577,6 +8629,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8597,6 +8655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8615,6 +8679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8631,25 +8701,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.4",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -8697,9 +8758,9 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.24"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xmltree"
@@ -8727,16 +8788,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.4"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+checksum = "2b2dd50a6d6115feb3e5d7d0efd45e8ca364b6c83722c1e9c602f5764e0e9597"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.2",
  "static_assertions",
  "web-time",
 ]
@@ -8752,9 +8813,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8764,9 +8825,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8776,39 +8837,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
-dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8817,18 +8857,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8857,10 +8897,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8869,9 +8920,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/blockchain-proxy/src/blockchain_proxy.rs
+++ b/blockchain-proxy/src/blockchain_proxy.rs
@@ -73,7 +73,7 @@ impl<'a> From<&'a Arc<RwLock<LightBlockchain>>> for BlockchainProxy {
 impl BlockchainProxy {
     /// Returns a wrapper/proxy around a read locked blockchain.
     /// The `BlockchainReadProxy` implements `AbstractBlockchain` and allows to access common blockchain functions.
-    pub fn read(&self) -> BlockchainReadProxy {
+    pub fn read(&self) -> BlockchainReadProxy<'_> {
         match self {
             #[cfg(feature = "full")]
             BlockchainProxy::Full(blockchain) => BlockchainReadProxy::Full(blockchain.read()),

--- a/blockchain/src/blockchain/blockchain.rs
+++ b/blockchain/src/blockchain/blockchain.rs
@@ -239,15 +239,15 @@ impl Blockchain {
         let accounts = Accounts::new(env.clone());
 
         // Verify accounts hash if the tree is complete or changes only happened in the complete part.
-        if let Some(accounts_hash) = accounts.get_root_hash(None) {
-            if main_chain.head.state_root() != &accounts_hash {
-                log::error!(
-                    "Main chain's head state root: {:?}, Account state root: {:?}",
-                    main_chain.head.state_root(),
-                    &accounts_hash
-                );
-                return Err(BlockchainError::InconsistentState);
-            }
+        if let Some(accounts_hash) = accounts.get_root_hash(None)
+            && main_chain.head.state_root() != &accounts_hash
+        {
+            log::error!(
+                "Main chain's head state root: {:?}, Account state root: {:?}",
+                main_chain.head.state_root(),
+                &accounts_hash
+            );
+            return Err(BlockchainError::InconsistentState);
         }
 
         // Load macro chain from store.
@@ -421,11 +421,11 @@ impl Blockchain {
         self.genesis_block_number
     }
 
-    pub fn read_transaction(&self) -> MdbxReadTransaction {
+    pub fn read_transaction(&self) -> MdbxReadTransaction<'_> {
         self.db.read_transaction()
     }
 
-    pub fn write_transaction(&self) -> MdbxWriteTransaction {
+    pub fn write_transaction(&self) -> MdbxWriteTransaction<'_> {
         self.db.write_transaction()
     }
 }

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -126,17 +126,17 @@ impl Blockchain {
         let accounts = &self.state.accounts;
 
         // Verify accounts hash if the tree is complete or changes only happened in the complete part.
-        if let Some(accounts_hash) = accounts.get_root_hash(Some(txn)) {
-            if *block.state_root() != accounts_hash {
-                warn!(
-                    %block,
-                    header_root = %block.state_root(),
-                    accounts_root = %accounts_hash,
-                    reason = "Header accounts hash doesn't match real accounts hash",
-                    "Rejecting block"
-                );
-                return Err(PushError::InvalidBlock(BlockError::AccountsHashMismatch));
-            }
+        if let Some(accounts_hash) = accounts.get_root_hash(Some(txn))
+            && *block.state_root() != accounts_hash
+        {
+            warn!(
+                %block,
+                header_root = %block.state_root(),
+                accounts_root = %accounts_hash,
+                reason = "Header accounts hash doesn't match real accounts hash",
+                "Rejecting block"
+            );
+            return Err(PushError::InvalidBlock(BlockError::AccountsHashMismatch));
         }
 
         // Verify the initial punished set for the next batch.

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -144,7 +144,7 @@ impl Blockchain {
     }
 
     /// Returns the contract data store for the staking contract.
-    pub fn get_staking_contract_store(&self) -> DataStore {
+    pub fn get_staking_contract_store(&self) -> DataStore<'_> {
         self.state
             .accounts
             .data_store(&Policy::STAKING_CONTRACT_ADDRESS)

--- a/blockchain/src/history/utils.rs
+++ b/blockchain/src/history/utils.rs
@@ -27,7 +27,7 @@ impl EpochBasedIndex {
 }
 
 impl AsDatabaseBytes for EpochBasedIndex {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         let bytes = [
             &self.epoch_number.to_be_bytes()[..],
             &self.index.to_be_bytes()[..],

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -145,7 +145,7 @@ impl<N: Network> ConsensusProxy<N> {
     /// Subscribe to remote address notification events
     pub async fn subscribe_address_notifications(
         &self,
-    ) -> BoxStream<(AddressNotification, N::PubsubId)> {
+    ) -> BoxStream<'_, (AddressNotification, N::PubsubId)> {
         let txn_stream = self
             .network
             .subscribe_subtopic::<AddressSubscriptionTopic>(
@@ -175,7 +175,7 @@ impl<N: Network> ConsensusProxy<N> {
     ) -> Result<Vec<(Blake2bHash, u32)>, RequestError> {
         let mut obtained_receipts = HashSet::new();
 
-        // If we need to include pre-genesis data, we set the appropiate services flag
+        // If we need to include pre-genesis data, we set the appropriate services flag
         let services = if include_pre_genesis {
             Services::PRE_GENESIS_TRANSACTIONS | Services::TRANSACTION_INDEX
         } else {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -608,20 +608,20 @@ impl<N: Network> Future for Consensus<N> {
         }
 
         // Poll any head requests if active.
-        if let Some(ref mut head_requests) = self.head_requests {
-            if let Poll::Ready(mut result) = head_requests.poll_unpin(cx) {
-                // Reset head requests.
-                self.head_requests = None;
+        if let Some(ref mut head_requests) = self.head_requests
+            && let Poll::Ready(mut result) = head_requests.poll_unpin(cx)
+        {
+            // Reset head requests.
+            self.head_requests = None;
 
-                // Push unknown blocks to the block queue, trying to sync.
-                for (block, peer_id) in result.unknown_blocks.drain(..) {
-                    self.sync.push_block(block, BlockSource::requested(peer_id));
-                }
+            // Push unknown blocks to the block queue, trying to sync.
+            for (block, peer_id) in result.unknown_blocks.drain(..) {
+                self.sync.push_block(block, BlockSource::requested(peer_id));
+            }
 
-                // Update established state using the result.
-                if let Some(event) = self.check_established(Some(result)) {
-                    self.events.send(event).ok();
-                }
+            // Update established state using the result.
+            if let Some(event) = self.check_established(Some(result)) {
+                self.events.send(event).ok();
             }
         }
 

--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -54,12 +54,12 @@ impl<N: Network> Handle<N, BlockchainProxy> for RequestMacroChain {
         let mut start_block_hash = None;
         for locator in self.locators.iter() {
             let chain_info = blockchain.get_chain_info(locator, false);
-            if let Ok(chain_info) = chain_info {
-                if chain_info.on_main_chain {
-                    // We found a block, ignore remaining block locator hashes.
-                    start_block_hash = Some(locator.clone());
-                    break;
-                }
+            if let Ok(chain_info) = chain_info
+                && chain_info.on_main_chain
+            {
+                // We found a block, ignore remaining block locator hashes.
+                start_block_hash = Some(locator.clone());
+                break;
             }
         }
         let Some(start_block_hash) = start_block_hash else {
@@ -318,12 +318,12 @@ impl RequestMissingBlocks {
         let mut start_hash = None;
         let mut start_block_number = None;
         for locator in self.locators.iter() {
-            if let Ok(chain_info) = blockchain.get_chain_info(locator, false) {
-                if chain_info.on_main_chain {
-                    start_hash = Some(locator.clone());
-                    start_block_number = Some(chain_info.head.block_number());
-                    break;
-                }
+            if let Ok(chain_info) = blockchain.get_chain_info(locator, false)
+                && chain_info.on_main_chain
+            {
+                start_hash = Some(locator.clone());
+                start_block_number = Some(chain_info.head.block_number());
+                break;
             }
         }
 

--- a/consensus/src/sync/history/sync_clustering.rs
+++ b/consensus/src/sync/history/sync_clustering.rs
@@ -201,10 +201,10 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
         }
 
         // Discard checkpoint block if it is old.
-        if let Some(checkpoint) = &epoch_ids.checkpoint {
-            if checkpoint.block_number <= our_block_number {
-                epoch_ids.checkpoint = None;
-            }
+        if let Some(checkpoint) = &epoch_ids.checkpoint
+            && checkpoint.block_number <= our_block_number
+        {
+            epoch_ids.checkpoint = None;
         }
 
         // TODO Sanity check: All of the remaining ids should be unknown
@@ -232,12 +232,12 @@ impl<TNetwork: Network> HistoryMacroSync<TNetwork> {
                     None => break 'outer,
                 };
 
-                if let Job::PushBatchSet(cid, batch_set_id, _) = job {
-                    if id == batch_set_id {
-                        num_ids_to_remove += 1;
-                        cluster_id = *cid;
-                        break;
-                    }
+                if let Job::PushBatchSet(cid, batch_set_id, _) = job
+                    && id == batch_set_id
+                {
+                    num_ids_to_remove += 1;
+                    cluster_id = *cid;
+                    break;
                 }
             }
         }

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -235,10 +235,10 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         }
 
         // Discard checkpoint block if it is old.
-        if let Some(checkpoint) = &epoch_ids.checkpoint {
-            if checkpoint.block_number <= our_block_number {
-                epoch_ids.checkpoint = None;
-            }
+        if let Some(checkpoint) = &epoch_ids.checkpoint
+            && checkpoint.block_number <= our_block_number
+        {
+            epoch_ids.checkpoint = None;
         }
 
         // After discarding all epoch_ids & checkpoint prior to our current state

--- a/consensus/src/sync/live/block_queue/block_request_component.rs
+++ b/consensus/src/sync/live/block_queue/block_request_component.rs
@@ -257,15 +257,15 @@ impl<N: Network> BlockRequestComponent<N> {
 
                     // If it is a macro block, also check the signatures.
                     let last_block = response.blocks.last().unwrap(); // cannot be empty
-                    if last_block.is_macro() {
-                        if let Err(e) = last_block.verify_validators(&request.epoch_validators) {
-                            log::error!(
-                                last_block = last_block.block_number(),
-                                error = %e,
-                                "Received invalid chain of missing blocks (macro block does not verify)"
-                            );
-                            return false;
-                        }
+                    if last_block.is_macro()
+                        && let Err(e) = last_block.verify_validators(&request.epoch_validators)
+                    {
+                        log::error!(
+                            last_block = last_block.block_number(),
+                            error = %e,
+                            "Received invalid chain of missing blocks (macro block does not verify)"
+                        );
+                        return false;
                     }
 
                     true

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -674,14 +674,13 @@ impl<N: Network> BlockQueue<N> {
         for new_block in new_blocks {
             if let BTreeMapEntry::Occupied(mut requested_hashes) =
                 self.pending_requests.entry(new_block.block_number())
+                && let Some(sender) = requested_hashes.get_mut().remove(&new_block.hash())
             {
-                if let Some(sender) = requested_hashes.get_mut().remove(&new_block.hash()) {
-                    if let Err(error) = sender.send(Ok(new_block.clone())) {
-                        log::warn!(?error, "Failed to send block for a missing block request");
-                    }
-                    if requested_hashes.get().is_empty() {
-                        requested_hashes.remove();
-                    }
+                if let Err(error) = sender.send(Ok(new_block.clone())) {
+                    log::warn!(?error, "Failed to send block for a missing block request");
+                }
+                if requested_hashes.get().is_empty() {
+                    requested_hashes.remove();
                 }
             }
         }

--- a/consensus/src/sync/live/state_queue/chunk_request_component.rs
+++ b/consensus/src/sync/live/state_queue/chunk_request_component.rs
@@ -50,17 +50,17 @@ impl<N: Network> ChunkRequestComponent<N> {
             },
             |request, (response, _, peer_id), _| {
                 // Verifies the response chunk size.
-                if let ResponseChunk::Chunk(chunk) = response {
-                    if chunk.chunk.items.len() > request.limit as usize {
-                        debug!(
-                                "Peer[{}] Chunk size exceeded the request limit. Req: {:?} Chunk size: {}",
-                                peer_id,
-                                request,
-                                chunk.chunk.items.len()
-                            );
-                        // TODO: Ban peer
-                        return false;
-                    }
+                if let ResponseChunk::Chunk(chunk) = response
+                    && chunk.chunk.items.len() > request.limit as usize
+                {
+                    debug!(
+                        "Peer[{}] Chunk size exceeded the request limit. Req: {:?} Chunk size: {}",
+                        peer_id,
+                        request,
+                        chunk.chunk.items.len()
+                    );
+                    // TODO: Ban peer
+                    return false;
                 }
                 true
             },

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -602,10 +602,10 @@ impl<N: Network> Stream for StateQueue<N> {
         if self.peers_became_nonempty.is_none() {
             self.peers_became_nonempty = self.chunk_request_component.wait_for_peers();
         }
-        if let Some(peers_became_nonempty) = &mut self.peers_became_nonempty {
-            if peers_became_nonempty.as_mut().poll(cx).is_ready() {
-                self.peers_became_nonempty = None;
-            }
+        if let Some(peers_became_nonempty) = &mut self.peers_became_nonempty
+            && peers_became_nonempty.as_mut().poll(cx).is_ready()
+        {
+            self.peers_became_nonempty = None;
         }
         // Obvious TOCTOU, but it would otherwise need to lock the
         // `chunk_request_component`'s peer list.

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -2,7 +2,7 @@ use std::{
     cmp,
     cmp::Ordering,
     collections::{BinaryHeap, VecDeque},
-    fmt::{Debug, Display, Formatter},
+    fmt::{Debug, Display},
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -63,15 +63,6 @@ impl<TId, TOutput> Ord for OrderWrapper<TId, TOutput> {
     fn cmp(&self, other: &Self) -> Ordering {
         // BinaryHeap is a max heap, so compare backwards here.
         other.index.cmp(&self.index)
-    }
-}
-
-#[derive(Debug)]
-pub struct Error;
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt("error", f)
     }
 }
 
@@ -376,33 +367,33 @@ where
         self.try_push_futures();
 
         // Check to see if we've already received the next value.
-        if let Some(next_output) = self.queued_outputs.peek() {
-            if next_output.index == self.next_outgoing_index {
-                let request = self.queued_outputs.pop().unwrap();
+        if let Some(next_output) = self.queued_outputs.peek()
+            && next_output.index == self.next_outgoing_index
+        {
+            let request = self.queued_outputs.pop().unwrap();
 
-                match request.data {
-                    Some(mut data) => {
-                        if (self.verify_fn)(&request.id, &mut data, &mut self.verify_state) {
+            match request.data {
+                Some(mut data) => {
+                    if (self.verify_fn)(&request.id, &mut data, &mut self.verify_state) {
+                        self.next_outgoing_index += 1;
+                        return Poll::Ready(Some(Ok(data)));
+                    } else {
+                        debug!(peer_id = %request.peer, id = ?request.id, "Verification failed");
+                        let id = request.id.clone();
+                        if !self.retry_request(
+                            request.id,
+                            request.index,
+                            request.peer,
+                            request.num_tries,
+                        ) {
                             self.next_outgoing_index += 1;
-                            return Poll::Ready(Some(Ok(data)));
-                        } else {
-                            debug!(peer_id = %request.peer, id = ?request.id, "Verification failed");
-                            let id = request.id.clone();
-                            if !self.retry_request(
-                                request.id,
-                                request.index,
-                                request.peer,
-                                request.num_tries,
-                            ) {
-                                self.next_outgoing_index += 1;
-                                return Poll::Ready(Some(Err(id)));
-                            }
+                            return Poll::Ready(Some(Err(id)));
                         }
                     }
-                    None => {
-                        self.next_outgoing_index += 1;
-                        return Poll::Ready(Some(Err(request.id)));
-                    }
+                }
+                None => {
+                    self.next_outgoing_index += 1;
+                    return Poll::Ready(Some(Err(request.id)));
                 }
             }
         }

--- a/database/benches/hash_keys.rs
+++ b/database/benches/hash_keys.rs
@@ -59,13 +59,13 @@ impl Distribution<Address> for StandardUniform {
 }
 
 impl AsDatabaseBytes for Blake2bHash {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(&self.0)
     }
 }
 
 impl AsDatabaseBytes for Address {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(&self.0)
     }
 }

--- a/database/database-value/src/lib.rs
+++ b/database/database-value/src/lib.rs
@@ -26,12 +26,12 @@ pub trait FromDatabaseBytes {
 pub trait AsDatabaseBytes {
     /// Returns the byte representation to be used in key encoding.
     /// In the default implementation, this will also be used for the value bytes.
-    fn as_key_bytes(&self) -> Cow<[u8]>;
+    fn as_key_bytes(&self) -> Cow<'_, [u8]>;
 
     /// Returns the byte representation to be used in value encoding.
     /// This is used if the value needs to be sorted differently in a dup table.
     /// DUP values use a lexicographic sort order.
-    fn as_value_bytes(&self) -> Cow<[u8]> {
+    fn as_value_bytes(&self) -> Cow<'_, [u8]> {
         self.as_key_bytes()
     }
 
@@ -41,7 +41,7 @@ pub trait AsDatabaseBytes {
 }
 
 impl AsDatabaseBytes for () {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(&[])
     }
 
@@ -97,25 +97,25 @@ impl FromDatabaseBytes for Vec<u8> {
 }
 
 impl AsDatabaseBytes for Vec<u8> {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(&self[..])
     }
 }
 
 impl AsDatabaseBytes for String {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes())
     }
 }
 
 impl AsDatabaseBytes for str {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes())
     }
 }
 
 impl AsDatabaseBytes for CStr {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.to_bytes())
     }
 }
@@ -139,7 +139,7 @@ macro_rules! impl_num_traits {
             }
         }
         impl AsDatabaseBytes for $typ {
-            fn as_key_bytes(&self) -> Cow<[u8]> {
+            fn as_key_bytes(&self) -> Cow<'_, [u8]> {
                 unsafe {
                     #[allow(clippy::size_of_in_element_count)]
                     Cow::Borrowed(slice::from_raw_parts(
@@ -149,7 +149,7 @@ macro_rules! impl_num_traits {
                 }
             }
 
-            fn as_value_bytes(&self) -> Cow<[u8]> {
+            fn as_value_bytes(&self) -> Cow<'_, [u8]> {
                 // It is important to use to_be_bytes here for lexical ordering.
                 Cow::Owned(self.to_be_bytes().to_vec())
             }

--- a/database/src/mdbx/cursor.rs
+++ b/database/src/mdbx/cursor.rs
@@ -35,7 +35,7 @@ impl<Kind: TransactionKind, T: DupTable> MdbxCursor<'_, Kind, T>
 where
     T::Value: DupTableValue,
 {
-    fn encode_subkey(subkey: &DupSubKey<T>) -> Cow<[u8]> {
+    fn encode_subkey(subkey: &DupSubKey<T>) -> Cow<'_, [u8]> {
         let enc_key = subkey.as_value_bytes();
         if let Some(new_len) = T::Value::FIXED_SIZE {
             let mut owned = enc_key.into_owned();

--- a/database/src/mdbx/transaction/mod.rs
+++ b/database/src/mdbx/transaction/mod.rs
@@ -26,7 +26,7 @@ where
         MdbxTransaction { txn }
     }
 
-    pub(super) fn open_table<T: Table>(&self, _table: &T) -> libmdbx::Table {
+    pub(super) fn open_table<T: Table>(&self, _table: &T) -> libmdbx::Table<'_> {
         self.txn.open_table(Some(T::NAME)).unwrap()
     }
 }

--- a/database/src/utils.rs
+++ b/database/src/utils.rs
@@ -43,7 +43,7 @@ impl<I: Key, V: Value> DupTableValue for IndexedValue<I, V> {
 }
 
 impl<I: Key, V: Value> AsDatabaseBytes for IndexedValue<I, V> {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         let bytes = [
             &self.index.as_value_bytes()[..],
             &self.value.as_value_bytes()[..],

--- a/genesis-builder/src/config.rs
+++ b/genesis-builder/src/config.rs
@@ -135,7 +135,7 @@ pub struct GenesisHTLC {
 impl GenesisConfig {
     pub fn trimmed_from_genesis(header: &MacroHeader) -> GenesisConfig {
         assert!(
-            header.timestamp % 1000 == 0,
+            header.timestamp.is_multiple_of(1000),
             "genesis blocks must be on whole seconds",
         );
         let supply = Coin::deserialize_all(&header.extra_data)

--- a/handel/src/aggregation.rs
+++ b/handel/src/aggregation.rs
@@ -483,25 +483,25 @@ where
         }
 
         // Poll the verification future if there is one.
-        if let Some(future) = &mut self.current_verification {
-            if let Poll::Ready((result, contribution)) = future.poll_unpin(cx) {
-                // If a result is produced, unset the future such that a new one can take its place.
-                self.current_verification = None;
+        if let Some(future) = &mut self.current_verification
+            && let Poll::Ready((result, contribution)) = future.poll_unpin(cx)
+        {
+            // If a result is produced, unset the future such that a new one can take its place.
+            self.current_verification = None;
 
-                if result.is_ok() {
-                    // If the contribution was successfully verified, apply it and return the new
-                    // best aggregate.
-                    best_aggregate = Some(self.apply_contribution(contribution))
-                } else {
-                    // Verification failed, ban sender.
-                    warn!(
-                        id = %self.protocol.identify(),
-                        ?result,
-                        ?contribution,
-                        "Rejecting invalid contribution"
-                    );
-                    self.network.ban_node(contribution.origin);
-                }
+            if result.is_ok() {
+                // If the contribution was successfully verified, apply it and return the new
+                // best aggregate.
+                best_aggregate = Some(self.apply_contribution(contribution))
+            } else {
+                // Verification failed, ban sender.
+                warn!(
+                    id = %self.protocol.identify(),
+                    ?result,
+                    ?contribution,
+                    "Rejecting invalid contribution"
+                );
+                self.network.ban_node(contribution.origin);
             }
         };
 

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -176,7 +176,7 @@ impl Hasher for Blake2bHasher {
 }
 
 impl AsDatabaseBytes for Blake2bHash {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes())
     }
 

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -332,7 +332,7 @@ impl Hasher for Sha256Hasher {
 
     fn finish(self) -> Sha256Hash {
         let result = self.0.finalize();
-        Sha256Hash::from(result.as_slice())
+        Sha256Hash::from(&result[..])
     }
 }
 

--- a/hash/src/pbkdf2.rs
+++ b/hash/src/pbkdf2.rs
@@ -25,7 +25,7 @@ pub fn compute_pbkdf2_sha512(
     }
 
     let mut l = derived_key_length / Sha512Hash::len();
-    if derived_key_length % Sha512Hash::len() != 0 {
+    if !derived_key_length.is_multiple_of(Sha512Hash::len()) {
         l += 1;
     }
     let r = derived_key_length - (l - 1) * Sha512Hash::len();

--- a/hash/src/sha512.rs
+++ b/hash/src/sha512.rs
@@ -176,6 +176,6 @@ impl Hasher for Sha512Hasher {
 
     fn finish(self) -> Sha512Hash {
         let result = self.0.finalize();
-        Sha512Hash::from(result.as_slice())
+        Sha512Hash::from(&result[..])
     }
 }

--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -198,7 +198,7 @@ impl fmt::Debug for Address {
 }
 
 impl AsDatabaseBytes for Address {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes())
     }
 

--- a/keys/src/multisig/mod.rs
+++ b/keys/src/multisig/mod.rs
@@ -250,7 +250,7 @@ impl KeyPair {
         Ok(partial_signature)
     }
 
-    /// Delinearized the private key in the same way as the public key delinearization.
+    /// Delinearized the private key in the same way as the public key demineralization.
     /// It multiplies it with a scalar derived from the hash and the public key itself.
     pub(crate) fn delinearize_private_key(&self, public_keys_hash: &[u8; 64]) -> Scalar {
         // Compute H(C||P).
@@ -339,7 +339,7 @@ pub fn hash_public_keys(public_keys: &[Ed25519PublicKey]) -> [u8; 64] {
     for public_key in public_keys {
         h.update(public_key.as_bytes());
     }
-    public_keys_hash.copy_from_slice(h.finalize().as_slice());
+    public_keys_hash.copy_from_slice(&h.finalize());
     public_keys_hash
 }
 
@@ -354,7 +354,7 @@ impl ToScalar for ::ed25519_zebra::SigningKey {
 
         // Convert the low half to a scalar with Ed25519 "clamping"
         let mut scalar_bytes = [0u8; 32];
-        scalar_bytes[..].copy_from_slice(&h.as_slice()[0..32]);
+        scalar_bytes[..].copy_from_slice(&h[0..32]);
         scalar_bytes[0] &= 248;
         scalar_bytes[31] &= 127;
         scalar_bytes[31] |= 64;

--- a/keys/src/private_key.rs
+++ b/keys/src/private_key.rs
@@ -30,7 +30,7 @@ impl PrivateKey {
         // Convert to scalar as in RFC 8032, section 6, `def secret_expand(secret)`:
         // https://www.rfc-editor.org/rfc/rfc8032.html#section-6
         let mut scalar_bytes = [0u8; 32];
-        scalar_bytes.copy_from_slice(&Sha512::digest(self.as_bytes()).as_slice()[..32]);
+        scalar_bytes.copy_from_slice(&Sha512::digest(self.as_bytes())[..32]);
         scalar_bytes[0] &= 248;
         scalar_bytes[31] &= 127;
         scalar_bytes[31] |= 64;

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -194,42 +194,40 @@ impl ClientInner {
 
         #[cfg(feature = "zkp-prover")]
         // If the Prover is active we need to ensure that the proving keys are present.
-        if let Some(ref zk_prover_config) = config.zk_prover {
-            if !all_files_created(&zk_prover_config.prover_keys_path, true) {
-                match config.network_id {
-                    NetworkId::DevAlbatross => {
-                        log::info!("Setting up zero-knowledge prover keys for devnet.");
-                        log::info!(
-                            "This task only needs to be run once and might take about an hour."
-                        );
-                        log::info!(
-                            "Alternatively, you can place the proving keys in this folder: {:?}.",
-                            zk_prover_config.prover_keys_path
-                        );
-                        setup(
-                            &mut ChaCha20Rng::from_seed(DEVELOPMENT_SEED),
-                            &zk_prover_config.prover_keys_path,
-                            config.network_id,
-                            true,
-                        )?;
-                        log::info!("Setting the verification key.");
-                        let vk = load_verifying_data(&zk_prover_config.prover_keys_path)?;
-                        if vk != *ZKP_VERIFYING_DATA {
-                            return Err(Error::NanoZKP(NanoZKPError::InvalidMetadata));
-                        }
-                        log::debug!("Finished ZKP setup.");
+        if let Some(ref zk_prover_config) = config.zk_prover
+            && !all_files_created(&zk_prover_config.prover_keys_path, true)
+        {
+            match config.network_id {
+                NetworkId::DevAlbatross => {
+                    log::info!("Setting up zero-knowledge prover keys for devnet.");
+                    log::info!("This task only needs to be run once and might take about an hour.");
+                    log::info!(
+                        "Alternatively, you can place the proving keys in this folder: {:?}.",
+                        zk_prover_config.prover_keys_path
+                    );
+                    setup(
+                        &mut ChaCha20Rng::from_seed(DEVELOPMENT_SEED),
+                        &zk_prover_config.prover_keys_path,
+                        config.network_id,
+                        true,
+                    )?;
+                    log::info!("Setting the verification key.");
+                    let vk = load_verifying_data(&zk_prover_config.prover_keys_path)?;
+                    if vk != *ZKP_VERIFYING_DATA {
+                        return Err(Error::NanoZKP(NanoZKPError::InvalidMetadata));
                     }
-                    NetworkId::TestAlbatross | NetworkId::MainAlbatross => {
-                        log::error!(
-                            "Proving keys missing, please place them in this folder: {:?}.",
-                            zk_prover_config.prover_keys_path
-                        );
-                        return Err(Error::NanoZKP(NanoZKPError::Filesystem(io::Error::other(
-                            "Proving keys do not exist.",
-                        ))));
-                    }
-                    _ => {}
+                    log::debug!("Finished ZKP setup.");
                 }
+                NetworkId::TestAlbatross | NetworkId::MainAlbatross => {
+                    log::error!(
+                        "Proving keys missing, please place them in this folder: {:?}.",
+                        zk_prover_config.prover_keys_path
+                    );
+                    return Err(Error::NanoZKP(NanoZKPError::Filesystem(io::Error::other(
+                        "Proving keys do not exist.",
+                    ))));
+                }
+                _ => {}
             }
         }
 
@@ -658,14 +656,13 @@ impl ClientInner {
             config.consensus.sync_mode,
             SyncMode::Full | SyncMode::History
         ) && validator_or_mempool.is_none()
+            && let BlockchainProxy::Full(ref blockchain) = blockchain_proxy
         {
-            if let BlockchainProxy::Full(ref blockchain) = blockchain_proxy {
-                validator_or_mempool = Some(ValidatorOrMempool::Mempool(MempoolTask::new(
-                    &consensus,
-                    Arc::clone(blockchain),
-                    config.mempool,
-                )));
-            }
+            validator_or_mempool = Some(ValidatorOrMempool::Mempool(MempoolTask::new(
+                &consensus,
+                Arc::clone(blockchain),
+                config.mempool,
+            )));
         }
 
         // Start network.

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -65,16 +65,15 @@ impl ConfigFile {
     }
 
     fn create_example(path: &Path) -> io::Result<()> {
-        if let Some(parent) = path.parent() {
-            if parent != Path::new("") {
-                if let Err(error) = fs::create_dir_all(parent) {
-                    log::warn!(
-                        %error,
-                        "Failed to create Nimiq home directory {}",
-                        parent.display(),
-                    );
-                }
-            }
+        if let Some(parent) = path.parent()
+            && parent != Path::new("")
+            && let Err(error) = fs::create_dir_all(parent)
+        {
+            log::warn!(
+                %error,
+                "Failed to create Nimiq home directory {}",
+                parent.display(),
+            );
         }
 
         log::info!("Creating example config at: {}", path.display());
@@ -105,10 +104,10 @@ impl ConfigFile {
     ///
     pub fn find(command_line_opt: Option<&CommandLine>) -> Result<ConfigFile, Error> {
         // If the path was set by the command line, only try this path
-        if let Some(command_line) = command_line_opt {
-            if let Some(path) = &command_line.config {
-                return Self::from_file(path);
-            }
+        if let Some(command_line) = command_line_opt
+            && let Some(path) = &command_line.config
+        {
+            return Self::from_file(path);
         }
 
         // Load config.

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -605,10 +605,10 @@ impl Behaviour {
         let contacts = self.contacts.read();
         for peer_id in self.peer_ids.connected.keys() {
             let peer_score = contacts.get(peer_id).map(|e| e.get_score());
-            if let Some(score) = peer_score {
-                if score < 0.0 {
-                    info!(%peer_id, score, "Peer has a negative score");
-                }
+            if let Some(score) = peer_score
+                && score < 0.0
+            {
+                info!(%peer_id, score, "Peer has a negative score");
             }
         }
         drop(contacts);
@@ -625,11 +625,11 @@ impl Behaviour {
         debug!(%peer_id, "Banned peer");
 
         // Mark its outer protocol address as banned if we have it
-        if let Some(contact) = self.contacts.read().get(&peer_id) {
-            if let Some(outer_protocol_address) = contact.get_outer_protocol_address() {
-                debug!(address = %outer_protocol_address, "Banned address");
-                self.addresses.mark_banned(outer_protocol_address);
-            }
+        if let Some(contact) = self.contacts.read().get(&peer_id)
+            && let Some(outer_protocol_address) = contact.get_outer_protocol_address()
+        {
+            debug!(address = %outer_protocol_address, "Banned address");
+            self.addresses.mark_banned(outer_protocol_address);
         }
     }
 
@@ -849,16 +849,16 @@ impl Behaviour {
         }
 
         // Check if peer subnet IP limit is reached
-        if let Some(subnet_ip_count) = subnet_ip_count {
-            if *subnet_ip_count > self.config.peer_count_per_subnet_max {
-                // Subnet mask
-                debug!(
-                    subnet_ip = %ip_info.subnet_ip.unwrap(),
-                    limit = self.config.peer_count_per_subnet_max,
-                    "Max peer connections per IP subnet limit reached"
-                );
-                return Err(ConnectionDenied::new(Error::MaxSubnetConnectionsReached));
-            }
+        if let Some(subnet_ip_count) = subnet_ip_count
+            && *subnet_ip_count > self.config.peer_count_per_subnet_max
+        {
+            // Subnet mask
+            debug!(
+                subnet_ip = %ip_info.subnet_ip.unwrap(),
+                limit = self.config.peer_count_per_subnet_max,
+                "Max peer connections per IP subnet limit reached"
+            );
+            return Err(ConnectionDenied::new(Error::MaxSubnetConnectionsReached));
         }
 
         Ok(())
@@ -874,13 +874,12 @@ impl Behaviour {
         }
 
         // Decrement peer subnet IP counter
-        if let Some(subnet_ip) = ip_info.subnet_ip {
-            if let Entry::Occupied(mut subnet_count) = self.limits.ip_subnet_count.entry(subnet_ip)
-            {
-                *subnet_count.get_mut() = subnet_count.get().saturating_sub(1);
-                if *subnet_count.get() == 0 {
-                    subnet_count.remove();
-                }
+        if let Some(subnet_ip) = ip_info.subnet_ip
+            && let Entry::Occupied(mut subnet_count) = self.limits.ip_subnet_count.entry(subnet_ip)
+        {
+            *subnet_count.get_mut() = subnet_count.get().saturating_sub(1);
+            if *subnet_count.get() == 0 {
+                subnet_count.remove();
             }
         }
     }
@@ -959,11 +958,11 @@ impl NetworkBehaviour for Behaviour {
         _local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<(), ConnectionDenied> {
-        if let Some(outer_protocol_address) = handler::outer_protocol_address(remote_addr) {
-            if self.addresses.is_banned(outer_protocol_address) {
-                debug!(%remote_addr, "Address is banned");
-                return Err(ConnectionDenied::new(Error::BannedIp));
-            }
+        if let Some(outer_protocol_address) = handler::outer_protocol_address(remote_addr)
+            && self.addresses.is_banned(outer_protocol_address)
+        {
+            debug!(%remote_addr, "Address is banned");
+            return Err(ConnectionDenied::new(Error::BannedIp));
         }
 
         // Get IP from multiaddress if it exists.

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -180,10 +180,10 @@ impl Handler {
         peer_contact_book: Arc<RwLock<PeerContactBook>>,
         peer_address: Multiaddr,
     ) -> Self {
-        if let Some(peer_contact) = peer_contact_book.write().get(&peer_id) {
-            if let Some(outer_protocol_address) = outer_protocol_address(&peer_address) {
-                peer_contact.set_outer_protocol_address(outer_protocol_address);
-            }
+        if let Some(peer_contact) = peer_contact_book.write().get(&peer_id)
+            && let Some(outer_protocol_address) = outer_protocol_address(&peer_address)
+        {
+            peer_contact.set_outer_protocol_address(outer_protocol_address);
         }
 
         Self {
@@ -344,12 +344,12 @@ impl ConnectionHandler for Handler {
     ) -> Poll<ConnectionHandlerEvent<Self::OutboundProtocol, (), HandlerOutEvent>> {
         loop {
             // Check if we hit the state transition timeout
-            if let Some(ref mut state_timeout) = self.state_timeout {
-                if state_timeout.as_mut().poll(cx).is_ready() {
-                    return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                        HandlerOutEvent::Error(Error::StateTransitionTimeout { state: self.state }),
-                    ));
-                }
+            if let Some(ref mut state_timeout) = self.state_timeout
+                && state_timeout.as_mut().poll(cx).is_ready()
+            {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    HandlerOutEvent::Error(Error::StateTransitionTimeout { state: self.state }),
+                ));
             }
 
             // Send message

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -490,10 +490,10 @@ impl NetworkInterface for Network {
 
         // First we try to get the connected peers that support the desired services
         for peer_id in connected_peers.iter() {
-            if let Some(peer_info) = self.get_peer_info(*peer_id) {
-                if peer_info.get_services().contains(services) {
-                    filtered_peers.push(*peer_id);
-                }
+            if let Some(peer_info) = self.get_peer_info(*peer_id)
+                && peer_info.get_services().contains(services)
+            {
+                filtered_peers.push(*peer_id);
             }
         }
 

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -681,12 +681,11 @@ fn handle_dht_inbound_put(
     // Now verify that we should overwrite it because it's better than the one we have
     let mut overwrite = true;
     let store = event_info.swarm.behaviour_mut().dht.store_mut();
-    if let Some(current_record) = store.get(&record.key) {
-        if let Ok(current_dht_record) = DhtRecord::try_from(&current_record.into_owned()) {
-            if current_dht_record > dht_record {
-                overwrite = false;
-            }
-        }
+    if let Some(current_record) = store.get(&record.key)
+        && let Ok(current_dht_record) = DhtRecord::try_from(&current_record.into_owned())
+        && current_dht_record > dht_record
+    {
+        overwrite = false;
     }
     if overwrite && store.put(record).is_err() {
         error!("Could not store record in DHT record store");

--- a/network-libp2p/tests/request_response.rs
+++ b/network-libp2p/tests/request_response.rs
@@ -51,40 +51,6 @@ struct TestResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct TestRequest2 {
-    request: u64,
-}
-impl RequestCommon for TestRequest2 {
-    type Kind = RequestMarker;
-    const TYPE_ID: u16 = 42;
-    type Response = TestResponse2;
-
-    const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_TEST_REQUEST;
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct TestResponse2 {
-    response: u64,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct TestRequest3 {
-    request: u64,
-}
-impl RequestCommon for TestRequest3 {
-    type Kind = RequestMarker;
-    const TYPE_ID: u16 = 42;
-    type Response = TestResponse3;
-
-    const MAX_REQUESTS: u32 = MAX_REQUEST_RESPONSE_TEST_REQUEST;
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct TestResponse3 {
-    response: [u8; 8],
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 struct TestRequest4 {
     request: u64,
 }

--- a/network-mock/src/observable_hash_map.rs
+++ b/network-mock/src/observable_hash_map.rs
@@ -66,7 +66,7 @@ impl<K: Clone + Eq + Hash, V: Clone> ObservableHashMap<K, V> {
     pub fn get<'a>(&'a self, k: &K) -> Option<&'a V> {
         self.inner.get(k)
     }
-    pub fn keys(&self) -> hash_map::Keys<K, V> {
+    pub fn keys(&self) -> hash_map::Keys<'_, K, V> {
         self.inner.keys()
     }
     pub fn subscribe(&self) -> broadcast::Receiver<Event<K, V>> {

--- a/pow-migration/src/lib.rs
+++ b/pow-migration/src/lib.rs
@@ -279,11 +279,11 @@ pub async fn migrate(
                 let mut imported_address = false;
 
                 for account in wallet_addresses {
-                    if let nimiq_rpc::primitives::Account::Basic(basic_account) = account {
-                        if basic_account.address == validator_address.to_user_friendly_address() {
-                            imported_address = true;
-                            break;
-                        }
+                    if let nimiq_rpc::primitives::Account::Basic(basic_account) = account
+                        && basic_account.address == validator_address.to_user_friendly_address()
+                    {
+                        imported_address = true;
+                        break;
                     }
                 }
 

--- a/pow-migration/src/state.rs
+++ b/pow-migration/src/state.rs
@@ -223,43 +223,43 @@ pub async fn get_validators(
         let mut voting_key = vec![vec![0u8]; 5];
         let mut txns_parsed = [false; 6];
         for txn in txns {
-            if let Some(data_hex) = &txn.data {
-                if let Ok(data) = hex::decode(data_hex) {
-                    if data.len() < 64 {
-                        continue;
+            if let Some(data_hex) = &txn.data
+                && let Ok(data) = hex::decode(data_hex)
+            {
+                if data.len() < 64 {
+                    continue;
+                }
+                match data[0] {
+                    1u8 => {
+                        if let Ok(sk) = SchnorrPublicKey::from_bytes(&data[12..44])
+                            && let Ok(addr) = Address::deserialize_from_vec(&data[44..])
+                        {
+                            signing_key = sk;
+                            address = addr;
+                            txns_parsed[0] = true;
+                        }
                     }
-                    match data[0] {
-                        1u8 => {
-                            if let Ok(sk) = SchnorrPublicKey::from_bytes(&data[12..44]) {
-                                if let Ok(addr) = Address::deserialize_from_vec(&data[44..]) {
-                                    signing_key = sk;
-                                    address = addr;
-                                    txns_parsed[0] = true;
-                                }
-                            }
-                        }
-                        2u8 => {
-                            voting_key[0] = data[7..].to_vec();
-                            txns_parsed[1] = true;
-                        }
-                        3u8 => {
-                            voting_key[1] = data[7..].to_vec();
-                            txns_parsed[2] = true;
-                        }
-                        4u8 => {
-                            voting_key[2] = data[7..].to_vec();
-                            txns_parsed[3] = true;
-                        }
-                        5u8 => {
-                            voting_key[3] = data[7..].to_vec();
-                            txns_parsed[4] = true;
-                        }
-                        6u8 => {
-                            voting_key[4] = data[7..].to_vec();
-                            txns_parsed[5] = true;
-                        }
-                        _ => {}
+                    2u8 => {
+                        voting_key[0] = data[7..].to_vec();
+                        txns_parsed[1] = true;
                     }
+                    3u8 => {
+                        voting_key[1] = data[7..].to_vec();
+                        txns_parsed[2] = true;
+                    }
+                    4u8 => {
+                        voting_key[2] = data[7..].to_vec();
+                        txns_parsed[3] = true;
+                    }
+                    5u8 => {
+                        voting_key[3] = data[7..].to_vec();
+                        txns_parsed[4] = true;
+                    }
+                    6u8 => {
+                        voting_key[4] = data[7..].to_vec();
+                        txns_parsed[5] = true;
+                    }
+                    _ => {}
                 }
             }
         }
@@ -300,24 +300,22 @@ pub async fn get_validators(
             .iter()
             .filter(|&txn| txn.value >= Policy::VALIDATOR_DEPOSIT)
         {
-            if let Some(data) = &txn.data {
-                if let Ok(address_bytes) = hex::decode(data) {
-                    if let Ok(address_str) = std::str::from_utf8(&address_bytes) {
-                        if let Ok(address) = Address::from_str(address_str) {
-                            if let Some(mut validator) = possible_validators.remove(&address) {
-                                log::info!(%address, "Found commit transaction for validator");
-                                // If the transaction had a value greater than the deposit, the excess will be converted
-                                // to stake by `get_stakers`.
-                                validator.total_stake = Coin::from_u64_unchecked(txn.value);
-                                validators.push(validator);
-                            } else {
-                                log::warn!(
-                                    %address,
-                                    "Found commit transaction for unknown validator"
-                                );
-                            }
-                        }
-                    }
+            if let Some(data) = &txn.data
+                && let Ok(address_bytes) = hex::decode(data)
+                && let Ok(address_str) = std::str::from_utf8(&address_bytes)
+                && let Ok(address) = Address::from_str(address_str)
+            {
+                if let Some(mut validator) = possible_validators.remove(&address) {
+                    log::info!(%address, "Found commit transaction for validator");
+                    // If the transaction had a value greater than the deposit, the excess will be converted
+                    // to stake by `get_stakers`.
+                    validator.total_stake = Coin::from_u64_unchecked(txn.value);
+                    validators.push(validator);
+                } else {
+                    log::warn!(
+                        %address,
+                        "Found commit transaction for unknown validator"
+                    );
                 }
             }
         }
@@ -402,57 +400,49 @@ pub async fn get_stakers(
         // First order transactions by timestamp
         txns.sort_by_cached_key(|transaction| transaction.timestamp);
         for txn in txns.iter() {
-            if let Some(data) = &txn.data {
-                if let Ok(address_bytes) = hex::decode(data) {
-                    if let Ok(address_str) = std::str::from_utf8(&address_bytes) {
-                        if let Ok(address) = Address::from_str(address_str) {
-                            if let Some(validator) = validators.get(address_str) {
-                                log::info!(staker_address=txn.from_address, validator_address=%address, "Found pre-stake transaction for validator");
-                                if let Ok(staker_address) = Address::from_str(&txn.from_address) {
-                                    let stake = Coin::from_u64_unchecked(txn.value);
-                                    match stakers.entry(staker_address.clone()) {
-                                        Entry::Occupied(mut entry) => {
-                                            // If we have an entry for this staker, treat this as a switch to another
-                                            // validator or an increase of the stake (if the validator isn't changed)
-                                            let staker = entry.get_mut();
+            if let Some(data) = &txn.data
+                && let Ok(address_bytes) = hex::decode(data)
+                && let Ok(address_str) = std::str::from_utf8(&address_bytes)
+                && let Ok(address) = Address::from_str(address_str)
+            {
+                if let Some(validator) = validators.get(address_str) {
+                    log::info!(staker_address=txn.from_address, validator_address=%address, "Found pre-stake transaction for validator");
+                    if let Ok(staker_address) = Address::from_str(&txn.from_address) {
+                        let stake = Coin::from_u64_unchecked(txn.value);
+                        match stakers.entry(staker_address.clone()) {
+                            Entry::Occupied(mut entry) => {
+                                // If we have an entry for this staker, treat this as a switch to another
+                                // validator or an increase of the stake (if the validator isn't changed)
+                                let staker = entry.get_mut();
 
-                                            // Update the staker entry
-                                            staker.delegation =
-                                                validator.validator.validator_address.clone();
-                                            staker.balance += stake;
-                                        }
-                                        Entry::Vacant(entry) => {
-                                            // If there wasn't a staker registered for this address, check minimum stake
-                                            if stake
-                                                >= Coin::from_u64_unchecked(Policy::MINIMUM_STAKE)
-                                            {
-                                                entry.insert(GenesisStaker {
-                                                    staker_address,
-                                                    balance: stake,
-                                                    delegation: validator
-                                                        .validator
-                                                        .validator_address
-                                                        .clone(),
-                                                    inactive_balance: Coin::ZERO,
-                                                    inactive_from: None,
-                                                });
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    log::error!(
-                                        staker_address = txn.from_address,
-                                        "Could not build staker address from transaction sender"
-                                    );
+                                // Update the staker entry
+                                staker.delegation = validator.validator.validator_address.clone();
+                                staker.balance += stake;
+                            }
+                            Entry::Vacant(entry) => {
+                                // If there wasn't a staker registered for this address, check minimum stake
+                                if stake >= Coin::from_u64_unchecked(Policy::MINIMUM_STAKE) {
+                                    entry.insert(GenesisStaker {
+                                        staker_address,
+                                        balance: stake,
+                                        delegation: validator.validator.validator_address.clone(),
+                                        inactive_balance: Coin::ZERO,
+                                        inactive_from: None,
+                                    });
                                 }
-                            } else {
-                                log::warn!(
-                                    staker_address = txn.from_address,
-                                    "Found pre-staking transaction for unknown validator, ignored"
-                                );
                             }
                         }
+                    } else {
+                        log::error!(
+                            staker_address = txn.from_address,
+                            "Could not build staker address from transaction sender"
+                        );
                     }
+                } else {
+                    log::warn!(
+                        staker_address = txn.from_address,
+                        "Found pre-staking transaction for unknown validator, ignored"
+                    );
                 }
             }
         }

--- a/pow-migration/tests/mod.rs
+++ b/pow-migration/tests/mod.rs
@@ -5,7 +5,6 @@
 #[cfg(feature = "pow-migration-tests")]
 mod pow_migration_test {
     use nimiq_database::mdbx::MdbxDatabase;
-    use nimiq_genesis_builder::config::GenesisConfig;
     use nimiq_keys::Address;
     use nimiq_pow_migration::{
         migrate,

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -126,10 +126,10 @@ impl Staker {
         // to finish and thus that the validator will not be jailed due to misbehavior.
         if let Some(validator_address) = &self.delegation {
             // Funds are not released if release block height has not passed yet.
-            if let Some(inactive_from) = self.inactive_from {
-                if block_number < Policy::block_after_reporting_window(inactive_from) {
-                    return false;
-                }
+            if let Some(inactive_from) = self.inactive_from
+                && block_number < Policy::block_after_reporting_window(inactive_from)
+            {
+                return false;
             }
 
             // Funds are only released if the validator is not jailed.

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -146,7 +146,7 @@ impl Accounts {
         }
     }
 
-    pub fn data_store(&self, address: &Address) -> DataStore {
+    pub fn data_store(&self, address: &Address) -> DataStore<'_> {
         DataStore::new(&self.tree, address)
     }
 

--- a/primitives/account/src/logs.rs
+++ b/primitives/account/src/logs.rs
@@ -472,7 +472,7 @@ impl BlockLogger {
     }
 
     #[cfg(feature = "interaction-traits")]
-    pub(crate) fn inherent_logger(&mut self) -> InherentLogger {
+    pub(crate) fn inherent_logger(&mut self) -> InherentLogger<'_> {
         match self.block_log {
             BlockLog::RevertedBlock {
                 ref mut inherent_logs,

--- a/primitives/block/src/block_proof.rs
+++ b/primitives/block/src/block_proof.rs
@@ -108,10 +108,10 @@ impl BlockInclusionProof {
             let current_block = &number_to_block[&hops[i]];
             let next_hop = &number_to_block[&hops[i + 1]];
 
-            if let Some(interlink) = &current_block.header.interlink {
-                if !interlink.contains(&next_hop.hash()) {
-                    return false;
-                }
+            if let Some(interlink) = &current_block.header.interlink
+                && !interlink.contains(&next_hop.hash())
+            {
+                return false;
             }
         }
 

--- a/primitives/mmr/src/mmr/partial.rs
+++ b/primitives/mmr/src/mmr/partial.rs
@@ -150,10 +150,10 @@ impl<H: Merge + PartialEq + Clone, S: Store<H>> PartialMerkleMountainRange<H, S>
         let root = bagging(peaks_hashes.into_iter().map(Ok).rev())?;
 
         // Compare root against stored root of previous proofs.
-        if let Some(ref stored_root) = self.root {
-            if root.ne(stored_root) {
-                return Err(Error::InvalidProof);
-            }
+        if let Some(ref stored_root) = self.root
+            && root.ne(stored_root)
+        {
+            return Err(Error::InvalidProof);
         }
 
         // All done, we can commit and update our state.

--- a/primitives/mmr/src/store/memory.rs
+++ b/primitives/mmr/src/store/memory.rs
@@ -11,7 +11,7 @@ impl<H: Clone> MemoryStore<H> {
         MemoryStore { inner: vec![] }
     }
 
-    pub fn transaction(&mut self) -> MemoryTransaction<H, Self> {
+    pub fn transaction(&mut self) -> MemoryTransaction<'_, H, Self> {
         MemoryTransaction::new(self)
     }
 }

--- a/primitives/src/key_nibbles.rs
+++ b/primitives/src/key_nibbles.rs
@@ -163,7 +163,7 @@ impl KeyNibbles {
         let mut new_bytes_length = 0;
 
         // If the slice starts at the beginning of a byte, then it's an easy case.
-        if start % 2 == 0 {
+        if start.is_multiple_of(2) {
             new_bytes_length = byte_end - byte_start;
             new_bytes[0..new_bytes_length].copy_from_slice(&self.bytes[byte_start..byte_end]);
         }
@@ -190,7 +190,7 @@ impl KeyNibbles {
         if end % 2 == 1 {
             let last_nibble = self.bytes[byte_end] & 0xf0;
 
-            if start % 2 == 0 {
+            if start.is_multiple_of(2) {
                 new_bytes[new_bytes_length] = last_nibble;
             } else {
                 new_bytes[new_bytes_length - 1] |= last_nibble >> 4;
@@ -267,7 +267,7 @@ impl str::FromStr for KeyNibbles {
             return Ok(KeyNibbles::ROOT);
         }
         let mut bytes: [u8; KeyNibbles::MAX_BYTES] = [0; KeyNibbles::MAX_BYTES];
-        if s.len() % 2 == 0 {
+        if s.len().is_multiple_of(2) {
             hex::decode_to_slice(s, &mut bytes[..(s.len() / 2)])?;
 
             Ok(KeyNibbles {
@@ -327,7 +327,7 @@ impl ops::Add<&KeyNibbles> for &KeyNibbles {
     fn add(self, other: &KeyNibbles) -> KeyNibbles {
         let mut bytes = self.bytes;
 
-        if self.len() % 2 == 0 {
+        if self.len().is_multiple_of(2) {
             // Easy case: the lhs ends with a full byte.
             bytes[self.bytes_len()..self.bytes_len() + other.bytes_len()]
                 .copy_from_slice(&other.bytes[..other.bytes_len()]);
@@ -343,7 +343,7 @@ impl ops::Add<&KeyNibbles> for &KeyNibbles {
                 next_byte = (byte & 0xf) << 4;
             }
 
-            if other.length % 2 == 0 {
+            if other.length.is_multiple_of(2) {
                 // Push next_byte
                 bytes[bytes_length] = next_byte;
             }

--- a/primitives/src/slots_allocation.rs
+++ b/primitives/src/slots_allocation.rs
@@ -204,7 +204,7 @@ impl Validators {
     }
 
     /// Iterates over the validators.
-    pub fn iter(&self) -> Iter<Validator> {
+    pub fn iter(&self) -> Iter<'_, Validator> {
         self.validators.iter()
     }
 }

--- a/primitives/src/trie/trie_node.rs
+++ b/primitives/src/trie/trie_node.rs
@@ -243,11 +243,11 @@ impl TrieNode {
         Ok(self.value.replace(new_value))
     }
 
-    pub fn iter_children(&self) -> Iter {
+    pub fn iter_children(&self) -> Iter<'_> {
         self.into_iter()
     }
 
-    pub fn iter_children_mut(&mut self) -> IterMut {
+    pub fn iter_children_mut(&mut self) -> IterMut<'_> {
         self.into_iter()
     }
 

--- a/primitives/src/trie/trie_proof_node.rs
+++ b/primitives/src/trie/trie_proof_node.rs
@@ -105,7 +105,7 @@ impl TrieProofNode {
         self.child(child_prefix)?.key(&self.key, &None)
     }
 
-    pub fn iter_children(&self) -> Iter {
+    pub fn iter_children(&self) -> Iter<'_> {
         Iter::from_children(&self.children)
     }
 }

--- a/primitives/transaction/src/historic_transaction.rs
+++ b/primitives/transaction/src/historic_transaction.rs
@@ -40,7 +40,7 @@ impl Deref for RawTransactionHash {
     }
 }
 impl AsDatabaseBytes for RawTransactionHash {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         self.0.as_key_bytes()
     }
 
@@ -75,7 +75,7 @@ impl Deref for ExecutedTransactionHash {
     }
 }
 impl AsDatabaseBytes for ExecutedTransactionHash {
-    fn as_key_bytes(&self) -> Cow<[u8]> {
+    fn as_key_bytes(&self) -> Cow<'_, [u8]> {
         Cow::Owned(self.deref().0.to_vec())
     }
 

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -319,14 +319,11 @@ impl Transaction {
             && self.recipient_type == AccountType::Basic
             && self.recipient_data.is_empty()
             && self.flags.is_empty()
+            && let Ok(signature_proof) = SignatureProof::deserialize_all(&self.proof)
+            && self.sender == Address::from(&signature_proof.public_key)
+            && signature_proof.merkle_path.is_empty()
         {
-            if let Ok(signature_proof) = SignatureProof::deserialize_all(&self.proof) {
-                if self.sender == Address::from(&signature_proof.public_key)
-                    && signature_proof.merkle_path.is_empty()
-                {
-                    return TransactionFormat::Basic;
-                }
-            }
+            return TransactionFormat::Basic;
         }
         TransactionFormat::Extended
     }

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -829,10 +829,10 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
             None => return Err(MerkleRadixTrieError::TrieAlreadyComplete),
         }
 
-        if let Some(end_key) = &chunk.end_key {
-            if start_key > *end_key {
-                return Err(MerkleRadixTrieError::InvalidChunk("invalid keys"));
-            }
+        if let Some(end_key) = &chunk.end_key
+            && start_key > *end_key
+        {
+            return Err(MerkleRadixTrieError::InvalidChunk("invalid keys"));
         }
         if !chunk.items.is_empty() {
             if start_key > chunk.items[0].key {
@@ -841,22 +841,22 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
                 ));
             }
             let last_item_key = chunk.items.last().unwrap().key.clone();
-            if let Some(end_key) = &chunk.end_key {
-                if last_item_key >= *end_key {
-                    return Err(MerkleRadixTrieError::InvalidChunk(
-                        "last key is inconsistent with key range",
-                    ));
-                }
+            if let Some(end_key) = &chunk.end_key
+                && last_item_key >= *end_key
+            {
+                return Err(MerkleRadixTrieError::InvalidChunk(
+                    "last key is inconsistent with key range",
+                ));
             }
             let end_key_range = chunk.end_key.clone().map(|end_key| end_key..);
             for proof_node in chunk.proof.nodes.iter() {
                 for child in proof_node.iter_children() {
-                    if let Ok(key) = child.key(&proof_node.key, &end_key_range) {
-                        if key > last_item_key {
-                            return Err(MerkleRadixTrieError::InvalidChunk(
-                                "invalid keys end, found stumps",
-                            ));
-                        }
+                    if let Ok(key) = child.key(&proof_node.key, &end_key_range)
+                        && key > last_item_key
+                    {
+                        return Err(MerkleRadixTrieError::InvalidChunk(
+                            "invalid keys end, found stumps",
+                        ));
                     }
                 }
             }
@@ -876,10 +876,10 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         // one of the nodes of the proof.
         if let Some(end_key) = &chunk.end_key {
             let mut is_valid_end = false;
-            if let Some(last_proof_node) = chunk.proof.nodes.first() {
-                if last_proof_node.key == *end_key {
-                    is_valid_end = true;
-                }
+            if let Some(last_proof_node) = chunk.proof.nodes.first()
+                && last_proof_node.key == *end_key
+            {
+                is_valid_end = true;
             }
             if !is_valid_end {
                 for proof_node in &chunk.proof.nodes {
@@ -894,12 +894,12 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
             if !is_valid_end {
                 return Err(MerkleRadixTrieError::InvalidChunk("invalid end key"));
             }
-            if let Some(last_proof_node) = chunk.proof.nodes.first() {
-                if last_proof_node.key >= *end_key {
-                    return Err(MerkleRadixTrieError::InvalidChunk(
-                        "end key inconsistent with last proof node",
-                    ));
-                }
+            if let Some(last_proof_node) = chunk.proof.nodes.first()
+                && last_proof_node.key >= *end_key
+            {
+                return Err(MerkleRadixTrieError::InvalidChunk(
+                    "end key inconsistent with last proof node",
+                ));
             }
         }
 
@@ -1187,10 +1187,10 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         keys.sort_by(|&k1, &k2| k1.post_order_cmp(k2));
 
         let missing_range = self.get_missing_range(txn);
-        if let Some(missing) = &missing_range {
-            if keys.iter().any(|&key| missing.contains(key)) {
-                return Err(IncompleteTrie);
-            }
+        if let Some(missing) = &missing_range
+            && keys.iter().any(|&key| missing.contains(key))
+        {
+            return Err(IncompleteTrie);
         }
 
         let wanted_values: BTreeSet<&KeyNibbles> = keys.iter().cloned().collect();

--- a/rpc-client/src/main.rs
+++ b/rpc-client/src/main.rs
@@ -96,10 +96,10 @@ async fn run_app(opt: Opt) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = dotenvy::dotenv() {
-        if !e.not_found() {
-            panic!("could not read .env file: {e}");
-        }
+    if let Err(e) = dotenvy::dotenv()
+        && !e.not_found()
+    {
+        panic!("could not read .env file: {e}");
     }
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -418,60 +418,59 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             did_something = false;
 
             // First, check if the future round aggregation verification has completed.
-            if let Some(verification) = &mut self.future_round_verification {
-                if let Poll::Ready(verification_result) = verification.poll_unpin(cx) {
-                    did_something = true;
-                    self.future_round_verification = None;
+            if let Some(verification) = &mut self.future_round_verification
+                && let Poll::Ready(verification_result) = verification.poll_unpin(cx)
+            {
+                did_something = true;
+                self.future_round_verification = None;
 
-                    // If the signature was found to be valid, add the contributing validators to
-                    // the set of contributors for that future round.
-                    if let Ok((round, new_contributors)) = verification_result {
-                        if round > self.state.current_round {
-                            // future contributions need to be tracked separately, as once a round has f+1 contributions
-                            // it can be fast tracked
-                            let contributors = self.future_contributions.entry(round).or_default();
-                            *contributors |= new_contributors;
+                // If the signature was found to be valid, add the contributing validators to
+                // the set of contributors for that future round.
+                if let Ok((round, new_contributors)) = verification_result {
+                    if round > self.state.current_round {
+                        // future contributions need to be tracked separately, as once a round has f+1 contributions
+                        // it can be fast tracked
+                        let contributors = self.future_contributions.entry(round).or_default();
+                        *contributors |= new_contributors;
 
-                            // check if the skip ahead condition is fulfilled. If so, the state machine can be set to propose for round id.0
-                            if contributors.len() >= TProtocol::F_PLUS_ONE {
-                                // Vote None for all aggregations in between, as there is nothing to go by.
-                                // Keep track on aggregations which receive a vote.
-                                for round_number in self.state.current_round..round {
-                                    if let Entry::Vacant(entry) =
-                                        self.state.votes.entry((round_number, Step::Prevote))
-                                    {
-                                        entry.insert(None);
-                                        self.pending_aggregation_starts
-                                            .insert((round_number, Step::Prevote));
-                                    }
-                                    if let Entry::Vacant(entry) =
-                                        self.state.votes.entry((round_number, Step::Precommit))
-                                    {
-                                        entry.insert(None);
-                                        self.pending_aggregation_starts
-                                            .insert((round_number, Step::Precommit));
-                                    }
+                        // check if the skip ahead condition is fulfilled. If so, the state machine can be set to propose for round id.0
+                        if contributors.len() >= TProtocol::F_PLUS_ONE {
+                            // Vote None for all aggregations in between, as there is nothing to go by.
+                            // Keep track on aggregations which receive a vote.
+                            for round_number in self.state.current_round..round {
+                                if let Entry::Vacant(entry) =
+                                    self.state.votes.entry((round_number, Step::Prevote))
+                                {
+                                    entry.insert(None);
+                                    self.pending_aggregation_starts
+                                        .insert((round_number, Step::Prevote));
                                 }
-
-                                // Skip to that round
-                                self.state.current_round = round;
-                                self.state.current_step = Step::Propose;
-                                self.future_contributions.retain(|&round, _contributors| {
-                                    round > self.state.current_round
-                                });
-                                self.future_round_messages
-                                    .retain(|_, message| message.tag.0 > self.state.current_round);
-
-                                // The state changed and thus must be exported.
-                                *should_export_state = true;
-
-                                // Return to account for the state change
-                                return None;
+                                if let Entry::Vacant(entry) =
+                                    self.state.votes.entry((round_number, Step::Precommit))
+                                {
+                                    entry.insert(None);
+                                    self.pending_aggregation_starts
+                                        .insert((round_number, Step::Precommit));
+                                }
                             }
+
+                            // Skip to that round
+                            self.state.current_round = round;
+                            self.state.current_step = Step::Propose;
+                            self.future_contributions
+                                .retain(|&round, _contributors| round > self.state.current_round);
+                            self.future_round_messages
+                                .retain(|_, message| message.tag.0 > self.state.current_round);
+
+                            // The state changed and thus must be exported.
+                            *should_export_state = true;
+
+                            // Return to account for the state change
+                            return None;
                         }
-                    } else {
-                        // TODO: ban the peer
                     }
+                } else {
+                    // TODO: ban the peer
                 }
             }
 
@@ -714,10 +713,10 @@ impl<TProtocol: Protocol> Stream for Tendermint<TProtocol> {
             self.requested_proposals.poll_next_unpin(cx)
         {
             self.pending_proposal_requests.remove(&id);
-            if let Some(signed_proposal) = signed_proposal {
-                if self.process_proposal(signed_proposal).is_some() {
-                    should_export_state = true;
-                }
+            if let Some(signed_proposal) = signed_proposal
+                && self.process_proposal(signed_proposal).is_some()
+            {
+                should_export_state = true;
             }
             // Do nothing if the future ultimately resolved to None or Pending.
         }
@@ -736,16 +735,16 @@ impl<TProtocol: Protocol> Stream for Tendermint<TProtocol> {
         };
 
         // If a message failed to dispatch, try again, as polling the aggregations should have cleared up the buffer.
-        if let Some(message) = failed_message_opt {
-            if let Some(sender) = self.aggregation_senders.get(&message.tag) {
-                match sender.try_send(message.aggregation) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Closed(_aggregation_message)) => {
-                        panic!("Channel was closed unexpectedly.");
-                    }
-                    Err(mpsc::error::TrySendError::Full(_aggregation_message)) => {
-                        log::error!("Dispatching message failed with full channel twice!");
-                    }
+        if let Some(message) = failed_message_opt
+            && let Some(sender) = self.aggregation_senders.get(&message.tag)
+        {
+            match sender.try_send(message.aggregation) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Closed(_aggregation_message)) => {
+                    panic!("Channel was closed unexpectedly.");
+                }
+                Err(mpsc::error::TrySendError::Full(_aggregation_message)) => {
+                    log::error!("Dispatching message failed with full channel twice!");
                 }
             }
         }

--- a/tools/src/rpc-schema/main.rs
+++ b/tools/src/rpc-schema/main.rs
@@ -62,28 +62,28 @@ fn main() -> Result<(), Error> {
         Ok(entries) => {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.is_file() {
-                    if let Ok(contents) = fs::read_to_string(&path) {
-                        match parse_file(&contents) {
-                            Ok(ast) => {
-                                let structs = parser::extract_structs_from_ast(&ast);
-                                let fns = parser::extract_fns_from_ast(&ast);
-                                for index in 0..structs.len() {
-                                    builder = builder.with_schema(structs.get(index).unwrap());
-                                }
-                                for index in 0..fns.len() {
-                                    builder = builder.with_method(
-                                        fns.get(index).unwrap(),
-                                        path.file_name()
-                                            .unwrap()
-                                            .to_string_lossy()
-                                            .replace(".rs", ""),
-                                    );
-                                }
+                if path.is_file()
+                    && let Ok(contents) = fs::read_to_string(&path)
+                {
+                    match parse_file(&contents) {
+                        Ok(ast) => {
+                            let structs = parser::extract_structs_from_ast(&ast);
+                            let fns = parser::extract_fns_from_ast(&ast);
+                            for index in 0..structs.len() {
+                                builder = builder.with_schema(structs.get(index).unwrap());
                             }
-                            Err(err) => {
-                                return Err(AppError::ParsingError(err).into());
+                            for index in 0..fns.len() {
+                                builder = builder.with_method(
+                                    fns.get(index).unwrap(),
+                                    path.file_name()
+                                        .unwrap()
+                                        .to_string_lossy()
+                                        .replace(".rs", ""),
+                                );
                             }
+                        }
+                        Err(err) => {
+                            return Err(AppError::ParsingError(err).into());
                         }
                     }
                 }

--- a/utils/src/merkle/incremental.rs
+++ b/utils/src/merkle/incremental.rs
@@ -142,7 +142,7 @@ impl<H: HashOutput> IncrementalMerkleProofBuilder<H> {
             // The next node on the level is at current_index + 1.
             // We only need to add it to the proof, if our current index is
             // at an even position (left side of two hashes).
-            if current_pos % 2 == 0 {
+            if current_pos.is_multiple_of(2) {
                 proof
                     .nodes
                     .push(self.tree[current_level][current_pos + 1].clone());
@@ -365,10 +365,10 @@ impl<H: HashOutput> IncrementalMerkleProof<H> {
         }
 
         // Check root against previous root.
-        if let Some(prev_root) = previous_result.map(|r| &r.root) {
-            if prev_root != &root {
-                return Err(IncrementalMerkleProofError::InvalidProof);
-            }
+        if let Some(prev_root) = previous_result.map(|r| &r.root)
+            && prev_root != &root
+        {
+            return Err(IncrementalMerkleProofError::InvalidProof);
         }
 
         Ok(IncrementalMerkleProofResult {

--- a/utils/src/merkle/mod.rs
+++ b/utils/src/merkle/mod.rs
@@ -22,7 +22,7 @@ pub fn compute_root_from_content<D: Hasher, T: SerializeContent>(values: &[T]) -
     compute_root_from_hashes::<D::Output>(&v).into_owned()
 }
 
-pub fn compute_root_from_hashes<T: HashOutput>(values: &[T]) -> Cow<T> {
+pub fn compute_root_from_hashes<T: HashOutput>(values: &[T]) -> Cow<'_, T> {
     let mut hasher = T::Builder::default();
     match values.len() {
         0 => {
@@ -332,7 +332,7 @@ impl<'de, H: HashOutput> Deserialize<'de> for PoWMerklePath<H> {
         // I cannot use `deserializer.deserialize_bytes()` or anything similar that deserializes vecs, because
         // they internally read the first byte as the length byte and then only let you work with that number
         // of following bytes.
-        // Additionally, the number of fields passed to `deserializer.deserialize_stuct()` limits the number
+        // Additionally, the number of fields passed to `deserializer.deserialize_struct()` limits the number
         // of times one can call `seq.next_element()` in the visitor before it throws a `SerdeDeCustom` error.
         // Since we don't know how many nodes we need to parse from the input without looking at the input first
         // (need to read that first byte), we cannot use it.
@@ -359,7 +359,7 @@ pub type PoWBlake2bMerklePath = PoWMerklePath<Blake2bHash>;
 #[test]
 fn it_can_correctly_deserialize_pow_merkle_path() {
     // PoW merkle paths have the u8 count of nodes as the first byte, then the left-bits, then immediately the
-    // node hashes themselves - no length bytes inbetween.
+    // node hashes themselves - no length bytes in between.
     let bin = hex::decode("0280de8d7ee7e54f301095294d494024430c8b251b4ebf9b1384922dc7f9dd24422f830e231d26cdc3bbd1f55f1918757568522acae62c21e8046190ea84d6e8ff16")
         .unwrap();
     let _ = PoWMerklePath::<Blake2bHash>::deserialize_all(&bin).unwrap();

--- a/validator-network/src/network_impl.rs
+++ b/validator-network/src/network_impl.rs
@@ -124,10 +124,10 @@ where
         fallback: Arc<DhtFallback<N>>,
     ) -> Result<Option<N::PeerId>, NetworkError<N::Error>> {
         let result = Self::resolve_peer_id_dht(network, validator_address).await;
-        if !matches!(result, Ok(Some(_))) {
-            if let Some(peer_id) = fallback(validator_address.clone()).await {
-                return Ok(Some(peer_id));
-            }
+        if !matches!(result, Ok(Some(_)))
+            && let Some(peer_id) = fallback(validator_address.clone()).await
+        {
+            return Ok(Some(peer_id));
         }
         result
     }
@@ -292,10 +292,10 @@ where
         };
 
         // Clear the peer ID cache only if the error happened for the same Peer ID that we have cached.
-        if let CacheState::Resolved(cached_peer_id) = *cache_entry {
-            if cached_peer_id == *peer_id {
-                *cache_entry = CacheState::Empty(cached_peer_id);
-            }
+        if let CacheState::Resolved(cached_peer_id) = *cache_entry
+            && cached_peer_id == *peer_id
+        {
+            *cache_entry = CacheState::Empty(cached_peer_id);
         }
     }
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -393,11 +393,11 @@ where
 
         let blockchain = self.blockchain.read();
 
-        if let Some(hash) = head_hash {
-            if blockchain.head_hash() != *hash {
-                log::debug!("Bypassed initializing block producer for obsolete block");
-                return;
-            }
+        if let Some(hash) = head_hash
+            && blockchain.head_hash() != *hash
+        {
+            log::debug!("Bypassed initializing block producer for obsolete block");
+            return;
         }
 
         let head = blockchain.head();

--- a/validator/tests/mock.rs
+++ b/validator/tests/mock.rs
@@ -6,7 +6,6 @@ use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_database::mdbx::MdbxDatabase;
 use nimiq_genesis_builder::GenesisBuilder;
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
-use nimiq_network_interface::request::{MessageMarker, RequestCommon};
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_primitives::{networks::NetworkId, policy::Policy};
@@ -16,21 +15,6 @@ use nimiq_test_utils::validator::{
 };
 use nimiq_time::timeout;
 use nimiq_utils::spawn;
-use nimiq_validator::aggregation::{
-    skip_block::SignedSkipBlockMessage, update::SerializableLevelUpdate,
-};
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Deserialize, Serialize)]
-struct SkipBlockMessage(SerializableLevelUpdate<SignedSkipBlockMessage>);
-
-impl RequestCommon for SkipBlockMessage {
-    type Kind = MessageMarker;
-    const TYPE_ID: u16 = 2;
-    const MAX_REQUESTS: u32 = 500;
-    const TIME_WINDOW: Duration = Duration::from_millis(500);
-    type Response = ();
-}
 
 #[test(tokio::test)]
 async fn one_validator_can_create_micro_blocks() {

--- a/wallet/src/wallet_store.rs
+++ b/wallet/src/wallet_store.rs
@@ -26,11 +26,11 @@ impl WalletStore {
         }
     }
 
-    pub fn create_read_transaction(&self) -> MdbxReadTransaction {
+    pub fn create_read_transaction(&self) -> MdbxReadTransaction<'_> {
         self.env.read_transaction()
     }
 
-    pub fn create_write_transaction(&self) -> MdbxWriteTransaction {
+    pub fn create_write_transaction(&self) -> MdbxWriteTransaction<'_> {
         self.env.write_transaction()
     }
 

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -720,12 +720,12 @@ impl Client {
         start_at: Option<String>,
         min_peers: Option<usize>,
     ) -> Result<PlainTransactionReceiptArrayType, JsError> {
-        if let Some(max) = limit {
-            if max > MAX_TRANSACTIONS_BY_ADDRESS {
-                return Err(JsError::new(
-                    "The maximum number of transaction receipts exceeds the one that is supported",
-                ));
-            }
+        if let Some(max) = limit
+            && max > MAX_TRANSACTIONS_BY_ADDRESS
+        {
+            return Err(JsError::new(
+                "The maximum number of transaction receipts exceeds the one that is supported",
+            ));
         }
 
         let start_at = if let Some(start_at) = start_at {
@@ -792,12 +792,12 @@ impl Client {
             None
         };
 
-        if let Some(max) = limit {
-            if max > MAX_TRANSACTIONS_BY_ADDRESS {
-                return Err(JsError::new(
-                    "The maximum number of transactions exceeds the one that is supported",
-                ));
-            }
+        if let Some(max) = limit
+            && max > MAX_TRANSACTIONS_BY_ADDRESS
+        {
+            return Err(JsError::new(
+                "The maximum number of transactions exceeds the one that is supported",
+            ));
         }
 
         let address = Address::from_any(address)?.take_native();
@@ -835,12 +835,11 @@ impl Client {
         let mut receipts_to_fetch = vec![];
         for (hash, block_number) in receipts.iter() {
             // Skip known transactions that are already considered confirmed.
-            if let Some(known_tx) = known_txs.get(hash) {
-                if matches!(known_tx.state, TransactionState::Confirmed)
-                    && known_tx.block_height == Some(*block_number)
-                {
-                    continue;
-                }
+            if let Some(known_tx) = known_txs.get(hash)
+                && matches!(known_tx.state, TransactionState::Confirmed)
+                && known_tx.block_height == Some(*block_number)
+            {
+                continue;
             }
 
             // Ignore all receipts that are older than since_block_height.
@@ -866,10 +865,10 @@ impl Client {
             }
             // If the known transaction was earlier than the configured cutoff or the earliest
             // retrievable receipt, do not try to verify it.
-            if let Some(block_height) = details.block_height {
-                if block_height < since_block_height {
-                    continue;
-                }
+            if let Some(block_height) = details.block_height
+                && block_height < since_block_height
+            {
+                continue;
             }
 
             receipts_to_fetch.push((hash.clone(), details.block_height));

--- a/zkp-component/src/zkp_component.rs
+++ b/zkp-component/src/zkp_component.rs
@@ -261,10 +261,10 @@ impl<N: Network> ZKPComponent<N> {
         *zkp_state_lock = new_zkp_state;
 
         // Adds the new proof to storage.
-        if let Some(proof_storage) = &self.proof_storage {
-            if add_to_storage {
-                proof_storage.set_zkp(&zkp_state_lock.clone().into())
-            }
+        if let Some(proof_storage) = &self.proof_storage
+            && add_to_storage
+        {
+            proof_storage.set_zkp(&zkp_state_lock.clone().into())
         }
         drop(zkp_state_lock);
 

--- a/zkp-component/src/zkp_prover.rs
+++ b/zkp-component/src/zkp_prover.rs
@@ -199,38 +199,39 @@ impl<N: Network> Stream for ZKProver<N> {
         }
 
         // If a new proof was generated it sets the state and broadcasts the new proof.
-        if let Some(proof_future) = &mut self.proof_future {
-            if let Poll::Ready(proof) = proof_future.poll_unpin(cx) {
-                self.proof_future = None;
-                self.proof_future_abort = None;
-                match proof {
-                    Ok((new_zkp_state, block)) => {
-                        assert!(
-                            new_zkp_state.latest_proof.is_some(),
-                            "The generate new proof should never produces a empty proof"
-                        );
-                        let zkp_state_lock = self.zkp_state.upgradable_read();
+        if let Some(proof_future) = &mut self.proof_future
+            && let Poll::Ready(proof) = proof_future.poll_unpin(cx)
+        {
+            self.proof_future = None;
+            self.proof_future_abort = None;
+            match proof {
+                Ok((new_zkp_state, block)) => {
+                    assert!(
+                        new_zkp_state.latest_proof.is_some(),
+                        "The generate new proof should never produces a empty proof"
+                    );
+                    let zkp_state_lock = self.zkp_state.upgradable_read();
 
-                        // If we received a more recent proof in the meanwhile, we should have cancelled the proof generation process already.
-                        assert!(
-                            zkp_state_lock.latest_block.block_number() < new_zkp_state.latest_block.block_number(),
-                            "The generated proof should always be more recent than the current state"
-                        );
+                    // If we received a more recent proof in the meanwhile, we should have cancelled the proof generation process already.
+                    assert!(
+                        zkp_state_lock.latest_block.block_number()
+                            < new_zkp_state.latest_block.block_number(),
+                        "The generated proof should always be more recent than the current state"
+                    );
 
-                        let mut zkp_state_lock = RwLockUpgradableReadGuard::upgrade(zkp_state_lock);
-                        *zkp_state_lock = new_zkp_state;
+                    let mut zkp_state_lock = RwLockUpgradableReadGuard::upgrade(zkp_state_lock);
+                    *zkp_state_lock = new_zkp_state;
 
-                        let zkp_state_lock = RwLockWriteGuard::downgrade(zkp_state_lock);
+                    let zkp_state_lock = RwLockWriteGuard::downgrade(zkp_state_lock);
 
-                        let proof: ZKProof = zkp_state_lock.clone().into();
-                        Self::broadcast_zk_proof(&self.network, proof.clone());
-                        return Poll::Ready(Some((proof, block)));
-                    }
-                    Err(e) => {
-                        log::error!(error = %e, "Error generating ZK Proof for block");
-                    }
-                };
-            }
+                    let proof: ZKProof = zkp_state_lock.clone().into();
+                    Self::broadcast_zk_proof(&self.network, proof.clone());
+                    return Poll::Ready(Some((proof, block)));
+                }
+                Err(e) => {
+                    log::error!(error = %e, "Error generating ZK Proof for block");
+                }
+            };
         }
 
         Poll::Pending


### PR DESCRIPTION
Fixes the clippy warnings (elided lifetimes, removing nested if let clauses).
Increases the MSRV.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
