### PR TITLE
chore: Mark test and binary-only crates as publish = false

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-fuzz"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/network-mock/Cargo.toml
+++ b/network-mock/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-network-mock"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/pow-migration/Cargo.toml
+++ b/pow-migration/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-pow-migration"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/spammer/Cargo.toml
+++ b/spammer/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-spammer"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/test-log/Cargo.toml
+++ b/test-log/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-test-log"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/test-log/proc-macro/Cargo.toml
+++ b/test-log/proc-macro/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-test-log-proc-macro"
+publish = false
 version.workspace = true
 authors = ["Daniel Mueller <deso@posteo.net>"]
 edition.workspace = true

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-test-utils"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-tools"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/web-client/Cargo.toml
+++ b/web-client/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nimiq-web-client"
+publish = false
 version.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Test, dev tooling, and WASM crates that are never meant for crates.io. Makes the manifests the source of truth so cargo publish and the publish script skip them automatically. Arkworks-blocked library crates are left publishable for when those patches are upstreamed.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
