### PR TITLE
Fix `VestingContract::min_cap` panic on unbounded time fields

### DIFF
--- a/primitives/account/src/account/vesting_contract.rs
+++ b/primitives/account/src/account/vesting_contract.rs
@@ -68,11 +68,13 @@ impl VestingContract {
 
     fn min_cap(&self, time: u64) -> Coin {
         if self.time_step > 0 && self.step_amount > Coin::ZERO {
+            let total = u64::from(self.total_amount) as i128;
             let steps = (time as i128 - self.start_time as i128) / self.time_step as i128;
-            let min_cap =
-                u64::from(self.total_amount) as i128 - steps * u64::from(self.step_amount) as i128;
-            // Since all parameters have been validated, this will be safe as well.
-            Coin::from_u64_unchecked(min_cap.max(0) as u64)
+            let min_cap = total - steps * u64::from(self.step_amount) as i128;
+            // Clamp to [0, total_amount]: remaining locked funds can never exceed
+            // the initially locked total, and `total_amount` is already bounded by
+            // `Coin::MAX_SAFE_VALUE`, so the unchecked cast is safe.
+            Coin::from_u64_unchecked(min_cap.clamp(0, total) as u64)
         } else {
             Coin::ZERO
         }

--- a/primitives/account/tests/vesting_contract.rs
+++ b/primitives/account/tests/vesting_contract.rs
@@ -660,6 +660,73 @@ fn total_amount_exceeds_balance_panics_on_commit_outgoing() {
 }
 
 #[test]
+fn max_start_time_does_not_panic_on_outgoing() {
+    // `min_cap` must not panic for contracts with extreme `start_time`
+    // values. Returns `InsufficientFunds` in both mempool and block paths.
+
+    let mut rng = test_rng(true);
+    let key_owner = KeyPair::generate(&mut rng);
+    let key_recipient = KeyPair::generate(&mut rng);
+
+    let mut vesting_contract = VestingContract {
+        balance: Coin::from_u64_unchecked(1000),
+        owner: Address::from(&key_owner.public),
+        start_time: u64::MAX,
+        time_step: 1,
+        step_amount: Coin::from_u64_unchecked(1),
+        total_amount: Coin::from_u64_unchecked(1000),
+    };
+
+    let accounts = TestCommitRevert::with_initial_state(&[
+        (
+            Address::from(&key_owner.public),
+            Account::Basic(BasicAccount {
+                balance: Coin::from_u64_unchecked(1000),
+            }),
+        ),
+        (
+            Address([1u8; 20]),
+            Account::Vesting(vesting_contract.clone()),
+        ),
+    ]);
+
+    let block_state = BlockState::new(1, 1_700_000_000_000);
+    let tx = make_signed_transaction(key_owner.clone(), key_recipient.clone(), 1);
+
+    let sender_address = Address::from(&key_owner);
+    let data_store = accounts.data_store(&sender_address);
+    let mut reserved_balance = ReservedBalance::new(sender_address.clone());
+    {
+        let mut db_txn = accounts.env().write_transaction();
+        let result = vesting_contract.reserve_balance(
+            &tx,
+            &mut reserved_balance,
+            &block_state,
+            data_store.read(&mut db_txn),
+        );
+        assert!(
+            matches!(result, Err(AccountError::InsufficientFunds { .. })),
+            "Expected InsufficientFunds, got: {:?}",
+            result
+        );
+    }
+
+    let mut tx_logger = TransactionLog::empty();
+    let result = accounts.test_commit_outgoing_transaction(
+        &mut vesting_contract,
+        &tx,
+        &block_state,
+        &mut tx_logger,
+        true,
+    );
+    assert!(
+        matches!(result, Err(AccountError::InsufficientFunds { .. })),
+        "Expected InsufficientFunds, got: {:?}",
+        result
+    );
+}
+
+#[test]
 fn can_reserve_balance_after_time_step() {
     // -----------------------------------
     // Test setup:

--- a/primitives/transaction/src/account/vesting_contract.rs
+++ b/primitives/transaction/src/account/vesting_contract.rs
@@ -73,6 +73,15 @@ impl AccountTransactionVerification for VestingContractVerifier {
     }
 }
 
+/// Maximum allowed value for time-domain `u64` fields in vesting contract
+/// creation data, namely `start_time` (ms since epoch) and `time_step` (ms).
+///
+/// Matches JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 − 1) so that values
+/// round-trip through f64 without precision loss, and keeps the arithmetic in
+/// `VestingContract::min_cap` well inside the representable range regardless
+/// of the other parameter values.
+pub const MAX_TIME_VALUE: u64 = Coin::MAX_SAFE_VALUE;
+
 /// Data used to create vesting contracts.
 ///
 /// Used in [`Transaction::recipient_data`].
@@ -128,6 +137,9 @@ impl CreationTransactionData {
                 // Only step length: vest full amount at that time
                 let CreationTransactionData8 { owner, time_step } =
                     CreationTransactionData8::deserialize_all(data)?;
+                if time_step > MAX_TIME_VALUE {
+                    return Err(TransactionError::InvalidData);
+                }
                 CreationTransactionData {
                     owner,
                     start_time: 0,
@@ -143,6 +155,9 @@ impl CreationTransactionData {
                     time_step,
                     step_amount,
                 } = CreationTransactionData24::deserialize_all(data)?;
+                if start_time > MAX_TIME_VALUE || time_step > MAX_TIME_VALUE {
+                    return Err(TransactionError::InvalidData);
+                }
                 CreationTransactionData {
                     owner,
                     start_time,
@@ -159,6 +174,9 @@ impl CreationTransactionData {
                     step_amount,
                     total_amount,
                 } = CreationTransactionData32::deserialize_all(data)?;
+                if start_time > MAX_TIME_VALUE || time_step > MAX_TIME_VALUE {
+                    return Err(TransactionError::InvalidData);
+                }
                 if total_amount > tx_value {
                     return Err(TransactionError::InvalidData);
                 }

--- a/primitives/transaction/tests/vesting_contract_verify.rs
+++ b/primitives/transaction/tests/vesting_contract_verify.rs
@@ -4,7 +4,10 @@ use nimiq_primitives::{
 };
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
 use nimiq_transaction::{
-    account::{vesting_contract::CreationTransactionData, AccountTransactionVerification},
+    account::{
+        vesting_contract::{CreationTransactionData, MAX_TIME_VALUE},
+        AccountTransactionVerification,
+    },
     SignatureProof, Transaction, TransactionFlags,
 };
 
@@ -109,6 +112,79 @@ fn it_can_verify_creation_transaction() {
         AccountType::verify_incoming_transaction(&transaction),
         Err(TransactionError::InvalidData)
     );
+}
+
+#[test]
+fn it_rejects_out_of_bounds_time_values() {
+    // `start_time` and `time_step` must be bounded to `MAX_TIME_VALUE` to avoid
+    // arithmetic blow-ups in `VestingContract::min_cap`.
+
+    let tx_value = Coin::try_from(100).unwrap();
+    let owner = Address::from([0u8; 20]);
+
+    let parse = |data: &CreationTransactionData| {
+        CreationTransactionData::parse_data(&data.to_tx_data(), tx_value)
+    };
+
+    // 8-byte variant: only `time_step` is serialized (step_amount == total_amount, start_time == 0).
+    let data = CreationTransactionData {
+        owner: owner.clone(),
+        start_time: 0,
+        time_step: MAX_TIME_VALUE + 1,
+        step_amount: tx_value,
+        total_amount: tx_value,
+    };
+    assert!(matches!(parse(&data), Err(TransactionError::InvalidData)));
+
+    // 24-byte variant: reject out-of-bound `start_time` (step_amount == total_amount).
+    let data = CreationTransactionData {
+        owner: owner.clone(),
+        start_time: MAX_TIME_VALUE + 1,
+        time_step: 100,
+        step_amount: tx_value,
+        total_amount: tx_value,
+    };
+    assert!(matches!(parse(&data), Err(TransactionError::InvalidData)));
+
+    // 24-byte variant: reject out-of-bound `time_step`.
+    let data = CreationTransactionData {
+        owner: owner.clone(),
+        start_time: 100,
+        time_step: MAX_TIME_VALUE + 1,
+        step_amount: tx_value,
+        total_amount: tx_value,
+    };
+    assert!(matches!(parse(&data), Err(TransactionError::InvalidData)));
+
+    // 32-byte variant: reject out-of-bound `start_time` (step_amount != total_amount).
+    let data = CreationTransactionData {
+        owner: owner.clone(),
+        start_time: MAX_TIME_VALUE + 1,
+        time_step: 100,
+        step_amount: Coin::try_from(50).unwrap(),
+        total_amount: tx_value,
+    };
+    assert!(matches!(parse(&data), Err(TransactionError::InvalidData)));
+
+    // 32-byte variant: reject out-of-bound `time_step`.
+    let data = CreationTransactionData {
+        owner: owner.clone(),
+        start_time: 100,
+        time_step: MAX_TIME_VALUE + 1,
+        step_amount: Coin::try_from(50).unwrap(),
+        total_amount: tx_value,
+    };
+    assert!(matches!(parse(&data), Err(TransactionError::InvalidData)));
+
+    // Boundary: `MAX_TIME_VALUE` itself is accepted.
+    let data = CreationTransactionData {
+        owner,
+        start_time: MAX_TIME_VALUE,
+        time_step: MAX_TIME_VALUE,
+        step_amount: tx_value,
+        total_amount: tx_value,
+    };
+    assert!(parse(&data).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
A vesting contract with a pathological `start_time` (e.g. `u64::MAX`) caused `min_cap` to overflow `Coin::MAX_SAFE_VALUE`, panicking inside `Coin::from_u64_unchecked` on any outgoing transaction.

- Clamp `min_cap` to `[0, total_amount]` so the unchecked cast is safe.
- Reject creation transactions with `start_time` or `time_step` above `MAX_TIME_VALUE` (2^53 − 1) at parse time.