### PR TITLE
Fix missing proof-of-knowledge validation on voting key update

### DIFF
--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -144,10 +144,11 @@ impl IncomingStakingTransactionData {
                 }
 
                 // Check proof of knowledge, if necessary.
-                if let (Some(new_voting_key), Some(new_proof_of_knowledge)) =
-                    (new_voting_key, new_proof_of_knowledge)
-                {
-                    verify_proof_of_knowledge(new_voting_key, new_proof_of_knowledge)?;
+                match (new_voting_key, new_proof_of_knowledge) {
+                    (Some(key), Some(pok)) => verify_proof_of_knowledge(key, pok)?,
+                    (Some(_), None) => return Err(TransactionError::InvalidData),
+                    (None, Some(_)) => return Err(TransactionError::InvalidData),
+                    (None, None) => {} // no key change, nothing to verify
                 }
 
                 // Check that the signature is correct.


### PR DESCRIPTION
## Summary

- The `UpdateValidator` transaction accepted a new voting key without requiring a proof-of-knowledge when the PoK field was `None`. An attacker could set a rogue BLS key that, when aggregated with honest validators's keys, allows forging valid aggregate signatures—breaking Tendermint consensus integrity.
- Replace the `if let` that silently skipped validation with an exhaustive `match` that rejects mismatched `(Some key, None PoK)` and `(None key, Some PoK)` combinations.