### PR TITLE
Discard stale peers received via discovery

### DIFF
--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -427,27 +427,40 @@ impl PeerContactBook {
             }
         }
 
-        // Reject contacts with timestamps in the future
         let current_ts = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
+
+        // Reject contacts with timestamps in the future
         if info.contact().timestamp > current_ts {
             return;
         }
 
+        // Rejects contacts that are older than the allowed age
+        if info.exceeds_age(
+            Duration::from_secs(PeerContactBook::MAX_PEER_AGE),
+            Duration::from_secs(current_ts),
+        ) {
+            return;
+        }
+
         let info = Arc::new(info);
-        let is_new = self
-            .peer_contacts
-            .insert(info.peer_id, Arc::clone(&info))
-            .is_none();
-        if is_new {
-            log::trace!(
-                peer_id = %info.peer_id,
-                services = ?info.services(),
-                addresses = ?info.contact.inner.addresses,
-                "Adding peer contact",
-            );
+        match self.peer_contacts.entry(info.peer_id) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if entry.get().contact().timestamp < info.contact().timestamp {
+                    entry.insert(info);
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                log::trace!(
+                    peer_id = %info.peer_id,
+                    services = ?info.services(),
+                    addresses = ?info.contact.inner.addresses,
+                    "Adding peer contact",
+                );
+                entry.insert(info);
+            }
         }
     }
 

--- a/network-libp2p/tests/discovery.rs
+++ b/network-libp2p/tests/discovery.rs
@@ -594,3 +594,98 @@ async fn test_duplicate_discovery_substream_closes_without_panic() {
         "Attacker failed to negotiate two discovery substreams"
     );
 }
+
+#[test]
+fn test_insert_filtered_rejects_stale_timestamp() {
+    let own_contact = random_peer_contact(1, Services::FULL_BLOCKS);
+    let mut peer_contact_book = PeerContactBook::new(own_contact, false, true, true);
+
+    let stale_contact = {
+        let keypair = Keypair::generate_ed25519();
+        let stale_ts = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .saturating_sub(PeerContactBook::MAX_PEER_AGE + 1);
+
+        let peer_contact = PeerContact::new(
+            Some("/dns/stale.evil.local/tcp/443/wss".parse().unwrap()),
+            keypair.public(),
+            Services::FULL_BLOCKS,
+            stale_ts,
+        )
+        .expect("Peer contact must be creatable");
+
+        peer_contact.sign(&keypair)
+    };
+
+    let stale_peer_id = stale_contact.public_key().clone().to_peer_id();
+
+    peer_contact_book.insert_filtered(stale_contact, Services::FULL_BLOCKS, false);
+
+    assert!(
+        peer_contact_book.get(&stale_peer_id).is_none(),
+        "insert_filtered must reject contacts older than MAX_PEER_AGE"
+    );
+}
+
+#[test]
+fn test_insert_filtered_only_replaces_with_newer_timestamp() {
+    let own_contact = random_peer_contact(1, Services::FULL_BLOCKS);
+    let mut peer_contact_book = PeerContactBook::new(own_contact, false, true, true);
+
+    let keypair = Keypair::generate_ed25519();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let base_ts = now.saturating_sub(60);
+
+    let original_contact = PeerContact::new(
+        Some("/dns/peer.old.local/tcp/443/wss".parse().unwrap()),
+        keypair.public(),
+        Services::FULL_BLOCKS,
+        base_ts,
+    )
+    .expect("Peer contact must be creatable")
+    .sign(&keypair);
+    let same_timestamp_contact = PeerContact::new(
+        Some("/dns/peer.same.local/tcp/443/wss".parse().unwrap()),
+        keypair.public(),
+        Services::FULL_BLOCKS,
+        base_ts,
+    )
+    .expect("Peer contact must be creatable")
+    .sign(&keypair);
+    let newer_contact = PeerContact::new(
+        Some("/dns/peer.new.local/tcp/443/wss".parse().unwrap()),
+        keypair.public(),
+        Services::FULL_BLOCKS,
+        base_ts + 1,
+    )
+    .expect("Peer contact must be creatable")
+    .sign(&keypair);
+
+    let peer_id = original_contact.public_key().clone().to_peer_id();
+
+    peer_contact_book.insert_filtered(original_contact.clone(), Services::FULL_BLOCKS, false);
+    assert_eq!(
+        peer_contact_book.get(&peer_id).unwrap().signed(),
+        &original_contact,
+        "fresh contact should be inserted"
+    );
+
+    peer_contact_book.insert_filtered(same_timestamp_contact, Services::FULL_BLOCKS, false);
+    assert_eq!(
+        peer_contact_book.get(&peer_id).unwrap().signed(),
+        &original_contact,
+        "same timestamp must not overwrite the existing contact"
+    );
+
+    peer_contact_book.insert_filtered(newer_contact.clone(), Services::FULL_BLOCKS, false);
+    assert_eq!(
+        peer_contact_book.get(&peer_id).unwrap().signed(),
+        &newer_contact,
+        "newer timestamp must replace the existing contact"
+    );
+}


### PR DESCRIPTION
## What's in this pull request?

The problem in a greater view: House keeping removes stale peers, but nodes still accept stale peers. So even though there is house keeping, all nodes ensure that they broadcast all the stale peers before all nodes have the chance to have them pruned by house keeping.

Now, if a node receives a stale peer or a peer from the future (functionality adapted from house keeping) then the peer will not be added. Plus, a peer that already exists is only overwritten if the peer info is newer than the existing info.

Note: The tests were written by AI.

#### This fixes #3652.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
