### PR TITLE
web-client: Pin the wasm-bindgen version

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -131,6 +131,18 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2
+    - name: Resolve wasm-bindgen version from Cargo.lock
+      id: wasm-bindgen
+      run: |
+        VERSION=$(awk '
+          $0 == "name = \"wasm-bindgen\"" { found = 1; next }
+          found && /^version = / { gsub(/version = "|"/, ""); print; exit }
+        ' Cargo.lock)
+        if [ -z "$VERSION" ]; then echo "::error::Could not resolve wasm-bindgen version from Cargo.lock"; exit 1; fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: wasm-bindgen-cli@${{ steps.wasm-bindgen.outputs.version }}
     - name: Compile to wasm and generate bindings
       working-directory: ./web-client
       run: ./scripts/build.sh --only nodejs,types

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -18,6 +18,18 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - name: Resolve wasm-bindgen version from Cargo.lock
+        id: wasm-bindgen
+        run: |
+          VERSION=$(awk '
+            $0 == "name = \"wasm-bindgen\"" { found = 1; next }
+            found && /^version = / { gsub(/version = "|"/, ""); print; exit }
+          ' Cargo.lock)
+          if [ -z "$VERSION" ]; then echo "::error::Could not resolve wasm-bindgen version from Cargo.lock"; exit 1; fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@${{ steps.wasm-bindgen.outputs.version }}
       - name: Build package
         working-directory: ./web-client
         run: ./scripts/build.sh

--- a/.github/workflows/web_client_preview.yml
+++ b/.github/workflows/web_client_preview.yml
@@ -20,6 +20,18 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - name: Resolve wasm-bindgen version from Cargo.lock
+        id: wasm-bindgen
+        run: |
+          VERSION=$(awk '
+            $0 == "name = \"wasm-bindgen\"" { found = 1; next }
+            found && /^version = / { gsub(/version = "|"/, ""); print; exit }
+          ' Cargo.lock)
+          if [ -z "$VERSION" ]; then echo "::error::Could not resolve wasm-bindgen version from Cargo.lock"; exit 1; fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@${{ steps.wasm-bindgen.outputs.version }}
       - name: Build package
         working-directory: ./web-client
         run: ./scripts/build.sh

--- a/web-client/scripts/build.sh
+++ b/web-client/scripts/build.sh
@@ -67,10 +67,31 @@ function generate() {
 }
 
 # Prepare build environment
-if ! command -v wasm-bindgen &> /dev/null
-then
-    echo "Installing wasm-bindgen..."
-    cargo install wasm-bindgen-cli
+LOCKED_WASM_BINDGEN_VERSION=$(awk '
+    $0 == "name = \"wasm-bindgen\"" { found = 1; next }
+    found && /^version = / { gsub(/version = "|"/, ""); print; exit }
+' ../Cargo.lock)
+
+if [ -z "$LOCKED_WASM_BINDGEN_VERSION" ]; then
+    echo "Error: could not resolve wasm-bindgen version from ../Cargo.lock" >&2
+    exit 1
+fi
+
+if ! command -v wasm-bindgen &> /dev/null; then
+    echo "Error: wasm-bindgen-cli is not installed." >&2
+    echo "Install the version pinned in Cargo.lock with:" >&2
+    echo "    cargo install --locked wasm-bindgen-cli@$LOCKED_WASM_BINDGEN_VERSION" >&2
+    exit 1
+fi
+
+INSTALLED_WASM_BINDGEN_VERSION=$(wasm-bindgen --version | awk '{print $2}')
+if [ "$INSTALLED_WASM_BINDGEN_VERSION" != "$LOCKED_WASM_BINDGEN_VERSION" ]; then
+    echo "Error: wasm-bindgen-cli version mismatch." >&2
+    echo "  Cargo.lock pins:  $LOCKED_WASM_BINDGEN_VERSION" >&2
+    echo "  Installed:        $INSTALLED_WASM_BINDGEN_VERSION" >&2
+    echo "Reinstall with:" >&2
+    echo "    cargo install --locked wasm-bindgen-cli@$LOCKED_WASM_BINDGEN_VERSION" >&2
+    exit 1
 fi
 if ! command -v wasm-opt &> /dev/null
 then


### PR DESCRIPTION
Pin the wasm-bindgen version according to the version declared in the dependencies to avoid compilation issues caused by this mismatch. Also change the GH workflows that build the web client to install the correct pre-built version.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
