### PR TITLE
Initialize to test policy for unit albatross

### DIFF
--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -168,13 +168,11 @@ impl ClientInner {
         }
         let network_info = NetworkInfo::from_network_id(config.network_id);
 
-        let policy_config = Policy {
-            genesis_block_number: network_info.genesis_block().block_number(),
-            max_supported_version: network_info.max_supported_version(),
-            ..Default::default()
-        };
-
-        let _ = Policy::get_or_init(policy_config);
+        let _ = Policy::get_or_init_with_network_info(
+            config.network_id,
+            network_info.genesis_block().block_number(),
+            network_info.genesis_block().version(),
+        );
 
         // Verify Policy is configured with the genesis block number we expect
         if network_info.genesis_block().block_number() != Policy::genesis_block_number() {

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -7,6 +7,8 @@ use once_cell::sync::OnceCell;
 #[cfg(feature = "ts-types")]
 use wasm_bindgen::prelude::*;
 
+use crate::networks::NetworkId;
+
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
 
@@ -184,6 +186,27 @@ impl Policy {
     #[inline]
     pub fn get_or_init(policy: Policy) -> Policy {
         *GLOBAL_POLICY.get_or_init(|| policy)
+    }
+
+    #[inline]
+    pub fn get_or_init_with_network_info(
+        network_id: NetworkId,
+        genesis_block_number: u32,
+        max_supported_version: u16,
+    ) -> Policy {
+        // Run tests with different policy values:
+        let mut policy_config = match network_id {
+            NetworkId::UnitAlbatross => TEST_POLICY,
+            NetworkId::TestAlbatross | NetworkId::DevAlbatross | NetworkId::MainAlbatross => {
+                Policy::default()
+            }
+            _ => panic!("Invalid network id"),
+        };
+        // The genesis block number must be set accordingly
+        policy_config.genesis_block_number = genesis_block_number;
+        policy_config.max_supported_version = max_supported_version;
+
+        *GLOBAL_POLICY.get_or_init(|| policy_config)
     }
 }
 

--- a/zkp-component/zkp-prove/src/main.rs
+++ b/zkp-component/zkp-prove/src/main.rs
@@ -61,6 +61,7 @@ fn initialize(network_id: NetworkId) {
     };
     // The genesis block number must be set accordingly
     policy_config.genesis_block_number = genesis_block.block_number();
+    policy_config.max_supported_version = genesis_block.version();
 
     let _ = Policy::get_or_init(policy_config);
 }


### PR DESCRIPTION
## What's in this pull request?
The client is initialized always with default policy, despite the network ID being unit albatross, which makes the zkp verification fail when we try to run nimiq clients locally for testing.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
