### PR TITLE
history_sync: reject batches with overflowing transaction fee sums

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -152,7 +152,9 @@ impl Blockchain {
                 break;
             }
             if let HistoricTransactionData::Basic(tx) = &history[i].data {
-                cum_tx_fees += tx.get_raw_transaction().fee;
+                cum_tx_fees = cum_tx_fees
+                    .checked_add(tx.get_raw_transaction().fee)
+                    .ok_or(PushError::InvalidBlock(BlockError::TransactionFeeOverflow))?;
             }
             cum_hist_tx_size += history[i].data.serialized_size() as u64;
         }


### PR DESCRIPTION
The cumulative fee loop in extend_history_sync used `Coin::AddAssign`, which panics on overflow. A peer selected as a history-sync source could supply two crafted `HistoricTransaction::Basic` entries with near-max fees and crash a syncing node before the history root check at the end of the function had a chance to reject the batch.

Switch to checked_add and surface `BlockError::TransactionFeeOverflow` (same variant used by the normal push path) so the peer data is rejected cleanly instead of panicking.