### PR TITLE
OffsetTime: use `instant::SystemTime` to avoid wasm32 panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,6 +5067,7 @@ dependencies = [
  "clear_on_drop",
  "futures-util",
  "hex",
+ "instant",
  "libp2p-identity",
  "nimiq-collections",
  "nimiq-database-value",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 clear_on_drop = { version = "0.2", optional = true }
 futures = { workspace = true, optional = true }
 hex = { version = "0.4", optional = true }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 libp2p-identity = { version = "0.2", optional = true }
 log = { workspace = true, optional = true }
 parking_lot = "0.12"

--- a/utils/src/time.rs
+++ b/utils/src/time.rs
@@ -1,7 +1,9 @@
 use std::{
     sync::atomic::{AtomicI64, Ordering},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
+
+use instant::SystemTime;
 
 /// Time with fixed offset from wall-clock, in milliseconds
 #[derive(Debug, Default)]
@@ -38,15 +40,12 @@ impl OffsetTime {
 }
 
 pub fn systemtime_to_timestamp(time: SystemTime) -> u64 {
-    match time.duration_since(UNIX_EPOCH) {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
         Ok(duration) => duration.as_secs() * 1000 + u64::from(duration.subsec_nanos()) / 1_000_000,
-        Err(e) => panic!(
-            "SystemTime before UNIX EPOCH! Difference: {:?}",
-            e.duration()
-        ),
+        Err(_) => panic!("SystemTime before UNIX EPOCH"),
     }
 }
 
 pub fn timestamp_to_systemtime(timestamp: u64) -> SystemTime {
-    UNIX_EPOCH + Duration::from_millis(timestamp)
+    SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp)
 }


### PR DESCRIPTION
`std::time::SystemTime::now()` panics with "time not implemented on this platform" on `wasm32-unknown-unknown`. The `OffsetTime` helper has always used it, but no wasm code path called it until block-timestamp drift validation was added to the light-blockchain sync paths, which now crashes the web client during ZKP sync handling.

Switch `OffsetTime` (and the `systemtime_to_timestamp` / `timestamp_to_systemtime` helpers) to `instant::SystemTime`, the polyfill already used elsewhere in the workspace. On native targets it re-exports `std::time::SystemTime`, so callers that pass a std `SystemTime` (e.g. the validator) keep working unchanged.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
