### PR TITLE
Reject zero `num_steps` in vesting transaction builder

### DIFF
--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -68,6 +68,9 @@ pub enum TransactionBuilderError {
     /// [`signaling transaction`]: struct.TransactionBuilder.html#method.with_value
     #[error("The value must be zero for signaling transactions and cannot be zero for others.")]
     InvalidValue,
+    /// The `num_steps` argument passed to a vesting-contract helper was zero.
+    #[error("The number of vesting steps must be greater than zero.")]
+    InvalidNumSteps,
 }
 
 /// A helper to build arbitrary transactions.
@@ -543,6 +546,9 @@ impl TransactionBuilder {
         validity_start_height: u32,
         network_id: NetworkId,
     ) -> Result<Transaction, TransactionBuilderError> {
+        if num_steps == 0 {
+            return Err(TransactionBuilderError::InvalidNumSteps);
+        }
         let mut recipient = Recipient::new_vesting_builder(owner);
         recipient.with_steps(value, start_time, time_step, num_steps);
 

--- a/transaction-builder/src/recipient/vesting_contract.rs
+++ b/transaction-builder/src/recipient/vesting_contract.rs
@@ -110,6 +110,12 @@ impl VestingRecipientBuilder {
 
     /// This convenience function allows to quickly create a release schedule of `num_steps`
     /// payouts starting at `start_time + time_step`.
+    ///
+    /// If `num_steps` is zero, the step amount cannot be derived and is left unset;
+    /// a subsequent call to [`generate`] will then return
+    /// [`VestingRecipientBuilderError::NoStepAmount`].
+    ///
+    /// [`generate`]: struct.VestingRecipientBuilder.html#method.generate
     pub fn with_steps(
         &mut self,
         total_amount: Coin,
@@ -117,11 +123,13 @@ impl VestingRecipientBuilder {
         time_step: u64,
         num_steps: u32,
     ) -> &mut Self {
-        let step_amount = total_amount.div(u64::from(num_steps));
         self.with_total_amount(total_amount)
             .with_start_time(start_time)
-            .with_time_step(time_step)
-            .with_step_amount(step_amount);
+            .with_time_step(time_step);
+        if num_steps > 0 {
+            let step_amount = total_amount.div(u64::from(num_steps));
+            self.with_step_amount(step_amount);
+        }
         self
     }
 

--- a/transaction-builder/tests/vesting_contract.rs
+++ b/transaction-builder/tests/vesting_contract.rs
@@ -5,7 +5,10 @@ use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_test_log::test;
 use nimiq_transaction::{SignatureProof, Transaction};
-use nimiq_transaction_builder::{Recipient, Sender, TransactionBuilder};
+use nimiq_transaction_builder::{
+    recipient::vesting_contract::VestingRecipientBuilderError, Recipient, Sender,
+    TransactionBuilder, TransactionBuilderError,
+};
 
 #[test]
 #[allow(unused_must_use)]
@@ -104,6 +107,45 @@ fn it_can_create_creation_transaction() {
         .expect("Builder should be able to create transaction");
     let proof_builder = proof_builder.unwrap_basic();
     assert_eq!(proof_builder.transaction, transaction);
+}
+
+#[test]
+fn vesting_builder_rejects_zero_num_steps() {
+    let owner = Address::from([0u8; 20]);
+
+    // Direct builder use: `with_steps(_, _, _, 0)` must not panic, and `generate()`
+    // should then surface the missing step amount.
+    let mut recipient = Recipient::new_vesting_builder(owner.clone());
+    recipient.with_steps(Coin::from_u64_unchecked(10_000), 0, 100, 0);
+    assert!(matches!(
+        recipient.generate(),
+        Err(VestingRecipientBuilderError::NoStepAmount)
+    ));
+
+    // RPC entry point: `new_create_vesting` must reject `num_steps == 0`
+    // with a specific error instead of panicking.
+    let key_pair = KeyPair::from(
+        PrivateKey::deserialize_from_vec(
+            &hex::decode("9d5bd02379e7e45cf515c788048f5cf3c454ffabd3e83bd1d7667716c325c3c0")
+                .unwrap(),
+        )
+        .unwrap(),
+    );
+    let result = TransactionBuilder::new_create_vesting(
+        &key_pair,
+        owner,
+        0,
+        100,
+        0,
+        Coin::from_u64_unchecked(10_000),
+        Coin::ZERO,
+        0,
+        NetworkId::UnitAlbatross,
+    );
+    assert!(matches!(
+        result,
+        Err(TransactionBuilderError::InvalidNumSteps)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
`VestingRecipientBuilder::with_steps` divided `total_amount` by `num_steps` without validating that `num_steps > 0`, triggering a divide-by-zero panic in `Coin::div`. Guard the division in `with_steps` and validate `num_steps` up-front in
`TransactionBuilder::new_create_vesting`, returning the new `TransactionBuilderError::InvalidNumSteps`.