### PR TITLE
Bump tracing-loki to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7717,9 +7717,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-loki"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3beec919fbdf99d719de8eda6adae3281f8a5b71ae40431f44dc7423053d34"
+checksum = "a8d1ad78bf74c1790b0825ddc35ad1bb9498736c51c8437796b81cadf4916cd8"
 dependencies = [
  "loki-api",
  "reqwest",
@@ -7727,7 +7727,6 @@ dependencies = [
  "serde_json",
  "snap",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,7 +57,7 @@ thiserror = "2.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.52", features = ["rt"], optional = true }
 toml = "1.1"
-tracing-loki = { version = "0.2.6", optional = true }
+tracing-loki = { version = "0.2.7", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [
     "env-filter",
     "std",


### PR DESCRIPTION
tracing-loki 0.2.7 includes a change that allows compatibility with OpenTelemetry Collector as a destination.