### PR TITLE
ES256: return errors instead of panicking on invalid byte conversions

### DIFF
--- a/keys/src/es256_public_key.rs
+++ b/keys/src/es256_public_key.rs
@@ -71,15 +71,19 @@ impl FromStr for ES256PublicKey {
     }
 }
 
-impl<'a> From<&'a [u8; ES256PublicKey::SIZE]> for ES256PublicKey {
-    fn from(bytes: &'a [u8; ES256PublicKey::SIZE]) -> Self {
-        Self::from_bytes(bytes).expect("Unexpected size for")
+impl<'a> TryFrom<&'a [u8; ES256PublicKey::SIZE]> for ES256PublicKey {
+    type Error = KeysError;
+
+    fn try_from(bytes: &'a [u8; ES256PublicKey::SIZE]) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes)
     }
 }
 
-impl From<[u8; ES256PublicKey::SIZE]> for ES256PublicKey {
-    fn from(bytes: [u8; ES256PublicKey::SIZE]) -> Self {
-        ES256PublicKey::from(&bytes)
+impl TryFrom<[u8; ES256PublicKey::SIZE]> for ES256PublicKey {
+    type Error = KeysError;
+
+    fn try_from(bytes: [u8; ES256PublicKey::SIZE]) -> Result<Self, Self::Error> {
+        Self::from_bytes(&bytes)
     }
 }
 

--- a/keys/src/es256_signature.rs
+++ b/keys/src/es256_signature.rs
@@ -32,15 +32,6 @@ impl fmt::Display for ES256Signature {
     }
 }
 
-impl Default for ES256Signature {
-    fn default() -> Self {
-        ES256Signature(
-            p256::ecdsa::Signature::from_bytes(&[0u8; Self::SIZE].into())
-                .expect("Invalid slice length"),
-        )
-    }
-}
-
 impl FromHex for ES256Signature {
     type Error = ParseError;
 
@@ -49,17 +40,19 @@ impl FromHex for ES256Signature {
     }
 }
 
-impl<'a> From<&'a [u8; Self::SIZE]> for ES256Signature {
-    fn from(bytes: &'a [u8; Self::SIZE]) -> Self {
-        ES256Signature::from(*bytes)
+impl<'a> TryFrom<&'a [u8; Self::SIZE]> for ES256Signature {
+    type Error = SignatureError;
+
+    fn try_from(bytes: &'a [u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes)
     }
 }
 
-impl From<[u8; Self::SIZE]> for ES256Signature {
-    fn from(bytes: [u8; Self::SIZE]) -> Self {
-        ES256Signature(
-            p256::ecdsa::Signature::from_bytes(&bytes.into()).expect("Invalid slice length"),
-        )
+impl TryFrom<[u8; Self::SIZE]> for ES256Signature {
+    type Error = SignatureError;
+
+    fn try_from(bytes: [u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        Self::from_bytes(&bytes)
     }
 }
 


### PR DESCRIPTION
Replace the `From<[u8; N]>` / `From<&[u8; N]>` impls on `ES256PublicKey` and `ES256Signature` with `TryFrom`, matching the existing `Commitment` precedent in the multisig module. The previous impls called `from_bytes(...).expect(...)`, which panics on inputs that `p256` rejects (invalid SEC1 tag byte for the public key; zero or out-of-range `r`/`s` scalars for the signature). No current call site feeds untrusted bytes through these impls, but the `TryFrom` form removes the footgun.

Also remove the `Default` impl on `ES256Signature`: it attempted to construct a signature from all-zero bytes, which `p256` rejects (panicking with a misleading "Invalid slice length" message). The impl had no callers.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
