### PR TITLE
blockchain: Add proposal body root verification

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -426,6 +426,12 @@ impl Blockchain {
                 .clone()
         };
 
+        // Verify that the header's body_root matches the hash of the actual body.
+        if *block.body_root() != body.hash() {
+            debug!(%block, "Tendermint - await_proposal: body_root does not match body hash");
+            return Err(PushError::InvalidBlock(BlockError::BodyHashMismatch));
+        }
+
         // Verify macro block state before committing accounts.
         if let Err(error) = self.verify_block_state_pre_commit(block, txn) {
             debug!(%error, %block, "Tendermint - await_proposal: Invalid macro block state");


### PR DESCRIPTION
This adds proposal body root verification as a fix to a security vulnerability disclosed through our bug bounty program.

The attack scenario:
A malicious or compromised validator that is elected as proposer can publish a macro block proposal where `header.body_root` does not match the actual macro body hash.
The proposal can pass proposal verification because the macro proposal verification path validates the header but does not validate the binding `body_root == hash(body)`; later code expects this binding and may panic on mismatch, crashing validators.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
