### PR TITLE
Expose connected peer user-agents over RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
@@ -3190,6 +3191,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-identify"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "libp2p-identity"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,6 +3286,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -335,6 +335,7 @@ impl ClientInner {
         let network_config = NetworkConfig::new(
             identity_keypair,
             peer_contact,
+            config.network.user_agent.to_string(),
             seeds,
             network_info.genesis_hash().clone(),
             false,

--- a/network-libp2p/Cargo.toml
+++ b/network-libp2p/Cargo.toml
@@ -57,6 +57,7 @@ nimiq-validator-network = { workspace = true }
 libp2p = { version = "0.56", default-features = false, features = [
     "autonat",
     "gossipsub",
+    "identify",
     "kad",
     "macros",
     "noise",
@@ -71,6 +72,7 @@ libp2p = { version = "0.56", default-features = false, features = [
 libp2p = { version = "0.56", default-features = false, features = [
     "autonat",
     "gossipsub",
+    "identify",
     "kad",
     "macros",
     "noise",

--- a/network-libp2p/src/behaviour.rs
+++ b/network-libp2p/src/behaviour.rs
@@ -2,7 +2,7 @@ use std::{iter, sync::Arc};
 
 use libp2p::{
     autonat::v2::{self as autonat, client::Config as AutonatConfig},
-    connection_limits, gossipsub,
+    connection_limits, gossipsub, identify,
     kad::{self, store::MemoryStore},
     ping, request_response,
     swarm::NetworkBehaviour,
@@ -15,7 +15,7 @@ use crate::{
     connection_pool::behaviour::Config as PoolConfig,
     discovery::{self, peer_contacts::PeerContactBook},
     dispatch::codecs::MessageCodec,
-    Config,
+    Config, IDENTIFY_PROTOCOL,
 };
 
 /// Maximum simultaneous libp2p connections per peer
@@ -39,6 +39,7 @@ pub struct Behaviour {
     #[cfg(feature = "kad")]
     pub dht: kad::Behaviour<MemoryStore>,
     pub gossipsub: gossipsub::Behaviour,
+    pub identify: identify::Behaviour,
     pub ping: ping::Behaviour,
     pub request_response: request_response::Behaviour<MessageCodec>,
 }
@@ -79,6 +80,11 @@ impl Behaviour {
         gossipsub
             .with_peer_score(peer_score_params, thresholds)
             .expect("Valid score params and thresholds");
+
+        let identify = identify::Behaviour::new(
+            identify::Config::new(IDENTIFY_PROTOCOL.to_string(), public_key)
+                .with_agent_version(config.user_agent.clone()),
+        );
 
         // Ping behaviour:
         // - Send a ping every 15 seconds and timeout at 20 seconds.
@@ -133,6 +139,7 @@ impl Behaviour {
             dht,
             discovery,
             gossipsub,
+            identify,
             ping,
             pool,
             request_response,

--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -23,6 +23,8 @@ pub struct TlsConfig {
 pub struct Config {
     pub keypair: Keypair,
     pub peer_contact: PeerContact,
+    /// User-agent string announced to peers via libp2p identify.
+    pub user_agent: String,
     pub seeds: Vec<Multiaddr>,
     pub discovery: discovery::Config,
     pub kademlia: kad::Config,
@@ -50,6 +52,7 @@ impl Config {
     pub fn new(
         keypair: Keypair,
         peer_contact: PeerContact,
+        user_agent: String,
         seeds: Vec<Multiaddr>,
         genesis_hash: Blake2bHash,
         memory_transport: bool,
@@ -97,6 +100,7 @@ impl Config {
         Self {
             keypair,
             peer_contact,
+            user_agent,
             seeds,
             discovery: discovery::Config::new(
                 genesis_hash,

--- a/network-libp2p/src/lib.rs
+++ b/network-libp2p/src/lib.rs
@@ -20,6 +20,7 @@ mod utils;
 
 pub const DISCOVERY_PROTOCOL: &str = "/nimiq/discovery/0.0.1";
 pub const DHT_PROTOCOL: &str = "/nimiq/kad/0.0.1";
+pub const IDENTIFY_PROTOCOL: &str = "/nimiq/identify/0.0.1";
 pub const AUTONAT_DIAL_REQUEST_PROTOCOL: &str = "/libp2p/autonat/2/dial-request";
 pub const AUTONAT_DIAL_BACK_PROTOCOL: &str = "/libp2p/autonat/2/dial-back";
 

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -54,6 +54,8 @@ pub struct Network {
     /// If the peer is interesting, i.e.: it provides services that are interested to us,
     /// we store an entry with the peer contact itself.
     connected_peers: Arc<RwLock<HashMap<PeerId, PeerInfo>>>,
+    /// User-agent strings announced by connected peers via libp2p identify.
+    peer_user_agents: Arc<RwLock<HashMap<PeerId, String>>>,
     /// Stream used to send event messages
     events_tx: broadcast::Sender<NetworkEvent<PeerId>>,
     /// Stream used to send action messages
@@ -112,6 +114,7 @@ impl Network {
 
         let local_peer_id = *Swarm::local_peer_id(&swarm);
         let connected_peers = Arc::new(RwLock::new(HashMap::new()));
+        let peer_user_agents = Arc::new(RwLock::new(HashMap::new()));
 
         let events_tx = broadcast::Sender::new(64);
         let (action_tx, action_rx) = mpsc::channel(64);
@@ -128,6 +131,7 @@ impl Network {
             action_rx,
             validate_rx,
             Arc::clone(&connected_peers),
+            Arc::clone(&peer_user_agents),
             update_scores,
             Arc::clone(&contacts),
             #[cfg(feature = "kad")]
@@ -142,6 +146,7 @@ impl Network {
             contacts,
             local_peer_id,
             connected_peers,
+            peer_user_agents,
             events_tx,
             action_tx,
             validate_tx,
@@ -160,6 +165,15 @@ impl Network {
     /// If that peer has multiple associated addresses all but the first are omitted.
     pub fn get_address_book(&self) -> Vec<(PeerId, PeerInfo)> {
         self.contacts.read().known_peers()
+    }
+
+    /// Retrieves user-agent strings announced by connected peers via libp2p identify.
+    pub fn get_peer_user_agents(&self) -> Vec<(PeerId, String)> {
+        self.peer_user_agents
+            .read()
+            .iter()
+            .map(|(peer_id, user_agent)| (*peer_id, user_agent.clone()))
+            .collect()
     }
 
     /// Gets the network information

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -12,7 +12,7 @@ use libp2p::{
         muxing::StreamMuxerBox,
         transport::{Boxed, MemoryTransport},
     },
-    gossipsub,
+    gossipsub, identify,
     identity::Keypair,
     kad::{
         self, store::RecordStore, BootstrapError, BootstrapOk, GetRecordError, GetRecordOk,
@@ -61,6 +61,7 @@ struct EventInfo<'a> {
     swarm: &'a mut NimiqSwarm,
     state: &'a mut TaskState,
     connected_peers: &'a RwLock<HashMap<PeerId, PeerInfo>>,
+    peer_user_agents: &'a RwLock<HashMap<PeerId, String>>,
     rate_limiting: &'a mut RateLimits,
     #[cfg(feature = "kad")]
     dht_verifier: &'a dyn dht::Verifier,
@@ -139,6 +140,7 @@ pub(crate) async fn swarm_task(
     mut action_rx: mpsc::Receiver<NetworkAction>,
     mut validate_rx: mpsc::UnboundedReceiver<ValidateMessage<PeerId>>,
     connected_peers: Arc<RwLock<HashMap<PeerId, PeerInfo>>>,
+    peer_user_agents: Arc<RwLock<HashMap<PeerId, String>>>,
     mut update_scores: Interval,
     contacts: Arc<RwLock<PeerContactBook>>,
     #[cfg(feature = "kad")] dht_verifier: impl dht::Verifier,
@@ -183,6 +185,7 @@ pub(crate) async fn swarm_task(
                                 swarm: &mut swarm,
                                 state: &mut task_state,
                                 connected_peers: &connected_peers,
+                                peer_user_agents: &peer_user_agents,
                                 rate_limiting: &mut rate_limiting,
                                 #[cfg(feature = "kad")]
                                 dht_verifier: &dht_verifier,
@@ -382,6 +385,7 @@ fn handle_event(event: SwarmEvent<behaviour::BehaviourEvent>, event_info: EventI
             // Remove Peer
             if num_established == 0 {
                 event_info.connected_peers.write().remove(&peer_id);
+                event_info.peer_user_agents.write().remove(&peer_id);
                 event_info.swarm.behaviour_mut().remove_peer(peer_id);
 
                 // Removes or marks to remove the respective rate limits.
@@ -475,6 +479,7 @@ fn handle_behaviour_event(event: behaviour::BehaviourEvent, event_info: EventInf
         behaviour::BehaviourEvent::Dht(event) => handle_dht_event(event, event_info),
         behaviour::BehaviourEvent::Discovery(event) => handle_discovery_event(event, event_info),
         behaviour::BehaviourEvent::Gossipsub(event) => handle_gossipsub_event(event, event_info),
+        behaviour::BehaviourEvent::Identify(event) => handle_identify_event(event, event_info),
         behaviour::BehaviourEvent::Ping(event) => handle_ping_event(event, event_info),
         behaviour::BehaviourEvent::RequestResponse(event) => {
             handle_request_response_event(event, event_info)
@@ -498,6 +503,32 @@ fn handle_autonat_client_event(event: autonat::v2::client::Event, event_info: Ev
 
 fn handle_autonat_server_event(event: autonat::v2::server::Event, _event_info: EventInfo) {
     log::trace!(?event, "AutoNAT inbound probe");
+}
+
+fn handle_identify_event(event: identify::Event, event_info: EventInfo) {
+    match event {
+        identify::Event::Received { peer_id, info, .. } => {
+            debug!(
+                %peer_id,
+                user_agent = %info.agent_version,
+                protocol_version = %info.protocol_version,
+                "Identify info received",
+            );
+            event_info
+                .peer_user_agents
+                .write()
+                .insert(peer_id, info.agent_version);
+        }
+        identify::Event::Error { peer_id, error, .. } => {
+            debug!(%peer_id, %error, "Identify error");
+        }
+        identify::Event::Sent { peer_id, .. } => {
+            trace!(%peer_id, "Identify info sent");
+        }
+        identify::Event::Pushed { peer_id, .. } => {
+            trace!(%peer_id, "Identify info pushed");
+        }
+    }
 }
 
 #[cfg(feature = "kad")]

--- a/rpc-interface/src/network.rs
+++ b/rpc-interface/src/network.rs
@@ -18,4 +18,7 @@ pub trait NetworkInterface {
 
     /// Returns the address book
     async fn get_address_book(&self) -> RPCResult<Vec<(String, PeerType)>, (), Self::Error>;
+
+    /// Returns user-agent strings announced by connected peers.
+    async fn get_peer_user_agents(&self) -> RPCResult<Vec<(String, String)>, (), Self::Error>;
 }

--- a/rpc-server/src/dispatchers/network.rs
+++ b/rpc-server/src/dispatchers/network.rs
@@ -71,4 +71,14 @@ impl NetworkInterface for NetworkDispatcher {
 
         Ok(rpc_address_book.into())
     }
+
+    async fn get_peer_user_agents(&self) -> RPCResult<Vec<(String, String)>, (), Self::Error> {
+        Ok(self
+            .network
+            .get_peer_user_agents()
+            .into_iter()
+            .map(|(peer_id, user_agent)| (peer_id.to_string(), user_agent))
+            .collect::<Vec<_>>()
+            .into())
+    }
 }


### PR DESCRIPTION
## What

This PR wires the configured Nimiq user-agent into libp2p identify and exposes the user-agents reported by connected peers through RPC.

It adds:
- a Nimiq identify protocol constant (`/nimiq/identify/0.0.1`)
- libp2p identify behaviour configured with the existing local user-agent string
- storage of received peer `agent_version` strings keyed by `PeerId`
- a new RPC method: `getPeerUserAgents`, returning `(peerId, userAgent)` pairs

## Why

At the moment the configured `user_agent` appears to be local-only from an observer's point of view: it is configured and printed locally, but peer client versions are not available through RPC and did not show up in TRACE logs during a quick experiment.

For network observability tools such as public node maps, exposing reported peer versions makes it possible to show:
- reported client version distribution
- adoption of new releases
- stale/outdated nodes
- better diagnostics around network diversity

The user-agent should still be treated as self-reported metadata, similar to browser user-agents.

## Verification

Ran locally:

- `cargo check -p nimiq-network-libp2p --all-features`
- `cargo check -p nimiq-rpc-interface -p nimiq-rpc-server`

Both completed successfully.