### PR TITLE
Fixing web client flaky tests

### DIFF
--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -1393,13 +1393,13 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use nimiq_primitives::policy::{Policy, MAINNET_POLICY};
+    use nimiq_primitives::policy::{Policy, TEST_POLICY};
 
     use super::is_transaction_expired;
 
     #[test]
     fn expiry_check_uses_block_count_not_batch_count() {
-        let _ = Policy::get_or_init(MAINNET_POLICY);
+        let _ = Policy::get_or_init(TEST_POLICY);
 
         let batch_window = Policy::transaction_validity_window();
         let block_window = Policy::transaction_validity_window_blocks();
@@ -1415,8 +1415,8 @@ mod tests {
         );
 
         let validity_start_height = 10_000;
-        let current_height = 10_500;
-        let blocks_elapsed = current_height - validity_start_height;
+        let blocks_elapsed = batch_window + 1;
+        let current_height = validity_start_height + blocks_elapsed;
 
         assert!(
             blocks_elapsed < block_window,
@@ -1435,7 +1435,7 @@ mod tests {
 
     #[test]
     fn expiry_boundary_conditions_match_block_window() {
-        let _ = Policy::get_or_init(MAINNET_POLICY);
+        let _ = Policy::get_or_init(TEST_POLICY);
 
         let block_window = Policy::transaction_validity_window_blocks();
         let current_height = 20_000;

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -1271,7 +1271,11 @@ extern "C" {
 #[cfg(all(test, feature = "client"))]
 mod tests {
     use nimiq_keys::Address;
-    use nimiq_primitives::{coin::Coin, networks::NetworkId, policy::Policy};
+    use nimiq_primitives::{
+        coin::Coin,
+        networks::NetworkId::UnitAlbatross,
+        policy::{Policy, TEST_POLICY},
+    };
     use nimiq_transaction::{
         historic_transaction::{
             EquivocationEvent, HistoricTransaction, HistoricTransactionData, JailEvent,
@@ -1285,7 +1289,7 @@ mod tests {
 
     fn make_penalize_historic_tx() -> HistoricTransaction {
         HistoricTransaction {
-            network_id: NetworkId::UnitAlbatross,
+            network_id: UnitAlbatross,
             block_number: 100,
             block_time: 1000,
             data: HistoricTransactionData::Penalize(PenalizeEvent {
@@ -1298,7 +1302,7 @@ mod tests {
 
     fn make_jail_historic_tx() -> HistoricTransaction {
         HistoricTransaction {
-            network_id: NetworkId::UnitAlbatross,
+            network_id: UnitAlbatross,
             block_number: 100,
             block_time: 1000,
             data: HistoricTransactionData::Jail(JailEvent {
@@ -1312,7 +1316,7 @@ mod tests {
 
     fn make_equivocation_historic_tx() -> HistoricTransaction {
         HistoricTransaction {
-            network_id: NetworkId::UnitAlbatross,
+            network_id: UnitAlbatross,
             block_number: 100,
             block_time: 1000,
             data: HistoricTransactionData::Equivocation(EquivocationEvent {
@@ -1331,7 +1335,7 @@ mod tests {
             Coin::from_u64_unchecked(100),
             Coin::from_u64_unchecked(0),
             1,
-            NetworkId::UnitAlbatross,
+            UnitAlbatross,
         );
         inner.flags = flags;
         Transaction::from(inner)
@@ -1339,7 +1343,7 @@ mod tests {
 
     #[test]
     fn penalize_inherent_does_not_panic_on_conversion() {
-        let _ = Policy::get_or_init(nimiq_primitives::policy::TEST_POLICY);
+        let _ = Policy::get_or_init(TEST_POLICY);
         let hist_tx = make_penalize_historic_tx();
         let current_block = Policy::genesis_block_number() + 1;
 
@@ -1361,7 +1365,7 @@ mod tests {
 
     #[test]
     fn jail_inherent_does_not_panic_on_conversion() {
-        let _ = Policy::get_or_init(nimiq_primitives::policy::TEST_POLICY);
+        let _ = Policy::get_or_init(TEST_POLICY);
         let hist_tx = make_jail_historic_tx();
         let current_block = Policy::genesis_block_number() + 1;
 
@@ -1383,7 +1387,7 @@ mod tests {
 
     #[test]
     fn equivocation_inherent_does_not_panic_on_conversion() {
-        let _ = Policy::get_or_init(nimiq_primitives::policy::TEST_POLICY);
+        let _ = Policy::get_or_init(TEST_POLICY);
         let hist_tx = make_equivocation_historic_tx();
         let current_block = Policy::genesis_block_number() + 1;
 

--- a/web-client/src/lib.rs
+++ b/web-client/src/lib.rs
@@ -13,7 +13,7 @@ mod primitives;
 
 #[cfg(test)]
 mod tests {
-    use nimiq_primitives::policy::Policy;
+    use nimiq_primitives::policy::{Policy, TEST_POLICY};
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -28,6 +28,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     pub fn it_can_create_and_sign_basic_transactions() {
+        let _ = Policy::get_or_init(TEST_POLICY);
+
         let keypair = KeyPair::generate();
 
         let mut tx = TransactionBuilder::new_basic(
@@ -54,6 +56,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     pub fn it_can_create_and_sign_validator_transactions() {
+        let _ = Policy::get_or_init(TEST_POLICY);
+
         let keypair = KeyPair::generate();
 
         let mut tx = TransactionBuilder::new_create_validator(

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -6,7 +6,7 @@ use std::{
 use futures::{poll, Stream, StreamExt};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_consensus::{sync::syncer_proxy::SyncerProxy, BlsCache, Consensus};
-use nimiq_genesis::NetworkId;
+use nimiq_genesis::NetworkId::UnitAlbatross;
 use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{Network, Topic};
 use nimiq_network_mock::MockHub;
@@ -28,7 +28,7 @@ pub async fn it_can_initialize_with_mock_network() {
 
     let mock_network = Arc::new(hub.new_network());
 
-    let blockchain = Arc::new(RwLock::new(LightBlockchain::new(NetworkId::DevAlbatross)));
+    let blockchain = Arc::new(RwLock::new(LightBlockchain::new(UnitAlbatross)));
 
     let blockchain_proxy = BlockchainProxy::from(&blockchain);
 


### PR DESCRIPTION
## What's in this pull request?
Locally, the tests for the web client fail frequently. The problem is that there are tests assuming test policy while others initialize it with the mainnet policy. Since policy is a OnceCell, the nondeterministic nature of the test ordering may result in the wrong policy being initialized and thus a test failure.

This pr fixes it by initializing policy with `TEST_POLICY` and making test-related changes to hard-coded block heights.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
