### PR TITLE
Fix MerkleProof and MerklePath deserialization bounds checks

### DIFF
--- a/utils/src/merkle/mod.rs
+++ b/utils/src/merkle/mod.rs
@@ -211,7 +211,7 @@ impl<'de, H: HashOutput> Visitor<'de> for MerklePathVisitor<H> {
         let node_hashes: Vec<H> = seq
             .next_element()?
             .ok_or_else(|| A::Error::invalid_length(2, &self))?;
-        if left_bits_size > left_bits.len() {
+        if left_bits_size != left_bits.len() {
             return Err(A::Error::invalid_length(left_bits.len(), &self));
         }
         if node_hashes.len() != count {
@@ -655,7 +655,7 @@ impl<'de, H: HashOutput> Visitor<'de> for MerkleProofVisitor<H> {
         let operation_bits: Vec<u8> = seq
             .next_element()?
             .ok_or_else(|| A::Error::invalid_length(1, &self))?;
-        if operation_bits.len() > operations_size {
+        if operation_bits.len() != operations_size {
             return Err(A::Error::invalid_length(operations_size, &self));
         }
         let nodes: Vec<H> = seq


### PR DESCRIPTION
`MerkleProofVisitor` had an inverted bounds check that accepted undersized `operation_bits`, causing an out-of-bounds panic in `decompress()`. Both visitors now use strict equality checks to reject any bitfield that doesn't match the expected size.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
