### PR TITLE
Guard `rebranch_to` against empty `target_chain`

### DIFF
--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -92,6 +92,13 @@ impl Blockchain {
         (Vec<(Blake2bHash, ChainInfo)>, Vec<BlockLog>),
         Vec<(Blake2bHash, ChainInfo, Option<TrieDiff>)>,
     > {
+        // Rebranching to an empty target chain is not meaningful: there is nothing
+        // to apply and the ancestor would become the new head, which the callers
+        // do not handle. Reject so the proposal/push is treated as an invalid fork.
+        if target_chain.is_empty() {
+            return Err(vec![]);
+        }
+
         // Keeps track of the currently investigated block
         let mut current = (self.state.head_hash.clone(), self.state.main_chain.clone());
         // Collects the reverted blocks


### PR DESCRIPTION
`verify_inferior_chain_macro_block_proposal` calls `fork_chain.remove(0)` to strip the proposed block before invoking `rebranch_to`. If the proposal's parent is the common ancestor, `fork_chain` becomes empty, and `rebranch_to` would panic on `target_chain.last().unwrap()` when updating `main_chain_successor`.

This state is not reachable under normal protocol invariants (the non-inferior path would be taken, or `verify_macro_successor` would reject the proposal), but guard defensively so a broken invariant elsewhere cannot turn into a validator-wide crash. Returning `Err(vec![])` funnels into the existing error handling in both callers, which abort the write transaction and surface `PushError::InvalidFork`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
