### PR TITLE
MMR: Reject oversized `mmr_size` in proof verification

### DIFF
--- a/primitives/mmr/src/mmr/partial.rs
+++ b/primitives/mmr/src/mmr/partial.rs
@@ -6,7 +6,7 @@ use crate::{
     mmr::{
         peaks::PeakIterator,
         position::{leaf_number_to_index, Position},
-        proof::RangeProof,
+        proof::{RangeProof, MAX_MMR_SIZE},
         utils::bagging,
         MerkleMountainRange,
     },
@@ -69,6 +69,10 @@ impl<H: Merge + PartialEq + Clone, S: Store<H>> PartialMerkleMountainRange<H, S>
     where
         T: Hash<H>,
     {
+        if range_proof.proof.mmr_size > MAX_MMR_SIZE {
+            return Err(Error::InvalidProof);
+        }
+
         // This is an optimized version of the proof's `compute_root` that is connected to a store.
         // Check if proof has right size.
         if self
@@ -472,5 +476,27 @@ mod tests {
 
         let proof = mmr.prove_range(1..=1, Some(mmr.len()), true).unwrap();
         assert_eq!(pmmr.push_proof(proof, &[2, 3, 5]), Err(Error::InvalidProof));
+    }
+
+    /// A crafted `RangeProof` with an oversized `mmr_size` must be rejected
+    /// before it can reach `PeakIterator::new`.
+    #[test]
+    fn push_proof_rejects_oversized_mmr_size() {
+        use crate::mmr::proof::{Proof, RangeProof};
+
+        let mut pmmr: PartialMerkleMountainRange<TestHash, _> =
+            PartialMerkleMountainRange::new(MemoryStore::new());
+
+        for bad_size in [usize::MAX, (usize::MAX / 2) + 1] {
+            let proof: RangeProof<TestHash> = RangeProof {
+                proof: Proof {
+                    mmr_size: bad_size,
+                    nodes: vec![],
+                },
+                assume_previous: false,
+            };
+            let leaves: [usize; 0] = [];
+            assert_eq!(pmmr.push_proof(proof, &leaves), Err(Error::InvalidProof));
+        }
     }
 }

--- a/primitives/mmr/src/mmr/peaks.rs
+++ b/primitives/mmr/src/mmr/peaks.rs
@@ -15,9 +15,13 @@ impl PeakIterator {
             // the largest n for which 2^n - 1 <= size.
             // The following code uses k = 2^n.
             let mut k = 1;
-            // Find largest k such that k - 1 <= size.
+            // Find largest k such that k - 1 <= size. `checked_mul` prevents a wrap
+            // of `k` to 0 (infinite loop).
             while k - 1 <= size {
-                k <<= 1;
+                match k.checked_mul(2) {
+                    Some(next) => k = next,
+                    None => break,
+                }
             }
             // Calculate peak index when starting with index 1.
             let peak_index_one_based = (k >> 1) - 1;

--- a/primitives/mmr/src/mmr/proof.rs
+++ b/primitives/mmr/src/mmr/proof.rs
@@ -39,6 +39,11 @@ impl<H: Merge + Eq, T: Hash<H>> SizeProof<H, T> {
     }
 }
 
+/// Largest `mmr_size` we are willing to verify. Anything above this is physically
+/// impossible (a valid MMR with this many nodes would be a gigantic state).
+/// Rejecting early turns crafted sizes into a clean `InvalidProof`.
+pub(crate) const MAX_MMR_SIZE: usize = usize::MAX / 2;
+
 /// A Merkle proof for a MMR.
 #[derive(Clone, Debug)]
 #[cfg_attr(
@@ -66,6 +71,12 @@ impl<H: Merge + Clone> Proof<H> {
     where
         T: Hash<H>,
     {
+        // Reject proofs whose `mmr_size` is large enough to wedge `PeakIterator`
+        // or overflow `Position` arithmetic. No legitimate MMR ever reaches this.
+        if self.mmr_size > MAX_MMR_SIZE {
+            return Err(Error::InvalidProof);
+        }
+
         // Sort by positions and check that we only prove leaves.
         let positions: Result<Vec<(Position, H)>, Error> = leaves
             .iter()
@@ -202,6 +213,13 @@ impl<H: Merge + Clone + Eq> Proof<H> {
     where
         T: Hash<H>,
     {
+        // Must run before the `mmr_size == 0` shortcut below, otherwise a crafted
+        // proof with empty `nodes` and oversize `mmr_size` would never reach the
+        // guard in `calculate_root`.
+        if self.mmr_size > MAX_MMR_SIZE {
+            return Err(Error::InvalidProof);
+        }
+
         // If the proof came from an empty tree we just need to check that we are not trying to
         // prove any leaves and that the given root matches the empty tree root.
         if self.mmr_size == 0 && self.nodes.is_empty() {
@@ -797,5 +815,36 @@ mod tests {
             proof.verify_with_start(&mmr.get_root().unwrap(), 2, &[0]),
             Err(Error::ProveInvalidLeaves)
         );
+    }
+
+    /// A crafted `Proof` with `mmr_size > MAX_MMR_SIZE` must be rejected
+    /// as `InvalidProof` by both `calculate_root` and `verify`, rather than panicking
+    /// or hanging inside `PeakIterator::new`.
+    #[test]
+    fn calculate_root_rejects_oversized_mmr_size() {
+        let leaf: usize = 1;
+        let leaves = [(0usize, &leaf)];
+
+        for bad_size in [usize::MAX, (usize::MAX / 2) + 1] {
+            let proof: Proof<TestHash> = Proof {
+                mmr_size: bad_size,
+                nodes: vec![TestHash(42)],
+            };
+            assert_eq!(proof.calculate_root(&leaves), Err(Error::InvalidProof));
+            assert_eq!(
+                proof.verify(&TestHash(0), &leaves),
+                Err(Error::InvalidProof)
+            );
+        }
+
+        // At the boundary `mmr_size == MAX_MMR_SIZE` we do not short-circuit on
+        // size; the proof proceeds into verification. The outcome is necessarily
+        // an `Err` (the crafted proof is not consistent), but the important bit
+        // is that verification terminates cleanly rather than hanging/panicking.
+        let proof_at_boundary: Proof<TestHash> = Proof {
+            mmr_size: MAX_MMR_SIZE,
+            nodes: vec![TestHash(42)],
+        };
+        assert!(proof_at_boundary.calculate_root(&leaves).is_err());
     }
 }


### PR DESCRIPTION
## What's in this pull request?
`PeakIterator::new(size)` runs `while k - 1 <= size { k <<= 1 }` with no overflow guard. For any attacker-controlled `size >= 1 << 63`, the shift wraps `k` to 0, turning the predicate into an infinite loop in release builds, an arithmetic-overflow panic in debug builds.

## Fix

1. `PeakIterator::new` altered with `checked_mul(2)` so the search loop terminates for any `usize`, regardless of caller validation.
2. Added `MAX_MMR_SIZE` and reject `mmr_size > MAX_MMR_SIZE` with `Error::InvalidProof`.

## Impact

- **Consensus**: none. No serialization or state-transition change. Previously-accepted proofs are still accepted; only physically impossible `mmr_size` values are now rejected with `Error::InvalidProof` instead of hanging/panicking.
- **Network**: wire format unchanged. The guard is a post-deserialization validation rule.
- **Public API**: `Proof::calculate_root`, `Proof::verify`, `RangeProof::verify*`, and `PartialMerkleMountainRange::push_proof` gain one extra `Err(Error::InvalidProof)` return path. Signatures unchanged — no breaking change.
- **Validator**: validators doing history sync from untrusted peers can no longer be stalled by a single crafted `HistoryChunk`.