### PR TITLE
Add Vite plugin export

### DIFF
--- a/web-client/dist/README.md
+++ b/web-client/dist/README.md
@@ -26,6 +26,13 @@ If you use any bundler for your project, like Webpack or Vite, you should probab
 
 For detailed installation instructions for your bundler/framework, refer to the [Nimiq Developer Center](https://www.nimiq.com/developers/build/web-client/installation).
 
+> [!TIP]
+> For Vite users: Use the included Vite plugin for automatic configuration:
+> ```ts
+> import nimiq from '@nimiq/core/vite'
+> export default defineConfig({ plugins: [nimiq()] })
+> ```
+
 ```js
 // With Webpack: import the package asynchronously:
 const Nimiq = await import('@nimiq/core');

--- a/web-client/dist/README.md
+++ b/web-client/dist/README.md
@@ -26,6 +26,19 @@ If you use any bundler for your project, like Webpack or Vite, you should probab
 
 For detailed installation instructions for your bundler/framework, refer to the [Nimiq Developer Center](https://www.nimiq.com/developers/build/web-client/installation).
 
+> [!TIP]
+> **For Vite**: Use the included Vite plugin for automatic configuration:
+>
+> ```ts
+> import nimiq from "@nimiq/core/vite";
+>
+> export default defineConfig({
+>    plugins: [
+>        nimiq(),
+>    ],
+>});
+> ```
+
 ```js
 // With Webpack: import the package asynchronously:
 const Nimiq = await import('@nimiq/core');

--- a/web-client/dist/package.json
+++ b/web-client/dist/package.json
@@ -26,6 +26,11 @@
       "browser": "./web/index.js",
       "import": "./web/index.js",
       "types": "./types/web.d.ts"
+    },
+    "./vite": {
+      "import": "./vite.js",
+      "require": "./vite.js",
+      "types": "./types/vite.d.ts"
     }
   },
   "homepage": "https://nimiq.com",
@@ -51,6 +56,15 @@
   ],
   "dependencies": {
     "comlink": "^4.4.1",
-    "websocket": "^1.0.34"
+    "websocket": "^1.0.34",
+    "vite-plugin-wasm": "^3.5.0"
+  },
+  "peerDependencies": {
+    "vite": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
   }
 }

--- a/web-client/dist/package.json
+++ b/web-client/dist/package.json
@@ -26,6 +26,11 @@
       "browser": "./web/index.js",
       "import": "./web/index.js",
       "types": "./types/web.d.ts"
+    },
+    "./vite": {
+      "import": "./vite.js",
+      "require": "./vite.js",
+      "types": "./types/vite.d.ts"
     }
   },
   "homepage": "https://nimiq.com",
@@ -51,6 +56,15 @@
   ],
   "dependencies": {
     "comlink": "^4.4.1",
-    "websocket": "^1.0.34"
+    "websocket": "^1.0.34",
+    "vite-plugin-wasm": "^3.5.0"
+  },
+  "peerDependencies": {
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
   }
 }

--- a/web-client/dist/types/vite.d.ts
+++ b/web-client/dist/types/vite.d.ts
@@ -1,0 +1,17 @@
+import type { PluginOption } from 'vite'
+
+export interface NimiqPluginOptions {
+  /**
+   * Configure worker support for WASM
+   * @default true
+   */
+  worker?: boolean
+}
+
+/**
+ * Vite plugin for Nimiq blockchain integration
+ * Configures WebAssembly support and optimizations required for @nimiq/core
+ */
+export default function nimiq(options?: NimiqPluginOptions): PluginOption[]
+
+export { nimiq }

--- a/web-client/dist/vite.js
+++ b/web-client/dist/vite.js
@@ -1,0 +1,45 @@
+import wasm from 'vite-plugin-wasm'
+
+/**
+ * Vite plugin for Nimiq blockchain integration
+ * Configures WebAssembly support and optimizations required for @nimiq/core
+ *
+ * Note: This plugin does not include top-level await support. Modern browsers
+ * support top-level await natively. If you need support for older browsers,
+ * you can add vite-plugin-top-level-await to your plugins.
+ *
+ * @param {object} [options] - Plugin options
+ * @param {boolean} [options.worker=true] - Configure worker support for WASM
+ * @returns {import('vite').Plugin[]} Array of Vite plugins
+ */
+export default function nimiq({ worker = true } = {}) {
+  return [
+    wasm(),
+    {
+      name: 'vite-plugin-nimiq',
+      config() {
+        return {
+          optimizeDeps: {
+            exclude: ['@nimiq/core'],
+          },
+          build: {
+            target: 'esnext',
+            rollupOptions: {
+              output: {
+                format: 'es',
+              },
+            },
+          },
+          ...(worker && {
+            worker: {
+              format: 'es',
+              plugins: () => [wasm()],
+            },
+          }),
+        }
+      },
+    },
+  ]
+}
+
+export { nimiq }

--- a/web-client/dist/vite.js
+++ b/web-client/dist/vite.js
@@ -1,0 +1,45 @@
+import wasm from 'vite-plugin-wasm'
+
+/**
+ * Vite plugin for Nimiq blockchain integration
+ * Configures WebAssembly support and optimizations required for @nimiq/core
+ *
+ * Note: This plugin does not include top-level await support. Modern browsers
+ * support top-level await natively. If you need support for older browsers,
+ * you can add vite-plugin-top-level-await to your plugins array manually.
+ *
+ * @param {object} [options] - Plugin options
+ * @param {boolean} [options.worker=true] - Configure worker support for WASM
+ * @returns {import('vite').Plugin[]} Array of Vite plugins
+ */
+export default function nimiq({ worker = true } = {}) {
+  return [
+    wasm(),
+    {
+      name: 'vite-plugin-nimiq',
+      config() {
+        return {
+          optimizeDeps: {
+            exclude: ['@nimiq/core'],
+          },
+          build: {
+            target: 'esnext',
+            rollupOptions: {
+              output: {
+                format: 'es',
+              },
+            },
+          },
+          ...(worker && {
+            worker: {
+              format: 'es',
+              plugins: () => [wasm()],
+            },
+          }),
+        }
+      },
+    },
+  ]
+}
+
+export { nimiq }


### PR DESCRIPTION
Exports Vite plugin via `@nimiq/core/vite`. Simplifies Vite configuration for users.

## Usage

```ts
import nimiq from '@nimiq/core/vite'
export default defineConfig({ plugins: [nimiq()] })
```

## Preview

- **Docs**: https://deploy-preview-157--developer-center.netlify.app/web-client/integrations/vite#nimiq-web-client-vite-integration
- **Starter Templates**: https://github.com/onmax/nimiq-starter/pull/4