### PR TITLE
Network: guard against already-removed DHT query in quorum handler

### DIFF
--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -598,13 +598,15 @@ fn handle_dht_get(
             let count = store_dht_record(&mut event_info.state.dht_get_results, id, dht_record);
             // Check if we already have a quorum
             if count == event_info.state.dht_quorum {
-                event_info
-                    .swarm
-                    .behaviour_mut()
-                    .dht
-                    .query_mut(&id)
-                    .unwrap()
-                    .finish();
+                if let Some(mut query) = event_info.swarm.behaviour_mut().dht.query_mut(&id) {
+                    query.finish();
+                } else {
+                    warn!(
+                        query_id = ?id,
+                        ?step,
+                        "Quorum reached but DHT query already removed from Kademlia pool"
+                    );
+                }
             }
         }
         Ok(GetRecordOk::FinishedWithNoAdditionalRecord { cache_candidates }) => {


### PR DESCRIPTION
## What's in this pull request?
In `handle_dht_get`, when a DHT `GetRecord` query reached quorum the code called:

```rust
event_info.swarm.behaviour_mut().dht
    .query_mut(&id)
    .unwrap()
    .finish();
```

`Kademlia::query_mut` returns `Option<QueryMut>` and yields `None` if the query has already been removed from the internal pool . In that case the `.unwrap()` panics and takes the node down.

## Fix

Replace the `.unwrap()` with a `if let Some(…)` guard.

## Impact

- **Consensus impact:** None.
- **Network impact:** None on the wire. Behaviour change is strictly local: where the node would previously panic under a narrow timing condition, it now logs a warning and continues.
- **Public API impact:** None.
- **Validator impact:** Removes a theoretical node-crash path in the DHT lookup handler. Validators that perform DHT lookups gain liveness robustness; no behavioural change on the happy path.