### PR TITLE
Upgrade rand/rand_core and rand_chacha to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -884,7 +884,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -894,7 +905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1187,6 +1198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,7 +1336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -2090,8 +2110,24 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -2637,6 +2673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idb"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3036,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -3834,7 +3882,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-vrf",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
@@ -3904,8 +3952,8 @@ dependencies = [
  "nimiq-zkp-primitives",
  "parking_lot",
  "prometheus-client 0.24.1",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
@@ -3972,7 +4020,7 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-utils",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core_compat",
  "serde",
  "thiserror 2.0.18",
@@ -4041,7 +4089,7 @@ dependencies = [
  "nimiq-zkp-component",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -4057,7 +4105,7 @@ dependencies = [
  "libmdbx",
  "nimiq-database-value",
  "pprof",
- "rand 0.9.2",
+ "rand 0.10.1",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -4168,7 +4216,7 @@ dependencies = [
  "nimiq-time",
  "nimiq-utils",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -4305,7 +4353,7 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-utils",
  "p256",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core_compat",
  "serde",
  "sha2",
@@ -4363,8 +4411,8 @@ dependencies = [
  "nimiq-zkp-component",
  "nimiq-zkp-primitives",
  "parking_lot",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -4399,7 +4447,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-zkp",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4530,7 +4578,8 @@ dependencies = [
  "nimiq-macros",
  "nimiq-test-log",
  "nimiq-utils",
- "rand 0.9.2",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
  "serde",
  "unicode-normalization",
 ]
@@ -4578,7 +4627,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "prometheus-client 0.24.1",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "sha2",
  "thiserror 2.0.18",
@@ -4624,8 +4673,8 @@ dependencies = [
  "hex",
  "nimiq-hash",
  "nimiq-primitives",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_core_compat",
 ]
 
@@ -4655,7 +4704,7 @@ dependencies = [
  "nimiq-web-client",
  "nimiq_rpc",
  "percentage",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4838,7 +4887,7 @@ dependencies = [
  "nimiq-transaction",
  "nimiq-transaction-builder",
  "nimiq-utils",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "tokio",
  "tokio-metrics",
@@ -4872,7 +4921,7 @@ dependencies = [
  "nimiq-test-log",
  "nimiq-time",
  "nimiq-utils",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "tokio",
  "tokio-stream",
@@ -4949,8 +4998,8 @@ dependencies = [
  "nimiq-zkp-primitives",
  "parking_lot",
  "paste",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_core_compat",
  "serde",
  "tempfile",
@@ -5081,8 +5130,8 @@ dependencies = [
  "nimiq-test-utils",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
- "rand_core 0.9.3",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
  "serde",
  "subtle",
  "thiserror 2.0.18",
@@ -5134,7 +5183,7 @@ dependencies = [
  "nimiq-vrf",
  "nimiq-zkp-component",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "tokio",
@@ -5178,7 +5227,7 @@ dependencies = [
  "nimiq-serde",
  "nimiq-test-log",
  "nimiq-test-utils",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "sha2",
  "tracing",
@@ -5212,6 +5261,7 @@ dependencies = [
  "ark-serialize",
  "futures-util",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hex",
  "idb",
  "js-sys",
@@ -5236,7 +5286,7 @@ dependencies = [
  "nimiq-utils",
  "nimiq-zkp-component",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -5280,8 +5330,8 @@ dependencies = [
  "nimiq-zkp-primitives",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_core_compat",
  "serde",
  "serde_json",
@@ -5322,8 +5372,8 @@ dependencies = [
  "nimiq-test-utils",
  "nimiq-transaction",
  "nimiq-zkp-primitives",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_core_compat",
  "rayon",
  "serde",
@@ -5889,7 +5939,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5901,7 +5951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5969,6 +6019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6203,6 +6263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6230,6 +6296,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6247,6 +6324,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6277,11 +6364,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_core_compat"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcffc3e5a51aaad9a99954ffc4b25bf2261192d6625ba613395ea560aef0844"
 dependencies = [
+ "rand_core 0.10.1",
  "rand_core 0.5.1",
  "rand_core 0.6.4",
  "rand_core 0.9.3",
@@ -7007,7 +7101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7018,7 +7112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -8007,7 +8101,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -8125,6 +8228,40 @@ name = "wasm-bindgen-test-shared"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"
@@ -8636,6 +8773,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.4"
 log = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = { version = "0.24.1", optional = true }
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["sync"] }
@@ -52,7 +52,7 @@ nimiq-vrf = { workspace = true }
 nimiq-zkp = { workspace = true }
 
 [dev-dependencies]
-rand_chacha = "0.9"
+rand_chacha = "0.10"
 tempfile = "3.27"
 
 nimiq-tendermint = { workspace = true }

--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -12,7 +12,7 @@ use nimiq_primitives::policy::Policy;
 use nimiq_transaction::{
     historic_transaction::HistoricTransaction, inherent::Inherent, Transaction,
 };
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{CryptoRng, Rng};
 use thiserror::Error;
 
 use crate::{interface::HistoryInterface, Blockchain};
@@ -284,7 +284,7 @@ impl BlockProducer {
     /// NOT a complete block. It still needs to go through the Tendermint protocol in order to be
     /// finalized.
     // Note: Needs to be called with the Blockchain lock held.
-    pub fn next_macro_block_proposal_with_rng<R: RngCore + CryptoRng>(
+    pub fn next_macro_block_proposal_with_rng<R: Rng + CryptoRng>(
         &self,
         // The (upgradable) read locked guard to the blockchain.
         blockchain: &Blockchain,

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -18,8 +18,8 @@ byteorder = "1.5.0"
 hex = "0.4"
 log = { workspace = true }
 parking_lot = { version = "0.12.5", optional = true }
-rand = "0.9"
-rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_9"] }
+rand = "0.10"
+rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_10"] }
 serde = { version = "1.0", optional = true }
 thiserror = "2.0"
 

--- a/bls/src/types/keypair.rs
+++ b/bls/src/types/keypair.rs
@@ -1,5 +1,5 @@
 use nimiq_hash::Hash;
-use nimiq_utils::key_rng::{CryptoRng, RngCore, SecureGenerate};
+use nimiq_utils::key_rng::{CryptoRng, Rng, SecureGenerate};
 
 use crate::{PublicKey, SecretKey, SigHash, Signature};
 
@@ -38,7 +38,7 @@ impl KeyPair {
 }
 
 impl SecureGenerate for KeyPair {
-    fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         let secret = SecretKey::generate(rng);
         KeyPair::from(secret)
     }

--- a/bls/src/types/secret_key.rs
+++ b/bls/src/types/secret_key.rs
@@ -1,7 +1,7 @@
 use ark_ff::{UniformRand, Zero};
 use ark_mnt6_753::{Fr, G1Projective};
 use nimiq_hash::Hash;
-use nimiq_utils::key_rng::{CryptoRng, RngCore, SecureGenerate};
+use nimiq_utils::key_rng::{CryptoRng, Rng, SecureGenerate};
 
 use crate::{CompressedSignature, SigHash, Signature};
 
@@ -37,8 +37,8 @@ impl SecretKey {
 }
 
 impl SecureGenerate for SecretKey {
-    fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let rng = &mut rand_core_compat::Rng09(rng);
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+        let rng = &mut rand_core_compat::Rng010(rng);
         let mut x = Fr::rand(rng);
         loop {
             if !x.is_zero() {

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -27,7 +27,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1.1"
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["rt", "sync", "time"] }

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -32,7 +32,7 @@ use nimiq_test_utils::{
 };
 use nimiq_utils::time::OffsetTime;
 use parking_lot::{Mutex, RwLock};
-use rand::Rng;
+use rand::RngExt;
 use tokio::{sync::mpsc, task::yield_now};
 use tokio_stream::wrappers::ReceiverStream;
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -37,7 +37,7 @@ pprof = { version = "0.15", features = [
     "frame-pointer",
     "criterion",
 ] }
-rand = "0.9"
+rand = "0.10"
 
 [[bench]]
 name = "hash_keys"

--- a/database/benches/hash_keys.rs
+++ b/database/benches/hash_keys.rs
@@ -11,7 +11,7 @@ use nimiq_database_value::{AsDatabaseBytes, FromDatabaseBytes};
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{
     distr::{Distribution, StandardUniform},
-    rng, Rng,
+    rng, Rng, RngExt,
 };
 
 const TABLE: &str = "bench";

--- a/handel/Cargo.toml
+++ b/handel/Cargo.toml
@@ -31,7 +31,7 @@ nimiq-time = { workspace = true }
 nimiq-utils = { workspace = true, features = ["futures"] }
 
 [dev-dependencies]
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 tokio = { version = "1.52", features = ["rt", "time", "macros"] }
 

--- a/handel/src/level.rs
+++ b/handel/src/level.rs
@@ -162,7 +162,7 @@ impl Level {
 mod test {
     use nimiq_collections::bitset::BitSet;
     use nimiq_test_log::test;
-    use rand::Rng;
+    use rand::RngExt;
     use serde::{Deserialize, Serialize};
 
     use super::*;

--- a/handel/src/partitioner.rs
+++ b/handel/src/partitioner.rs
@@ -130,7 +130,7 @@ impl Partitioner for BinomialPartitioner {
 #[cfg(test)]
 mod tests {
     use nimiq_test_log::test;
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::*;
 

--- a/handel/src/store.rs
+++ b/handel/src/store.rs
@@ -292,7 +292,7 @@ mod tests {
     use nimiq_collections::BitSet;
     use nimiq_test_log::test;
     use parking_lot::RwLock;
-    use rand::Rng;
+    use rand::RngExt;
     use serde::{Deserialize, Serialize};
 
     use super::*;

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -32,8 +32,8 @@ ed25519-zebra = "4.2"
 hex = "0.4"
 itertools = "0.14"
 p256 = "0.13"
-rand = "0.9"
-rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_9"] }
+rand = "0.10"
+rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_10"] }
 serde = { version = "1.0", optional = true }
 sha2 = "0.10"
 thiserror = "2.0"

--- a/keys/src/key_pair.rs
+++ b/keys/src/key_pair.rs
@@ -1,6 +1,6 @@
 use ed25519_zebra::{SigningKey, VerificationKeyBytes};
 use nimiq_utils::key_rng::SecureGenerate;
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 #[cfg(feature = "serde-derive")]
 use serde::{Deserialize, Serialize};
 
@@ -21,8 +21,8 @@ impl KeyPair {
 }
 
 impl SecureGenerate for KeyPair {
-    fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let zebra_priv_key = SigningKey::new(rand_core_compat::Rng09(rng));
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+        let zebra_priv_key = SigningKey::new(rand_core_compat::Rng010(rng));
         let priv_key = PrivateKey(zebra_priv_key);
         let pub_key = Ed25519PublicKey(VerificationKeyBytes::from(&zebra_priv_key));
         KeyPair {

--- a/keys/src/multisig/commitment.rs
+++ b/keys/src/multisig/commitment.rs
@@ -2,7 +2,7 @@ use curve25519_dalek::{
     constants, edwards::CompressedEdwardsY, traits::Identity, EdwardsPoint, Scalar,
 };
 use nimiq_utils::key_rng::SecureGenerate;
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{CryptoRng, Rng, RngExt};
 use sha2::digest::Update;
 use zeroize::Zeroize;
 
@@ -91,9 +91,7 @@ impl CommitmentPair {
     }
 
     /// Returns as many commitments as required by the MuSig2 parameter v (`MUSIG2_PARAMETER_V`).
-    pub fn generate_all<R: Rng + RngCore + CryptoRng>(
-        rng: &mut R,
-    ) -> [CommitmentPair; MUSIG2_PARAMETER_V] {
+    pub fn generate_all<R: Rng + CryptoRng>(rng: &mut R) -> [CommitmentPair; MUSIG2_PARAMETER_V] {
         let mut commitments = Vec::with_capacity(MUSIG2_PARAMETER_V);
         for _ in 0..MUSIG2_PARAMETER_V {
             commitments.push(CommitmentPair::generate(rng));
@@ -101,7 +99,7 @@ impl CommitmentPair {
         commitments.try_into().unwrap()
     }
 
-    fn generate_internal<R: Rng + RngCore + CryptoRng>(
+    fn generate_internal<R: Rng + CryptoRng>(
         rng: &mut R,
     ) -> Result<CommitmentPair, InvalidScalarError> {
         // Create random 32 bytes.
@@ -151,7 +149,7 @@ impl CommitmentPair {
 }
 
 impl SecureGenerate for CommitmentPair {
-    fn generate<R: Rng + RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         CommitmentPair::generate_internal(rng).expect("Failed to generate CommitmentPair")
     }
 }

--- a/keys/src/multisig/mod.rs
+++ b/keys/src/multisig/mod.rs
@@ -7,7 +7,7 @@ use curve25519_dalek::{
 };
 use nimiq_hash::{sha512::Sha512Hasher, Hasher};
 use nimiq_utils::key_rng::SecureGenerate;
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{CryptoRng, Rng};
 use sha2::{self, Digest, Sha512};
 
 use self::{
@@ -88,8 +88,8 @@ pub struct CommitmentsBuilder {
 }
 
 impl CommitmentsBuilder {
-    /// Creates new commitment pairs from an Rng.
-    pub fn new<R: Rng + RngCore + CryptoRng>(
+    /// Creates new commitment pairs from an RNG.
+    pub fn new<R: Rng + CryptoRng>(
         own_public_key: Ed25519PublicKey,
         rng: &mut R,
     ) -> CommitmentsBuilder {

--- a/keys/src/private_key.rs
+++ b/keys/src/private_key.rs
@@ -7,7 +7,7 @@ use std::{
 use curve25519_dalek::scalar::Scalar;
 use hex::FromHex;
 use nimiq_utils::key_rng::SecureGenerate;
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 use sha2::{Digest as _, Sha512};
 
 use crate::errors::{KeysError, ParseError};
@@ -52,8 +52,10 @@ impl PrivateKey {
 }
 
 impl SecureGenerate for PrivateKey {
-    fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        PrivateKey(ed25519_zebra::SigningKey::new(rand_core_compat::Rng09(rng)))
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+        PrivateKey(ed25519_zebra::SigningKey::new(rand_core_compat::Rng010(
+            rng,
+        )))
     }
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -46,8 +46,8 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = { workspace = true }
 log-panics = { version = "2.1", features = ["with-backtrace"], optional = true }
 parking_lot = "0.12"
-rand = "0.9"
-rand_chacha = "0.9"
+rand = "0.10"
+rand_chacha = "0.10"
 rustls = { version = "0.23.40", default-features = false, optional = true }
 rustls-pemfile = "2.2"
 serde = "1.0"

--- a/light-blockchain/Cargo.toml
+++ b/light-blockchain/Cargo.toml
@@ -32,7 +32,7 @@ nimiq-vrf = { workspace = true }
 nimiq-zkp = { workspace = true }
 
 [dev-dependencies]
-rand = "0.9"
+rand = "0.10"
 
 nimiq-blockchain = { workspace = true }
 nimiq-test-utils = { workspace = true }

--- a/light-blockchain/src/chain_store.rs
+++ b/light-blockchain/src/chain_store.rs
@@ -380,7 +380,7 @@ mod tests {
     use nimiq_primitives::networks::NetworkId;
     use nimiq_test_log::test;
     use nimiq_test_utils::test_rng;
-    use rand::{Rng, RngCore};
+    use rand::{Rng, RngExt};
 
     use super::*;
 

--- a/mnemonic/Cargo.toml
+++ b/mnemonic/Cargo.toml
@@ -22,7 +22,8 @@ workspace = true
 [dependencies]
 bitvec = "1.0"
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"
+rand_core = "0.10"
 serde = "1.0"
 unicode-normalization = "0.1"
 

--- a/mnemonic/src/lib.rs
+++ b/mnemonic/src/lib.rs
@@ -11,7 +11,8 @@ use nimiq_utils::{
     key_rng::SecureGenerate,
     otp::{otp, Algorithm},
 };
-use rand::{rngs::OsRng, CryptoRng, RngCore, TryRngCore as _};
+use rand::{rngs::SysRng, CryptoRng, Rng};
+use rand_core::UnwrapErr;
 use unicode_normalization::UnicodeNormalization;
 
 #[cfg(feature = "key-derivation")]
@@ -64,7 +65,7 @@ impl Entropy {
 }
 
 impl SecureGenerate for Entropy {
-    fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         let mut bytes = [0u8; Entropy::SIZE];
         rng.fill_bytes(&mut bytes[..]);
         bytes.into()
@@ -79,7 +80,7 @@ impl Entropy {
 
     pub fn export_encrypted(&self, key: &[u8]) -> Result<Vec<u8>, String> {
         let mut salt = [0u8; Entropy::ENCRYPTION_SALT_SIZE];
-        OsRng.unwrap_err().fill_bytes(&mut salt);
+        UnwrapErr(SysRng).fill_bytes(&mut salt);
 
         let mut data = Vec::with_capacity(/*purposeId*/ 4 + Entropy::SIZE);
         data.extend_from_slice(&Entropy::PURPOSE_ID.to_be_bytes());

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -32,7 +32,7 @@ parking_lot = "0.12"
 pin-project = "1.1"
 pin-project-lite = "0.2.17"
 prometheus-client = { version = "0.24.1", optional = true }
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 sha2 = "0.10"
 thiserror = "2.0"

--- a/network-libp2p/src/connection_pool/behaviour.rs
+++ b/network-libp2p/src/connection_pool/behaviour.rs
@@ -549,7 +549,7 @@ impl Behaviour {
                     None
                 }
             })
-            .choose_multiple(&mut rand::rng(), num_peers)
+            .sample(&mut rand::rng(), num_peers)
     }
 
     /// This function is used to select a list of peers, based on services flag, in order to dial them.
@@ -577,7 +577,7 @@ impl Behaviour {
                     None
                 }
             })
-            .choose_multiple(&mut rand::rng(), num_peers)
+            .sample(&mut rand::rng(), num_peers)
     }
 
     fn choose_seeds_to_dial(&self) -> Vec<Multiaddr> {
@@ -595,7 +595,7 @@ impl Behaviour {
             .iter()
             .filter(|address| !own_addresses.contains(address) && self.addresses.can_dial(*address))
             .cloned()
-            .choose_multiple(&mut rand::rng(), num_seeds)
+            .sample(&mut rand::rng(), num_seeds)
     }
 
     fn housekeeping(&mut self) {

--- a/network-libp2p/src/discovery/handler.rs
+++ b/network-libp2p/src/discovery/handler.rs
@@ -241,7 +241,7 @@ impl Handler {
     ) -> Vec<SignedPeerContact> {
         peer_contact_book
             .query(self.services_filter)
-            .choose_multiple(&mut rand::rng(), limit)
+            .sample(&mut rand::rng(), limit)
             .into_iter()
             .map(|c| c.signed().clone())
             .collect()

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -55,7 +55,7 @@ nimiq-utils = { workspace = true, features = ["spawn"] }
 nimiq-vrf = { workspace = true }
 nimiq_rpc = "0.5"
 percentage = "0.1"
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 serde_derive = "1.0"
 thiserror = "2.0"

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 hex = "0.4"
 log = { workspace = true }
 parking_lot = "0.12"
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 thiserror = "2.0"
 

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -28,7 +28,7 @@ use nimiq_test_utils::{
     transactions::{IncomingType, OutgoingType, TransactionsGenerator, ValidatorState},
 };
 use nimiq_transaction::{inherent::Inherent, SignatureProof, Transaction};
-use rand::Rng;
+use rand::RngExt;
 use tempfile::tempdir;
 
 const VOLATILE_ENV: bool = true;

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
 log = { workspace = true }
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "time", "tracing"] }
 tokio-metrics = { version = "0.5" }

--- a/spammer/src/main.rs
+++ b/spammer/src/main.rs
@@ -31,7 +31,7 @@ use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_utils::spawn;
 use rand::{
     distr::{weighted::WeightedIndex, Distribution},
-    Rng,
+    RngExt,
 };
 use serde::Deserialize;
 

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 log = { workspace = true }
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 tokio = { version = "1.52", features = [
     "macros",

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -14,7 +14,7 @@ use futures::{
 use nimiq_collections::BitSet;
 use nimiq_time::{sleep, Sleep};
 use nimiq_utils::stream::{FuturesUnordered, SelectAll};
-use rand::{rng, Rng};
+use rand::{rng, RngExt};
 use tokio::{sync::mpsc, time::Duration};
 use tokio_stream::wrappers::ReceiverStream;
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -39,9 +39,9 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = { workspace = true }
 parking_lot = "0.12"
 paste = "1.0"
-rand = "0.9"
-rand_chacha = "0.9"
-rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_9"] }
+rand = "0.10"
+rand_chacha = "0.10"
+rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_10"] }
 serde = "1.0"
 tempfile = "3.27"
 tokio = { version = "1.52", features = ["rt", "time", "tracing"] }

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -19,7 +19,7 @@ use nimiq_serde::Deserialize;
 use nimiq_transaction::Transaction;
 use nimiq_transaction_builder::TransactionBuilder;
 use parking_lot::RwLock;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use crate::{blockchain_with_rng::*, test_rng};
 

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -23,7 +23,7 @@ use nimiq_transaction::{
 };
 use nimiq_transaction_builder::TransactionProofBuilder;
 use nimiq_trie::WriteTransactionProxy;
-use rand::{CryptoRng, Rng};
+use rand::{CryptoRng, Rng, RngExt};
 
 pub enum ValidatorState {
     Active,

--- a/test-utils/src/zkp_test_data.rs
+++ b/test-utils/src/zkp_test_data.rs
@@ -86,7 +86,7 @@ pub fn simulate_merger_wrapper(
 
     // Simulate proof.
     let toxic_waste = load_merger_wrapper_simulator(path).expect("Missing toxic waste.");
-    let proof = toxic_waste.simulate_proof(&inputs, &mut rand_core_compat::Rng09(rng));
+    let proof = toxic_waste.simulate_proof(&inputs, &mut rand_core_compat::Rng010(rng));
     ZKProof {
         block_number: block.block_number(),
         proof: Some(proof),

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -28,8 +28,8 @@ libp2p-identity = { version = "0.2", optional = true }
 log = { workspace = true, optional = true }
 parking_lot = "0.12"
 pin-project = "1.1"
-rand = { version = "0.9", optional = true }
-rand_core = { version = "0.9", optional = true }
+rand = { version = "0.10", optional = true }
+rand_core = { version = "0.10", optional = true }
 serde = "1.0"
 subtle = { version = "2.6", optional = true }
 thiserror = { version = "2.0", optional = true }
@@ -62,7 +62,7 @@ merkle = [
     "nimiq-collections",
     "nimiq-hash",
 ]
-otp = ["clear_on_drop", "nimiq-hash", "rand"]
+otp = ["clear_on_drop", "nimiq-hash", "rand", "rand_core"]
 spawn = ["tokio", "tokio/rt", "wasm-bindgen-futures"]
 tagged-signing = ["hex"]
 time = []

--- a/utils/src/key_rng.rs
+++ b/utils/src/key_rng.rs
@@ -1,11 +1,11 @@
-use rand::rngs::OsRng;
-pub use rand::{CryptoRng, RngCore};
+use rand::rngs::SysRng;
+pub use rand::{CryptoRng, Rng};
 use rand_core::UnwrapErr;
 
-pub type SecureRng = UnwrapErr<OsRng>;
+pub type SecureRng = UnwrapErr<SysRng>;
 
 pub trait SecureGenerate: Sized {
-    fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
+    fn generate<R: Rng + CryptoRng>(rng: &mut R) -> Self;
 
     #[inline]
     fn generate_default_csprng() -> Self {

--- a/utils/src/otp.rs
+++ b/utils/src/otp.rs
@@ -7,7 +7,8 @@ use clear_on_drop::clear::Clear;
 use nimiq_database_value_derive::DbSerializable;
 use nimiq_hash::argon2kdf::{compute_argon2_kdf, Argon2Error, Argon2Variant};
 use nimiq_serde::{Deserialize, Serialize};
-use rand::{rngs::OsRng, RngCore as _, TryRngCore as _};
+use rand::{rngs::SysRng, Rng as _};
+use rand_core::UnwrapErr;
 
 pub fn otp(
     secret: &[u8],
@@ -277,7 +278,7 @@ impl<T: Clear + Deserialize + Serialize> Locked<T> {
         algorithm: Algorithm,
     ) -> Result<Self, Argon2Error> {
         let mut salt = vec![0; salt_length];
-        OsRng.unwrap_err().fill_bytes(salt.as_mut_slice());
+        UnwrapErr(SysRng).fill_bytes(salt.as_mut_slice());
         Self::lock(secret, password, iterations, salt, algorithm)
     }
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -25,7 +25,7 @@ hashlink = "0.11"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = { workspace = true }
 parking_lot = "0.12"
-rand = "0.9"
+rand = "0.10"
 rayon = "1.12"
 serde = "1.0"
 tokio = { version = "1.52", features = ["rt", "time", "tracing"] }

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = "1.5"
 curve25519-dalek = { version = "4.1.3", features = ["digest"] }
 hex = "0.4"
 log = { workspace = true }
-rand = "0.9"
+rand = "0.10"
 serde = { version = "1.0", optional = true }
 sha2 = "0.10"
 

--- a/vrf/src/vrf.rs
+++ b/vrf/src/vrf.rs
@@ -17,7 +17,7 @@ use nimiq_keys::{Ed25519PublicKey, KeyPair};
 #[cfg(feature = "serde-derive")]
 use nimiq_macros::add_serialization_fns_typed_arr;
 use nimiq_macros::create_typed_array;
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 use sha2::{Digest, Sha256, Sha512};
 
 use crate::rng::Rng;
@@ -168,7 +168,7 @@ impl VrfSeed {
     /// Produces the next VRF Seed given the current VRF Seed (which is part of the message), a
     /// key pair and a nonce.
     #[must_use]
-    pub fn sign_next_with_rng<R: RngCore + CryptoRng>(
+    pub fn sign_next_with_rng<R: rand::Rng + CryptoRng>(
         &self,
         keypair: &KeyPair,
         nonce: u32,
@@ -327,6 +327,7 @@ mod tests {
     use nimiq_keys::SecureGenerate;
     use nimiq_test_log::test;
     use nimiq_test_utils::test_rng;
+    use rand::Rng;
 
     use super::*;
 

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -25,12 +25,14 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 ark-serialize = "0.4"
 futures = { workspace = true }
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
+# We need to enable the `wasm_js` feature of getrandom 0.3 while we still indirectly depend on it
+getrandom_0_3 = { package="getrandom", version = "0.3", features = ["wasm_js"] }
 hex = "0.4"
 idb = "0.6.5"
 js-sys = "0.3"
 log = { workspace = true }
-rand = "0.9"
+rand = "0.10"
 serde = "1.0"
 serde_bytes = "0.11"
 thiserror = "2.0"

--- a/zkp-circuits/Cargo.toml
+++ b/zkp-circuits/Cargo.toml
@@ -27,9 +27,9 @@ required-features = ["zkp-prover", "parallel", "cli"]
 clap = { version = "4.6", features = ["cargo", "string", "derive"] }
 hex = "0.4"
 log = { workspace = true }
-rand = "0.9"
-rand_chacha = "0.9"
-rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_9"] }
+rand = "0.10"
+rand_chacha = "0.10"
+rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_10"] }
 rayon = { version = "^1.12", optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/zkp-circuits/src/gadgets/mnt6/macro_block.rs
+++ b/zkp-circuits/src/gadgets/mnt6/macro_block.rs
@@ -388,7 +388,7 @@ mod tests {
     use nimiq_test_log::test;
     use nimiq_test_utils::{block_production::TemporaryBlockProducer, test_rng};
     use nimiq_transaction::reward::RewardTransaction;
-    use rand::Rng as _;
+    use rand::RngExt as _;
 
     use super::*;
 
@@ -510,7 +510,7 @@ mod tests {
         let cs = ConstraintSystem::<MNT6Fq>::new_ref();
 
         // Create random number generator.
-        let rng = &mut rand_core_compat::Rng09(test_rng(true));
+        let rng = &mut rand_core_compat::Rng010(test_rng(true));
 
         // Create more block parameters.
         let block_number = u32::rand(rng);
@@ -550,7 +550,7 @@ mod tests {
         let cs = ConstraintSystem::<MNT6Fq>::new_ref();
 
         // Create random number generator.
-        let rng = &mut rand_core_compat::Rng09(test_rng(true));
+        let rng = &mut rand_core_compat::Rng010(test_rng(true));
 
         // Create more block parameters.
         let block_number = u32::rand(rng);
@@ -592,7 +592,7 @@ mod tests {
         let cs = ConstraintSystem::<MNT6Fq>::new_ref();
 
         // Create random number generator.
-        let rng = &mut rand_core_compat::Rng09(test_rng(true));
+        let rng = &mut rand_core_compat::Rng010(test_rng(true));
 
         // Create more block parameters.
         let block_number = u32::rand(rng);
@@ -634,7 +634,7 @@ mod tests {
         let cs = ConstraintSystem::<MNT6Fq>::new_ref();
 
         // Create random number generator.
-        let rng = &mut rand_core_compat::Rng09(test_rng(true));
+        let rng = &mut rand_core_compat::Rng010(test_rng(true));
 
         // Create more block parameters.
         let block_number = u32::rand(rng);
@@ -676,7 +676,7 @@ mod tests {
         let cs = ConstraintSystem::<MNT6Fq>::new_ref();
 
         // Create random number generator.
-        let rng = &mut rand_core_compat::Rng09(test_rng(true));
+        let rng = &mut rand_core_compat::Rng010(test_rng(true));
 
         // Create more block parameters.
         let block_number = u32::rand(rng);
@@ -724,7 +724,7 @@ mod tests {
         let cs = ConstraintSystem::<MNT6Fq>::new_ref();
 
         // Create random number generator.
-        let rng = &mut rand_core_compat::Rng09(test_rng(true));
+        let rng = &mut rand_core_compat::Rng010(test_rng(true));
 
         // Create more block parameters.
         let block_number = u32::rand(rng);

--- a/zkp-circuits/src/setup.rs
+++ b/zkp-circuits/src/setup.rs
@@ -49,7 +49,7 @@ pub fn setup<R: rand::Rng + rand::CryptoRng>(
         return Ok(());
     }
 
-    let rng = &mut rand_core_compat::Rng09(rng);
+    let rng = &mut rand_core_compat::Rng010(rng);
     setup_pk_tree_leaf(rng, path, "pk_tree_5")?;
     setup_pk_tree_node_mnt4(rng, path, "pk_tree_4", 4)?;
     setup_pk_tree_node_mnt6(rng, path, "pk_tree_3", 3)?;

--- a/zkp-circuits/src/test_setup.rs
+++ b/zkp-circuits/src/test_setup.rs
@@ -248,7 +248,7 @@ pub fn setup_merger_wrapper_simulation<R: rand::CryptoRng>(
     rng: &mut R,
     path: &Path,
 ) -> Result<ToxicWaste<MNT6_753>, NanoZKPError> {
-    let rng = &mut rand_core_compat::Rng09(rng);
+    let rng = &mut rand_core_compat::Rng010(rng);
 
     // Create parameters for our circuit
     let circuit = MergerWrapperCircuit::rand(rng);

--- a/zkp-circuits/zkp-constraints/main.rs
+++ b/zkp-circuits/zkp-constraints/main.rs
@@ -42,7 +42,7 @@ fn main() {
     // Print sizes for each circuit.
     info!("====== ZKP constraint estimation initiated ======");
     let start = Instant::now();
-    let mut rng = &mut rand_core_compat::Rng09(rand::rng());
+    let mut rng = &mut rand_core_compat::Rng010(rand::rng());
 
     let circuit: mnt6::PKTreeLeafCircuit = rng.r#gen();
     evaluate_circuit(circuit, "pk_tree_leaf mnt6");

--- a/zkp-primitives/pedersen-generators/Cargo.toml
+++ b/zkp-primitives/pedersen-generators/Cargo.toml
@@ -26,9 +26,9 @@ ark-mnt4-753 = "0.4"
 ark-mnt6-753 = "0.4"
 hex = "0.4"
 
-rand = "0.9"
-rand_chacha = "0.9"
-rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_9"] }
+rand = "0.10"
+rand_chacha = "0.10"
+rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_10"] }
 
 nimiq-hash = { workspace = true }
 nimiq-primitives = { workspace = true, features = ["policy"] }

--- a/zkp-primitives/pedersen-generators/src/generators.rs
+++ b/zkp-primitives/pedersen-generators/src/generators.rs
@@ -38,7 +38,7 @@ impl<C: CurveGroup> PedersenParameters<C> {
 fn pedersen_generators<P: Pairing>(number: usize, personalization: u64) -> Vec<P::G1> {
     // This gets a verifiably random seed. We pass in the personalization value to get unique results.
     let seed = generate_random_seed(personalization);
-    let mut rng = rand_core_compat::Rng09(ChaCha20Rng::from_seed(seed));
+    let mut rng = rand_core_compat::Rng010(ChaCha20Rng::from_seed(seed));
 
     // Initialize the vector that will contain the generators.
     let mut generators = Vec::new();

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -27,11 +27,8 @@ ark-std = "0.4"
 log = { workspace = true }
 once_cell = "1.21"
 parking_lot = "0.12"
-rand = "0.9"
-rand_core_compat = { version = "0.1", features = [
-    "rand_core_0_6",
-    "rand_core_0_9",
-] }
+rand = "0.10"
+rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_10"] }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"
@@ -47,7 +44,7 @@ nimiq-zkp-circuits = { workspace = true }
 nimiq-zkp-primitives = { workspace = true }
 
 [dev-dependencies]
-rand_chacha = "0.9"
+rand_chacha = "0.10"
 tracing-subscriber = { version = "0.3" }
 
 nimiq-log = { workspace = true }

--- a/zkp/src/proof_system/prove.rs
+++ b/zkp/src/proof_system/prove.rs
@@ -94,7 +94,7 @@ pub fn prove(
     // Make sure proofs cache is up-to-date.
     update_proof_cache(prover_keys_path, &final_block.hash_blake2s().0)?;
 
-    let rng = &mut rand_core_compat::Rng09(rand::rng());
+    let rng = &mut rand_core_compat::Rng010(rand::rng());
     let proofs = prover_keys_path.join("proofs");
 
     const NUM_PROOFS: usize = 4;

--- a/zkp/tests/prover/recursive_input.rs
+++ b/zkp/tests/prover/recursive_input.rs
@@ -97,7 +97,7 @@ impl ConstraintSynthesizer<FqMNT6> for OuterCircuit {
 #[cfg_attr(not(feature = "expensive-tests"), ignore)]
 fn recursive_input_works() {
     // Create random number generator.
-    let rng = &mut rand_core_compat::Rng09(test_rng(false));
+    let rng = &mut rand_core_compat::Rng010(test_rng(false));
 
     // Create random bits and inputs for red.
     let mut bytes = [0u8; NUMBER_OF_BYTES];


### PR DESCRIPTION
Upgrade rand/rand_core and rand_chacha to 0.10. Also upgrade `getrandom` to 0.4.2,

This closes #3630, closes #3610, closes #3630 and closes #3700.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
