### PR TITLE
Fix rebranch state propagation

### DIFF
--- a/blockchain/src/blockchain/rebranch_utils.rs
+++ b/blockchain/src/blockchain/rebranch_utils.rs
@@ -4,9 +4,9 @@ use nimiq_account::{BlockLog, BlockLogger};
 use nimiq_blockchain_interface::{ChainInfo, PushError};
 use nimiq_database::mdbx::{MdbxReadTransaction, MdbxWriteTransaction};
 use nimiq_hash::Blake2bHash;
-use nimiq_primitives::trie::trie_diff::TrieDiff;
+use nimiq_primitives::{policy::Policy, trie::trie_diff::TrieDiff};
 
-use crate::Blockchain;
+use crate::{history::interface::HistoryInterface, Blockchain};
 
 impl Blockchain {
     /// Finds the common ancestor between the current main chain in the context of `txn` and the fork chain given by
@@ -189,9 +189,10 @@ impl Blockchain {
         // Next, push each block of the target chain.
 
         // Pushing must happen in reverse.
-        let mut target_chain_iter = target_chain.iter().rev();
+        let mut prev_chain_info = ancestor.1.clone();
 
-        while let Some(block) = target_chain_iter.next() {
+        for i in (0..target_chain.len()).rev() {
+            let block = &mut target_chain[i];
             // Collect logs for the upcoming push.
             let mut block_logger = BlockLogger::new_applied(
                 block.0.clone(),
@@ -206,9 +207,20 @@ impl Blockchain {
                 write_txn,
                 &mut block_logger,
             ) {
-                Ok(total_tx_size)
-                    // push the logs into the logs collection
-                    => block_logs.push(block_logger.build(total_tx_size)),
+                Ok(total_tx_size) => {
+                    block.1.history_tree_len = self.history_store.total_len_at_epoch(
+                        Policy::epoch_at(block.1.head.block_number()),
+                        Some(write_txn),
+                    ) as u64;
+                    block
+                        .1
+                        .set_cumulative_hist_tx_size(&prev_chain_info, total_tx_size);
+
+                    // Push the logs into the logs collection once the chain info matches the
+                    // committed history state for this adopted block.
+                    block_logs.push(block_logger.build(total_tx_size));
+                    prev_chain_info = block.1.clone();
+                }
                 Err(e) => {
                     // If a block fails to apply here it does not verify fully.
                     // This block and all blocks after this thus should be removed from the store
@@ -223,10 +235,7 @@ impl Blockchain {
 
                     // Since a write txn is open which cannot be closed the vec of the to-be-removed
                     // blocks is returned so the caller side can deal with it.
-                    let remove_chain = vec![block.clone()]
-                        .into_iter()
-                        .chain(target_chain_iter.cloned())
-                        .collect();
+                    let remove_chain = target_chain[..=i].iter().rev().cloned().collect();
                     return Err(remove_chain);
                 }
             }

--- a/blockchain/tests/rebranching.rs
+++ b/blockchain/tests/rebranching.rs
@@ -1,7 +1,18 @@
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
+use nimiq_genesis::NetworkId;
+use nimiq_keys::{KeyPair, PrivateKey};
 use nimiq_primitives::policy::Policy;
+use nimiq_serde::Deserialize;
 use nimiq_test_log::test;
-use nimiq_test_utils::block_production::TemporaryBlockProducer;
+use nimiq_test_utils::{
+    block_production::TemporaryBlockProducer,
+    blockchain::{generate_transactions, REWARD_KEY},
+};
+
+fn key_pair_with_funds() -> KeyPair {
+    let priv_key = PrivateKey::deserialize_from_vec(&hex::decode(REWARD_KEY).unwrap()).unwrap();
+    priv_key.into()
+}
 
 #[test]
 fn it_can_rebranch_skip_block() {
@@ -150,6 +161,93 @@ fn it_can_rebranch_forks() {
 
     assert_eq!(temp_producer1.push(fork2d), Ok(PushResult::Extended));
     assert_eq!(temp_producer2.push(fork1d), Ok(PushResult::Ignored));
+}
+
+#[test]
+fn rebranched_blocks_preserve_history_chain_info() {
+    let temp_producer1 = TemporaryBlockProducer::new();
+    let temp_producer2 = TemporaryBlockProducer::new();
+    let funded_key_pair = key_pair_with_funds();
+
+    let shared = temp_producer1.next_block(vec![], false);
+    assert_eq!(temp_producer2.push(shared), Ok(PushResult::Extended));
+
+    let fork1_txs = generate_transactions(
+        &funded_key_pair,
+        temp_producer2.blockchain.read().block_number() + 1,
+        NetworkId::UnitAlbatross,
+        1,
+        1,
+    );
+    let fork1 = temp_producer2.next_block_with_txs(vec![0x48], false, fork1_txs);
+    let inferior = temp_producer1.next_block(vec![], false);
+
+    assert_eq!(temp_producer1.push(fork1.clone()), Ok(PushResult::Forked));
+    assert_eq!(temp_producer2.push(inferior), Ok(PushResult::Forked));
+
+    let fork2_txs = generate_transactions(
+        &funded_key_pair,
+        temp_producer2.blockchain.read().block_number() + 1,
+        NetworkId::UnitAlbatross,
+        1,
+        2,
+    );
+    let fork2 = temp_producer2.next_block_with_txs(vec![], false, fork2_txs);
+
+    assert_eq!(
+        temp_producer1.push(fork2.clone()),
+        Ok(PushResult::Rebranched)
+    );
+
+    let source_chain = temp_producer2.blockchain.read();
+    let source_fork1 = source_chain
+        .chain_store
+        .get_chain_info(&fork1.hash(), false, None)
+        .unwrap();
+    let source_fork2 = source_chain
+        .chain_store
+        .get_chain_info(&fork2.hash(), false, None)
+        .unwrap();
+
+    assert!(source_fork1.history_tree_len > 0);
+    assert!(source_fork1.cum_hist_tx_size > 0);
+    assert!(source_fork2.history_tree_len > 0);
+    assert!(source_fork2.cum_hist_tx_size > 0);
+
+    let rebranched_chain = temp_producer1.blockchain.read();
+    let adopted_fork1 = rebranched_chain
+        .chain_store
+        .get_chain_info(&fork1.hash(), false, None)
+        .unwrap();
+    let adopted_fork2 = rebranched_chain
+        .chain_store
+        .get_chain_info(&fork2.hash(), false, None)
+        .unwrap();
+
+    assert_eq!(
+        adopted_fork1.history_tree_len,
+        source_fork1.history_tree_len
+    );
+    assert_eq!(
+        adopted_fork1.cum_hist_tx_size,
+        source_fork1.cum_hist_tx_size
+    );
+    assert_eq!(
+        adopted_fork2.history_tree_len,
+        source_fork2.history_tree_len
+    );
+    assert_eq!(
+        adopted_fork2.cum_hist_tx_size,
+        source_fork2.cum_hist_tx_size
+    );
+    assert_eq!(
+        rebranched_chain.state.main_chain.history_tree_len,
+        source_fork2.history_tree_len
+    );
+    assert_eq!(
+        rebranched_chain.state.main_chain.cum_hist_tx_size,
+        source_fork2.cum_hist_tx_size
+    );
 }
 
 #[test]


### PR DESCRIPTION
During a rebranch, the history tree length,
and cumulative historic transaction size was not properly propagated