### PR TITLE
Fix KeyPair.fromHex rejecting output from toHex

### DIFF
--- a/web-client/extras/tests/KeyPair.test.ts
+++ b/web-client/extras/tests/KeyPair.test.ts
@@ -1,0 +1,32 @@
+import { KeyPair, PrivateKey } from '@nimiq/core';
+import { describe, expect, it } from 'vitest';
+
+describe('KeyPair', () => {
+    it('can roundtrip toHex/fromHex', () => {
+        const kp1 = KeyPair.generate();
+        const hex = kp1.toHex();
+        const kp2 = KeyPair.fromHex(hex);
+
+        expect(kp2.privateKey.toHex()).toBe(kp1.privateKey.toHex());
+        expect(kp2.publicKey.toHex()).toBe(kp1.publicKey.toHex());
+    });
+
+    it('accepts 128-char hex (no padding)', () => {
+        const kp1 = KeyPair.generate();
+        const hex = kp1.privateKey.toHex() + kp1.publicKey.toHex();
+
+        expect(hex.length).toBe(128);
+        const kp2 = KeyPair.fromHex(hex);
+        expect(kp2.privateKey.toHex()).toBe(kp1.privateKey.toHex());
+    });
+
+    it('rejects short hex strings', () => {
+        expect(() => KeyPair.fromHex('a'.repeat(100))).toThrow();
+    });
+
+    it('derives from PrivateKey', () => {
+        const priv = PrivateKey.generate();
+        const kp = KeyPair.derive(priv);
+        expect(kp.privateKey.toHex()).toBe(priv.toHex());
+    });
+});

--- a/web-client/src/primitives/key_pair.rs
+++ b/web-client/src/primitives/key_pair.rs
@@ -35,8 +35,13 @@ impl KeyPair {
     /// Throws when the string is not valid hex format or when it represents less than 64 bytes.
     #[wasm_bindgen(js_name = fromHex)]
     pub fn from_hex(hex: &str) -> Result<KeyPair, JsError> {
+        if hex.len() < 128 {
+            return Err(JsError::new(
+                "Invalid hex: expected at least 128 characters (64 bytes)",
+            ));
+        }
         let private = nimiq_keys::PrivateKey::from_str(&hex[0..64])?;
-        let public = nimiq_keys::Ed25519PublicKey::from_str(&hex[64..])?;
+        let public = nimiq_keys::Ed25519PublicKey::from_str(&hex[64..128])?;
         // TODO: Deserialize locked state if bytes remaining
         let key_pair = nimiq_keys::KeyPair { private, public };
         Ok(KeyPair::from(key_pair))


### PR DESCRIPTION
## Bug

In `web-client/src/primitives/key_pair.rs`:
- [`serialize()`](https://github.com/nimiq/core-rs-albatross/blob/albatross/web-client/src/primitives/key_pair.rs#L66) adds extra `0x00` byte for "unlocked state" (not implemented)
- [`toHex()`](https://github.com/nimiq/core-rs-albatross/blob/albatross/web-client/src/primitives/key_pair.rs#L101) encodes this → 130 hex chars
- [`fromHex()`](https://github.com/nimiq/core-rs-albatross/blob/albatross/web-client/src/primitives/key_pair.rs#L39) parses `&hex[64..]` for public key → gets 66 chars instead of 64 → fails

https://t.me/c/1328779526/31057

## Fix

Ignore trailing bytes to have backward compatibility.

<details>
<summary>Reproduction steps</summary>

### 1. Create test script

```js
// test-keypair.js
const { KeyPair } = require('./dist/nodejs/main-wasm/index.js')

const kp1 = KeyPair.generate()
const hex1 = kp1.toHex()
console.log(`Generated KeyPair hex (${hex1.length} chars): ${hex1}`)

try {
  const kp2 = KeyPair.fromHex(hex1)
  console.log(`Roundtrip: PASS`)
  console.log(`Private keys match: ${kp1.privateKey.toHex() === kp2.privateKey.toHex() ? 'PASS' : 'FAIL'}`)
  console.log(`Public keys match: ${kp1.publicKey.toHex() === kp2.publicKey.toHex() ? 'PASS' : 'FAIL'}`)
} catch (e) {
  console.log(`FAIL - fromHex threw: ${e.message}`)
}
```

### 2. Reproduce bug on `albatross`

```bash
git checkout albatross
cd web-client
./scripts/build.sh --only nodejs --skip-wasm-opt --skip-launcher --skip-lib
node test-keypair.js
```

Expected output:
```
Generated KeyPair hex (130 chars): bdd3a8d5...c200
FAIL - fromHex threw: Invalid length when parsing byte slice.
```

### 3. Verify fix on this branch

```bash
git checkout fix/keypair-fromhex-padding
./scripts/build.sh --only nodejs --skip-wasm-opt --skip-launcher --skip-lib
node test-keypair.js
```

Expected output:
```
Generated KeyPair hex (130 chars): 547b9a70...1700
Roundtrip: PASS
Private keys match: PASS
Public keys match: PASS
```

</details>


