### PR TITLE
Remaining multisig methods for web-client

### DIFF
--- a/web-client/extras/tests/MuSig2.test.ts
+++ b/web-client/extras/tests/MuSig2.test.ts
@@ -46,17 +46,40 @@ describe('MuSig2', async () => {
         );
         expect(walletAddress.toUserFriendlyAddress()).toEqual(_wallet_address);
 
+        // Create public key combinations for a 2-of-3 wallet
+        const combinedPublicKeys = PublicKey.combinations(
+            [keyPairA.publicKey, keyPairB.publicKey, keyPairC.publicKey],
+            2,
+        );
+
         // Create an unsigned transaction from the multi-signature wallet
         const tx = TransactionBuilder.newBasic(walletAddress, Address.NULL, BigInt(10), 0n, 0, 5);
         expect(tx.toHex()).toEqual(_unsigned_transaction);
 
+        // Signer A and B will be signing, aggregate their public keys
+        const aggregatedPublicKey = PublicKey.sum([keyPairA.publicKey, keyPairB.publicKey]);
+        expect(aggregatedPublicKey.toHex()).toEqual(_signing_public_key);
 
-        // Create commitment pairs
+        // Ensure the signing public key is part of the combinations
+        expect(combinedPublicKeys.map(key => key.toHex()).includes(aggregatedPublicKey.toHex())).toBe(true);
+
+        // Create commitment pairs for A and B
         const commitmentPairA1 = CommitmentPair.fromHex(_commitment_pair_a_1);
         const commitmentPairA2 = CommitmentPair.fromHex(_commitment_pair_a_2);
 
         const commitmentPairB1 = CommitmentPair.fromHex(_commitment_pair_b_1);
         const commitmentPairB2 = CommitmentPair.fromHex(_commitment_pair_b_2);
+
+        // Aggregate commitments for MuSig2
+        const aggregated_commitment = Commitment.sumMuSig2(
+            [keyPairA.publicKey, keyPairB.publicKey],
+            [
+                [commitmentPairA1.commitment, commitmentPairA2.commitment],
+                [commitmentPairB1.commitment, commitmentPairB2.commitment],
+            ],
+            tx.serializeContent()
+        );
+        expect(aggregated_commitment.toHex()).toEqual(_aggregate_commitment);
 
         // Create partial signatures
         const partialSigA = PartialSignature.create(
@@ -79,30 +102,10 @@ describe('MuSig2', async () => {
         );
         expect(partialSigB.toHex()).toEqual(_partial_signature_b);
 
-        // Aggregate commitments
-        const aggregated_commitment = Commitment.sumMuSig2(
-            [keyPairA.publicKey, keyPairB.publicKey],
-            [
-                [commitmentPairA1.commitment, commitmentPairA2.commitment],
-                [commitmentPairB1.commitment, commitmentPairB2.commitment],
-            ],
-            tx.serializeContent()
-        );
-        expect(aggregated_commitment.toHex()).toEqual(_aggregate_commitment);
-
-        // Aggregate partial signatures
+        // Aggregate partial signatures and convert to final signature
         const signature = PartialSignature
             .sum([partialSigA, partialSigB])
             .toSignature(aggregated_commitment);
-
-        // Combine public keys and aggregate signer public key
-        const combinedPublicKeys = PublicKey.combinations(
-            [keyPairA.publicKey, keyPairB.publicKey, keyPairC.publicKey],
-            2,
-        );
-        const aggregatedPublicKey = PublicKey.sum([keyPairA.publicKey, keyPairB.publicKey]);
-        expect(combinedPublicKeys.map(key => key.toHex()).includes(aggregatedPublicKey.toHex())).toBe(true);
-        expect(aggregatedPublicKey.toHex()).toEqual(_signing_public_key);
 
         // Create and attach the multi-signature proof to the transaction
         const proof = SignatureProof.multiSig(aggregatedPublicKey, combinedPublicKeys, signature);

--- a/web-client/extras/tests/MuSig2.test.ts
+++ b/web-client/extras/tests/MuSig2.test.ts
@@ -113,5 +113,6 @@ describe('MuSig2', async () => {
 
         // Verify that everything worked correctly
         expect(tx.toHex()).toEqual(_signed_transaction);
+        expect(() => tx.verify()).not.toThrow();
     });
 });

--- a/web-client/extras/tests/MuSig2.test.ts
+++ b/web-client/extras/tests/MuSig2.test.ts
@@ -1,0 +1,114 @@
+import {
+    Address,
+    Commitment,
+    CommitmentPair,
+    KeyPair,
+    PartialSignature,
+    PublicKey,
+    SignatureProof,
+    TransactionBuilder,
+} from '@nimiq/core';
+import { describe, expect, it } from 'vitest';
+
+describe('MuSig2', async () => {
+    it('can create a 2-of-3 multi-signature', () => {
+        // Test vectors
+        const _keypair_a = "14a3bc3b25c73b6ca3e829aef329a2a6dc69ae52b8d20a164831a021b6a9f9feec98d39d98a58c13d399673d6da7dc6c74f379eddd8c8628e40ffc6be7c2498300";
+        const _keypair_b = "2da15ede9992fad834b73283dd1a24f5a7a52b067b09be132ddb5232df863125bb639b6bbf6db003a94a83ef9d12f12fcc5990f63954b7f6d88f5be58f8c411200";
+        const _keypair_c = "a3b3d799e7fca4baa3568d58e0c909af1f832926020163a1d48998621a15c9c6b81b12bcb1a6e9ba49a6dec268705c2cc2d70d1d7e22493a4128559eadacdbd400";
+        const _wallet_address = "NQ77 XKHG BUSE L76F 030F FY5U 0C6H 6HXU BSPX";
+
+        const _commitment_pair_a_1 = "61514436ba3671457a39ab8b89c166a6dbf9dcf2320142412faca62c0e30180ec441e06b23ef64095dd24ba9976e1bd6086dd34f6d2892ec92c8f3a5365e352f";
+        const _commitment_pair_a_2 = "246a60bacd6be35bc248de42bd8d8035c66766af037859797a3c6c87475fc20a6af6931e2199aa73707d1e2363502af6a637a33ddc9464b5a60dab9c5535240d";
+
+        const _commitment_pair_b_1 = "1c25176a8d9531dfdabd393e24457ef768b8f91ad1aa5b5c5d531c59d61493068bcf3923fe74da2c0dae83a0f0a4ad78c3ace4737e1bab09ae839059cc06b75a";
+        const _commitment_pair_b_2 = "9d372fe33120b7555f06112efa51a179e745ae03cc0942319a0b2a605c680708170b6a773e7f633ef7c3830ebe16a4a7dde24ba4040c18b361b6aa5fad2d0e6f";
+
+        const _signing_public_key = "768aa1e50751d31c7e16708903f6906621da68fd1daae12210480dac10d8a57b";
+        const _aggregate_commitment = "f52764eed6c6f89f6a07781f035707aab471e846a9b815c73d0eb620cf345b82";
+        const _b_scalar = "9556574afd98401d38bee97e9ecc70a3d0d29f3221fd4b73a71f6444678b3306";
+
+        const _partial_signature_a = "0f751ab3db73576994159919a970b529a68e0c1f5b49501243c573106cff200d";
+        const _partial_signature_b = "db2cd118d2e46fed51cff0341a139b90159a134095d7a003671d71d53a33520c";
+
+        const _unsigned_transaction = "01f4e305f34ea1ccf00c0f7fcbc030d1347dc5eafe000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000050000";
+        const _signed_transaction = "01f4e305f34ea1ccf00c0f7fcbc030d1347dc5eafe000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000500a50100768aa1e50751d31c7e16708903f6906621da68fd1daae12210480dac10d8a57b02018002ff2353719738df451db5eaa049f2b8c95493c34b008aa4d9d452e6820bec66034b43399405dfc64024a1b9ff974fb9b1f428461d28b7d262c16d1dc5d8894542f52764eed6c6f89f6a07781f035707aab471e846a9b815c73d0eb620cf345b82fdcdf56e93f5b4fe0f4892abe48971a5bb28205ff020f115aae2e4e5a6327309";
+
+        // Create KeyPairs
+        const keyPairA = KeyPair.fromHex(_keypair_a);
+        const keyPairB = KeyPair.fromHex(_keypair_b);
+        const keyPairC = KeyPair.fromHex(_keypair_c);
+
+        // Generate the multi-signature wallet address
+        const walletAddress = Address.fromPublicKeys(
+            [keyPairA.publicKey, keyPairB.publicKey, keyPairC.publicKey],
+            2,
+        );
+        expect(walletAddress.toUserFriendlyAddress()).toEqual(_wallet_address);
+
+        // Create an unsigned transaction from the multi-signature wallet
+        const tx = TransactionBuilder.newBasic(walletAddress, Address.NULL, BigInt(10), 0n, 0, 5);
+        expect(tx.toHex()).toEqual(_unsigned_transaction);
+
+
+        // Create commitment pairs
+        const commitmentPairA1 = CommitmentPair.fromHex(_commitment_pair_a_1);
+        const commitmentPairA2 = CommitmentPair.fromHex(_commitment_pair_a_2);
+
+        const commitmentPairB1 = CommitmentPair.fromHex(_commitment_pair_b_1);
+        const commitmentPairB2 = CommitmentPair.fromHex(_commitment_pair_b_2);
+
+        // Create partial signatures
+        const partialSigA = PartialSignature.create(
+            keyPairA.privateKey,
+            keyPairA.publicKey,
+            [commitmentPairA1, commitmentPairA2],
+            [keyPairB.publicKey],
+            [[commitmentPairB1.commitment, commitmentPairB2.commitment]],
+            tx.serializeContent(),
+        );
+        expect(partialSigA.toHex()).toEqual(_partial_signature_a);
+
+        const partialSigB = PartialSignature.create(
+            keyPairB.privateKey,
+            keyPairB.publicKey,
+            [commitmentPairB1, commitmentPairB2],
+            [keyPairA.publicKey],
+            [[commitmentPairA1.commitment, commitmentPairA2.commitment]],
+            tx.serializeContent(),
+        );
+        expect(partialSigB.toHex()).toEqual(_partial_signature_b);
+
+        // Aggregate commitments
+        const aggregated_commitment = Commitment.sumMuSig2(
+            [keyPairA.publicKey, keyPairB.publicKey],
+            [
+                [commitmentPairA1.commitment, commitmentPairA2.commitment],
+                [commitmentPairB1.commitment, commitmentPairB2.commitment],
+            ],
+            tx.serializeContent()
+        );
+        expect(aggregated_commitment.toHex()).toEqual(_aggregate_commitment);
+
+        // Aggregate partial signatures
+        const signature = PartialSignature
+            .sum([partialSigA, partialSigB])
+            .toSignature(aggregated_commitment);
+
+        // Combine public keys and aggregate signer public key
+        const combinedPublicKeys = PublicKey.combinations(
+            [keyPairA.publicKey, keyPairB.publicKey, keyPairC.publicKey],
+            2,
+        );
+        const aggregatedPublicKey = PublicKey.sum([keyPairA.publicKey, keyPairB.publicKey]);
+        expect(combinedPublicKeys.map(key => key.toHex()).includes(aggregatedPublicKey.toHex())).toBe(true);
+        expect(aggregatedPublicKey.toHex()).toEqual(_signing_public_key);
+
+        // Create and attach the multi-signature proof to the transaction
+        const proof = SignatureProof.multiSig(aggregatedPublicKey, combinedPublicKeys, signature);
+        tx.proof = proof.serialize();
+
+        // Verify that everything worked correctly
+        expect(tx.toHex()).toEqual(_signed_transaction);
+    });
+});

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -23,6 +23,7 @@ pub struct Address {
 
 #[wasm_bindgen]
 impl Address {
+    /// The all-zeroes burn address.
     #[wasm_bindgen(getter = NULL)]
     pub fn null() -> Address {
         Address::from(nimiq_keys::Address::default())

--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -23,6 +23,11 @@ pub struct Address {
 
 #[wasm_bindgen]
 impl Address {
+    #[wasm_bindgen(getter = NULL)]
+    pub fn null() -> Address {
+        Address::from(nimiq_keys::Address::default())
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(bytes: &[u8]) -> Result<Address, JsError> {
         Ok(Address::from(nimiq_keys::Address::from(

--- a/web-client/src/common/merkle_path.rs
+++ b/web-client/src/common/merkle_path.rs
@@ -3,6 +3,7 @@ use nimiq_hash::Blake2bHash;
 use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+/// A Merkle path consisting of a sequence of hashes that can be used to verify the inclusion of a leaf in a Merkle tree.
 #[wasm_bindgen]
 pub struct MerklePath {
     inner: nimiq_utils::merkle::Blake2bMerklePath,
@@ -10,6 +11,7 @@ pub struct MerklePath {
 
 #[wasm_bindgen]
 impl MerklePath {
+    /// Returns the hashes in the Merkle path.
     #[wasm_bindgen(getter)]
     pub fn hashes(&self) -> Vec<Uint8Array> {
         self.inner
@@ -19,11 +21,13 @@ impl MerklePath {
             .collect()
     }
 
+    /// Returns the length of the Merkle path.
     #[wasm_bindgen(getter)]
     pub fn length(&self) -> usize {
         self.inner.len()
     }
 
+    /// Computes the Merkle root of the path given a leaf hash.
     #[wasm_bindgen(js_name = computeRoot)]
     pub fn compute_root(&self, leaf: &[u8]) -> Result<Vec<u8>, JsError> {
         match Blake2bHash::deserialize_from_vec(leaf) {
@@ -34,10 +38,12 @@ impl MerklePath {
         }
     }
 
+    /// Serializes the Merkle path into a byte array.
     pub fn serialize(&self) -> Vec<u8> {
         self.inner.serialize_to_vec()
     }
 
+    /// Deserializes a Merkle path from a byte array.
     pub fn deserialize(data: &[u8]) -> Result<MerklePath, JsError> {
         match nimiq_utils::merkle::Blake2bMerklePath::deserialize_from_vec(data) {
             Ok(path) => Ok(path.into()),

--- a/web-client/src/common/merkle_path.rs
+++ b/web-client/src/common/merkle_path.rs
@@ -1,0 +1,56 @@
+use js_sys::Uint8Array;
+use nimiq_hash::Blake2bHash;
+use nimiq_serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct MerklePath {
+    inner: nimiq_utils::merkle::Blake2bMerklePath,
+}
+
+#[wasm_bindgen]
+impl MerklePath {
+    #[wasm_bindgen(getter)]
+    pub fn hashes(&self) -> Vec<Uint8Array> {
+        self.inner
+            .hashes()
+            .iter()
+            .map(|hash| hash.serialize_to_vec().as_slice().into())
+            .collect()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn length(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[wasm_bindgen(js_name = computeRoot)]
+    pub fn compute_root(&self, leaf: &[u8]) -> Result<Vec<u8>, JsError> {
+        match Blake2bHash::deserialize_from_vec(leaf) {
+            Ok(leaf_hash) => Ok(self.inner.compute_root(&leaf_hash).serialize_to_vec()),
+            Err(_) => Err(JsError::new(
+                "Failed to deserialize leaf: not a Blake2b hash",
+            )),
+        }
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.serialize_to_vec()
+    }
+
+    pub fn deserialize(data: &[u8]) -> Result<MerklePath, JsError> {
+        match nimiq_utils::merkle::Blake2bMerklePath::deserialize_from_vec(data) {
+            Ok(path) => Ok(path.into()),
+            Err(e) => Err(JsError::new(&format!(
+                "Failed to deserialize MerklePath: {}",
+                e
+            ))),
+        }
+    }
+}
+
+impl From<nimiq_utils::merkle::Blake2bMerklePath> for MerklePath {
+    fn from(path: nimiq_utils::merkle::Blake2bMerklePath) -> Self {
+        MerklePath { inner: path }
+    }
+}

--- a/web-client/src/common/merkle_path.rs
+++ b/web-client/src/common/merkle_path.rs
@@ -30,12 +30,9 @@ impl MerklePath {
     /// Computes the Merkle root of the path given a leaf hash.
     #[wasm_bindgen(js_name = computeRoot)]
     pub fn compute_root(&self, leaf: &[u8]) -> Result<Vec<u8>, JsError> {
-        match Blake2bHash::deserialize_from_vec(leaf) {
-            Ok(leaf_hash) => Ok(self.inner.compute_root(&leaf_hash).serialize_to_vec()),
-            Err(_) => Err(JsError::new(
-                "Failed to deserialize leaf: not a Blake2b hash",
-            )),
-        }
+        let leaf_hash = Blake2bHash::deserialize_from_vec(leaf)
+            .map_err(|_| JsError::new("Failed to deserialize leaf: not a Blake2b hash"))?;
+        Ok(self.inner.compute_root(&leaf_hash).serialize_to_vec())
     }
 
     /// Serializes the Merkle path into a byte array.
@@ -45,13 +42,9 @@ impl MerklePath {
 
     /// Deserializes a Merkle path from a byte array.
     pub fn deserialize(data: &[u8]) -> Result<MerklePath, JsError> {
-        match nimiq_utils::merkle::Blake2bMerklePath::deserialize_from_vec(data) {
-            Ok(path) => Ok(path.into()),
-            Err(e) => Err(JsError::new(&format!(
-                "Failed to deserialize MerklePath: {}",
-                e
-            ))),
-        }
+        nimiq_utils::merkle::Blake2bMerklePath::deserialize_from_vec(data)
+            .map(|path| path.into())
+            .map_err(|err| JsError::new(&format!("Failed to deserialize MerklePath: {}", err)))
     }
 }
 

--- a/web-client/src/common/mod.rs
+++ b/web-client/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod address;
 pub mod client_configuration;
 pub mod hashed_time_locked_contract;
+pub mod merkle_path;
 pub mod signature_proof;
 pub mod staking_contract;
 pub mod transaction;

--- a/web-client/src/common/signature_proof.rs
+++ b/web-client/src/common/signature_proof.rs
@@ -6,10 +6,10 @@ use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "primitives")]
-use crate::common::address::Address;
-#[cfg(feature = "primitives")]
 use crate::common::transaction::PlainTransactionProofType;
 use crate::common::transaction::{PlainStandardProof, PlainTransactionProof};
+#[cfg(feature = "primitives")]
+use crate::common::{address::Address, merkle_path::MerklePath};
 #[cfg(feature = "primitives")]
 use crate::primitives::{
     es256_public_key::ES256PublicKey, es256_signature::ES256Signature, public_key::PublicKey,
@@ -184,6 +184,12 @@ impl SignatureProof {
                 JsValue::unchecked_into(key.into())
             }
         }
+    }
+
+    /// The embedded merkle path.
+    #[wasm_bindgen(getter, js_name = merklePath)]
+    pub fn merkle_path(&self) -> MerklePath {
+        self.inner.merkle_path.clone().into()
     }
 
     /// Serializes the proof to a byte array, e.g. for assigning it to a `transaction.proof` field.

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -37,6 +37,8 @@ impl Commitment {
     }
 
     /// Sums up multiple commitments into one aggregated commitment.
+    ///
+    /// Attention: This is a simple summation, not a MuSig2 aggregation! For MuSig2 aggregation, use {@link Commitment.sumMuSig2}.
     pub fn sum(commitments: &CommitmentAnyArrayType) -> Result<Commitment, JsError> {
         let commitments = Commitment::unpack_commitments(commitments)?;
         if commitments.is_empty() {
@@ -48,24 +50,32 @@ impl Commitment {
         Ok(Commitment::from(aggregate_commitment))
     }
 
+    /// Aggregates commitments into one aggregated commitment using the MuSig2 scheme.
+    ///
+    /// - Each commitment group must correspond to the public key at the same index in the `publicKeys` array.
+    /// - The number of commitment groups and public keys must be the same.
+    /// - Each commitment group must contain exactly `MUSIG2_PARAMETER_V = 2` commitments.
+    /// - The `data` parameter is the same data that will be signed using the aggregated commitment, e.g. the serialized content of a transaction.
+    ///
+    /// Returns the aggregated commitment.
     #[wasm_bindgen(js_name = sumMuSig2)]
     pub fn sum_musig2(
         public_keys: &PublicKeyAnyArrayType,
-        commitments: &CommitmentAnyArrayArrayType,
+        commitment_groups: &CommitmentAnyArrayArrayType,
         data: &[u8],
     ) -> Result<Commitment, JsError> {
         let public_keys = PublicKey::unpack_public_keys(public_keys)?;
 
-        let commitments = Commitment::unpack_commitments_list(commitments)?;
+        let commitment_groups = Commitment::unpack_commitments_list(commitment_groups)?;
 
-        assert_eq!(public_keys.len(), commitments.len());
+        assert_eq!(public_keys.len(), commitment_groups.len());
 
         // Pack commitments into compile-time-known groups of MUSIG2_PARAMETER_V
         let mut commitment_pairs: Vec<
             [nimiq_keys::multisig::commitment::Commitment; MUSIG2_PARAMETER_V],
         > = vec![];
 
-        for group in &commitments {
+        for group in &commitment_groups {
             let mut commitment_pair =
                 [nimiq_keys::multisig::commitment::Commitment::default(); MUSIG2_PARAMETER_V];
             commitment_pair.copy_from_slice(group);

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -65,10 +65,13 @@ impl Commitment {
         data: &[u8],
     ) -> Result<Commitment, JsError> {
         let public_keys = PublicKey::unpack_public_keys(public_keys)?;
-
         let commitment_groups = Commitment::unpack_commitments_list(commitment_groups)?;
 
-        assert_eq!(public_keys.len(), commitment_groups.len());
+        if public_keys.len() != commitment_groups.len() {
+            return Err(JsError::new(
+                "The number of public keys must match the number of commitment groups",
+            ));
+        }
 
         // Pack commitments into compile-time-known groups of MUSIG2_PARAMETER_V
         let mut commitment_pairs: Vec<

--- a/web-client/src/multisig/commitment.rs
+++ b/web-client/src/multisig/commitment.rs
@@ -1,11 +1,13 @@
 use std::iter::Sum;
 
 use js_sys::Array;
+use nimiq_keys::multisig::{CommitmentsBuilder, MUSIG2_PARAMETER_V};
 use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_derive::TryFromJsValue;
 
 use super::random_secret::RandomSecret;
+use crate::primitives::public_key::{PublicKey, PublicKeyAnyArrayType};
 
 /// A cryptographic commitment to a {@link RandomSecret}. The commitment is public, while the secret is, well, secret.
 #[derive(TryFromJsValue)]
@@ -44,6 +46,45 @@ impl Commitment {
         let aggregate_commitment =
             nimiq_keys::multisig::commitment::Commitment::sum(commitments.into_iter());
         Ok(Commitment::from(aggregate_commitment))
+    }
+
+    #[wasm_bindgen(js_name = sumMuSig2)]
+    pub fn sum_musig2(
+        public_keys: &PublicKeyAnyArrayType,
+        commitments: &CommitmentAnyArrayArrayType,
+        data: &[u8],
+    ) -> Result<Commitment, JsError> {
+        let public_keys = PublicKey::unpack_public_keys(public_keys)?;
+
+        let commitments = Commitment::unpack_commitments_list(commitments)?;
+
+        assert_eq!(public_keys.len(), commitments.len());
+
+        // Pack commitments into compile-time-known groups of MUSIG2_PARAMETER_V
+        let mut commitment_pairs: Vec<
+            [nimiq_keys::multisig::commitment::Commitment; MUSIG2_PARAMETER_V],
+        > = vec![];
+
+        for group in &commitments {
+            let mut commitment_pair =
+                [nimiq_keys::multisig::commitment::Commitment::default(); MUSIG2_PARAMETER_V];
+            commitment_pair.copy_from_slice(group);
+            commitment_pairs.push(commitment_pair);
+        }
+
+        let mut builder =
+            CommitmentsBuilder::with_public_commitments(public_keys[0], commitment_pairs[0]);
+
+        public_keys[1..]
+            .iter()
+            .zip(commitment_pairs[1..].iter())
+            .for_each(|(&public_key, &commitments)| {
+                builder.push_signer(public_key, commitments);
+            });
+
+        let commitment_data = builder.build(data);
+
+        Ok(Commitment::from(commitment_data.aggregate_commitment))
     }
 
     /// Parses a commitment from a {@link Commitment} instance, a hex string representation, or a byte array.

--- a/web-client/src/multisig/partial_signature.rs
+++ b/web-client/src/multisig/partial_signature.rs
@@ -73,10 +73,10 @@ impl PartialSignature {
         Self::deserialize(bytes)
     }
 
-    pub fn combine(
-        partial_signatures: PartialSignatureAnyArrayType,
+    pub fn sum(
+        partial_signatures: &PartialSignatureAnyArrayType,
     ) -> Result<PartialSignature, JsError> {
-        let sigs = PartialSignature::unpack_partial_signatures(&partial_signatures)?;
+        let sigs = PartialSignature::unpack_partial_signatures(partial_signatures)?;
         let aggregated_signature =
             sigs.iter()
                 .sum::<nimiq_keys::multisig::partial_signature::PartialSignature>();

--- a/web-client/src/multisig/partial_signature.rs
+++ b/web-client/src/multisig/partial_signature.rs
@@ -73,6 +73,9 @@ impl PartialSignature {
         Self::deserialize(bytes)
     }
 
+    /// Sums an array of partial signatures into an aggregated partial signature.
+    ///
+    /// Afterwards, use `.toSignature(aggregatedCommitment)` on the result to get the final signature.
     pub fn sum(
         partial_signatures: &PartialSignatureAnyArrayType,
     ) -> Result<PartialSignature, JsError> {
@@ -83,12 +86,19 @@ impl PartialSignature {
         Ok(PartialSignature::from(aggregated_signature))
     }
 
+    /// Converts an (aggregated) partial signature into a final signature using the aggregated commitment.
     #[wasm_bindgen(js_name = toSignature)]
     pub fn to_signature(&self, aggregated_commitment: Commitment) -> Signature {
         let sig = self.inner.to_signature(aggregated_commitment.native_ref());
         sig.into()
     }
 
+    /// Creates a new partial signature for the MuSig2 scheme.
+    ///
+    /// - `ownCommitmentPairs` must be 2 pairs of random secret and commitments generated for this signing session.
+    /// - `otherCommitments` must contain 2 commitments each for all other signers.
+    ///
+    /// Returns the created partial signature.
     pub fn create(
         own_private_key: &PrivateKey,
         own_public_key: &PublicKey,

--- a/web-client/src/multisig/partial_signature.rs
+++ b/web-client/src/multisig/partial_signature.rs
@@ -1,3 +1,4 @@
+use js_sys::Array;
 use nimiq_keys::multisig::{CommitmentsBuilder, MUSIG2_PARAMETER_V};
 use nimiq_serde::Deserialize;
 use wasm_bindgen::prelude::*;
@@ -10,6 +11,7 @@ use super::{
 use crate::primitives::{
     private_key::PrivateKey,
     public_key::{PublicKey, PublicKeyAnyArrayType},
+    signature::Signature,
 };
 
 /// A partial signature is a signature of one of the co-signers in a multisig.
@@ -37,11 +39,11 @@ impl PartialSignature {
     ///
     /// Throws when a PartialSignature cannot be parsed from the argument.
     #[wasm_bindgen(js_name = fromAny)]
-    pub fn from_any(secret: &PartialSignatureAnyType) -> Result<PartialSignature, JsError> {
-        let js_value: &JsValue = secret.unchecked_ref();
+    pub fn from_any(sig: &PartialSignatureAnyType) -> Result<PartialSignature, JsError> {
+        let js_value: &JsValue = sig.unchecked_ref();
 
-        if let Ok(secret) = PartialSignature::try_from(js_value) {
-            return Ok(secret);
+        if let Ok(sig) = PartialSignature::try_from(js_value) {
+            return Ok(sig);
         }
 
         if let Ok(string) = serde_wasm_bindgen::from_value::<String>(js_value.to_owned()) {
@@ -69,6 +71,22 @@ impl PartialSignature {
     #[wasm_bindgen(constructor)]
     pub fn new(bytes: &[u8]) -> Result<PartialSignature, JsError> {
         Self::deserialize(bytes)
+    }
+
+    pub fn combine(
+        partial_signatures: PartialSignatureAnyArrayType,
+    ) -> Result<PartialSignature, JsError> {
+        let sigs = PartialSignature::unpack_partial_signatures(&partial_signatures)?;
+        let aggregated_signature =
+            sigs.iter()
+                .sum::<nimiq_keys::multisig::partial_signature::PartialSignature>();
+        Ok(PartialSignature::from(aggregated_signature))
+    }
+
+    #[wasm_bindgen(js_name = toSignature)]
+    pub fn to_signature(&self, aggregated_commitment: Commitment) -> Signature {
+        let sig = self.inner.to_signature(aggregated_commitment.native_ref());
+        sig.into()
     }
 
     pub fn create(
@@ -168,10 +186,31 @@ impl PartialSignature {
     pub fn take_native(self) -> nimiq_keys::multisig::partial_signature::PartialSignature {
         self.inner
     }
+
+    pub fn unpack_partial_signatures(
+        sigs: &PartialSignatureAnyArrayType,
+    ) -> Result<Vec<nimiq_keys::multisig::partial_signature::PartialSignature>, JsError> {
+        // Unpack the array of sigs
+        let js_value: &JsValue = sigs.unchecked_ref();
+        let array: &Array = js_value
+            .dyn_ref()
+            .ok_or_else(|| JsError::new("`sigs` must be an array"))?;
+
+        let mut sigs = Vec::<_>::with_capacity(array.length().try_into()?);
+        for any in array.iter() {
+            let sig = PartialSignature::from_any(&any.into())?.take_native();
+            sigs.push(sig);
+        }
+
+        Ok(sigs)
+    }
 }
 
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(typescript_type = "PartialSignature | string | Uint8Array")]
     pub type PartialSignatureAnyType;
+
+    #[wasm_bindgen(typescript_type = "(PartialSignature | string | Uint8Array)[]")]
+    pub type PartialSignatureAnyArrayType;
 }

--- a/web-client/src/multisig/partial_signature.rs
+++ b/web-client/src/multisig/partial_signature.rs
@@ -86,7 +86,7 @@ impl PartialSignature {
         Ok(PartialSignature::from(aggregated_signature))
     }
 
-    /// Converts an (aggregated) partial signature into a final signature using the aggregated commitment.
+    /// Converts a (aggregated) partial signature into a final signature using the aggregated commitment.
     #[wasm_bindgen(js_name = toSignature)]
     pub fn to_signature(&self, aggregated_commitment: Commitment) -> Signature {
         let sig = self.inner.to_signature(aggregated_commitment.native_ref());

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -95,6 +95,7 @@ impl PublicKey {
         Self::deserialize(raw_bytes)
     }
 
+    /// Generates all possible combinations (sums) of delinearized public keys for a given number of signers.
     pub fn combinations(
         keys: &PublicKeyAnyArrayType,
         num_signers: usize,
@@ -104,6 +105,7 @@ impl PublicKey {
         Ok(combined_keys.into_iter().map(PublicKey::from).collect())
     }
 
+    /// Sums public keys into one combined public key.
     pub fn sum(keys: &PublicKeyAnyArrayType) -> Result<PublicKey, JsError> {
         let keys = PublicKey::unpack_public_keys(keys)?;
         let combined_key =

--- a/web-client/src/primitives/public_key.rs
+++ b/web-client/src/primitives/public_key.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use js_sys::Array;
+use nimiq_keys::multisig::address::combine_public_keys;
 use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_derive::TryFromJsValue;
@@ -92,6 +93,22 @@ impl PublicKey {
             return Err(JsError::new("Public key primitive: Invalid raw length"));
         }
         Self::deserialize(raw_bytes)
+    }
+
+    pub fn combinations(
+        keys: &PublicKeyAnyArrayType,
+        num_signers: usize,
+    ) -> Result<Vec<PublicKey>, JsError> {
+        let keys = PublicKey::unpack_public_keys(keys)?;
+        let combined_keys = combine_public_keys(keys, num_signers);
+        Ok(combined_keys.into_iter().map(PublicKey::from).collect())
+    }
+
+    pub fn sum(keys: &PublicKeyAnyArrayType) -> Result<PublicKey, JsError> {
+        let keys = PublicKey::unpack_public_keys(keys)?;
+        let combined_key =
+            nimiq_keys::multisig::public_key::DelinearizedPublicKey::sum_delinearized(&keys);
+        Ok(PublicKey::from(combined_key))
     }
 
     /// Creates a new public key from a byte array.


### PR DESCRIPTION
## What's in this pull request?

This PR add the remaining multisig methods needed to create a full MuSig2 signature proof from scratch with the web-client, aka the @nimiq/core NPM package. A test is added that verifies this works in Javascript.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
