### PR TITLE
Fix for absent duplicate keys in RequestTrieProof

### DIFF
--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -749,6 +749,10 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTrieProof {
         if self.keys.len() > Self::MAX_KEYS {
             return Err(ResponseTrieProofError::TooManyKeys);
         }
+        let unique_keys: std::collections::BTreeSet<_> = self.keys.iter().collect();
+        if unique_keys.len() != self.keys.len() {
+            return Err(ResponseTrieProofError::DuplicateKeys);
+        }
 
         // We only prove accounts that exist in our current state
         let blockchain = blockchain.read();

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -608,6 +608,8 @@ pub enum ResponseTrieProofError {
     IncompleteTrie,
     #[error("too many keys")]
     TooManyKeys,
+    #[error("duplicate keys")]
+    DuplicateKeys,
     #[error("unknown error")]
     #[serde(other)]
     Other,

--- a/consensus/tests/request_handlers.rs
+++ b/consensus/tests/request_handlers.rs
@@ -2,14 +2,15 @@ use std::sync::Arc;
 
 use nimiq_blockchain::{Blockchain, BlockchainConfig};
 use nimiq_consensus::messages::{
-    RequestTransactionReceiptsByAddress, RequestTransactionsProof, ResponseTransactionProofError,
+    RequestTransactionReceiptsByAddress, RequestTransactionsProof, RequestTrieProof,
+    ResponseTransactionProofError, ResponseTrieProofError,
 };
 use nimiq_database::mdbx::MdbxDatabase;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_network_interface::request::Handle;
 use nimiq_network_mock::{MockNetwork, MockPeerId};
-use nimiq_primitives::{networks::NetworkId, policy::Policy};
+use nimiq_primitives::{key_nibbles::KeyNibbles, networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
 use nimiq_utils::time::OffsetTime;
 use parking_lot::RwLock;
@@ -22,6 +23,18 @@ fn blockchain_without_history_index() -> Arc<RwLock<Blockchain>> {
                 index_history: false,
                 ..Default::default()
             },
+            NetworkId::UnitAlbatross,
+            Arc::new(OffsetTime::new()),
+        )
+        .unwrap(),
+    ))
+}
+
+fn blockchain_with_accounts() -> Arc<RwLock<Blockchain>> {
+    Arc::new(RwLock::new(
+        Blockchain::new(
+            MdbxDatabase::new_volatile(Default::default()).unwrap(),
+            BlockchainConfig::default(),
             NetworkId::UnitAlbatross,
             Arc::new(OffsetTime::new()),
         )
@@ -87,4 +100,23 @@ fn transaction_receipts_request_without_index_returns_empty_list() {
     );
 
     assert!(response.receipts.is_empty());
+}
+
+#[test]
+fn trie_proof_request_rejects_duplicate_missing_keys() {
+    let blockchain = blockchain_with_accounts();
+    let absent_key: KeyNibbles = "deadbeefdeadbeefdeadbeef01".parse().unwrap();
+
+    let response = <RequestTrieProof as Handle<MockNetwork, Arc<RwLock<Blockchain>>>>::handle(
+        &RequestTrieProof {
+            keys: vec![absent_key.clone(), absent_key],
+        },
+        MockPeerId(0),
+        &blockchain,
+    );
+
+    assert!(matches!(
+        response,
+        Err(ResponseTrieProofError::DuplicateKeys)
+    ));
 }


### PR DESCRIPTION
The RequestTrieProof request handler validates only the upper bound (<= MAX_KEYS = 255) on self.keys and forwards the list unchanged to MerkleRadixTrie::get_proof. Inside that function, duplicate keys that are not present in the current accounts trie each reach the _ arm of match pointer_node.child_key(..) and attempt to insert into the missing_proven_by BTreeMap. On the second insertion, BTreeMap::insert returns Some(_), violating the assert!(... .is_none()).

## What's in this pull request?