### PR TITLE
Update WASM tooling to support latest Rust version

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -127,7 +127,7 @@ jobs:
         tool-cache: true
         large-packages: false
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.86.0
+    - uses: dtolnay/rust-toolchain@stable
       with:
         targets: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.86.0
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ temp-state
 .vscode
 # Python
 __pycache__/
+# WASM tooling
+web-client/binaryen-version_*/

--- a/web-client/scripts/build.sh
+++ b/web-client/scripts/build.sh
@@ -58,8 +58,9 @@ function generate() {
     wasm-bindgen --weak-refs --target "$TARGET" --out-name index --out-dir "$OUT_DIR" --no-typescript "$CARGO_OUTPUT"
 
     if [ "$RUN_WASM_OPT" = "true" ]; then
+        echo "Optimizing $TYPE WASM..."
         # Optimize bindgen's WASM output for size
-        wasm-opt -Os -o "$OPT_OUTPUT" "$BINDGEN_OUTPUT"
+        wasm-opt "$BINDGEN_OUTPUT" -Os -o "$OPT_OUTPUT"
         # Replace bindgen's WASM output with the optimized one
         mv "$OPT_OUTPUT" "$BINDGEN_OUTPUT"
     fi
@@ -73,8 +74,27 @@ then
 fi
 if ! command -v wasm-opt &> /dev/null
 then
-    echo "Installing wasm-opt..."
-    cargo install wasm-opt
+    BINARYEN_VERSION=124
+    BINARYEN_FOLDER="binaryen-version_$BINARYEN_VERSION"
+
+    # Test if correct wasm-opt is already downloaded
+    if [ -f "$BINARYEN_FOLDER/wasm-opt" ]; then
+        export PATH="$PATH:$(pwd)/$BINARYEN_FOLDER"
+    else
+        echo "Downloading wasm-opt $BINARYEN_VERSION..."
+        # Download release from GitHub
+        curl https://github.com/WebAssembly/binaryen/releases/download/version_$BINARYEN_VERSION/$BINARYEN_FOLDER-x86_64-linux.tar.gz --location --output binaryen.tar.gz
+        # Extract archive
+        tar -xvzf binaryen.tar.gz
+        # Delete archive
+        rm binaryen.tar.gz
+        # Move wasm-opt binary to root of extracted folder and delete everything else
+        mv ./$BINARYEN_FOLDER/bin/wasm-opt ./$BINARYEN_FOLDER/wasm-opt
+        rm -rf ./$BINARYEN_FOLDER/bin
+        rm -rf ./$BINARYEN_FOLDER/include
+        rm -rf ./$BINARYEN_FOLDER/lib
+        export PATH="$PATH:$(pwd)/$BINARYEN_FOLDER"
+    fi
 fi
 
 contains() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}


### PR DESCRIPTION
The version used by the wasm-opt crate is sadly outdated (116) and the crate was not updated in a long time.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
