### PR TITLE
Fix validity-store replay window to match transaction validity

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1090,53 +1090,45 @@ mod tests {
     }
 
     #[test]
-    fn transaction_in_validity_window_works() {
+    fn transaction_in_validity_window_matches_protocol_validity() {
         // Initialize History Store.
         let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let history_store = HistoryStore::new(env.clone(), NetworkId::UnitAlbatross);
 
-        // Create historic transactions.
-        let ext_0 = create_transaction(Policy::genesis_block_number() + 1, 0);
-        let ext_1 = create_transaction(Policy::genesis_block_number() + 1, 1);
+        let first_inclusion_block = Policy::genesis_block_number() + 1;
+        let validity_start_height = first_inclusion_block + Policy::blocks_per_batch();
+        let last_valid_block =
+            validity_start_height + Policy::transaction_validity_window_blocks() - 1;
 
-        let hist_txs = vec![ext_0.clone(), ext_1.clone()];
+        // Create a transaction that is first accepted at the earliest possible block in its
+        // validity range. This is the case that used to fall out of replay protection too early.
+        let replay_tx =
+            create_transaction_with_validity_start(first_inclusion_block, 0, validity_start_height);
+        let raw_tx = match &replay_tx.data {
+            HistoricTransactionData::Basic(tx) => tx.get_raw_transaction(),
+            _ => unreachable!("test helper must create a basic transaction"),
+        };
 
-        // Add historic transactions to History Store.
+        assert!(raw_tx.is_valid_at(first_inclusion_block));
+        assert!(raw_tx.is_valid_at(last_valid_block));
+        assert!(!raw_tx.is_valid_at(last_valid_block + 1));
+
+        // Add the transaction to the history store at its first valid block.
         let mut txn = env.write_transaction();
-        history_store.add_to_history(&mut txn, Policy::genesis_block_number() + 1, &hist_txs);
+        history_store.add_to_history(&mut txn, first_inclusion_block, &[replay_tx.clone()]);
 
-        // Those transactions should be part of the valitidy window
-        assert!(history_store.tx_in_validity_window(&ext_0.tx_hash(), Some(&txn)));
+        assert!(history_store.tx_in_validity_window(&replay_tx.tx_hash(), Some(&txn)));
 
-        assert!(history_store.tx_in_validity_window(&ext_1.tx_hash(), Some(&txn)));
-
-        // Now keep pushing transactions to the history store until we are past the transaction validity window
-        let validity_window_blocks = Policy::transaction_validity_window_blocks();
-
-        let mut txn_hashes = vec![];
-
-        for bn in 2..validity_window_blocks + 10 {
-            let historic_txn = create_transaction(Policy::genesis_block_number() + bn, bn as u64);
-            txn_hashes.push(historic_txn.tx_hash());
-            history_store.add_to_history(
-                &mut txn,
-                Policy::genesis_block_number() + bn,
-                &[historic_txn],
-            );
+        let validity_store = history_store.validity_store.as_ref().unwrap();
+        for block_number in first_inclusion_block + 1..=last_valid_block {
+            validity_store.update_validity_store(&mut txn, block_number);
         }
 
-        // Since we are past the txn in validity window, the first two transaction should no longer be in it
-        assert!(!history_store.tx_in_validity_window(&ext_0.tx_hash(), Some(&txn)));
+        assert!(history_store.tx_in_validity_window(&replay_tx.tx_hash(), Some(&txn)));
 
-        assert!(!history_store.tx_in_validity_window(&ext_1.tx_hash(), Some(&txn)));
+        validity_store.update_validity_store(&mut txn, last_valid_block + 1);
 
-        for txn_hash in &txn_hashes[..8] {
-            assert!(!history_store.tx_in_validity_window(txn_hash, Some(&txn)));
-        }
-
-        for txn_hash in &txn_hashes[8..] {
-            assert!(history_store.tx_in_validity_window(txn_hash, Some(&txn)));
-        }
+        assert!(!history_store.tx_in_validity_window(&replay_tx.tx_hash(), Some(&txn)));
     }
 
     #[test]
@@ -1577,6 +1569,14 @@ mod tests {
     }
 
     fn create_transaction(block: u32, value: u64) -> HistoricTransaction {
+        create_transaction_with_validity_start(block, value, 0)
+    }
+
+    fn create_transaction_with_validity_start(
+        block: u32,
+        value: u64,
+        validity_start_height: u32,
+    ) -> HistoricTransaction {
         HistoricTransaction {
             network_id: NetworkId::UnitAlbatross,
             block_number: block,
@@ -1590,7 +1590,7 @@ mod tests {
                     Address::burn_address(),
                     Coin::from_u64_unchecked(value),
                     Coin::from_u64_unchecked(0),
-                    0,
+                    validity_start_height,
                     NetworkId::UnitAlbatross,
                 ),
             )),

--- a/blockchain/src/history/history_store_index.rs
+++ b/blockchain/src/history/history_store_index.rs
@@ -813,53 +813,42 @@ mod tests {
     }
 
     #[test]
-    fn transaction_in_validity_window_works() {
+    fn transaction_in_validity_window_matches_protocol_validity() {
         // Initialize History Store.
         let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
         let history_store = HistoryStoreIndex::new(env.clone(), NetworkId::UnitAlbatross);
 
-        // Create historic transactions.
-        let ext_0 = create_transaction(Policy::genesis_block_number() + 1, 0);
-        let ext_1 = create_transaction(Policy::genesis_block_number() + 1, 1);
+        let first_inclusion_block = Policy::genesis_block_number() + 1;
+        let validity_start_height = first_inclusion_block + Policy::blocks_per_batch();
+        let last_valid_block =
+            validity_start_height + Policy::transaction_validity_window_blocks() - 1;
 
-        let hist_txs = vec![ext_0.clone(), ext_1.clone()];
+        let replay_tx =
+            create_transaction_with_validity_start(first_inclusion_block, 0, validity_start_height);
+        let raw_tx = match &replay_tx.data {
+            HistoricTransactionData::Basic(tx) => tx.get_raw_transaction(),
+            _ => unreachable!("test helper must create a basic transaction"),
+        };
 
-        // Add historic transactions to History Store.
+        assert!(raw_tx.is_valid_at(first_inclusion_block));
+        assert!(raw_tx.is_valid_at(last_valid_block));
+        assert!(!raw_tx.is_valid_at(last_valid_block + 1));
+
         let mut txn = env.write_transaction();
-        history_store.add_to_history(&mut txn, Policy::genesis_block_number() + 1, &hist_txs);
+        history_store.add_to_history(&mut txn, first_inclusion_block, &[replay_tx.clone()]);
 
-        // Those transactions should be part of the valitidy window
-        assert!(history_store.tx_in_validity_window(&ext_0.tx_hash(), Some(&txn)));
+        assert!(history_store.tx_in_validity_window(&replay_tx.tx_hash(), Some(&txn)));
 
-        assert!(history_store.tx_in_validity_window(&ext_1.tx_hash(), Some(&txn)));
-
-        // Now keep pushing transactions to the history store until we are past the transaction validity window
-        let validity_window_blocks = Policy::transaction_validity_window_blocks();
-
-        let mut txn_hashes = vec![];
-
-        for bn in 2..validity_window_blocks + 10 {
-            let historic_txn = create_transaction(Policy::genesis_block_number() + bn, bn as u64);
-            txn_hashes.push(historic_txn.tx_hash());
-            history_store.add_to_history(
-                &mut txn,
-                Policy::genesis_block_number() + bn,
-                &[historic_txn],
-            );
+        let validity_store = history_store.history_store.validity_store.as_ref().unwrap();
+        for block_number in first_inclusion_block + 1..=last_valid_block {
+            validity_store.update_validity_store(&mut txn, block_number);
         }
 
-        // Since we are past the txn in validity window, the first two transaction should no longer be in it
-        assert!(!history_store.tx_in_validity_window(&ext_0.tx_hash(), Some(&txn)));
+        assert!(history_store.tx_in_validity_window(&replay_tx.tx_hash(), Some(&txn)));
 
-        assert!(!history_store.tx_in_validity_window(&ext_1.tx_hash(), Some(&txn)));
+        validity_store.update_validity_store(&mut txn, last_valid_block + 1);
 
-        for txn_hash in &txn_hashes[..8] {
-            assert!(!history_store.tx_in_validity_window(txn_hash, Some(&txn)));
-        }
-
-        for txn_hash in &txn_hashes[8..] {
-            assert!(history_store.tx_in_validity_window(txn_hash, Some(&txn)));
-        }
+        assert!(!history_store.tx_in_validity_window(&replay_tx.tx_hash(), Some(&txn)));
     }
 
     #[test]
@@ -1521,6 +1510,14 @@ mod tests {
     }
 
     fn create_transaction(block: u32, value: u64) -> HistoricTransaction {
+        create_transaction_with_validity_start(block, value, 0)
+    }
+
+    fn create_transaction_with_validity_start(
+        block: u32,
+        value: u64,
+        validity_start_height: u32,
+    ) -> HistoricTransaction {
         HistoricTransaction {
             network_id: NetworkId::UnitAlbatross,
             block_number: block,
@@ -1534,7 +1531,7 @@ mod tests {
                     Address::burn_address(),
                     Coin::from_u64_unchecked(value),
                     Coin::from_u64_unchecked(0),
-                    0,
+                    validity_start_height,
                     NetworkId::UnitAlbatross,
                 ),
             )),

--- a/blockchain/src/history/validity_store.rs
+++ b/blockchain/src/history/validity_store.rs
@@ -48,10 +48,14 @@ impl ValidityStore {
     ) -> bool {
         let txn = txn_option.or_new(&self.db);
 
-        // Calculate first block in window.
-        let validity_window_start = self
-            .last_bn(&txn)
-            .saturating_sub(Policy::transaction_validity_window_blocks());
+        // Equivalently, at the current block height, `Transaction::is_valid_at` accepts any
+        // transaction whose `validity_start_height` is in
+        // `[current_block_height - validity_window_blocks + 1, current_block_height + blocks_per_batch]`.
+        // A transaction first included in the earliest valid block must therefore stay protected
+        // against replays for `validity_window_blocks + blocks_per_batch` blocks.
+        let lookback =
+            Policy::transaction_validity_window_blocks().saturating_add(Policy::blocks_per_batch());
+        let validity_window_start = self.last_bn(&txn).saturating_sub(lookback);
 
         // If the vector is empty then we have never seen a transaction with this hash.
         let block_number = txn.get(&self.txn_hashes, raw_tx_hash);


### PR DESCRIPTION
Extend ValidityStore::has_transaction to cover transaction_validity_window_blocks + blocks_per_batch, preventing duplicate transaction replays during the late-validity gap. Add regression tests in both history store implementations for non-zero validity_start_height to verify replay protection holds through the full protocol validity window and expires at the correct boundary.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
