### PR TITLE
Mempool: Limit the number of txns per sender

### DIFF
--- a/lib/src/config/config.rs
+++ b/lib/src/config/config.rs
@@ -808,6 +808,7 @@ impl ClientConfigBuilder {
         self.mempool = Some(MempoolConfig {
             size_limit,
             control_size_limit,
+            tx_per_sender_limit: MempoolConfig::default().tx_per_sender_limit,
             filter_rules,
             filter_limit,
         });

--- a/lib/src/config/config_file/client.example.toml
+++ b/lib/src/config/config_file/client.example.toml
@@ -315,6 +315,10 @@ level = "debug"
 # Default: 6_000_000
 #control_size_limit = 6_000_000
 
+# Maximum number of transactions per sender stored in the mempool.
+# Default: 1000
+#tx_per_sender_limit = 1000
+
 # Maximum size of the transaction black list.
 # Default: 25000
 #blacklist_limit = 25000

--- a/lib/src/config/config_file/mod.rs
+++ b/lib/src/config/config_file/mod.rs
@@ -412,6 +412,7 @@ pub struct MempoolSettings {
     pub filter: Option<MempoolFilterSettings>,
     pub size_limit: Option<usize>,
     pub control_size_limit: Option<usize>,
+    pub tx_per_sender_limit: Option<usize>,
     pub blacklist_limit: Option<usize>,
 }
 
@@ -473,6 +474,9 @@ impl From<MempoolSettings> for MempoolConfig {
             control_size_limit: mempool
                 .control_size_limit
                 .unwrap_or(Mempool::DEFAULT_CONTROL_SIZE_LIMIT),
+            tx_per_sender_limit: mempool
+                .tx_per_sender_limit
+                .unwrap_or(Mempool::DEFAULT_TX_PER_SENDER_LIMIT),
             filter_limit: mempool
                 .blacklist_limit
                 .unwrap_or(MempoolFilter::DEFAULT_BLACKLIST_SIZE),

--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -10,6 +10,8 @@ pub struct MempoolConfig {
     pub size_limit: usize,
     /// Total size limit of transactions in the control mempool (bytes)
     pub control_size_limit: usize,
+    /// Maximum number of transactions stored per sender
+    pub tx_per_sender_limit: usize,
     /// Mempool filter rules
     pub filter_rules: MempoolRules,
     /// Mempool filter limit or size
@@ -21,6 +23,7 @@ impl Default for MempoolConfig {
         MempoolConfig {
             size_limit: Mempool::DEFAULT_SIZE_LIMIT,
             control_size_limit: Mempool::DEFAULT_CONTROL_SIZE_LIMIT,
+            tx_per_sender_limit: Mempool::DEFAULT_TX_PER_SENDER_LIMIT,
             filter_rules: MempoolRules::default(),
             filter_limit: MempoolFilter::DEFAULT_BLACKLIST_SIZE,
         }

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -63,11 +63,15 @@ impl Mempool {
     /// Default total size limit of control transactions in the mempool (bytes)
     pub const DEFAULT_CONTROL_SIZE_LIMIT: usize = 6_000_000;
 
+    /// Default maximum number of transactions per sender stored in the mempool
+    pub const DEFAULT_TX_PER_SENDER_LIMIT: usize = 1000;
+
     /// Creates a new mempool
     pub fn new(blockchain: Arc<RwLock<Blockchain>>, config: MempoolConfig) -> Self {
         let state = Arc::new(RwLock::new(MempoolState::new(
             config.size_limit,
             config.control_size_limit,
+            config.tx_per_sender_limit,
         )));
 
         Self {

--- a/mempool/src/mempool_state.rs
+++ b/mempool/src/mempool_state.rs
@@ -26,16 +26,24 @@ pub(crate) struct MempoolState {
     // The pending balance per sender.
     pub(crate) state_by_sender: HashMap<Address, SenderPendingState>,
 
+    // Maximum number of transactions stored per sender.
+    pub(crate) tx_per_sender_limit: usize,
+
     #[cfg(feature = "metrics")]
     pub(crate) metrics: Arc<MempoolMetrics>,
 }
 
 impl MempoolState {
-    pub fn new(regular_txns_limit: usize, control_txns_limit: usize) -> Self {
+    pub fn new(
+        regular_txns_limit: usize,
+        control_txns_limit: usize,
+        tx_per_sender_limit: usize,
+    ) -> Self {
         MempoolState {
             regular_transactions: MempoolTransactions::new(regular_txns_limit),
             control_transactions: MempoolTransactions::new(control_txns_limit),
             state_by_sender: HashMap::new(),
+            tx_per_sender_limit,
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }
@@ -65,6 +73,13 @@ impl MempoolState {
         let tx_hash = tx.hash();
         if self.contains(&tx_hash) {
             return Err(VerifyErr::Known);
+        }
+
+        // Reject if this sender already has too many transactions in the mempool.
+        if let Some(sender_state) = self.state_by_sender.get(&tx.sender)
+            && sender_state.txns.len() >= self.tx_per_sender_limit
+        {
+            return Err(VerifyErr::SenderLimitReached);
         }
 
         // Reserve the balance necessary for this transaction on the sender account.

--- a/mempool/src/verify.rs
+++ b/mempool/src/verify.rs
@@ -28,6 +28,8 @@ pub enum VerifyErr {
     Filtered,
     #[error("Can't verify transaction without consensus")]
     NoConsensus,
+    #[error("Sender has reached the maximum number of transactions in the mempool")]
+    SenderLimitReached,
 }
 
 /// Verifies a transaction and adds it to the mempool.

--- a/mempool/tests/mod.rs
+++ b/mempool/tests/mod.rs
@@ -11,7 +11,9 @@ use nimiq_keys::{
     Address, Ed25519PublicKey as SchnorrPublicKey, KeyPair as SchnorrKeyPair,
     PrivateKey as SchnorrPrivateKey, SecureGenerate,
 };
-use nimiq_mempool::{config::MempoolConfig, mempool::Mempool, mempool_transactions::TxPriority};
+use nimiq_mempool::{
+    config::MempoolConfig, mempool::Mempool, mempool_transactions::TxPriority, verify::VerifyErr,
+};
 use nimiq_network_mock::{MockHub, MockId, MockNetwork, MockPeerId};
 use nimiq_primitives::{coin::Coin, networks::NetworkId, policy::Policy};
 use nimiq_serde::{Deserialize, Serialize};
@@ -2202,5 +2204,102 @@ async fn it_can_reject_invalid_vesting_contract_transaction() {
         mempool.num_transactions(),
         0,
         "Number of txns in the mempools is not what is expected"
+    );
+}
+
+#[test(tokio::test)]
+async fn tx_per_sender_limit_is_enforced() {
+    let tx_per_sender_limit = 3_usize;
+    let num_recipients = tx_per_sender_limit + 1;
+
+    let mut rng = test_rng(true);
+    let mut genesis_builder = GenesisBuilder::default();
+    genesis_builder.with_network(NetworkId::UnitAlbatross);
+
+    // One sender with enough balance for all transactions
+    let sender_accounts =
+        generate_accounts(vec![1_000_000; 1], &mut genesis_builder, true, &mut rng);
+    // One distinct recipient per transaction
+    let recipient_accounts = generate_accounts(
+        vec![0; num_recipients],
+        &mut genesis_builder,
+        false,
+        &mut rng,
+    );
+
+    let mut mempool_transactions = vec![];
+    for i in 0..num_recipients {
+        mempool_transactions.push(TestTransaction {
+            fee: (i + 1) as u64,
+            value: 1,
+            sender: sender_accounts[0].clone(),
+            recipient: recipient_accounts[i].clone(),
+        });
+    }
+    let (txns, _) = generate_transactions(mempool_transactions, true);
+
+    let mut rng2 = test_rng(true);
+    genesis_builder.with_genesis_validator(
+        Address::from(&SchnorrKeyPair::generate(&mut rng2)),
+        SchnorrPublicKey::from([0u8; 32]),
+        BlsKeyPair::generate(&mut rng2).public_key,
+        Address::default(),
+        None,
+        None,
+        false,
+    );
+
+    let time = Arc::new(OffsetTime::new());
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let genesis_info = genesis_builder.generate(env.clone()).unwrap();
+
+    let genesis_block = match genesis_info.block {
+        Block::Macro(mut block) => {
+            block.header.block_number = Policy::genesis_block_number();
+            Block::Macro(block)
+        }
+        Block::Micro(_) => panic!(),
+    };
+
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::with_genesis(
+            env.clone(),
+            BlockchainConfig::default(),
+            time,
+            NetworkId::UnitAlbatross,
+            genesis_block,
+            genesis_info.accounts,
+        )
+        .unwrap(),
+    ));
+
+    let mempool = Mempool::new(
+        Arc::clone(&blockchain),
+        MempoolConfig {
+            tx_per_sender_limit,
+            ..Default::default()
+        },
+    );
+
+    // The first `tx_per_sender_limit` transactions must be accepted.
+    for tx in txns.iter().take(tx_per_sender_limit) {
+        assert_eq!(
+            mempool.add_transaction(tx.clone(), None),
+            Ok(()),
+            "Expected transaction to be accepted"
+        );
+    }
+    assert_eq!(mempool.num_transactions(), tx_per_sender_limit);
+
+    // The next transaction from the same sender must be rejected.
+    assert_eq!(
+        mempool.add_transaction(txns[tx_per_sender_limit].clone(), None),
+        Err(VerifyErr::SenderLimitReached),
+        "Expected transaction to be rejected due to per-sender limit"
+    );
+    assert_eq!(
+        mempool.num_transactions(),
+        tx_per_sender_limit,
+        "Mempool size should be unchanged after rejected transaction"
     );
 }


### PR DESCRIPTION
Introduce a max cap on the number of txns we store in the mempool from the same sender

## What's in this pull request?

...
#### This fixes #___.

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
