### PR TITLE
Remove unnecesary functions from RPC

### DIFF
--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -22,12 +22,6 @@ pub enum ValidatorCommand {
     /// Returns the address of the local validator.
     ValidatorAddress {},
 
-    /// Returns the signing key of the local validator.
-    ValidatorSigningKey {},
-
-    /// Returns the voting key of the local validator.
-    ValidatorVotingKey {},
-
     /// Sends a transaction to the network to create this validator. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee and the validator deposit. The sender wallet must be unlocked
     /// prior to this command.
@@ -40,6 +34,9 @@ pub enum ValidatorCommand {
     CreateNewValidator {
         /// The fee will be paid from this address. This address must be already unlocked.
         sender_wallet: Address,
+
+        /// The Schnorr signing secret key used by the validator.
+        signing_secret_key: String,
 
         /// The BLS key used by the validator.
         voting_secret_key: String,
@@ -93,6 +90,9 @@ pub enum ValidatorCommand {
         /// The fee will be paid from this address. This wallet must be already unlocked.
         sender_wallet: Address,
 
+        /// The Schnorr signing secret key used by the validator.
+        signing_secret_key: String,
+
         #[clap(flatten)]
         tx_commons: TxCommon,
     },
@@ -103,6 +103,9 @@ pub enum ValidatorCommand {
     ReactivateValidator {
         /// The fee will be paid from this address. This wallet must be already unlocked.
         sender_wallet: Address,
+
+        /// The Schnorr signing secret key used by the validator.
+        signing_secret_key: String,
 
         #[clap(flatten)]
         tx_commons: TxCommon,
@@ -127,14 +130,6 @@ impl HandleSubcommand for ValidatorCommand {
                 println!("{:#?}", client.validator.get_address().await?);
             }
 
-            ValidatorCommand::ValidatorSigningKey {} => {
-                println!("{:#?}", client.validator.get_signing_key().await?);
-            }
-
-            ValidatorCommand::ValidatorVotingKey {} => {
-                println!("{:#?}", client.validator.get_voting_key().await?);
-            }
-
             ValidatorCommand::SetAutoReactivateValidator {
                 automatic_reactivate,
             } => {
@@ -147,20 +142,20 @@ impl HandleSubcommand for ValidatorCommand {
 
             ValidatorCommand::CreateNewValidator {
                 sender_wallet,
+                signing_secret_key,
                 voting_secret_key,
                 reward_address,
                 signal_data,
                 tx_commons,
             } => {
                 let validator_address = client.validator.get_address().await?.data;
-                let key_data = client.validator.get_signing_key().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
                         .create_new_validator_transaction(
                             sender_wallet,
                             validator_address,
-                            key_data,
+                            signing_secret_key,
                             voting_secret_key,
                             reward_address,
                             signal_data,
@@ -175,7 +170,7 @@ impl HandleSubcommand for ValidatorCommand {
                         .send_new_validator_transaction(
                             sender_wallet,
                             validator_address,
-                            key_data,
+                            signing_secret_key,
                             voting_secret_key,
                             reward_address,
                             signal_data,
@@ -231,17 +226,17 @@ impl HandleSubcommand for ValidatorCommand {
 
             ValidatorCommand::DeactivateValidator {
                 sender_wallet,
+                signing_secret_key,
                 tx_commons,
             } => {
                 let validator_address = client.validator.get_address().await?.data;
-                let key_data = client.validator.get_signing_key().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
                         .create_deactivate_validator_transaction(
                             sender_wallet,
                             validator_address,
-                            key_data,
+                            signing_secret_key,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )
@@ -253,7 +248,7 @@ impl HandleSubcommand for ValidatorCommand {
                         .send_deactivate_validator_transaction(
                             sender_wallet,
                             validator_address,
-                            key_data,
+                            signing_secret_key,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )
@@ -264,17 +259,17 @@ impl HandleSubcommand for ValidatorCommand {
 
             ValidatorCommand::ReactivateValidator {
                 sender_wallet,
+                signing_secret_key,
                 tx_commons,
             } => {
                 let validator_address = client.validator.get_address().await?.data;
-                let key_data = client.validator.get_signing_key().await?.data;
                 if tx_commons.dry {
                     let tx = client
                         .consensus
                         .create_reactivate_validator_transaction(
                             sender_wallet,
                             validator_address,
-                            key_data,
+                            signing_secret_key,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )
@@ -286,7 +281,7 @@ impl HandleSubcommand for ValidatorCommand {
                         .send_reactivate_validator_transaction(
                             sender_wallet,
                             validator_address,
-                            key_data,
+                            signing_secret_key,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )

--- a/rpc-interface/src/validator.rs
+++ b/rpc-interface/src/validator.rs
@@ -11,15 +11,6 @@ pub trait ValidatorInterface {
     /// Returns our validator address.
     async fn get_address(&self) -> RPCResult<Address, (), Self::Error>;
 
-    /// Returns our validator signing key.
-    async fn get_signing_key(&self) -> RPCResult<String, (), Self::Error>;
-
-    /// Returns our current validator voting key.
-    async fn get_voting_key(&self) -> RPCResult<String, (), Self::Error>;
-
-    /// Returns all available voting keys.
-    async fn get_voting_keys(&self) -> RPCResult<Vec<String>, (), Self::Error>;
-
     // Adds a voting key that will be used when the key expected by the chain changes
     async fn add_voting_key(&self, secret_key: String) -> RPCResult<(), (), Self::Error>;
 

--- a/rpc-server/src/dispatchers/validator.rs
+++ b/rpc-server/src/dispatchers/validator.rs
@@ -6,7 +6,7 @@ use nimiq_consensus::ConsensusProxy;
 use nimiq_keys::Address;
 use nimiq_network_libp2p::Network;
 use nimiq_rpc_interface::{types::RPCResult, validator::ValidatorInterface};
-use nimiq_serde::{Deserialize, Serialize};
+use nimiq_serde::Deserialize;
 use nimiq_validator::validator::ValidatorState;
 use parking_lot::RwLock;
 
@@ -33,35 +33,6 @@ impl ValidatorInterface for ValidatorDispatcher {
 
     async fn get_address(&self) -> RPCResult<Address, (), Self::Error> {
         Ok(self.validator.read().validator_address.clone().into())
-    }
-
-    // TODO: why do we give out secret keys via RPC?
-    async fn get_signing_key(&self) -> RPCResult<String, (), Self::Error> {
-        Ok(hex::encode(self.validator.read().signing_key.private.serialize_to_vec()).into())
-    }
-
-    async fn get_voting_key(&self) -> RPCResult<String, (), Self::Error> {
-        Ok(hex::encode(
-            self.validator
-                .read()
-                .voting_keys
-                .get_current_key()
-                .secret_key
-                .serialize_to_vec(),
-        )
-        .into())
-    }
-
-    async fn get_voting_keys(&self) -> RPCResult<Vec<String>, (), Self::Error> {
-        Ok(self
-            .validator
-            .read()
-            .voting_keys
-            .get_keys()
-            .into_iter()
-            .map(|key| hex::encode(key.secret_key.serialize_to_vec()))
-            .collect::<Vec<String>>()
-            .into())
     }
 
     async fn add_voting_key(&self, secret_key: String) -> RPCResult<(), (), Self::Error> {


### PR DESCRIPTION
Remove functions to obtain the signing and voting keys via RPC



...
#### This fixes #3270 .

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
