### PR TITLE
Fix web client network buffer panic

### DIFF
--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -16,7 +16,7 @@ use nimiq::client::ConsensusProxy;
 pub use nimiq::{
     config::{
         config::ClientConfig,
-        config_file::{LogSettings, Seed},
+        config_file::{LogSettings, NetworkSettings, Seed},
     },
     extras::{panic::initialize_panic_reporting, web_logging::initialize_web_logging},
 };
@@ -176,6 +176,8 @@ impl Client {
         config.network.peer_count_per_ip_max = web_config.peer_count_per_ip_max;
         config.network.peer_count_per_subnet_max = web_config.peer_count_per_subnet_max;
         config.network.num_initial_connections = web_config.num_initial_connections;
+        // Ensure bounded channels use a non-zero buffer size (matches the config default of 1024).
+        config.network.network_buffer_size = NetworkSettings::default_network_buffer_size();
 
         log::info!(?config, "Final configuration");
 


### PR DESCRIPTION
Fixes panic in web client where network_buffer_size defaults to 0 causing 'mpsc bounded channel requires buffer > 0' error. Regression in v2.2.0. Repro & verification: https://github.com/onmax/network-buffer-repro (read readme for instructions)

<details><summary>Report from AI</summary>
<p>

- The regression starts in 0925b4f053 (https://github.com/nimiq/core-rs-albatross/commit/0925b4f053c05eae9abda92e3fe1ac48fb883f39) (“Make network buffer size configurable”). That change adds
    network_buffer_size to NetworkConfig (https://github.com/nimiq/core-rs-albatross/blob/0925b4f053c05eae9abda92e3fe1ac48fb883f39/lib/src/config/config.rs#L135-L200) and threads it through network-
    libp2p::Config → Network (https://github.com/nimiq/core-rs-albatross/blob/0925b4f053c05eae9abda92e3fe1ac48fb883f39/network-libp2p/src/network.rs#L60-L140). The commit relies on the derive(Default)
    implementation, which leaves the new field as usize::default() (zero) unless it is explicitly overridden.
- CLI/server builds stay safe because when the config file is deserialized the Serde default keeps injecting NetworkSettings::default_network_buffer_size() (https://github.com/nimiq/core-rs-albatross/
    blob/0925b4f053c05eae9abda92e3fe1ac48fb883f39/lib/src/config/config_file/mod.rs#L190-L221), preserving the 1024 buffer. The WASM/web path, however, uses ClientConfig::builder() directly (see web-
    client/src/client/lib.rs (https://github.com/nimiq/core-rs-albatross/blob/c765300ad28debd5953118475c95d4d29f781205/web-client/src/client/lib.rs#L143-L189)); it never writes network_buffer_size, so after
    0925b4f053 the field falls back to zero. When the light client starts it now calls tokio::sync::mpsc::channel(0), which panics with “bounded channel requires buffer > 0,” matching the issue and the
    repro you linked.

## Takeaways

1. 0925b4f053 is the introducing commit between v1.1.1 and v1.2.0.
2. Any ClientConfig::builder() call that doesn’t set network_buffer_size now produces a zero-capacity channel; add a custom Default or explicit setter to avoid similar regressions elsewhere.


</p>
</details> 