### PR TITLE
Trie: reject ROOT-keyed items in `put_chunk`

### DIFF
--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -355,6 +355,11 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         value: Vec<u8>,
         missing_range: &Option<ops::RangeFrom<KeyNibbles>>,
     ) {
+        debug_assert!(
+            !key.is_empty(),
+            "empty (ROOT) key must be rejected at the put_chunk boundary",
+        );
+
         // Start by getting the root node.
         let mut cur_node = self
             .get_root(txn)
@@ -413,7 +418,8 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
             // with the given key. Update the value.
             if cur_node.key == *key {
                 // Update the node and store it.
-                // TODO This unwrap() will fail when attempting to store a value at the root node
+                // `put_raw` rejects empty keys at its entry, so `cur_node` here never has
+                // `root_data.is_some()`; `put_value` cannot return `RootCantHaveValue`.
                 let prev_kind = cur_node.kind();
                 let old_value = cur_node.put_value(value).unwrap();
                 self.put_node(txn, &cur_node, old_value.into());
@@ -840,6 +846,15 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
                     "first key is inconsistent with key range",
                 ));
             }
+
+            // The root node holds no value, so a ROOT-keyed item would panic in `put_raw`.
+            // ROOT is the minimum key, so checking `items[0]` suffices given the sort check below.
+            if chunk.items[0].key.is_empty() {
+                return Err(MerkleRadixTrieError::InvalidChunk(
+                    "item key must not be the root key",
+                ));
+            }
+
             let last_item_key = chunk.items.last().unwrap().key.clone();
             if let Some(end_key) = &chunk.end_key
                 && last_item_key >= *end_key
@@ -2212,6 +2227,35 @@ mod tests {
             trie.put_chunk(&mut txn, KeyNibbles::ROOT, chunk, hash),
             Err(MerkleRadixTrieError::TrieAlreadyComplete)
         );
+    }
+
+    #[test]
+    fn put_chunk_rejects_root_keyed_item() {
+        // A ROOT-keyed item used to reach `put_raw` and panic on
+        // `put_value(...).unwrap()`; `put_chunk` must reject it as `InvalidChunk`.
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let trie = MerkleRadixTrie::new_incomplete(&env, TestTrie);
+        let mut raw_txn = env.write_transaction();
+        let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
+        assert!(!trie.is_complete(&txn));
+
+        let proof_root = TrieNode::new_root();
+        let expected_hash = proof_root.hash_assert();
+        let proof = TrieProof::new(vec![proof_root.into()], Default::default());
+
+        let malicious_chunk = TrieChunk::new(
+            None,
+            vec![TrieItem::new(
+                KeyNibbles::ROOT,
+                vec![0xab, 0xbc, 0xcd, 0xde],
+            )],
+            proof,
+        );
+
+        match trie.put_chunk(&mut txn, KeyNibbles::ROOT, malicious_chunk, expected_hash) {
+            Err(MerkleRadixTrieError::InvalidChunk(_)) => {}
+            other => panic!("expected InvalidChunk(_), got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What's in this pull request?
`MerkleRadixTrie::put_chunk` processes `TrieChunk` data from state-sync peers. It validates sorting, key range, and the Merkle proof but does not reject items whose key is `KeyNibbles::ROOT` (the empty-nibbles root key). When such an item reaches `put_raw`, the equal-key branch calls `cur_node.put_value(value).unwrap()` on the root node.

A malicious sync peer crafts a `ResponseChunk::Chunk` whose `items[0].key == KeyNibbles::ROOT`. ROOT is the lexicographically smallest key, so the sort check passes. The proof verifies because it is over the last item's Merkle path, not every item. The crash fires on the first chunk the node commits.

## Fix

1. Reject any item whose key is empty, inside the existing `if !chunk.items.is_empty() { … }` block, using the existing `InvalidChunk` error variant. `items[0]` is sufficient because the existing sort check guarantees strictly increasing keys and ROOT is the minimum.

## Impact

- **Consensus / wire format / public API**: none. `InvalidChunk` is already returned for other chunk validation failures; `commit_chunks` already aborts the txn, logs a warn, and triggers `reset_chunk_request_chain()` in the live-sync layer. Honest peers never construct ROOT-keyed items.