### PR TITLE
Remove unwrap/ safer arithmetic logic

### DIFF
--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -24,7 +24,11 @@ impl LightBlockchain {
         trusted_proof: bool,
     ) -> Result<PushResult, PushError> {
         // Must be an election block.
-        assert!(block.is_election());
+        if !block.is_election() {
+            return Err(PushError::InvalidBlock(
+                nimiq_block::BlockError::InvalidBlockType,
+            ));
+        }
 
         let block_hash_blake2b = block.hash_cached();
         let block_hash_blake2s = block.unwrap_macro_ref().hash_blake2s();

--- a/light-blockchain/tests/push.rs
+++ b/light-blockchain/tests/push.rs
@@ -723,3 +723,29 @@ fn can_push_zkps() {
         assert_eq!(blockchain2_rg.block_number(), block_number);
     }
 }
+
+#[test]
+fn push_zkp_rejects_non_election_blocks() {
+    let temp_producer = TemporaryLightBlockProducer::new();
+
+    let micro_block = {
+        let blockchain = temp_producer.blockchain.read();
+        next_micro_block(
+            &temp_producer.producer.signing_key,
+            &blockchain,
+            &BlockConfig::default(),
+        )
+    };
+    let block = Block::Micro(micro_block);
+
+    assert!(!block.is_election());
+
+    let result = LightBlockchain::push_zkp(
+        temp_producer.light_blockchain.upgradable_read(),
+        block,
+        Default::default(),
+        true,
+    );
+
+    assert_eq!(result, Err(InvalidBlock(BlockError::InvalidBlockType)));
+}

--- a/primitives/transaction/src/lib.rs
+++ b/primitives/transaction/src/lib.rs
@@ -383,7 +383,7 @@ impl Transaction {
             >= self
                 .validity_start_height
                 .saturating_sub(Policy::blocks_per_batch())
-            && block_height < self.validity_start_height + window
+            && block_height < self.validity_start_height.saturating_add(window)
     }
 
     pub fn contract_creation_address(&self) -> Address {

--- a/primitives/transaction/tests/validity.rs
+++ b/primitives/transaction/tests/validity.rs
@@ -1,0 +1,56 @@
+//! Regression tests for transaction validity window arithmetic.
+
+use nimiq_keys::Address;
+use nimiq_primitives::{coin::Coin, networks::NetworkId, policy::Policy};
+use nimiq_test_log::test;
+use nimiq_transaction::Transaction;
+
+fn basic_transaction(validity_start_height: u32) -> Transaction {
+    Transaction::new_basic(
+        Address::from([1u8; 20]),
+        Address::from([2u8; 20]),
+        Coin::try_from(100u64).unwrap(),
+        Coin::try_from(0u64).unwrap(),
+        validity_start_height,
+        NetworkId::UnitAlbatross,
+    )
+}
+
+#[test]
+fn is_valid_at_does_not_overflow_on_large_validity_start_height() {
+    let window = Policy::transaction_validity_window_blocks();
+    assert_eq!(
+        window,
+        Policy::transaction_validity_window() * Policy::blocks_per_batch()
+    );
+
+    // `overflow_start + window` would overflow without saturating arithmetic.
+    let overflow_start = u32::MAX - (window - 1);
+    let tx = basic_transaction(overflow_start);
+
+    assert!(
+        tx.is_valid_at(overflow_start),
+        "is_valid_at({}) returned false for validity_start_height={}",
+        overflow_start,
+        overflow_start,
+    );
+}
+
+#[test]
+fn is_valid_at_does_not_overflow_at_u32_max() {
+    let tx = basic_transaction(u32::MAX);
+
+    assert!(!tx.is_valid_at(u32::MAX));
+    assert!(tx.is_valid_at(u32::MAX - 1));
+}
+
+#[test]
+fn is_valid_at_works_for_normal_values() {
+    let tx = basic_transaction(1000);
+    let window = Policy::transaction_validity_window_blocks();
+
+    assert!(tx.is_valid_at(1000));
+    assert!(tx.is_valid_at(1000 + window - Policy::blocks_per_batch() - 1));
+    assert!(!tx.is_valid_at(1000 + window));
+    assert!(!tx.is_valid_at(2000));
+}


### PR DESCRIPTION
Remove unwrap in light blockchain
Use safer arithmetic logic for txn validity computation

These are no real issues in practice since push_zkip is only called with macro blocks and the txn validity can no longer be exploited



## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
