### PR TITLE
Fix empty-address panic in known_peers()

### DIFF
--- a/network-libp2p/src/discovery/peer_contacts.rs
+++ b/network-libp2p/src/discovery/peer_contacts.rs
@@ -512,20 +512,12 @@ impl PeerContactBook {
     pub fn known_peers(&self) -> Vec<(PeerId, PeerInfo)> {
         self.peer_contacts
             .iter()
-            .map(|(peer_id, contact)| {
-                (
+            .filter_map(|(peer_id, contact)| {
+                let address = contact.contact.inner.addresses.first()?.clone();
+                Some((
                     *peer_id,
-                    PeerInfo::new(
-                        contact
-                            .contact
-                            .inner
-                            .addresses
-                            .first()
-                            .expect("every peer should have at least one address")
-                            .clone(),
-                        contact.contact.inner.services,
-                    ),
-                )
+                    PeerInfo::new(address, contact.contact.inner.services),
+                ))
             })
             .collect()
     }


### PR DESCRIPTION
Skip peers with empty addresses in `known_peers()` instead of panicking, preventing a DoS via poisoned peer contacts with no advertised addresses.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
