### PR TITLE
Transaction builder: fix `StakingDataBuilder` panic on malformed recipient data

### DIFF
--- a/transaction-builder/src/proof/staking_contract.rs
+++ b/transaction-builder/src/proof/staking_contract.rs
@@ -30,10 +30,12 @@ impl StakingDataBuilder {
     /// This method sets the required `signature` proof by signing the transaction
     /// using a key pair.
     pub fn sign_with_key_pair(&mut self, key_pair: &KeyPair) -> &mut Self {
-        // Deserialize the data.
-        let mut data =
+        // On malformed recipient_data, leave `self.data` as `None` so `generate()` returns `None`.
+        let Ok(mut data) =
             IncomingStakingTransactionData::deserialize_from_vec(&self.transaction.recipient_data)
-                .unwrap();
+        else {
+            return self;
+        };
 
         // If this is a stake transaction, we don't need to sign it.
         match data {

--- a/transaction-builder/tests/staking_contract.rs
+++ b/transaction-builder/tests/staking_contract.rs
@@ -10,7 +10,9 @@ use nimiq_transaction::{
     account::staking_contract::{IncomingStakingTransactionData, OutgoingStakingTransactionData},
     SignatureProof, Transaction,
 };
-use nimiq_transaction_builder::{TransactionBuilder, TransactionBuilderError};
+use nimiq_transaction_builder::{
+    proof::staking_contract::StakingDataBuilder, TransactionBuilder, TransactionBuilderError,
+};
 
 const ADDRESS: &str = "9cd82948650d902d95d52ea2ec91eae6deb0c9fe";
 const PRIVATE_KEY: &str = "b410a7a583cbc13ef4f1cbddace30928bcb4f9c13722414bc4a2faaba3f4e187";
@@ -262,6 +264,29 @@ fn it_can_create_validator_transactions() {
     .unwrap();
 
     assert_eq!(tx, tx2);
+}
+
+#[test]
+fn it_rejects_malformed_staking_recipient_data() {
+    let key_pair = ed25519_key_pair();
+
+    // Empty buffer, truncated buffer, and unknown discriminant exercise different
+    // deserializer branches.
+    for bad in [vec![], vec![0xff, 0xff, 0xff, 0xff], vec![0xaa]] {
+        let mut tx = make_incoming_transaction(
+            IncomingStakingTransactionData::CreateStaker {
+                delegation: Some(Address::from_any_str(ADDRESS).unwrap()),
+                proof: Default::default(),
+            },
+            100_000_000,
+        );
+        tx.recipient_data = bad;
+
+        let mut builder = StakingDataBuilder::new(tx);
+        builder.sign_with_key_pair(&key_pair);
+
+        assert!(builder.generate().is_none());
+    }
 }
 
 fn make_incoming_transaction(data: IncomingStakingTransactionData, value: u64) -> Transaction {


### PR DESCRIPTION
## What's in this pull request?
`StakingDataBuilder::sign_with_key_pair()` in called `.unwrap()` on `IncomingStakingTransactionData::deserialize_from_vec(&self.transaction.recipient_data)`. If a caller constructed a `StakingDataBuilder` with a `Transaction` whose `recipient_data` was empty, truncated, or carried an unknown discriminant, the deserialization error panicked the process.

The builder is part of the public API and is accessible via `nimiq-transaction-builder`, so malformed input could crash the calling process.

## Fix
Replace the `.unwrap()` with a `let ... else` early return. On malformed `recipient_data`, the builder leaves `self.data` as `None` and the existing `generate()` returns `None` — the same signal already used when the builder is otherwise misconfigured. This preserves the builder-pattern API so none of the ~10 internal callers in TransactionBuilder need updating.