### PR TITLE
Update CONTRIBUTING.md - grammar mistakes and markdown errors

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,43 +1,36 @@
 # Contributing Guidelines
 
-For anyone looking to get involved to this project, we are glad to hear from you. Here are a few of the kind of contributions
-that we would be interested.
+For anyone looking to get involved in this project, we are glad to hear from you. Here are a few of the kind of contributions that we would be interested in.
 
-*  Bug fixes
-    -  If you find a bug, please first report it using GitHub issues.
-    -  Issues that have already been identified as a bug will be labeled `bug`.
-    -  If you'd like to submit a fix for a bug, create a Pull Request from your own fork and mention the issue number.
-        +  Include a test that isolates the bug and verifies that it was fixed.
-*  New Features
-    -  If you'd like to accomplish something in the library that it doesn't already do, describe the problem in a new
-       GitHub issue.
-    -  Issues that have been identified as a feature request will be labeled `enhancement`.
-    -  If you'd like to implement the new feature, please wait for feedback from the project maintainers before spending
-       too much time writing the code. In some cases, `enhancement`s may not align well with the project objectives at
-       the time.
-*  Tests, Documentation, Miscellaneous
-    -  If you think the test coverage could be improved, the documentation could be clearer, you've got an alternative
-       implementation of something that may have more advantages, or any other change we would be glad hear about
-       it.  
-       + If it's a trivial change, go ahead and create a Pull Request with the changes you have in mind.
-       + If not, open a GitHub issue to discuss the idea first.
+* Bug fixes
+    -   If you find a bug, please first report it using GitHub issues.
+    -   Issues that have already been identified as a bug will be labeled `bug`.
+    -   If you'd like to submit a fix for a bug, create a Pull Request from your own fork and mention the issue number.
+        +   Include a test that isolates the bug and verifies that it was fixed.
+* New Features
+    -   If you'd like to accomplish something in the library that it doesn't already do, describe the problem in a new GitHub issue.
+    -   Issues that have been identified as a feature request will be labeled `enhancement`.
+    -   If you'd like to implement the new feature, please wait for feedback from the project maintainers before spending too much time writing the code. In some cases, `enhancement`s may not align well with the project objectives at the time.
+* Tests, Documentation, Miscellaneous
+    -   If you think the test coverage could be improved, the documentation could be clearer, you've got an alternative implementation of something that may have more advantages, or any other change we would be glad to hear about.  
+        +   If it's a trivial change, go ahead and create a Pull Request with the changes you have in mind.
+        +   If not, open a GitHub issue to discuss the idea first.
 
 ## Requirements
 
 For a contribution to be accepted:
 
-*  The test suite must be complete and pass
-*  Code must follow existing styling conventions
-*  Commit messages must be descriptive. Related issues should be mentioned by number.
+* The test suite must be complete and pass
+* Code must follow existing styling conventions
+* Commit messages must be descriptive. Related issues should be mentioned by number.
 
-If the contribution doesn't meet these criteria, a maintainer will discuss with you on the issue. You can still
-continue to add more commits to the branch you have sent the Pull Request from.
+If the contribution doesn't meet these criteria, a maintainer will discuss with you on the issue. You can still continue to add more commits to the branch you have sent the Pull Request from.
 
 ## How To Start
 
 1. Fork this repository on GitHub.
-1. Clone/fetch your fork to your local development machine.
-1. Create a new branch (e.g. `issue-12`, `feat.add_foo`, etc) and check it out.
-1. Make your changes and commit them. (Did the tests pass?)
-1. Push your new branch to your fork. (e.g. `git push myname issue-12`)
-1. Open a Pull Request from your new branch to the original fork's `master` branch.
+2. Clone/fetch your fork to your local development machine.
+3. Create a new branch (e.g. `issue-12`, `feat.add_foo`, etc) and check it out.
+4. Make your changes and commit them. (Did the tests pass?)
+5. Push your new branch to your fork. (e.g. `git push myname issue-12`)
+6. Open a Pull Request from your new branch to the original repository's `master` branch.


### PR DESCRIPTION
## What's in this pull request?

Grammar and Phrasing Edits to the Contributing Guidelines Page.
Fixed prepositions: Changed "involved to" to "involved in" and added a missing "in" at the end of "...contributions that we would be interested in."

Fixed missing words: Added the missing "to" in the phrase "...we would be glad to hear about."

Corrected terminology: Changed the contradictory phrase "original fork's master branch" to "original repository's master branch."

Markdown and Formatting Fixes
Replaced non-breaking spaces: stripped out all the hidden non-breaking spaces (U+00A0) used for indentation and replaced them with standard spaces so the nested bullet points will actually render correctly.

Sequenced the numbered list: Updated the "How To Start" section from repeating 1. 1. 1. to sequential numbers (1. 2. 3., etc.) to make the raw text much easier to read.

#### This fixes N/A.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
