### PR TITLE
Create a new consensus sync tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ dependencies = [
  "nimiq-blockchain-proxy",
  "nimiq-bls",
  "nimiq-collections",
+ "nimiq-consensus",
  "nimiq-hash",
  "nimiq-jsonrpc-client",
  "nimiq-jsonrpc-core",

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -23,6 +23,7 @@ use nimiq_network_interface::{
     request::{OutboundRequestError, RequestError},
 };
 use nimiq_primitives::{key_nibbles::KeyNibbles, policy::Policy};
+use nimiq_serde::{Deserialize, Serialize};
 use nimiq_transaction::{
     historic_transaction::HistoricTransaction, ControlTransaction, ControlTransactionTopic,
     Transaction, TransactionTopic,
@@ -32,7 +33,7 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use super::{ConsensusRequest, ResolveBlockError, ResolveBlockRequest};
 use crate::{
-    consensus::remote_data_store::RemoteDataStore,
+    consensus::{remote_data_store::RemoteDataStore, SyncProgress},
     messages::{
         AddressNotification, AddressSubscriptionOperation, AddressSubscriptionTopic,
         RequestBlocksProof, RequestSubscribeToAddress, RequestTransactionReceiptsByAddress,
@@ -40,6 +41,19 @@ use crate::{
     },
     ConsensusEvent,
 };
+
+/// This struct is used to track the progress of the consensus sync
+/// and return it to the user.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsensusSyncStatus {
+    pub is_established: bool,
+    pub synced_validity_window: bool,
+    pub current_block: u32,
+    pub remaning_blocks: u32,
+    pub state_sync_progress: u32,
+}
+
 /// Implements the logic for handling consensus-related requests.
 ///
 /// The consensus proxy provides methods for interacting with peers, syncing nodes,
@@ -48,6 +62,7 @@ use crate::{
 pub struct ConsensusProxy<N: Network> {
     pub blockchain: BlockchainProxy,
     pub network: Arc<N>,
+    pub(crate) sync_progress: Arc<SyncProgress>,
     pub(crate) established_flag: Arc<AtomicBool>,
     pub(crate) synced_validity_window_flag: Arc<AtomicBool>,
     pub(crate) events: broadcast::Sender<ConsensusEvent>,
@@ -59,6 +74,7 @@ impl<N: Network> Clone for ConsensusProxy<N> {
         Self {
             blockchain: self.blockchain.clone(),
             network: Arc::clone(&self.network),
+            sync_progress: Arc::clone(&self.sync_progress),
             established_flag: Arc::clone(&self.established_flag),
             synced_validity_window_flag: Arc::clone(&self.synced_validity_window_flag),
             events: self.events.clone(),
@@ -75,6 +91,38 @@ impl<N: Network> ConsensusProxy<N> {
                     .publish::<TransactionTopic>(err.into_inner())
                     .await
             }
+        }
+    }
+
+    /// Returns the current sync status of the consensus.
+    pub fn get_sync_status(&self) -> ConsensusSyncStatus {
+        let is_established = self.is_established();
+        let synced_validity_window = self.blockchain.read().can_enforce_validity_window();
+        let current_block = self
+            .sync_progress
+            .current_block_number
+            .load(Ordering::Acquire);
+        let mut remaning_blocks = self
+            .sync_progress
+            .remaning_blocks_to_sync
+            .load(Ordering::Acquire);
+        let mut state_sync_progress = self
+            .sync_progress
+            .live_sync_progress
+            .load(Ordering::Acquire);
+
+        // If consensus is established, we set the remaning blocks to 0 and the state sync progress to 100
+        if is_established {
+            remaning_blocks = 0;
+            state_sync_progress = 100;
+        }
+
+        ConsensusSyncStatus {
+            is_established,
+            synced_validity_window,
+            current_block,
+            remaning_blocks,
+            state_sync_progress,
         }
     }
 

--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -50,7 +50,7 @@ pub struct ConsensusSyncStatus {
     pub is_established: bool,
     pub synced_validity_window: bool,
     pub current_block: u32,
-    pub remaning_blocks: u32,
+    pub remaining_blocks: u32,
     pub state_sync_progress: u32,
 }
 
@@ -102,18 +102,18 @@ impl<N: Network> ConsensusProxy<N> {
             .sync_progress
             .current_block_number
             .load(Ordering::Acquire);
-        let mut remaning_blocks = self
+        let mut remaining_blocks = self
             .sync_progress
-            .remaning_blocks_to_sync
+            .remaining_blocks_to_sync
             .load(Ordering::Acquire);
         let mut state_sync_progress = self
             .sync_progress
             .live_sync_progress
             .load(Ordering::Acquire);
 
-        // If consensus is established, we set the remaning blocks to 0 and the state sync progress to 100
+        // If consensus is established, we set the remaining blocks to 0 and the state sync progress to 100
         if is_established {
-            remaning_blocks = 0;
+            remaining_blocks = 0;
             state_sync_progress = 100;
         }
 
@@ -121,7 +121,7 @@ impl<N: Network> ConsensusProxy<N> {
             is_established,
             synced_validity_window,
             current_block,
-            remaning_blocks,
+            remaining_blocks,
             state_sync_progress,
         }
     }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -9,7 +9,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
         Arc,
     },
     task::{Context, Poll, Waker},
@@ -132,6 +132,14 @@ pub struct ResolveBlockRequest<N: Network> {
 pub enum ConsensusRequest<N: Network> {
     ResolveBlock(ResolveBlockRequest<N>),
 }
+
+/// This struct is used to track the sync progress to reach consensus.
+pub struct SyncProgress {
+    pub current_block_number: AtomicU32,
+    pub remaning_blocks_to_sync: AtomicU32,
+    pub live_sync_progress: Arc<AtomicU32>,
+}
+
 /// Coordinates synchronization between the blockchain and the network.
 /// Tracks peers, handles event notifications, and manages requests for chain data.
 /// Provides channels and flags for other components to maintain chain state.
@@ -140,6 +148,7 @@ pub struct Consensus<N: Network> {
     pub network: Arc<N>,
 
     pub sync: SyncerProxy<N>,
+    pub sync_progress: Arc<SyncProgress>,
 
     events: broadcast::Sender<ConsensusEvent>,
     established_flag: Arc<AtomicBool>,
@@ -196,6 +205,7 @@ impl<N: Network> Consensus<N> {
             syncer,
             Self::MIN_PEERS_ESTABLISHED,
             zkp_proxy,
+            Arc::new(AtomicU32::new(0)),
         )
     }
 
@@ -205,6 +215,7 @@ impl<N: Network> Consensus<N> {
         syncer: SyncerProxy<N>,
         min_peers: usize,
         zkp_proxy: ZKPComponentProxy<N>,
+        syncer_tracker: Arc<AtomicU32>,
     ) -> Self {
         Self::init_network_request_receivers(&network, &blockchain);
 
@@ -221,6 +232,12 @@ impl<N: Network> Consensus<N> {
         }
         let synced_validity_window_flag = Arc::new(AtomicBool::new(synced_validity_window_flag));
 
+        let sync_progress = Arc::new(SyncProgress {
+            current_block_number: AtomicU32::new(0),
+            remaning_blocks_to_sync: AtomicU32::new(0),
+            live_sync_progress: syncer_tracker,
+        });
+
         Consensus {
             blockchain,
             network,
@@ -229,6 +246,7 @@ impl<N: Network> Consensus<N> {
             established_flag,
             #[cfg(feature = "full")]
             last_batch_number: 0,
+            sync_progress,
             synced_validity_window_flag,
             head_requests: None,
             head_requests_time: None,
@@ -323,6 +341,7 @@ impl<N: Network> Consensus<N> {
         ConsensusProxy {
             blockchain: self.blockchain.clone(),
             network: Arc::clone(&self.network),
+            sync_progress: Arc::clone(&self.sync_progress),
             established_flag: Arc::clone(&self.established_flag),
             synced_validity_window_flag: Arc::clone(&self.synced_validity_window_flag),
             events: self.events.clone(),
@@ -556,6 +575,13 @@ impl<N: Network> Future for Consensus<N> {
                             "Catching up to tip of the chain (now at #{}, {} blocks remaining)",
                             block_number, remaining_in_buffer
                         );
+
+                        self.sync_progress
+                            .current_block_number
+                            .store(block_number, Ordering::Relaxed);
+                        self.sync_progress
+                            .remaning_blocks_to_sync
+                            .store(remaining_in_buffer as u32, Ordering::Relaxed);
 
                         if remaining_in_buffer == 0 {
                             self.head_requests_time = None;

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -136,7 +136,7 @@ pub enum ConsensusRequest<N: Network> {
 /// This struct is used to track the sync progress to reach consensus.
 pub struct SyncProgress {
     pub current_block_number: AtomicU32,
-    pub remaning_blocks_to_sync: AtomicU32,
+    pub remaining_blocks_to_sync: AtomicU32,
     pub live_sync_progress: Arc<AtomicU32>,
 }
 
@@ -234,7 +234,7 @@ impl<N: Network> Consensus<N> {
 
         let sync_progress = Arc::new(SyncProgress {
             current_block_number: AtomicU32::new(0),
-            remaning_blocks_to_sync: AtomicU32::new(0),
+            remaining_blocks_to_sync: AtomicU32::new(0),
             live_sync_progress: syncer_tracker,
         });
 
@@ -578,10 +578,10 @@ impl<N: Network> Future for Consensus<N> {
 
                         self.sync_progress
                             .current_block_number
-                            .store(block_number, Ordering::Relaxed);
+                            .store(block_number, Ordering::Release);
                         self.sync_progress
-                            .remaning_blocks_to_sync
-                            .store(remaining_in_buffer as u32, Ordering::Relaxed);
+                            .remaining_blocks_to_sync
+                            .store(remaining_in_buffer as u32, Ordering::Release);
 
                         if remaining_in_buffer == 0 {
                             self.head_requests_time = None;

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -577,7 +577,7 @@ impl<N: Network> Stream for StateQueue<N> {
                         let percentage = (key as f32 / u32::MAX as f32) * 100.0;
 
                         self.sync_progress
-                            .store(percentage as u32, Ordering::Relaxed);
+                            .store(percentage as u32, Ordering::Release);
 
                         log::info!(
                             ?start_key,

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -7,7 +7,10 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::{self, Display},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
 };
 
@@ -149,6 +152,9 @@ pub struct StateQueue<N: Network> {
     /// Reference to the blockchain.
     blockchain: Arc<RwLock<Blockchain>>,
 
+    /// Reference to the sync progress tracker
+    sync_progress: Arc<AtomicU32>,
+
     /// Reference to the network.
     network: Arc<N>,
 
@@ -194,6 +200,7 @@ impl<N: Network> StateQueue<N> {
         blockchain: Arc<RwLock<Blockchain>>,
         mut diff_queue: DiffQueue<N>,
         config: QueueConfig,
+        sync_tracker: Arc<AtomicU32>,
     ) -> Self {
         let chunk_request_component =
             ChunkRequestComponent::new(Arc::clone(&network), diff_queue.peer_list());
@@ -218,6 +225,7 @@ impl<N: Network> StateQueue<N> {
             blockchain,
             network,
             diff_queue,
+            sync_progress: sync_tracker,
             chunk_request_component,
             buffer: Default::default(),
             buffer_size: 0,
@@ -567,6 +575,10 @@ impl<N: Network> Stream for StateQueue<N> {
                             .unwrap_or(0);
 
                         let percentage = (key as f32 / u32::MAX as f32) * 100.0;
+
+                        self.sync_progress
+                            .store(percentage as u32, Ordering::Relaxed);
+
                         log::info!(
                             ?start_key,
                             "Received state sync chunk, ~{:.2}% complete",

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -11,7 +11,7 @@ use std::cmp::max;
 use std::{
     mem,
     pin::Pin,
-    sync::Arc,
+    sync::{atomic::AtomicU32, Arc},
     task::{Context, Poll},
 };
 
@@ -219,6 +219,7 @@ impl<N: Network> SyncerProxy<N> {
         zkp_component_proxy: ZKPComponentProxy<N>,
         network_event_rx: SubscribeEvents<N::PeerId>,
         full_sync_threshold: u32,
+        syncer_tracker: Arc<AtomicU32>,
     ) -> Self {
         // Start from the default configuration for the block queue.
         let mut queue_config = QueueConfig::default();
@@ -250,6 +251,7 @@ impl<N: Network> SyncerProxy<N> {
             Arc::clone(&blockchain),
             diff_queue,
             queue_config,
+            syncer_tracker,
         );
 
         // Set up live sync with state queue.

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, task::Poll};
+use std::{
+    sync::{atomic::AtomicU32, Arc},
+    task::Poll,
+};
 
 use futures::{join, poll, Future, Stream, StreamExt};
 use log::info;
@@ -102,6 +105,7 @@ fn get_incomplete_live_sync(
         Arc::clone(&incomplete_blockchain),
         diff_queue,
         QueueConfig::default(),
+        Arc::new(AtomicU32::new(0)),
     );
 
     let live_sync = StateLiveSync::with_queue(

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU32, Arc};
 
 use futures::{future, StreamExt};
 use nimiq_blockchain::{BlockProducer, Blockchain, BlockchainConfig};
@@ -58,6 +58,7 @@ async fn syncer(
                 zkp_prover.proxy(),
                 network.subscribe_events(),
                 0,
+                Arc::new(AtomicU32::new(0)),
             )
             .await
         }
@@ -214,6 +215,7 @@ pub async fn sync_two_peers(
         syncer2,
         1,
         zkp_prover2_proxy,
+        Arc::new(AtomicU32::new(0)),
     );
     let consensus2_proxy = consensus2.proxy();
     let events = blockchain2_proxy.read().notifier_as_stream();

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -1,4 +1,8 @@
-use std::{fs, io, num::NonZeroU8, sync::Arc};
+use std::{
+    fs, io,
+    num::NonZeroU8,
+    sync::{atomic::AtomicU32, Arc},
+};
 
 use instant::SystemTime;
 use nimiq_block::Block;
@@ -443,6 +447,8 @@ impl ClientInner {
         // Start buffering network events as early as possible
         let network_events = network.subscribe_events();
 
+        let syncer_tracker = Arc::new(AtomicU32::new(0));
+
         let (syncer_proxy, zkp_component) = match config.consensus.sync_mode {
             #[cfg(not(feature = "full-consensus"))]
             SyncMode::History => {
@@ -511,6 +517,7 @@ impl ClientInner {
                     zkp_component.proxy(),
                     network_events,
                     config.consensus.full_sync_threshold,
+                    Arc::clone(&syncer_tracker),
                 )
                 .await;
                 (syncer, zkp_component)
@@ -556,6 +563,7 @@ impl ClientInner {
             syncer_proxy,
             config.consensus.min_peers,
             zkp_component.proxy(),
+            syncer_tracker,
         );
 
         #[cfg(feature = "validator")]

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -38,6 +38,7 @@ nimiq-blockchain-interface = { workspace = true }
 nimiq-blockchain-proxy = { workspace = true }
 nimiq-bls = { workspace = true, features = ["serde-derive"] }
 nimiq-collections = { workspace = true }
+nimiq-consensus = {workspace = true}
 nimiq-hash = { workspace = true }
 nimiq-jsonrpc-client = { workspace = true }
 nimiq-jsonrpc-core = { workspace = true }

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use nimiq_consensus::consensus::consensus_proxy::ConsensusSyncStatus;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::coin::Coin;
@@ -15,6 +16,9 @@ pub trait ConsensusInterface {
     // `nimiq_jsonrpc_derive::proxy` requires the receiver type to be a mutable reference.
     #[allow(clippy::wrong_self_convention)]
     async fn is_consensus_established(&self) -> RPCResult<bool, (), Self::Error>;
+
+    /// Returns the status of the sync process
+    async fn get_sync_status(&self) -> RPCResult<ConsensusSyncStatus, (), Self::Error>;
 
     /// Given a serialized transaction, it will return the corresponding transaction struct.
     async fn get_raw_transaction_info(

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainReadProxy;
 use nimiq_bls::{KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
-use nimiq_consensus::ConsensusProxy;
+use nimiq_consensus::{consensus::consensus_proxy::ConsensusSyncStatus, ConsensusProxy};
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_keys::{Address, Ed25519PublicKey, KeyPair, PrivateKey};
 use nimiq_network_libp2p::Network;
@@ -75,6 +75,10 @@ impl ConsensusInterface for ConsensusDispatcher {
 
     async fn is_consensus_established(&self) -> RPCResult<bool, (), Self::Error> {
         Ok(self.consensus.is_established().into())
+    }
+
+    async fn get_sync_status(&self) -> RPCResult<ConsensusSyncStatus, (), Self::Error> {
+        Ok(self.consensus.get_sync_status().into())
     }
 
     async fn get_raw_transaction_info(

--- a/test-utils/src/node.rs
+++ b/test-utils/src/node.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{atomic::AtomicU32, Arc},
+};
 
 use nimiq_block::Block;
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
@@ -100,6 +103,7 @@ impl<N: NetworkInterface + TestNetwork> Node<N> {
             syncer,
             1,
             zkp_proxy.proxy(),
+            Arc::new(AtomicU32::new(0)),
         );
 
         Node {

--- a/validator/src/proposal_buffer.rs
+++ b/validator/src/proposal_buffer.rs
@@ -538,7 +538,10 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> Clone for ProposalReceiver<T
 
 #[cfg(test)]
 mod test {
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        sync::{atomic::AtomicU32, Arc},
+        time::Duration,
+    };
 
     use futures::{FutureExt, StreamExt};
     use nimiq_block::MacroHeader;
@@ -587,7 +590,14 @@ mod test {
         )
         .await;
 
-        Consensus::new(blockchain_proxy, net, syncer, 0, zkp_proxy)
+        Consensus::new(
+            blockchain_proxy,
+            net,
+            syncer,
+            0,
+            zkp_proxy,
+            Arc::new(AtomicU32::new(0)),
+        )
     }
 
     async fn setup() -> (

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, task::Poll};
+use std::{
+    sync::{atomic::AtomicU32, Arc},
+    task::Poll,
+};
 
 use futures::{poll, Stream, StreamExt};
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -51,6 +54,7 @@ pub async fn it_can_initialize_with_mock_network() {
         syncer,
         3,
         zkp_component.proxy(),
+        Arc::new(AtomicU32::new(0)),
     );
 
     if let Poll::Ready(_) = poll!(consensus) {


### PR DESCRIPTION
Add a method that returns the status of the sync progress within consensus. Currently, it tracks:
 - Validity window synced
 - State sync progress
 - Current block/remaning blocks for live sync
 - Consensus established

Fixes #2815

## What's in this pull request?

...
#### This fixes #2815 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
