### PR TITLE
Fix history sync on testnet & Simplifying history sync artificial checkpoint blocks

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -199,54 +199,55 @@ impl Blockchain {
         let mut block_state = vec![];
         let mut block_transactions = vec![];
         let mut block_inherents = vec![];
-
-        let mut prev_batch = 0;
-        let mut prev_block = 0;
+        let mut prev_batch = this
+            .chain_store
+            .get_block(&this.state.head_hash, false, Some(&txn))
+            .map_or(0, |head| Policy::batch_at(head.block_number()));
 
         for hist_tx in history.iter().skip(first_new_hist_tx) {
+            let prev_block = block_state
+                .last()
+                .map_or(Policy::genesis_block_number(), |b: &BlockState| b.number);
+
             if hist_tx.block_number > prev_block {
+                let new_batch = Policy::batch_at(hist_tx.block_number);
                 // If a macro block does not have any history items, we need to add it here so that
-                // we always commit FinalizeBatch/FinalizeEpoch inherents.
-                // FIXME We're missing the block timestamp to do this correctly.
-                // Also, this works only if a single macro block is missing between history items.
-                let batch_number = Policy::batch_at(hist_tx.block_number);
-                if batch_number > prev_batch
-                    && block_state.last().is_some_and(|block_state: &BlockState| {
-                        !Policy::is_macro_block_at(block_state.number)
-                    })
-                {
+                // we always commit FinalizeBatch/FinalizeEpoch inherents. The first checkpoint block
+                // of the first epoch is special because it may legitimately be missing entirely due
+                // to the reward payout delay.
+                if prev_batch <= 1 && new_batch == 2 {
                     debug!(
                         history_item_block_number = hist_tx.block_number,
                         prev_block,
-                        history_item_batch = batch_number,
                         prev_batch,
-                        last_block = ?block_state.last(),
-                        "Inserting macro block"
+                        history_item_batch = new_batch,
+                        "Adding the first checkpoint block manually since there weren't any txs on it."
                     );
-                    if batch_number != prev_batch + 1 {
-                        warn!(
-                            %block,
-                            reason = "missing batch in history",
-                            history_item_block_number = hist_tx.block_number,
-                            history_item_batch = batch_number,
-                            prev_batch,
-                            "Rejecting block",
-                        );
-                        txn.abort();
-                        #[cfg(feature = "metrics")]
-                        this.metrics.note_invalid_block();
-                        return Err(PushError::InvalidBlock(BlockError::InvalidHistoryRoot));
-                    }
 
+                    // Push the omitted macro block (checkpoint 1).
                     block_state.push(BlockState {
-                        number: Policy::macro_block_of(prev_batch).unwrap(),
-                        time: 0,                                        // FIXME
+                        number: Policy::macro_block_before(hist_tx.block_number),
+                        time: 0,
                         protocol_version: this.state.current_version(), // Cannot change, protocol version upgrades only on election blocks.
                     });
                     block_transactions.push(vec![]);
                     block_inherents.push(vec![]);
+                } else if prev_batch < new_batch && !Policy::is_macro_block_at(prev_block) {
+                    warn!(
+                        %block,
+                        reason = "missing macro block in history",
+                        history_item_block_number = hist_tx.block_number,
+                        history_item_batch = new_batch,
+                        prev_batch,
+                        "Rejecting block",
+                    );
+                    txn.abort();
+                    #[cfg(feature = "metrics")]
+                    this.metrics.note_invalid_block();
+                    return Err(PushError::InvalidBlock(BlockError::InvalidHistoryRoot));
                 }
 
+                // Push the block of the historic transaction.
                 block_state.push(BlockState {
                     number: hist_tx.block_number,
                     time: hist_tx.block_time,
@@ -255,8 +256,7 @@ impl Blockchain {
                 block_transactions.push(vec![]);
                 block_inherents.push(vec![]);
 
-                prev_batch = batch_number;
-                prev_block = hist_tx.block_number;
+                prev_batch = new_batch;
             }
 
             match &hist_tx.data {

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -197,46 +197,35 @@ impl Blockchain {
         let mut block_timestamps = vec![];
         let mut block_transactions = vec![];
         let mut block_inherents = vec![];
-
-        let mut prev_batch = 0;
         let mut prev_block = 0;
+        let mut prev_batch = 0;
 
         for hist_tx in history.iter().skip(first_new_hist_tx) {
             if hist_tx.block_number > prev_block {
-                // If a macro block does not have any history items, we need to add it here so that
-                // we always commit FinalizeBatch/FinalizeEpoch inherents.
-                // FIXME We're missing the block timestamp to do this correctly.
-                //  Also, this works only if a single macro block is missing between history items.
-                let batch_number = Policy::batch_at(hist_tx.block_number);
-                if batch_number > prev_batch
-                    && block_numbers
-                        .last()
-                        .map(|block_number| !Policy::is_macro_block_at(*block_number))
-                        .unwrap_or(false)
-                {
-                    debug!(
-                        history_item_block_number = hist_tx.block_number,
-                        prev_block,
-                        history_item_batch = batch_number,
-                        prev_batch,
-                        last_block_number = ?block_numbers.last(),
-                        "Inserting macro block"
+                let new_batch = Policy::batch_at(prev_block);
+                if prev_batch == 0 && new_batch > 1 {
+                    assert_eq!(
+                        new_batch, 2,
+                        "We cannot skip over macro blocks after batch 1 due to reward payout txs."
                     );
-                    assert_eq!(batch_number, prev_batch + 1, "Missing batch");
-
-                    block_numbers.push(Policy::macro_block_of(prev_batch).unwrap());
-                    block_timestamps.push(0); // FIXME
+                    block_state.push(BlockState {
+                        number: Policy::macro_block_after(hist_tx.block_number),
+                        time: 0, // FIX ME change the response to never skip macro_blocks.
+                        protocol_version: this.state.current_version(), // Cannot change, protocol version upgrades only on election blocks.
+                    });
                     block_transactions.push(vec![]);
                     block_inherents.push(vec![]);
                 }
-
-                block_numbers.push(hist_tx.block_number);
-                block_timestamps.push(hist_tx.block_time);
+                block_state.push(BlockState {
+                    number: hist_tx.block_number,
+                    time: hist_tx.block_time,
+                    protocol_version: this.state.current_version(), // Cannot change, protocol version upgrades only on election blocks.
+                });
                 block_transactions.push(vec![]);
                 block_inherents.push(vec![]);
 
-                prev_batch = batch_number;
                 prev_block = hist_tx.block_number;
+                prev_batch = new_batch;
             }
 
             match &hist_tx.data {

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -193,25 +193,30 @@ impl Blockchain {
         // We know it comes sorted because we already checked it against the history root and
         // historic transactions in the history tree come sorted by block number and type.
         // Ignore the historic transactions that were already added in past macro blocks.
-        let mut block_numbers = vec![];
-        let mut block_timestamps = vec![];
+        let mut block_state = vec![];
         let mut block_transactions = vec![];
         let mut block_inherents = vec![];
         let mut prev_block = 0;
-        let mut prev_batch = 0;
+        let mut prev_batch = this
+            .chain_store
+            .get_block(&this.state.head_hash, false, Some(&txn))
+            .map_or(0, |head| Policy::batch_at(head.block_number()));
 
         for hist_tx in history.iter().skip(first_new_hist_tx) {
             if hist_tx.block_number > prev_block {
-                let new_batch = Policy::batch_at(prev_block);
+                let new_batch = Policy::batch_at(hist_tx.block_number);
                 if prev_batch == 0 && new_batch > 1 {
+                    // This is the only macro block that can be missing since we delay the reward payments one batch.
+                    // If we are missing the very first macro block we add it artificially here and this also
+                    // means we lost its timestamp.
                     assert_eq!(
                         new_batch, 2,
                         "We cannot skip over macro blocks after batch 1 due to reward payout txs."
                     );
+                    log::debug!("Adding the first checkpoint block manually since there weren't any txs on it.");
                     block_state.push(BlockState {
                         number: Policy::macro_block_after(hist_tx.block_number),
-                        time: 0, // FIX ME change the response to never skip macro_blocks.
-                        protocol_version: this.state.current_version(), // Cannot change, protocol version upgrades only on election blocks.
+                        time: 0,
                     });
                     block_transactions.push(vec![]);
                     block_inherents.push(vec![]);
@@ -219,7 +224,6 @@ impl Blockchain {
                 block_state.push(BlockState {
                     number: hist_tx.block_number,
                     time: hist_tx.block_time,
-                    protocol_version: this.state.current_version(), // Cannot change, protocol version upgrades only on election blocks.
                 });
                 block_transactions.push(vec![]);
                 block_inherents.push(vec![]);
@@ -266,17 +270,19 @@ impl Blockchain {
         }
 
         // Add the final macro block (the one we're proving against) if it's not included yet.
-        if block_numbers
+        if block_state
             .last()
-            .map(|block_number| *block_number != block.block_number())
+            .map(|block_state| block_state.number != block.block_number())
             .unwrap_or(true)
         {
             debug!(
                 block_number = block.block_number(),
                 "Inserting final macro block"
             );
-            block_numbers.push(block.block_number());
-            block_timestamps.push(block.timestamp());
+            block_state.push(BlockState {
+                number: block.block_number(),
+                time: block.timestamp(),
+            });
             block_transactions.push(vec![]);
             block_inherents.push(vec![]);
         }
@@ -284,16 +290,16 @@ impl Blockchain {
         // We go over the blocks one more time and add the FinalizeBatch and FinalizeEpoch inherents
         // to the macro blocks. This is necessary because the History Store doesn't store those inherents
         // so we need to add them again in order to correctly sync.
-        for (i, block_number) in block_numbers.iter().enumerate() {
-            if Policy::is_macro_block_at(*block_number) {
+        for (i, block_state) in block_state.iter().enumerate() {
+            if Policy::is_macro_block_at(block_state.number) {
                 block_inherents
                     .get_mut(i)
                     .unwrap()
                     .push(Inherent::FinalizeBatch);
 
-                if Policy::is_election_block_at(*block_number) {
+                if Policy::is_election_block_at(block_state.number) {
                     assert_eq!(
-                        *block_number,
+                        block_state.number,
                         block.block_number(),
                         "Only the last block can be an election block"
                     );
@@ -330,7 +336,7 @@ impl Blockchain {
         }
 
         // Update the accounts tree, one block at a time.
-        for i in 0..block_numbers.len() {
+        for i in 0..block_state.len() {
             // Extract the transactions from the block
             let txns: Vec<Transaction> = block_transactions[i]
                 .iter()
@@ -338,12 +344,11 @@ impl Blockchain {
                 .collect();
 
             // Commit block to AccountsTree and create the receipts.
-            let block_state = BlockState::new(block_numbers[i], block_timestamps[i]);
             let receipts = this.state.accounts.commit_batch(
                 &mut (&mut txn).into(),
                 &txns,
                 &block_inherents[i],
-                &block_state,
+                &block_state[i],
                 &mut BlockLogger::empty(),
             );
 
@@ -352,7 +357,7 @@ impl Blockchain {
                 warn!(
                     %block,
                     reason = "commit of block failed",
-                    block_no = block_numbers[i],
+                    block_no = block_state[i].number,
                     num_transactions = block_transactions[i].len(),
                     num_inherents = block_inherents[i].len(),
                     error = &e as &dyn Error,

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -1,11 +1,12 @@
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
+use nimiq_account::Account;
 use nimiq_block::BlockError;
 use nimiq_blockchain::{interface::HistoryInterface, BlockProducer, Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::{AbstractBlockchain, BlockchainEvent, PushError, PushResult};
-use nimiq_database::mdbx::MdbxDatabase;
+use nimiq_database::{mdbx::MdbxDatabase, traits::WriteTransaction};
 use nimiq_genesis::NetworkId;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{key_nibbles::KeyNibbles, policy::Policy};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_test_log::test;
 use nimiq_test_utils::{
@@ -308,7 +309,7 @@ fn history_sync_emits_protocol_upgrade_event_when_version_changes() {
     let upgrade_history = blockchain1
         .read()
         .history_store
-        .get_epoch_transactions(1, None);
+        .get_epoch_transactions(upgrade_block.epoch_number(), None);
 
     let time2 = Arc::new(OffsetTime::new());
     let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
@@ -338,6 +339,420 @@ fn history_sync_emits_protocol_upgrade_event_when_version_changes() {
             BlockchainEvent::EpochFinalized(upgrade_hash.clone()),
             BlockchainEvent::ProtocolUpgrade(upgrade_hash, upgrade_version),
         ],
+    );
+}
+
+#[test]
+fn history_sync_replays_empty_first_batch_when_it_changes_state() {
+    fn seed_current_batch_punished_slot(blockchain: &Arc<RwLock<Blockchain>>) {
+        let blockchain = blockchain.write();
+        let mut staking_contract = blockchain.get_staking_contract();
+        let validator_address = staking_contract
+            .active_validators
+            .keys()
+            .next()
+            .expect("missing active validator")
+            .clone();
+
+        staking_contract
+            .punished_slots
+            .current_batch_punished_slots
+            .clear();
+        staking_contract
+            .punished_slots
+            .previous_batch_punished_slots
+            .clear();
+
+        let mut punished_slots = BTreeSet::new();
+        punished_slots.insert(0);
+        staking_contract
+            .punished_slots
+            .current_batch_punished_slots
+            .insert(validator_address, punished_slots);
+
+        let mut txn = blockchain.write_transaction();
+        blockchain
+            .state
+            .accounts
+            .tree
+            .put(
+                &mut (&mut txn).into(),
+                &KeyNibbles::from(&Policy::STAKING_CONTRACT_ADDRESS),
+                Account::Staking(staking_contract),
+            )
+            .unwrap();
+        txn.commit();
+    }
+
+    let genesis_block_number = Policy::genesis_block_number();
+    let num_macro_blocks = 2;
+
+    // Create a blockchain to produce the macro blocks.
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+    seed_current_batch_punished_slot(&blockchain);
+
+    // Create a second blockchain to push blocks to.
+    let time = Arc::new(OffsetTime::new());
+    let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env2,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+    seed_current_batch_punished_slot(&blockchain2);
+
+    // Produce the blocks on blockchain1.
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    produce_macro_blocks(&producer, &blockchain, num_macro_blocks);
+
+    // Get the first checkpoint and corresponding history tree transactions.
+    let blockchain_rg = blockchain.read();
+    let election_txs_1 = blockchain_rg.history_store.get_epoch_transactions(1, None);
+
+    let checkpoint_block_1_2 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_batch() * 2 + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+    let mut checkpoint_txs_1_2 = vec![];
+
+    for hist_tx in &election_txs_1 {
+        if hist_tx.block_number > Policy::blocks_per_batch() * 2 + genesis_block_number {
+            break;
+        }
+        checkpoint_txs_1_2.push(hist_tx.clone());
+    }
+
+    // The first checkpoint of the first epoch has no history items of its own. Replaying it still
+    // matters here because its FinalizeBatch clears the seeded punished slots before the next
+    // checkpoint reward is applied.
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            checkpoint_block_1_2,
+            &checkpoint_txs_1_2
+        ),
+        Ok(PushResult::Extended)
+    );
+}
+
+#[test]
+fn history_sync_replays_missing_first_checkpoint_before_second_batch_history() {
+    let genesis_block_number = Policy::genesis_block_number();
+
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain1 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    let producer = BlockProducer::new(signing_key(), voting_key());
+
+    // Leave the first batch empty so the first checkpoint is missing from history, then add
+    // transactions in the second batch before producing the target checkpoint.
+    produce_macro_blocks(&producer, &blockchain1, 1);
+    fill_micro_blocks_with_txns(&producer, &blockchain1, 1, 0);
+    produce_macro_blocks(&producer, &blockchain1, 1);
+
+    let blockchain_rg = blockchain1.read();
+    let checkpoint_block_1_2 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_batch() * 2 + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+    let checkpoint_txs_1_2 = blockchain_rg.history_store.get_epoch_transactions(1, None);
+
+    assert!(
+        checkpoint_txs_1_2
+            .iter()
+            .all(|hist_tx| hist_tx.block_number > Policy::blocks_per_batch() + genesis_block_number),
+        "test setup must keep the first batch empty",
+    );
+    assert!(
+        checkpoint_txs_1_2
+            .iter()
+            .any(|hist_tx| Policy::batch_at(hist_tx.block_number) == 2),
+        "test setup must retain second-batch history",
+    );
+
+    let time = Arc::new(OffsetTime::new());
+    let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env2,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            checkpoint_block_1_2,
+            &checkpoint_txs_1_2
+        ),
+        Ok(PushResult::Extended)
+    );
+    assert_eq!(blockchain_rg.head(), blockchain2.read().head());
+}
+
+#[test]
+fn history_sync_replays_missing_first_checkpoint_between_non_empty_batches() {
+    let genesis_block_number = Policy::genesis_block_number();
+
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain1 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    let producer = BlockProducer::new(signing_key(), voting_key());
+
+    // Put transactions in both batches, but jump directly to the second checkpoint. The first
+    // checkpoint itself still has no history items and must be replayed between the batches.
+    fill_micro_blocks_with_txns(&producer, &blockchain1, 1, 0);
+    produce_macro_blocks(&producer, &blockchain1, 1);
+    fill_micro_blocks_with_txns(&producer, &blockchain1, 1, 0);
+    produce_macro_blocks(&producer, &blockchain1, 1);
+
+    let blockchain_rg = blockchain1.read();
+    let checkpoint_block_1_2 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_batch() * 2 + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+    let checkpoint_txs_1_2 = blockchain_rg.history_store.get_epoch_transactions(1, None);
+
+    assert!(
+        checkpoint_txs_1_2
+            .iter()
+            .any(|hist_tx| Policy::batch_at(hist_tx.block_number) == 1),
+        "test setup must retain first-batch history",
+    );
+    assert!(
+        checkpoint_txs_1_2
+            .iter()
+            .any(|hist_tx| Policy::batch_at(hist_tx.block_number) == 2),
+        "test setup must retain second-batch history",
+    );
+    assert!(
+        checkpoint_txs_1_2.iter().all(|hist_tx| {
+            hist_tx.block_number != Policy::blocks_per_batch() + genesis_block_number
+        }),
+        "test setup must keep the first checkpoint absent from history",
+    );
+
+    let time = Arc::new(OffsetTime::new());
+    let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env2,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            checkpoint_block_1_2,
+            &checkpoint_txs_1_2
+        ),
+        Ok(PushResult::Extended)
+    );
+    assert_eq!(blockchain_rg.head(), blockchain2.read().head());
+}
+
+#[test]
+fn history_sync_rejects_missing_non_first_batch_history() {
+    let genesis_block_number = Policy::genesis_block_number();
+    let num_macro_blocks = 3;
+
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    produce_macro_blocks_with_txns(&producer, &blockchain, num_macro_blocks, 1, 0);
+
+    let blockchain_rg = blockchain.read();
+    let election_txs_1 = blockchain_rg.history_store.get_epoch_transactions(1, None);
+    let checkpoint_block_1_3 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_batch() * 3 + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+
+    let checkpoint_txs_1_3: Vec<_> = election_txs_1
+        .into_iter()
+        .filter(|hist_tx| {
+            hist_tx.block_number > Policy::blocks_per_batch() * 2 + genesis_block_number
+        })
+        .collect();
+
+    assert!(
+        !checkpoint_txs_1_3.is_empty(),
+        "test setup must retain history after the skipped batch",
+    );
+
+    let time = Arc::new(OffsetTime::new());
+    let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env2,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            checkpoint_block_1_3,
+            &checkpoint_txs_1_3
+        ),
+        Err(PushError::InvalidBlock(BlockError::InvalidHistoryRoot))
+    );
+}
+
+#[test]
+fn history_sync_rejects_missing_non_first_batch_history_after_prior_sync() {
+    let genesis_block_number = Policy::genesis_block_number();
+    let num_macro_blocks = (Policy::batches_per_epoch() + 2) as usize;
+
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    produce_macro_blocks_with_txns(&producer, &blockchain, num_macro_blocks, 1, 0);
+
+    let blockchain_rg = blockchain.read();
+    let election_block_1 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_epoch() + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+    let election_txs_1 = blockchain_rg.history_store.get_epoch_transactions(1, None);
+
+    let checkpoint_block_2_2 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_epoch() + 2 * Policy::blocks_per_batch() + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+    let checkpoint_txs_2_2: Vec<_> = blockchain_rg
+        .history_store
+        .get_epoch_transactions(2, None)
+        .into_iter()
+        .filter(|hist_tx| {
+            hist_tx.block_number
+                > Policy::blocks_per_epoch() + Policy::blocks_per_batch() + genesis_block_number
+        })
+        .collect();
+
+    assert!(
+        !checkpoint_txs_2_2.is_empty(),
+        "test setup must retain history after the skipped batch",
+    );
+
+    let time = Arc::new(OffsetTime::new());
+    let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env2,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            election_block_1,
+            &election_txs_1
+        ),
+        Ok(PushResult::Extended)
+    );
+    assert!(
+        Policy::batch_at(blockchain2.read().head().block_number()) > 1,
+        "test setup must start history sync from a later batch",
+    );
+
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            checkpoint_block_2_2,
+            &checkpoint_txs_2_2
+        ),
+        Err(PushError::InvalidBlock(BlockError::InvalidHistoryRoot))
     );
 }
 

--- a/blockchain/tests/history_sync.rs
+++ b/blockchain/tests/history_sync.rs
@@ -265,6 +265,115 @@ fn history_sync_works() {
     );
 }
 
+#[test]
+fn history_sync_works_for_first_epoch() {
+    let genesis_block_number = Policy::genesis_block_number();
+    // The minimum number of macro blocks necessary so that we have two election blocks and a few
+    // checkpoint blocks to push.
+    let num_macro_blocks = Policy::batches_per_epoch() as usize;
+
+    // Create a blockchain to produce the macro blocks.
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    // Create a second blockchain to push blocks to.
+    let time = Arc::new(OffsetTime::new());
+    let env2 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain2 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env2,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    // Create a third blockchain to push blocks to.
+    let time = Arc::new(OffsetTime::new());
+    let env3 = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain3 = Arc::new(RwLock::new(
+        Blockchain::new(
+            env3,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    ));
+
+    // Produce the blocks on blockchain1.
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    produce_macro_blocks(&producer, &blockchain, num_macro_blocks);
+
+    // Get the checkpoint blocks and corresponding history tree transactions.
+    let blockchain_rg = blockchain.read();
+
+    // Get the first election block and corresponding history tree transactions.
+    let election_txs_1 = blockchain_rg.history_store.get_epoch_transactions(1, None);
+    let election_block_1 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_epoch() + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+
+    let checkpoint_block_1_2 = blockchain_rg
+        .chain_store
+        .get_block_at(
+            Policy::blocks_per_batch() * 2 + genesis_block_number,
+            true,
+            None,
+        )
+        .unwrap();
+    let mut checkpoint_txs_1_2 = vec![];
+
+    for hist_tx in &election_txs_1 {
+        if hist_tx.block_number > Policy::blocks_per_batch() * 2 + genesis_block_number {
+            break;
+        }
+        checkpoint_txs_1_2.push(hist_tx.clone());
+    }
+
+    // Sync the first checkpoint to make sure it works
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            checkpoint_block_1_2,
+            &checkpoint_txs_1_2
+        ),
+        Ok(PushResult::Extended)
+    );
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain2.upgradable_read(),
+            election_block_1.clone(),
+            &election_txs_1
+        ),
+        Ok(PushResult::Extended)
+    );
+    // Sync directly the whole first epoch
+    assert_eq!(
+        Blockchain::push_history_sync(
+            blockchain3.upgradable_read(),
+            election_block_1,
+            &election_txs_1
+        ),
+        Ok(PushResult::Extended)
+    );
+}
+
 // Tests if the history sync works when micro blocks have already been pushed in the blockchain.
 // This basically tests if we can go from the history sync to the normal follow mode and back.
 #[test]


### PR DESCRIPTION
## What's in this pull request?
The extend history for syncing history nodes adds synthetic macro blocks if those are missing, so that it can recreate the `FinalizeBatch` inherents before pushing the history of an epoch. However, since we added the reward transactions to the body of the macro blocks, there is only one checkpoint block that can be empty - the first checkpoint block. This is because we pay rewards with a batch delay.
The pr #3758 did some hardening for the original assertion. However, it introduced a bug by rejecting the blocks when we have a gap of 2 batches. This shouldn't be the behaviour since we can have a valid code path for a gap, the case where we are in genesis block (batch 0) and batch 1 has no history, so the first item is on batch 2.

This PR:
- Fixes the introduced bug in 3758 
- Removes and fixes `extend_history_sync` FIX MEs and outdated comments
- Simplifies the addition of the synthetic missing checkpoint blocks to only do that when it's for checkpoint 1.
- Adds unit tests for this edge cases

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
