### PR TITLE
Use `safe_sub` for `total_stake` in failed `DeleteValidator`

### DIFF
--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -479,7 +479,7 @@ impl AccountTransactionInteraction for StakingContract {
                 } else {
                     // Update the balances of the validator and staking contract.
                     validator.deposit = new_deposit;
-                    validator.total_stake -= transaction.fee;
+                    validator.total_stake = validator.total_stake.safe_sub(transaction.fee)?;
                     self.balance -= transaction.fee;
 
                     // Update the validator entry.


### PR DESCRIPTION
In `commit_failed_transaction` for `DeleteValidator`, the update to `validator.total_stake` used bare `SubAssign` which panics on underflow. The preceding fee check only guarantees `fee <= deposit`; the stronger `total_stake >= fee` relation holds today only via the cross-module invariant `total_stake >= deposit`. Switch to `safe_sub` so the invariant is enforced locally and any future regression surfaces as an `AccountError` rather than a node panic.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
