### PR TITLE
web-client: Allow unpacking empty arrays

### DIFF
--- a/web-client/extras/tests/PartialSignature.test.ts
+++ b/web-client/extras/tests/PartialSignature.test.ts
@@ -43,4 +43,25 @@ describe('PartialSignature', () => {
 
         expect(partial_signature.serialize().length).toBe(32);
     });
+
+    it('can create a partial signature without other signers', () => {
+        const privateKey = PrivateKey.generate();
+        const publicKey = PublicKey.derive(privateKey);
+
+        const commitmentPairs = [
+            CommitmentPair.generate(),
+            CommitmentPair.generate(),
+        ];
+
+        const partial_signature = PartialSignature.create(
+            privateKey,
+            publicKey,
+            commitmentPairs,
+            [],
+            [],
+            new Uint8Array(139),
+        );
+
+        expect(partial_signature.serialize().length).toBe(32);
+    });
 });

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -1344,10 +1344,6 @@ impl Client {
             .dyn_ref()
             .ok_or_else(|| JsError::new("`addresses` must be an array"))?;
 
-        if array.length() == 0 {
-            return Err(JsError::new("No addresses provided"));
-        }
-
         let mut addresses = Vec::<_>::with_capacity(array.length().try_into()?);
         for any in array.iter() {
             let address = Address::from_any(&any.into())?.take_native();

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -287,6 +287,9 @@ impl Client {
             .map_err(|_| JsError::new("listener is not a function"))?;
 
         let addresses: HashSet<_, _> = Client::unpack_addresses(addresses)?.into_iter().collect();
+        if addresses.is_empty() {
+            return Err(JsError::new("No addresses provided"));
+        }
 
         // Add addresses to our global list of subscribed addresses
         {

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -86,6 +86,10 @@ impl Address {
         num_signers: usize,
     ) -> Result<Address, JsError> {
         let public_keys = PublicKey::unpack_public_keys(public_keys)?;
+        if public_keys.is_empty() {
+            return Err(JsError::new("No public keys provided"));
+        }
+
         let combined_public_keys = combine_public_keys(public_keys, num_signers);
         Ok(Address::from(compute_address(&combined_public_keys)))
     }

--- a/web-client/src/common/signature_proof.rs
+++ b/web-client/src/common/signature_proof.rs
@@ -223,10 +223,6 @@ impl SignatureProof {
             .dyn_ref()
             .ok_or_else(|| JsError::new("`public_keys` must be an array"))?;
 
-        if array.length() == 0 {
-            return Err(JsError::new("No public keys provided"));
-        }
-
         let mut public_keys = Vec::<_>::with_capacity(array.length().try_into()?);
         for item in array.iter() {
             let public_key = SignatureProof::unpack_public_key(item.unchecked_ref())

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -37,6 +37,10 @@ impl Commitment {
     /// Sums up multiple commitments into one aggregated commitment.
     pub fn sum(commitments: &CommitmentAnyArrayType) -> Result<Commitment, JsError> {
         let commitments = Commitment::unpack_commitments(commitments)?;
+        if commitments.is_empty() {
+            return Err(JsError::new("No commitments provided"));
+        }
+
         let aggregate_commitment =
             nimiq_keys::multisig::commitment::Commitment::sum(commitments.into_iter());
         Ok(Commitment::from(aggregate_commitment))

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -128,10 +128,6 @@ impl Commitment {
             .dyn_ref()
             .ok_or_else(|| JsError::new("`commitments` must be an array"))?;
 
-        if array.length() == 0 {
-            return Err(JsError::new("No commitments provided"));
-        }
-
         let mut commitments = Vec::<_>::with_capacity(array.length().try_into()?);
         for any in array.iter() {
             let commitment = Commitment::from_any(&any.into())?.take_native();
@@ -149,10 +145,6 @@ impl Commitment {
         let array: &Array = js_value
             .dyn_ref()
             .ok_or_else(|| JsError::new("`commitments_list` must be an array"))?;
-
-        if array.length() == 0 {
-            return Err(JsError::new("No commitments list provided"));
-        }
 
         let mut commitments_list = Vec::<_>::with_capacity(array.length().try_into()?);
         for any in array.iter() {

--- a/web-client/src/multisig/commitment_pair.rs
+++ b/web-client/src/multisig/commitment_pair.rs
@@ -140,10 +140,6 @@ impl CommitmentPair {
             .dyn_ref()
             .ok_or_else(|| JsError::new("`pairs` must be an array"))?;
 
-        if array.length() == 0 {
-            return Err(JsError::new("No pairs provided"));
-        }
-
         let mut pairs = Vec::<_>::with_capacity(array.length().try_into()?);
         for any in array.iter() {
             let pair = CommitmentPair::from_any(&any.into())?.take_native();

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -172,10 +172,6 @@ impl PublicKey {
             .dyn_ref()
             .ok_or_else(|| JsError::new("`keys` must be an array"))?;
 
-        if array.length() == 0 {
-            return Err(JsError::new("No keys provided"));
-        }
-
         let mut keys = Vec::<_>::with_capacity(array.length().try_into()?);
         for any in array.iter() {
             let key = PublicKey::from_any(&any.into())?.take_native();


### PR DESCRIPTION
## What's in this pull request?

It's currently not possible to create a `PartialSignature` from the web-client without any other public keys or commitments, e.g. for 1-of-X multisig wallets. The `unpack_*` methods in the web-client that convert a Javascript `Array` into a Rust `Vec` require(d) a non-empty list.

This requirement is not necessary and removing these checks fixes the 1-of-X use case.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
