### PR TITLE
Consensus: evict peers returning diffs with invalid tree-proof

### DIFF
--- a/consensus/src/sync/live/diff_queue/diff_request_component.rs
+++ b/consensus/src/sync/live/diff_queue/diff_request_component.rs
@@ -104,9 +104,11 @@ impl<N: Network> DiffRequestComponent<N> {
                                 // If valid, return the diff.
                                 return Ok(diff);
                             }
-                            warn!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: invalid diff");
+                            // A tree-proof mismatch is cryptographically tied to the response
+                            // contents; an honest peer cannot produce it by accident.
+                            warn!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: invalid diff, removing peer");
+                            peers.write().remove_peer(&peer_id);
                         }
-                        // TODO: remove peer, retry elsewhere
                         Ok(ResponseTrieDiff::IncompleteState) => {
                             debug!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: incomplete state")
                         }


### PR DESCRIPTION
## What's in this pull request?
`DiffRequestComponent::request_diff` keeps a peer in the live-sync peer list even when that peer repeatedly returns a `TreeProof` root hash that does not match the block's `diff_root`. After one full rotation the loop sleeps (capped at 30 s), resets `num_tries` to 0, and retries the same peer.

Framing as a permanent stall is overstated because peers must pass macro sync before entering this list and the loop rotates through N peers before sleeping. All peers the node is connected with must be malicious in order to stall node.

## Fix

Evict the peer only on a tree-proof mismatch Mirrors the `PeerList::remove_peer` design used by the sibling `ChunkRequestComponent`.

Deliberately **not** evicting on `IncompleteState` / `UnknownBlockHash` / network `Err`: an honest, lagging, or pruned peer can send these.

No circuit breaker on total retries either. Exponential backoff + eviction is sufficient.

## Impact

- **Consensus impact:** none.
- **Wire-format impact:** none.
- **Public-API break:** none — `request_diff` signature unchanged.
- **Behavioural change:** peers that return a tree-proof-invalid `PartialDiff` are now evicted from the live-sync peer list. They are re-added the next time they pass macro sync, same as any other peer.