### PR TITLE
Validate genesis_supply in get_supply_at RPC handler

### DIFF
--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -154,6 +154,14 @@ impl PolicyInterface for PolicyDispatcher {
         genesis_time: u64,
         current_time: u64,
     ) -> RPCResult<u64, (), Self::Error> {
+        if genesis_supply > Policy::TOTAL_SUPPLY {
+            log::error!(
+                genesis_supply,
+                "The supplied genesis_supply must not exceed Policy::TOTAL_SUPPLY"
+            );
+            return Err(Error::InvalidArgument(genesis_supply.to_string()));
+        }
+
         if current_time < genesis_time {
             log::error!(
                 current_time,


### PR DESCRIPTION
Reject genesis_supply values exceeding Policy::TOTAL_SUPPLY to prevent integer underflow in the supply_at calculation.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
