### PR TITLE
Remove unnecessary decompression and re-serialization in Validators::hash()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3846,6 +3846,7 @@ name = "nimiq-block"
 version = "1.4.0"
 dependencies = [
  "ark-ec",
+ "ark-serialize",
  "bitflags 2.11.1",
  "byteorder",
  "hex",

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -43,5 +43,6 @@ nimiq-utils = { workspace = true, features = ["merkle"] }
 nimiq-vrf = { workspace = true, features = ["serde-derive"] }
 
 [dev-dependencies]
+ark-serialize = "0.4"
 nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -452,4 +452,79 @@ mod test {
         };
         assert!(header.verify().is_err());
     }
+
+    /// Verifies that Validators::hash() does not panic when called with invalid
+    /// BLS voting keys. This is the root cause fix for the sync-path crash:
+    /// hash() now uses raw compressed bytes directly instead of decompressing.
+    #[test]
+    fn hash_with_invalid_bls_key_does_not_panic() {
+        use nimiq_hash::{Blake2sHash, Hash};
+
+        let invalid_compressed = BlsCompressedPublicKey {
+            public_key: [0xFF; BlsCompressedPublicKey::SIZE],
+        };
+
+        let validator = Validator::new(
+            nimiq_keys::Address::default(),
+            invalid_compressed,
+            SchnorrPublicKey::default(),
+            0..Policy::SLOTS,
+        );
+
+        let validators = Validators::new(vec![validator]);
+
+        // This must not panic. Previously it would via voting_keys_g2().expect().
+        let _hash: Blake2sHash = validators.hash();
+    }
+
+    /// Verifies that the raw-bytes hash produces the same output as the old
+    /// decompress-reserialize path for valid keys. This ensures ZKP circuit
+    /// compatibility is maintained.
+    #[test]
+    fn hash_output_unchanged_for_valid_keys() {
+        use ark_ec::CurveGroup;
+        use ark_serialize::CanonicalSerialize;
+        use nimiq_hash::{Blake2sHash, Hash};
+        use nimiq_keys::SecureGenerate;
+        use nimiq_primitives::{
+            merkle_tree::merkle_tree_construct, slots_allocation::PK_TREE_BREADTH,
+        };
+
+        let key_pair = nimiq_bls::KeyPair::generate_default_csprng();
+        let compressed = key_pair.public_key.compress();
+
+        let validator = Validator::new(
+            nimiq_keys::Address::default(),
+            compressed,
+            SchnorrPublicKey::default(),
+            0..Policy::SLOTS,
+        );
+
+        let validators = Validators::new(vec![validator]);
+
+        // Compute hash via the new code path (raw bytes).
+        let new_hash: Blake2sHash = validators.hash();
+
+        // Compute hash via the old code path (decompress + reserialize).
+        let public_keys = validators.voting_keys_g2().unwrap();
+        let bytes: Vec<u8> = public_keys
+            .iter()
+            .flat_map(|pk| {
+                let mut buffer = [0u8; 285];
+                CanonicalSerialize::serialize_compressed(&pk.into_affine(), &mut buffer[..])
+                    .unwrap();
+                buffer.to_vec()
+            })
+            .collect();
+        let mut inputs = Vec::new();
+        for i in 0..PK_TREE_BREADTH {
+            inputs.push(
+                bytes[i * bytes.len() / PK_TREE_BREADTH..(i + 1) * bytes.len() / PK_TREE_BREADTH]
+                    .to_vec(),
+            );
+        }
+        let old_hash: Blake2sHash = merkle_tree_construct(inputs);
+
+        assert_eq!(new_hash, old_hash);
+    }
 }

--- a/primitives/block/src/skip_block.rs
+++ b/primitives/block/src/skip_block.rs
@@ -79,18 +79,17 @@ impl SkipBlockProof {
 
         // Get the public key for each SLOT present in the signature and add them together to get
         // the aggregated public key.
-        let agg_pk =
-            signer_slots
-                .into_iter()
-                .fold(AggregatePublicKey::new(), |mut aggregate, slot| {
-                    let pk = validators
-                        .get_validator_by_slot_number(slot)
-                        .voting_key
-                        .uncompress()
-                        .expect("Failed to uncompress CompressedPublicKey");
-                    aggregate.aggregate(pk);
-                    aggregate
-                });
+        let mut agg_pk = AggregatePublicKey::new();
+        for slot in signer_slots {
+            let Some(pk) = validators
+                .get_validator_by_slot_number(slot)
+                .voting_key
+                .uncompress()
+            else {
+                return false;
+            };
+            agg_pk.aggregate(pk);
+        }
 
         // Verify the aggregated signature against our aggregated public key.
         agg_pk.verify_hash(skip_block.hash_with_prefix(), &self.sig.signature)

--- a/primitives/src/slots_allocation.rs
+++ b/primitives/src/slots_allocation.rs
@@ -16,8 +16,6 @@
 //! ```
 use std::{cmp::Ordering, collections::BTreeMap, fmt, ops::Range, slice::Iter};
 
-use ark_ec::CurveGroup;
-use ark_serialize::CanonicalSerialize;
 use nimiq_bls::{G2Projective, LazyPublicKey as LazyBlsPublicKey, PublicKey as BlsPublicKey};
 use nimiq_hash::{Hash, HashOutput};
 use nimiq_keys::{Address, Ed25519PublicKey as SchnorrPublicKey};
@@ -254,27 +252,27 @@ impl Hash for Validators {
     /// This function is meant to calculate the public key tree "off-circuit". Generating the public key
     /// tree with this function guarantees that it is compatible with the ZK circuit.
     fn hash<H: HashOutput>(&self) -> H {
-        let public_keys = self.voting_keys_g2().expect(
-            "BLS voting keys must be valid — call validate_keys() before hashing untrusted data",
-        );
+        let total_slots: usize = self.iter().map(|v| v.num_slots() as usize).sum();
 
-        // Checking that the number of public keys is equal to the number of validator slots.
-        assert_eq!(public_keys.len(), Policy::SLOTS as usize);
+        // Checking that the number of slots is equal to the expected number of validator slots.
+        assert_eq!(total_slots, Policy::SLOTS as usize);
 
-        // Checking that the number of public keys is a multiple of the number of leaves.
-        assert_eq!(public_keys.len() % PK_TREE_BREADTH, 0);
+        // Checking that the number of slots is a multiple of the number of leaves.
+        assert_eq!(total_slots % PK_TREE_BREADTH, 0);
 
-        // Serialize the public keys into bits.
+        // Use the raw compressed key bytes directly instead of decompressing to
+        // G2Projective and re-serializing. For valid keys, the canonical compressed
+        // serialization is a fixed-point of the uncompress -> serialize_compressed
+        // round-trip, so this produces identical output. For invalid keys, this
+        // avoids the panic that would occur during decompression.
         #[cfg(not(feature = "parallel"))]
-        let iter = public_keys.iter();
+        let iter = self.validators.iter();
         #[cfg(feature = "parallel")]
-        let iter = public_keys.par_iter();
+        let iter = self.validators.par_iter();
         let bytes: Vec<u8> = iter
-            .flat_map(|pk| {
-                let mut buffer = [0u8; 285];
-                CanonicalSerialize::serialize_compressed(&pk.into_affine(), &mut buffer[..])
-                    .unwrap();
-                buffer.to_vec()
+            .flat_map(|validator| {
+                let key_bytes = validator.voting_key.compressed().as_ref();
+                key_bytes.repeat(validator.num_slots() as usize)
             })
             .collect();
 


### PR DESCRIPTION
Remove unnecessary decompression and re-serialization in Validators::hash()