### PR TITLE
Add block timestamp drift validation across all sync paths

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -78,7 +78,8 @@ impl Blockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Verify that the block is a valid successor to the current macro head.
         block.verify_macro_successor(this.state.macro_info.head.unwrap_macro_ref())?;

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -51,7 +51,8 @@ impl Blockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(self.network_id)?;
+        let max_timestamp = self.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(self.network_id, max_timestamp)?;
 
         // Fetch predecessor block. Fail if it doesn't exist.
         let predecessor = self
@@ -380,7 +381,8 @@ impl Blockchain {
         let mut block = Block::Macro(proposed_block);
 
         // Make sure the header verifies
-        if let Err(error) = block.verify_header(self.network_id, false) {
+        let max_timestamp = self.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        if let Err(error) = block.verify_header(self.network_id, false, max_timestamp) {
             debug!(%error, %block, "Tendermint - await_proposal: Invalid block header");
             return Err(PushError::InvalidBlock(error));
         }

--- a/blockchain/src/blockchain/zkp_sync.rs
+++ b/blockchain/src/blockchain/zkp_sync.rs
@@ -47,7 +47,8 @@ impl Blockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Prepare the inputs to verify the proof.
         let genesis_block = this
@@ -181,7 +182,8 @@ impl Blockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Check if we have this block's successor.
         let prev_block = &this.state.election_head;
@@ -237,7 +239,8 @@ impl Blockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Verify that the block is a valid macro successor to our current macro head.
         block.verify_macro_successor(this.state.macro_info.head.unwrap_macro_ref())?;

--- a/consensus/src/sync/history/cluster.rs
+++ b/consensus/src/sync/history/cluster.rs
@@ -120,6 +120,7 @@ pub struct BatchSetVerifyState {
     network: NetworkId,
     predecessor: Block,
     validators: Validators,
+    max_timestamp: u64,
 }
 
 /// Represents a request for a specific chunk of the history for a macro block.
@@ -234,6 +235,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
                 network: blockchain.network_id,
                 predecessor: Block::Macro(blockchain.election_head().clone()),
                 validators: blockchain.election_head().get_validators().unwrap(),
+                max_timestamp: blockchain.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT),
             }
         };
         // Prepare the queue of epoch IDs.
@@ -256,6 +258,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
                     batch_set_info,
                     &verify_state.predecessor,
                     &verify_state.validators,
+                    verify_state.max_timestamp,
                 ) {
                     warn!(error = ?e, "Received invalid batch set");
                     return false;
@@ -315,8 +318,9 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         network: NetworkId,
         macro_predecessor: &Block,
         validators: &Validators,
+        max_timestamp: u64,
     ) -> Result<(), HistoryRequestError> {
-        if let Err(error) = block.verify(network) {
+        if let Err(error) = block.verify(network, max_timestamp) {
             warn!(%block, %error, reason = "Block intrinsic checks failed", "Invalid macro block");
             return Err(HistoryRequestError::InvalidMacroBlock);
         }
@@ -340,6 +344,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
         batch_set_info: &BatchSetInfo,
         predecessor_macro_block: &Block,
         validators: &Validators,
+        max_timestamp: u64,
     ) -> Result<(), HistoryRequestError> {
         // Check and verify the election macro block if it exists and get the parent election_hash of this epoch
         if let Some(election_macro_block) = &batch_set_info.election_macro_block {
@@ -349,7 +354,13 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
                 return Err(HistoryRequestError::InvalidBatchSetInfo);
             }
 
-            Self::verify_macro_block(&block, network, predecessor_macro_block, validators)?;
+            Self::verify_macro_block(
+                &block,
+                network,
+                predecessor_macro_block,
+                validators,
+                max_timestamp,
+            )?;
         }
 
         let mut last_seen_macro_block = predecessor_macro_block.clone();
@@ -366,7 +377,13 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             }
 
             // Check the macro block of the batch set.
