### PR TITLE
Inherent: Fix DiscreteDistribution panic in reward distribution

### DIFF
--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -297,14 +297,18 @@ impl Blockchain {
         // validators that will receive rewards).
         assert_eq!(transactions.len(), num_eligible_slots_for_accepted_tx.len());
 
-        // Get RNG from last block's seed and build lookup table based on number of eligible slots.
-        let mut rng = macro_header.seed.rng(VrfUseCase::RewardDistribution);
-        let lookup = DiscreteDistribution::new(&num_eligible_slots_for_accepted_tx);
-
         // Randomly give remainder to one accepting slot. We don't bother to distribute it over all
         // accepting slots because the remainder is always at most SLOTS - 1 Lunas.
-        let index = lookup.sample(&mut rng);
-        transactions[index].value += remainder;
+        // If there are no eligible slots (e.g. all rewards burned due to non-BasicAccount reward
+        // addresses or all slots penalized), burn the remainder too.
+        if !transactions.is_empty() && num_eligible_slots_for_accepted_tx.iter().any(|&s| s > 0) {
+            let mut rng = macro_header.seed.rng(VrfUseCase::RewardDistribution);
+            let lookup = DiscreteDistribution::new(&num_eligible_slots_for_accepted_tx);
+            let index = lookup.sample(&mut rng);
+            transactions[index].value += remainder;
+        } else {
+            burned_reward += remainder;
+        }
 
         // Do not create reward transactions for zero rewards
         transactions.retain(|transaction| !transaction.value.is_zero());

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -784,3 +784,93 @@ fn it_can_create_version_upgrade_inherents() {
     }
     assert!(got_reward && got_finalize_batch && got_finalize_epoch);
 }
+
+#[test]
+fn it_burns_all_rewards_when_all_slots_penalized() {
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let blockchain = Arc::new(
+        Blockchain::new(
+            env,
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            time,
+        )
+        .unwrap(),
+    );
+
+    let block_number = Policy::macro_block_of(2).unwrap();
+
+    let staking_contract = blockchain.get_staking_contract();
+    let active_validators = staking_contract.active_validators.clone();
+    let (validator_address, _) = active_validators.iter().next().unwrap();
+
+    // Penalize ALL slots so every slot has zero eligible count.
+    for slot in 0..Policy::SLOTS {
+        let penalize_inherent = Inherent::Penalize {
+            slot: PenalizedSlot {
+                slot,
+                validator_address: validator_address.clone(),
+                offense_event_block: 1 + Policy::genesis_block_number(),
+            },
+        };
+
+        let mut txn = blockchain.write_transaction();
+        assert!(blockchain
+            .state
+            .accounts
+            .commit(
+                &mut (&mut txn).into(),
+                &[],
+                &[penalize_inherent],
+                &BlockState::new(
+                    Policy::blocks_per_batch() + 1 + Policy::genesis_block_number(),
+                    1
+                ),
+                &mut BlockLogger::empty()
+            )
+            .is_ok());
+        txn.commit();
+    }
+
+    let staking_contract = blockchain.get_staking_contract();
+    let next_batch_initial_punished_set = staking_contract
+        .punished_slots
+        .next_batch_initial_punished_set(block_number, &active_validators);
+
+    let macro_header = MacroHeader {
+        network: NetworkId::UnitAlbatross,
+        version: 1,
+        block_number,
+        round: 0,
+        timestamp: blockchain.state.election_head.header.timestamp + 20000,
+        next_batch_initial_punished_set,
+        ..Default::default()
+    };
+
+    // This must not panic — previously it would trigger
+    // "Must have positive total probability" in DiscreteDistribution::new().
+    let reward_transactions =
+        blockchain.create_reward_transactions(&macro_header, &staking_contract);
+
+    // All rewards should be burned: expect exactly one burn transaction.
+    assert_eq!(
+        reward_transactions.len(),
+        1,
+        "Expected exactly one burn transaction"
+    );
+    assert_eq!(
+        reward_transactions[0].recipient,
+        Address::burn_address(),
+        "The only transaction should burn rewards"
+    );
+    assert_eq!(
+        reward_transactions[0].validator_address,
+        Address::burn_address(),
+    );
+    // The burn amount should equal the full reward pot (slot rewards + remainder).
+    assert!(
+        !reward_transactions[0].value.is_zero(),
+        "Burned reward should be non-zero"
+    );
+}

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -162,6 +162,10 @@ impl StakingContract {
 
         let mut rng = seed.rng(VrfUseCase::ValidatorSlotSelection);
 
+        assert!(
+            !validator_stakes.is_empty(),
+            "Cannot select validators: no active validators exist"
+        );
         let lookup = DiscreteDistribution::new(&validator_stakes);
 
         let mut slots_builder = ValidatorsBuilder::default();

--- a/vrf/src/discrete.rs
+++ b/vrf/src/discrete.rs
@@ -117,3 +117,34 @@ impl DiscreteDistribution {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Must have positive total probability")]
+    fn it_panics_on_empty_input() {
+        DiscreteDistribution::new(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Must have positive total probability")]
+    fn it_panics_on_all_zero_input() {
+        DiscreteDistribution::new(&[0, 0, 0]);
+    }
+
+    #[test]
+    fn it_creates_distribution_from_valid_input() {
+        let dist = DiscreteDistribution::new(&[1, 2, 3]);
+        assert_eq!(dist.n, 3);
+        assert_eq!(dist.T, 6);
+    }
+
+    #[test]
+    fn it_creates_distribution_from_single_entry() {
+        let dist = DiscreteDistribution::new(&[5]);
+        assert_eq!(dist.n, 1);
+        assert_eq!(dist.T, 5);
+    }
+}


### PR DESCRIPTION
## What's in this pull request?

- Fix a panic in `create_reward_transactions` where `DiscreteDistribution::new()` is called with empty or all-zero inputs, crashing the node at macro block boundaries
- Guard the distribution call so that when no eligible reward targets exist, the remainder is burned instead
- Add a descriptive assertion in `select_validators` for defense

## Problem

When computing validator rewards, the code filters out validators whose reward address is not a `BasicAccount`. If all validators have non-BasicAccount reward addresses, or all slots are fully penalized, `num_eligible_slots_for_accepted_tx` becomes empty or all-zero. This causes `DiscreteDistribution::new()` to panic with "Must have positive total probability", halting the chain.

A coordinated group of validators controlling all active slots could trigger this by redirecting their reward addresses to non-BasicAccount destinations (e.g. the staking contract address), causing a network-wide halt at the next macro block boundary.

## Fix

When no valid distribution targets exist, skip the `DiscreteDistribution` and burn the remainder along with all other rewards. The guard checks both that the transaction list is non-empty and that at least one entry has a positive eligible slot count.

## Consensus impact

None. The edge case this fixes currently crashes every node identically — no node has ever successfully produced a block under these conditions, so there is no existing consensus behavior to diverge from. The guard condition is deterministic (same inputs produce the same result on all nodes), and no serialization, deserialization, or state transition formats are modified. Patched and unpatched nodes agree on all blocks that can currently be produced; the fix only makes previously-crashing blocks producible.