### PR TITLE
Pass allow_ips config to RPC server ip_whitelist

### DIFF
--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -81,7 +81,7 @@ pub fn initialize_rpc_server(
         Config {
             bind_to: (config.bind_to.unwrap_or_else(default_bind), config.port).into(),
             enable_websocket: false,
-            ip_whitelist: None,
+            ip_whitelist: config.allow_ips.map(|ips| ips.into_iter().collect()),
             basic_auth,
             cors: Some(cors_config),
         },


### PR DESCRIPTION
The parsed allow_ips whitelist was being discarded by hardcoding ip_whitelist: None, bypassing intended IP-based access control.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