-            Self::verify_macro_block(&block, network, &last_seen_macro_block, validators)?;
+            Self::verify_macro_block(
+                &block,
+                network,
+                &last_seen_macro_block,
+                validators,
+                max_timestamp,
+            )?;
 
             // Check the history size proof.
             if !batch_set.history_len.verify(block.history_root()) {
@@ -619,6 +636,7 @@ impl<TNetwork: Network + 'static> SyncCluster<TNetwork> {
             network: blockchain.network_id,
             predecessor: Block::Macro(blockchain.election_head().clone()),
             validators: blockchain.election_head().get_validators().unwrap(),
+            max_timestamp: blockchain.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT),
         };
         self.batch_set_queue.set_verify_state(verify_state);
     }

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -162,8 +162,9 @@ impl<N: Network> BlockQueue<N> {
 
         // Validate header before hashing to reject malformed blocks (e.g. invalid BLS keys)
         // that would panic during hash computation.
+        let max_timestamp = blockchain.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
         if block
-            .verify_header(blockchain.network_id(), block.is_skip())
+            .verify_header(blockchain.network_id(), block.is_skip(), max_timestamp)
             .is_err()
         {
             block_source.reject_block(&self.network);

--- a/light-blockchain/src/push.rs
+++ b/light-blockchain/src/push.rs
@@ -69,7 +69,8 @@ impl LightBlockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Verify that the block is a valid immediate successor to its predecessor.
         let predecessor = &prev_info.head;

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -54,7 +54,8 @@ impl LightBlockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Verify the zk proof.
         if !trusted_proof {
@@ -141,7 +142,8 @@ impl LightBlockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Verify that the block is a valid macro successor to our current macro head.
         block.verify_macro_successor(&this.macro_head)?;
@@ -224,7 +226,8 @@ impl LightBlockchain {
         }
 
         // Perform block intrinsic checks.
-        block.verify(this.network_id)?;
+        let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
+        block.verify(this.network_id, max_timestamp)?;
 
         // Upgrade the blockchain lock
         let mut this = RwLockUpgradableReadGuard::upgrade(this);

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -338,14 +338,14 @@ impl Block {
     /// Verifies the block.
     /// Note that only intrinsic verifications are performed and further checks
     /// are needed when completely verifying a block.
-    pub fn verify(&self, network: NetworkId) -> Result<(), BlockError> {
+    pub fn verify(&self, network: NetworkId, max_timestamp: u64) -> Result<(), BlockError> {
         // Check the block type.
         if self.ty() != BlockType::of(self.block_number()) {
             return Err(BlockError::InvalidBlockType);
         }
 
         // Perform header intrinsic verification.
-        self.verify_header(network, self.is_skip())?;
+        self.verify_header(network, self.is_skip(), max_timestamp)?;
 
         // Verify body if it exists.
         if self.has_body() {
@@ -378,10 +378,27 @@ impl Block {
     /// Verifies the header.
     /// Note that only header intrinsic verifications are performed and further checks
     /// are needed when completely verifying a block header.
-    pub fn verify_header(&self, network: NetworkId, is_skip: bool) -> Result<(), BlockError> {
+    pub fn verify_header(
+        &self,
+        network: NetworkId,
+        is_skip: bool,
+        max_timestamp: u64,
+    ) -> Result<(), BlockError> {
         // Check whether the block is from the correct network.
         if self.network() != network {
             return Err(BlockError::NetworkMismatch);
+        }
+
+        // Check that the block timestamp does not exceed the permitted future drift.
+        if self.timestamp() > max_timestamp {
+            warn!(
+                header = %self,
+                timestamp = self.timestamp(),
+                max_timestamp,
+                reason = "timestamp too far in the future",
+                "Invalid block header"
+            );
+            return Err(BlockError::InvalidTimestamp);
         }
 
         // Check that the version is supported.

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -16,6 +16,9 @@ use nimiq_test_log::test;
 use nimiq_test_utils::blockchain::{generate_transactions, validator_address};
 use nimiq_transaction::ExecutedTransaction;
 
+/// Test blocks use timestamp 0; this allows up to 1 second into the future.
+const TEST_MAX_TIMESTAMP: u64 = 1000;
+
 #[test]
 fn test_verify_header_network() {
     let mut block = Block::Micro(MicroBlock {
@@ -32,19 +35,22 @@ fn test_verify_header_network() {
 
     // Check version at header level
     assert_eq!(
-        block.verify_header(NetworkId::UnitAlbatross, false),
+        block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Err(BlockError::NetworkMismatch)
     );
 
     // Error should remain at block level
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::NetworkMismatch)
     );
 
     // Fix the version and check that it passes
     block.unwrap_micro_ref_mut().header.network = NetworkId::UnitAlbatross;
-    assert_eq!(block.verify_header(NetworkId::UnitAlbatross, false), Ok(()));
+    assert_eq!(
+        block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 }
 
 #[test]
@@ -63,19 +69,22 @@ fn test_verify_header_version() {
 
     // Check version at header level
     assert_eq!(
-        block.verify_header(NetworkId::UnitAlbatross, false),
+        block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Err(BlockError::UnsupportedVersion)
     );
 
     // Error should remain at block level
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::UnsupportedVersion)
     );
 
     // Fix the version and check that it passes
     block.unwrap_micro_ref_mut().header.version = Policy::max_supported_version();
-    assert_eq!(block.verify_header(NetworkId::UnitAlbatross, false), Ok(()));
+    assert_eq!(
+        block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 }
 
 #[test]
@@ -107,12 +116,12 @@ fn test_verify_version_upgrades_micro_blocks() {
 
     // Should not allow version changes in micro blocks
     assert_eq!(
-        block1.verify_header(NetworkId::UnitAlbatross, false),
+        block1.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept lower versions"
     );
     assert_eq!(
-        block2.verify_header(NetworkId::UnitAlbatross, false),
+        block2.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept max version"
     );
@@ -125,7 +134,7 @@ fn test_verify_version_upgrades_micro_blocks() {
     // Fix the version and check that it passes
     block2.unwrap_micro_ref_mut().header.version = Policy::max_supported_version() - 1;
     assert_eq!(
-        block2.verify_header(NetworkId::UnitAlbatross, false),
+        block2.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept lower versions"
     );
@@ -187,12 +196,12 @@ fn test_verify_version_upgrades_macro_blocks() {
 
     // Should not allow version changes in non-election blocks
     assert_eq!(
-        macro_block1.verify_header(NetworkId::UnitAlbatross, false),
+        macro_block1.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept lower versions"
     );
     assert_eq!(
-        macro_block2.verify_header(NetworkId::UnitAlbatross, false),
+        macro_block2.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept max version"
     );
@@ -205,7 +214,7 @@ fn test_verify_version_upgrades_macro_blocks() {
     // Fix the version and check that it passes
     macro_block2.unwrap_macro_ref_mut().header.version = Policy::max_supported_version() - 2;
     assert_eq!(
-        macro_block2.verify_header(NetworkId::UnitAlbatross, false),
+        macro_block2.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept lower versions"
     );
@@ -218,7 +227,7 @@ fn test_verify_version_upgrades_macro_blocks() {
     // Scenario 2: Version upgrades above one in election blocks are not allowed
     // Should not allow version changes > 1
     assert_eq!(
-        election_block.verify_header(NetworkId::UnitAlbatross, false),
+        election_block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept max versions"
     );
@@ -232,7 +241,7 @@ fn test_verify_version_upgrades_macro_blocks() {
     // Fix the version and check that it passes
     election_block.unwrap_macro_ref_mut().header.version = Policy::max_supported_version() - 1;
     assert_eq!(
-        election_block.verify_header(NetworkId::UnitAlbatross, false),
+        election_block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Ok(()),
         "Should accept lower versions"
     );
@@ -260,33 +269,39 @@ fn test_verify_header_extra_data() {
 
     // Check extra data field at header level
     assert_eq!(
-        block.verify_header(NetworkId::UnitAlbatross, false),
+        block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
         Err(BlockError::ExtraDataTooLarge)
     );
     // Error should remain for a skip block
     assert_eq!(
-        block.verify_header(NetworkId::UnitAlbatross, true),
+        block.verify_header(NetworkId::UnitAlbatross, true, TEST_MAX_TIMESTAMP),
         Err(BlockError::ExtraDataTooLarge)
     );
 
     // Error should remain at block level
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::ExtraDataTooLarge)
     );
 
     // Fix the extra data field and check that it passes
     block.unwrap_micro_ref_mut().header.extra_data = vec![0; 32];
-    assert_eq!(block.verify_header(NetworkId::UnitAlbatross, false), Ok(()));
+    assert_eq!(
+        block.verify_header(NetworkId::UnitAlbatross, false, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
     // Error should remain for a skip block
     assert_eq!(
-        block.verify_header(NetworkId::UnitAlbatross, true),
+        block.verify_header(NetworkId::UnitAlbatross, true, TEST_MAX_TIMESTAMP),
         Err(BlockError::ExtraDataTooLarge)
     );
 
     // Fix the extra data field for a skip block and check that it passes
     block.unwrap_micro_ref_mut().header.extra_data = [].to_vec();
-    assert_eq!(block.verify_header(NetworkId::UnitAlbatross, true), Ok(()));
+    assert_eq!(
+        block.verify_header(NetworkId::UnitAlbatross, true, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 }
 
 #[test]
@@ -316,7 +331,7 @@ fn test_verify_body_root() {
 
     // The body root check must fail
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::BodyHashMismatch)
     );
 
@@ -328,7 +343,10 @@ fn test_verify_body_root() {
         body: Some(micro_body),
     });
 
-    assert_eq!(block.verify(NetworkId::UnitAlbatross), Ok(()));
+    assert_eq!(
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 }
 
 #[test]
@@ -369,7 +387,7 @@ fn test_verify_skip_block() {
 
     // The skip block body should fail
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::InvalidSkipBlockBody)
     );
 
@@ -382,7 +400,10 @@ fn test_verify_skip_block() {
         body: Some(micro_body),
     });
 
-    assert_eq!(block.verify(NetworkId::UnitAlbatross), Ok(()));
+    assert_eq!(
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 }
 
 #[test]
@@ -422,7 +443,7 @@ fn test_verify_micro_block_body_txns() {
 
     // The body check should fail
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::DuplicateTransaction)
     );
 
@@ -436,7 +457,10 @@ fn test_verify_micro_block_body_txns() {
         body: Some(micro_body),
     });
 
-    assert_eq!(block.verify(NetworkId::UnitAlbatross), Ok(()));
+    assert_eq!(
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 
     // Now modify the validity start height
     let txns: Vec<ExecutedTransaction> = generate_transactions(
@@ -465,7 +489,7 @@ fn test_verify_micro_block_body_txns() {
 
     // The body check should fail
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::ExpiredTransaction)
     );
 }
@@ -535,7 +559,7 @@ fn test_verify_micro_block_body_fork_proofs() {
 
     // The body check should fail
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::ForkProofsNotOrdered)
     );
 
@@ -553,7 +577,10 @@ fn test_verify_micro_block_body_fork_proofs() {
         body: Some(micro_body),
     });
 
-    assert_eq!(block.verify(NetworkId::UnitAlbatross), Ok(()));
+    assert_eq!(
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 
     // Lets have a duplicate fork proof
     fork_proofs.push(fork_proofs.last().unwrap().clone());
@@ -570,7 +597,7 @@ fn test_verify_micro_block_body_fork_proofs() {
     });
 
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::DuplicateForkProof)
     );
 
@@ -604,7 +631,7 @@ fn test_verify_micro_block_body_fork_proofs() {
 
     // The first fork proof should no longer be valid
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::InvalidForkProof)
     );
 }
@@ -636,7 +663,7 @@ fn test_verify_election_macro_body() {
 
     // The validators check should fail
     assert_eq!(
-        block.verify(NetworkId::UnitAlbatross),
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Err(BlockError::InvalidValidators)
     );
 
@@ -659,5 +686,8 @@ fn test_verify_election_macro_body() {
     });
 
     // Skipping the verification of the PK tree root should make the verify function to pass
-    assert_eq!(block.verify(NetworkId::UnitAlbatross), Ok(()));
+    assert_eq!(
+        block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
+        Ok(())
+    );
 }


### PR DESCRIPTION
Introduce `verify_block_timestamp` on `AbstractBlockchain` to reject blocks with timestamps exceeding the permitted future drift. Apply the check in history sync, zkp sync, light blockchain push/sync, and Tendermint proposal verification.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
