### PR TITLE
Prevent u32 underflow in `get_proposer_at` when block_number is 0

### DIFF
--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -73,8 +73,11 @@ impl Blockchain {
         offset: u32,
         txn_option: Option<&DBTransaction>,
     ) -> Result<Slot, BlockchainError> {
+        let predecessor = block_number
+            .checked_sub(1)
+            .ok_or(BlockchainError::BlockNotFound(block_number))?;
         let vrf_entropy = self
-            .get_block_at(block_number - 1, false, txn_option)?
+            .get_block_at(predecessor, false, txn_option)?
             .seed()
             .entropy();
 

--- a/light-blockchain/src/abstract_blockchain.rs
+++ b/light-blockchain/src/abstract_blockchain.rs
@@ -95,7 +95,10 @@ impl AbstractBlockchain for LightBlockchain {
     }
 
     fn get_proposer_at(&self, block_number: u32, offset: u32) -> Result<Slot, BlockchainError> {
-        let vrf_entropy = self.get_block_at(block_number - 1, false)?.seed().entropy();
+        let predecessor = block_number
+            .checked_sub(1)
+            .ok_or(BlockchainError::BlockNotFound(block_number))?;
+        let vrf_entropy = self.get_block_at(predecessor, false)?.seed().entropy();
         self.get_proposer(block_number, offset, vrf_entropy)
     }
 


### PR DESCRIPTION
Replace unchecked `block_number - 1` with `checked_sub`, returning `BlockchainError::BlockNotFound` instead of underflowing (which panics in debug and wraps to `u32::MAX` in release mode). Applied to both the full and light blockchain implementations.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
