### PR TITLE
bridge: Multiple bridge fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,6 +4382,7 @@ dependencies = [
  "nimiq-time",
  "nimiq-transaction",
  "nimiq-transaction-builder",
+ "nimiq-trie",
  "nimiq-utils",
  "nimiq-vrf",
  "parking_lot",

--- a/blockchain/src/blockchain/wrappers.rs
+++ b/blockchain/src/blockchain/wrappers.rs
@@ -9,7 +9,11 @@ use nimiq_database::{mdbx::MdbxReadTransaction as DBTransaction, traits::WriteTr
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::{
-    account::AccountError, key_nibbles::KeyNibbles, policy::Policy, slots_allocation::Slot,
+    account::{AccountError, AccountType},
+    coin::Coin,
+    key_nibbles::KeyNibbles,
+    policy::Policy,
+    slots_allocation::Slot,
 };
 use nimiq_transaction::{historic_transaction::RawTransactionHash, Transaction};
 
@@ -191,6 +195,51 @@ impl Blockchain {
         self.state
             .accounts
             .release_balance(account, transaction, reserved_balance, None)
+    }
+
+    /// For a bridge-sender transaction with a non-zero fee, reserve the fee against the
+    /// burn-proof signer's account. A permissionless bridge burn-release pays its fee
+    /// from the signer at commit (the bridge itself reserves/deducts only `value`), so
+    /// the fee must be reserved against the signer here or the transaction could pass
+    /// mempool admission and then fail at commit. No-op for non-bridge or zero-fee txs.
+    ///
+    /// The fee is reserved within the bridge sender's `ReservedBalance` (via `reserve_for`),
+    /// which aggregates multiple burn-releases routed through the same bridge by the same
+    /// signer. NOTE (follow-up): it does not aggregate a signer's obligations across
+    /// different bridges or with the signer's own (non-bridge) transactions; those
+    /// topologies can still over-commit a signer and need signer-bucket tracking.
+    pub fn reserve_bridge_signer_fee(
+        &self,
+        transaction: &Transaction,
+        reserved_balance: &mut ReservedBalance,
+    ) -> Result<(), AccountError> {
+        if transaction.sender_type != AccountType::Bridge || transaction.fee == Coin::ZERO {
+            return Ok(());
+        }
+
+        let signer = self.state.accounts.extract_signer_address(transaction)?;
+        let signer_balance = self
+            .get_account_if_complete(&signer)
+            .map(|account| account.balance())
+            .unwrap_or(Coin::ZERO);
+
+        reserved_balance.reserve_for(&signer, signer_balance, transaction.fee)
+    }
+
+    /// Release a previously reserved bridge signer fee (inverse of
+    /// [`Self::reserve_bridge_signer_fee`]). No-op for non-bridge or zero-fee txs.
+    pub fn release_bridge_signer_fee(
+        &self,
+        transaction: &Transaction,
+        reserved_balance: &mut ReservedBalance,
+    ) {
+        if transaction.sender_type != AccountType::Bridge || transaction.fee == Coin::ZERO {
+            return;
+        }
+
+        if let Ok(signer) = self.state.accounts.extract_signer_address(transaction) {
+            reserved_balance.release_for(&signer, transaction.fee);
+        }
     }
 
     /// Checks if we have seen some transaction with this hash inside the validity window. This is

--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -1043,7 +1043,9 @@ impl HistoryInterface for HistoryStore {
             return None;
         }
 
-        // Retrieve historic transactions up to the block number from database
+        // Retrieve historic transactions up to the block number from database.
+        // Fetched once and reused below; scanning the whole epoch twice per request
+        // is an unnecessary I/O amplification on this network/RPC-reachable path.
         let hist_txs = self.get_historic_txns(epoch_number, 0..num_txs as u32, Some(&txn));
 
         // Get the transaction at transaction_index before sorting
@@ -1057,9 +1059,8 @@ impl HistoryInterface for HistoryStore {
             }
         };
 
-        // Retrieve transactions up to the block number from database
-        let txs: Vec<Transaction> = self
-            .get_historic_txns(epoch_number, 0..num_txs as u32, Some(&txn))
+        // Reuse the already-fetched historic transactions instead of re-scanning the epoch.
+        let txs: Vec<Transaction> = hist_txs
             .iter()
             .filter_map(|historic_tx| {
                 if historic_tx.is_not_basic() {

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -59,6 +59,7 @@ nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }
 nimiq-time = { workspace = true }
 nimiq-transaction-builder = { workspace = true }
+nimiq-trie = { workspace = true }
 nimiq-vrf = { workspace = true }
 
 [features]

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -510,9 +510,24 @@ impl Mempool {
                     Some(transaction) => transaction,
                     None => return false,
                 };
-                let still_valid = blockchain
+                let mut still_valid = blockchain
                     .reserve_balance(&sender_account, tx, &mut sender_state.reserved_balance)
                     .is_ok();
+                if still_valid
+                    && blockchain
+                        .reserve_bridge_signer_fee(tx, &mut sender_state.reserved_balance)
+                        .is_err()
+                {
+                    // The bridge signer fee could not be re-reserved (no-op for non-bridge
+                    // txs). Roll back the value reservation and drop the tx, mirroring
+                    // `MempoolState::put`. The rollback must happen here: this bucket is
+                    // detached from `state_by_sender`, so the `remove` below hits its
+                    // sender-not-found early return and would release nothing.
+                    blockchain
+                        .release_balance(&sender_account, tx, &mut sender_state.reserved_balance)
+                        .ok();
+                    still_valid = false;
+                }
                 if !still_valid {
                     mempool_state.remove(blockchain, tx_hash, EvictionReason::Invalid);
                 }

--- a/mempool/src/mempool_state.rs
+++ b/mempool/src/mempool_state.rs
@@ -90,10 +90,22 @@ impl MempoolState {
         if let Some(sender_state) = self.state_by_sender.get_mut(&tx.sender) {
             let reserved_balance = &mut sender_state.reserved_balance;
             blockchain.reserve_balance(&sender_account, &tx, reserved_balance)?;
+            // Bridge burn-releases pay their fee from the burn-proof signer, not the
+            // sender; reserve it against the signer too. Roll back the value reservation
+            // if it cannot be reserved so the bucket is never left inconsistent.
+            if let Err(e) = blockchain.reserve_bridge_signer_fee(&tx, reserved_balance) {
+                blockchain
+                    .release_balance(&sender_account, &tx, reserved_balance)
+                    .ok();
+                return Err(e.into());
+            }
             sender_state.txns.insert(tx.hash());
         } else {
             let mut reserved_balance = ReservedBalance::new(tx.sender.clone());
             blockchain.reserve_balance(&sender_account, &tx, &mut reserved_balance)?;
+            // See above: also reserve the signer fee for bridge transactions. On failure
+            // the freshly-created `reserved_balance` is simply dropped (nothing inserted).
+            blockchain.reserve_bridge_signer_fee(&tx, &mut reserved_balance)?;
 
             let sender_state = SenderPendingState {
                 reserved_balance,
@@ -162,6 +174,8 @@ impl MempoolState {
         blockchain
             .release_balance(&sender_account, &tx, &mut sender_state.reserved_balance)
             .expect("Failed to release balance");
+        // Mirror of `put`: release the bridge signer fee reserved against the signer.
+        blockchain.release_bridge_signer_fee(&tx, &mut sender_state.reserved_balance);
 
         if sender_state.txns.is_empty() {
             self.state_by_sender.remove(&tx.sender);

--- a/mempool/tests/bridge_signer_fee.rs
+++ b/mempool/tests/bridge_signer_fee.rs
@@ -1,0 +1,338 @@
+use std::{sync::Arc, time::Duration};
+
+use nimiq_account::{Account, BridgeContract};
+use nimiq_block::{Block, MicroBlock, MicroBody, MicroHeader};
+use nimiq_blockchain::{Blockchain, BlockchainConfig};
+use nimiq_bls::KeyPair as BlsKeyPair;
+use nimiq_database::{mdbx::MdbxDatabase, traits::WriteTransaction};
+use nimiq_genesis_builder::GenesisBuilder;
+use nimiq_hash::{Blake2bHash, Blake2sHash, Hash};
+use nimiq_keys::{
+    Address, Ed25519PublicKey as SchnorrPublicKey, KeyPair as SchnorrKeyPair, SecureGenerate,
+};
+use nimiq_mempool::{config::MempoolConfig, mempool::Mempool, verify::VerifyErr};
+use nimiq_primitives::{
+    account::AccountType, coin::Coin, key_nibbles::KeyNibbles, networks::NetworkId, policy::Policy,
+};
+use nimiq_serde::Serialize;
+use nimiq_test_log::test;
+use nimiq_test_utils::test_rng;
+use nimiq_transaction::{
+    account::{
+        bridge_contract::OutgoingBridgeTransactionData,
+        htlc_contract::{AnyHash, AnyHash32},
+    },
+    bridge_contract::{
+        AddressFormat, AnyMerkleProof, ChainConfig, Endianness, OutgoingTransaction,
+        ValidationProgram,
+    },
+    SignatureProof, Transaction,
+};
+use nimiq_utils::{merkle::MerkleProof, time::OffsetTime};
+use nimiq_vrf::VrfSeed;
+use parking_lot::RwLock;
+
+// These integration tests exercise the signer-pays fee model for outgoing bridge
+// burn-releases end-to-end through the real `Mempool`. Outgoing bridge releases are
+// permissionless and pay their fee from the burn-proof *signer* (not the bridge), so
+// the mempool must reserve the fee against the signer's account at admission
+// (`Blockchain::reserve_bridge_signer_fee`), release it on removal, and re-reserve it
+// on the per-block rebuild. Mempool admission only verifies the self-signature — it
+// does not validate the burn proof or oracle state — so a self-signed release with a
+// placeholder proof is enough to drive these paths.
+
+const SOURCE_CHAIN_ID: u32 = 1;
+const BRIDGE_BALANCE: u64 = 1_000_000;
+const RELEASE_VALUE: u64 = 100;
+const FEE: u64 = 10;
+
+fn bridge_address() -> Address {
+    Address::from([0x0B; 20])
+}
+
+fn target_address() -> Address {
+    Address::from([0xAA; 20])
+}
+
+fn bridge_chain_config() -> ChainConfig {
+    ChainConfig {
+        chain_id: SOURCE_CHAIN_ID,
+        hash_function: AnyHash::Blake2b(AnyHash32::default()),
+        address_format: AddressFormat::Nimiq,
+        endianness: Endianness::LittleEndian,
+        block_time: Duration::from_secs(60),
+        validation_program: ValidationProgram::empty(),
+        max_proof_depth: 64,
+    }
+}
+
+struct BridgeFixture {
+    blockchain: Arc<RwLock<Blockchain>>,
+    mempool: Mempool,
+    signer: SchnorrKeyPair,
+    validity_start_height: u32,
+}
+
+/// Builds a blockchain whose genesis funds `signer_balance` to the burn-proof signer,
+/// seeds a `BridgeContract` (balance `BRIDGE_BALANCE`) directly into the accounts tree,
+/// and returns a fresh mempool over it.
+fn setup(signer_balance: u64) -> BridgeFixture {
+    let mut rng = test_rng(true);
+
+    let signer = SchnorrKeyPair::generate(&mut rng);
+    let signer_address = Address::from(&signer.public);
+
+    let mut genesis_builder = GenesisBuilder::default();
+    genesis_builder.with_network(NetworkId::UnitAlbatross);
+    genesis_builder.with_basic_account(
+        signer_address.clone(),
+        Coin::from_u64_unchecked(signer_balance),
+    );
+    // Genesis requires at least one validator.
+    genesis_builder.with_genesis_validator(
+        Address::from(&SchnorrKeyPair::generate(&mut rng)),
+        SchnorrPublicKey::from([0u8; 32]),
+        BlsKeyPair::generate(&mut rng).public_key,
+        Address::default(),
+        None,
+        None,
+        false,
+    );
+
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let genesis_info = genesis_builder.generate(env.clone()).unwrap();
+
+    let genesis_block = match genesis_info.block {
+        Block::Macro(mut block) => {
+            block.header.block_number = Policy::genesis_block_number();
+            // Bridge/oracle contracts activate at protocol version 3
+            // (`upgrades::v3::BRIDGE_ORACLE_CONTRACTS`). `blockchain.protocol_version()`
+            // reads the head block's version, so the genesis must report a
+            // bridge-enabled version or the mempool rejects every bridge transaction.
+            block.header.version = Policy::max_supported_version();
+            Block::Macro(block)
+        }
+        Block::Micro(_) => panic!("expected a macro genesis block"),
+    };
+
+    let time = Arc::new(OffsetTime::new());
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::with_genesis(
+            env,
+            BlockchainConfig::default(),
+            time,
+            NetworkId::UnitAlbatross,
+            genesis_block,
+            genesis_info.accounts,
+        )
+        .unwrap(),
+    ));
+
+    seed_bridge_account(&blockchain, &signer_address);
+
+    let validity_start_height = 1 + Policy::genesis_block_number();
+    let mempool = Mempool::new(Arc::clone(&blockchain), MempoolConfig::default());
+
+    BridgeFixture {
+        blockchain,
+        mempool,
+        signer,
+        validity_start_height,
+    }
+}
+
+/// Inserts a `BridgeContract` into the live accounts tree. The mempool reads accounts
+/// directly from the tree (it does not re-verify them against the head's state root),
+/// so a direct insert is sufficient to make the bridge sender resolvable — and avoids
+/// the oracle + valid-proof scaffolding a full contract-creation transaction would need.
+fn seed_bridge_account(blockchain: &Arc<RwLock<Blockchain>>, owner: &Address) {
+    let bridge = BridgeContract {
+        owner: owner.clone(),
+        oracle_address: Address::from([0x0E; 20]),
+        balance: Coin::from_u64_unchecked(BRIDGE_BALANCE),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: bridge_chain_config(),
+        transaction_count: 0,
+    };
+
+    let bc = blockchain.read();
+    let mut raw_txn = bc.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw_txn).into();
+    let tree = &bc.state().accounts.tree;
+    tree.put(
+        &mut txn,
+        &KeyNibbles::from(&bridge_address()),
+        Account::Bridge(bridge),
+    )
+    .expect("failed to seed bridge account");
+    tree.update_root(&mut txn).expect("failed to update root");
+    drop(txn);
+    raw_txn.commit();
+}
+
+/// Builds a self-signed outgoing bridge burn-release. `value` distinguishes otherwise
+/// identical releases so they hash differently. The burn proof is a placeholder — the
+/// mempool never validates it, only the sender_data self-signature.
+fn build_release(fixture: &BridgeFixture, value: u64, fee: u64) -> Transaction {
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: vec![0u8; 32],
+        merkle_proof: AnyMerkleProof::Blake2b(MerkleProof::<Blake2bHash>::new(&[], &[])),
+        oracle_state_index: 0,
+    };
+    let mut bridge_data = OutgoingBridgeTransactionData {
+        burn_proof: outgoing,
+        proof: SignatureProof::default(),
+    };
+
+    let mut tx = Transaction::new_extended(
+        bridge_address(),
+        AccountType::Bridge,
+        bridge_data.serialize_to_vec(),
+        target_address(),
+        AccountType::Basic,
+        vec![],
+        Coin::from_u64_unchecked(value),
+        Coin::from_u64_unchecked(fee),
+        fixture.validity_start_height,
+        NetworkId::UnitAlbatross,
+    );
+
+    // Sign the content while sender_data carries the default (empty) proof, then embed
+    // the real proof — the signature is verified over the default-proof content.
+    let signature = fixture.signer.sign(&tx.serialize_content());
+    bridge_data.set_signature(SignatureProof::from_ed25519(
+        fixture.signer.public,
+        signature,
+    ));
+    tx.sender_data = bridge_data.serialize_to_vec();
+
+    tx
+}
+
+/// A dummy micro block carrying `transactions`, used to drive `Mempool::update`.
+fn dummy_micro_block(transactions: Vec<Transaction>) -> Block {
+    let header = MicroHeader {
+        network: NetworkId::UnitAlbatross,
+        version: 0,
+        block_number: 1 + Policy::genesis_block_number(),
+        timestamp: 0,
+        parent_hash: Blake2bHash::default(),
+        seed: VrfSeed::default(),
+        extra_data: vec![0; 1],
+        state_root: Blake2bHash::default(),
+        body_root: Blake2sHash::default(),
+        diff_root: Blake2bHash::default(),
+        history_root: Blake2bHash::default(),
+        ..Default::default()
+    };
+    let body = MicroBody {
+        equivocation_proofs: vec![],
+        transactions: transactions
+            .into_iter()
+            .map(nimiq_transaction::ExecutedTransaction::Ok)
+            .collect(),
+    };
+    Block::Micro(MicroBlock {
+        header,
+        body: Some(body),
+        justification: None,
+    })
+}
+
+/// The signer fee is reserved against the signer at admission: a signer funded for only
+/// one fee gets exactly one of two burn-releases admitted, and the second is rejected on
+/// the signer's balance (not the bridge's, which has ample funds).
+#[test]
+fn signer_fee_is_reserved_against_signer_on_admission() {
+    let fixture = setup(FEE);
+
+    let tx1 = build_release(&fixture, RELEASE_VALUE, FEE);
+    let tx2 = build_release(&fixture, RELEASE_VALUE + 1, FEE);
+
+    assert!(
+        fixture.mempool.add_transaction(tx1.clone(), None).is_ok(),
+        "first burn-release should be admitted"
+    );
+    let res2 = fixture.mempool.add_transaction(tx2.clone(), None);
+    assert!(
+        matches!(res2, Err(VerifyErr::InvalidAccount(_))),
+        "second burn-release should be rejected because the signer cannot cover a second fee, got {res2:?}"
+    );
+
+    assert_eq!(fixture.mempool.num_transactions(), 1);
+    assert!(fixture.mempool.contains_transaction_by_hash(&tx1.hash()));
+    assert!(!fixture.mempool.contains_transaction_by_hash(&tx2.hash()));
+}
+
+/// Control for the test above: when the signer can cover both fees, both burn-releases
+/// are admitted. This isolates the signer-fee reservation as the cause of the rejection.
+#[test]
+fn both_releases_admitted_when_signer_covers_all_fees() {
+    let fixture = setup(2 * FEE);
+
+    let tx1 = build_release(&fixture, RELEASE_VALUE, FEE);
+    let tx2 = build_release(&fixture, RELEASE_VALUE + 1, FEE);
+
+    assert!(fixture.mempool.add_transaction(tx1, None).is_ok());
+    assert!(fixture.mempool.add_transaction(tx2, None).is_ok());
+    assert_eq!(fixture.mempool.num_transactions(), 2);
+}
+
+/// The signer fee is released when the release leaves the mempool: after the admitted
+/// release is removed (mined), the signer's reserved fee is freed and the previously
+/// rejected release can be admitted.
+#[test]
+fn signer_fee_is_released_when_release_is_removed() {
+    let fixture = setup(FEE);
+
+    let tx1 = build_release(&fixture, RELEASE_VALUE, FEE);
+    let tx2 = build_release(&fixture, RELEASE_VALUE + 1, FEE);
+
+    assert!(fixture.mempool.add_transaction(tx1.clone(), None).is_ok());
+    assert!(
+        fixture.mempool.add_transaction(tx2.clone(), None).is_err(),
+        "second release must be rejected while the signer fee is reserved"
+    );
+
+    // Mine tx1: `update` sees it as known and removes it, releasing the signer fee.
+    let block = dummy_micro_block(vec![tx1.clone()]);
+    fixture.mempool.update(&[(block.hash(), block)], &[]);
+    assert!(!fixture.mempool.contains_transaction_by_hash(&tx1.hash()));
+
+    // With the fee freed, tx2 is now admissible.
+    assert!(
+        fixture.mempool.add_transaction(tx2.clone(), None).is_ok(),
+        "second release should be admitted after the first one's fee is released"
+    );
+    assert_eq!(fixture.mempool.num_transactions(), 1);
+    assert!(fixture.mempool.contains_transaction_by_hash(&tx2.hash()));
+}
+
+/// The signer fee is re-reserved on the per-block rebuild (`recompute_sender_balances`):
+/// after an unrelated block adoption forces a rebuild, the admitted release survives and
+/// the signer's fee remains reserved, so a further release is still rejected.
+#[test]
+fn signer_fee_is_re_reserved_on_rebuild() {
+    let fixture = setup(FEE);
+
+    let tx1 = build_release(&fixture, RELEASE_VALUE, FEE);
+    assert!(fixture.mempool.add_transaction(tx1.clone(), None).is_ok());
+
+    // A non-empty adopted set forces `recompute_sender_balances` over every sender,
+    // re-reserving tx1's value and signer fee from scratch.
+    let block = dummy_micro_block(vec![]);
+    fixture.mempool.update(&[(block.hash(), block)], &[]);
+
+    assert_eq!(fixture.mempool.num_transactions(), 1);
+    assert!(
+        fixture.mempool.contains_transaction_by_hash(&tx1.hash()),
+        "the valid release must survive the rebuild"
+    );
+
+    // The fee is still reserved against the signer after the rebuild.
+    let tx2 = build_release(&fixture, RELEASE_VALUE + 1, FEE);
+    assert!(
+        fixture.mempool.add_transaction(tx2, None).is_err(),
+        "signer fee must remain reserved after the rebuild"
+    );
+}

--- a/primitives/account/src/account/bridge_contract/mod.rs
+++ b/primitives/account/src/account/bridge_contract/mod.rs
@@ -384,18 +384,14 @@ impl AccountTransactionInteraction for BridgeContract {
             }
         };
 
-        // Verify the oracle state index is valid
-        let oracle_state_index = outgoing_data.burn_proof.oracle_state_index as usize;
-        if oracle_state_index >= oracle.hashes.len() {
-            log::warn!(
-                oracle_state_index,
-                oracle_hashes_len = oracle.hashes.len(),
-                "Oracle state index out of bounds",
-            );
-            return Err(AccountError::InvalidTransaction(
-                TransactionError::InvalidData,
-            ));
-        }
+        // The relayer supplies a *global* index into the oracle's hash history.
+        // Validity is decided by `get_hash_at_index` below, which returns `None`
+        // (→ InvalidData) for any index outside the retained window
+        // [earliest_index, latest_index]. A physical `index >= oracle.hashes.len()`
+        // check would be wrong: `hashes` is a fixed-size ring buffer of length
+        // `hash_count`, so once it wraps, every valid global index is >= hash_count
+        // and would be rejected, permanently locking all withdrawals.
+        let oracle_state_index = outgoing_data.burn_proof.oracle_state_index;
 
         // Compute the leaf hash from burn transaction data
         let leaf_hash = outgoing_data
@@ -412,7 +408,7 @@ impl AccountTransactionInteraction for BridgeContract {
         let (prev_oracle_state_hash, current_oracle_state_hash) = {
             let prev_oracle_state_hash = if oracle_state_index > 0 {
                 oracle
-                    .get_hash_at_index(oracle_state_index.saturating_sub(1) as u64)
+                    .get_hash_at_index(oracle_state_index.saturating_sub(1))
                     .ok_or(AccountError::InvalidTransaction(
                         TransactionError::InvalidData,
                     ))?
@@ -421,7 +417,7 @@ impl AccountTransactionInteraction for BridgeContract {
             };
             (
                 prev_oracle_state_hash,
-                oracle.get_hash_at_index(oracle_state_index as u64).ok_or(
+                oracle.get_hash_at_index(oracle_state_index).ok_or(
                     AccountError::InvalidTransaction(TransactionError::InvalidData),
                 )?,
             )

--- a/primitives/account/src/account/bridge_contract/mod.rs
+++ b/primitives/account/src/account/bridge_contract/mod.rs
@@ -9,7 +9,7 @@ use nimiq_transaction::account::bridge_contract::{
     CreationTransactionData, OutgoingBridgeTransactionData,
 };
 #[cfg(feature = "interaction-traits")]
-use nimiq_transaction::{inherent::Inherent, HashType, SignatureProof, Transaction};
+use nimiq_transaction::{inherent::Inherent, HashType, Transaction};
 #[cfg(feature = "interaction-traits")]
 pub use store::BridgeContractStoreWrite;
 pub use store::BridgeNonce;
@@ -80,21 +80,12 @@ impl BridgeContract {
         new_balance: Coin,
         is_reserve: bool,
     ) -> Result<(), AccountError> {
-        // For outgoing transactions (bridge is sender), the signature is in sender_data
-        // For incoming transactions (bridge is recipient), the signature is in proof
-        let signature_proof = if transaction.sender_type == AccountType::Bridge {
-            // Outgoing transaction - signature is in sender_data
-            let outgoing_data =
-                OutgoingBridgeTransactionData::deserialize_all(&transaction.sender_data)?;
-            outgoing_data.proof
-        } else {
-            // Incoming transaction - signature is in proof field
-            SignatureProof::deserialize_all(&transaction.proof)?
-        };
-
-        if !signature_proof.is_signed_by(&self.owner) {
-            return Err(AccountError::InvalidSignature);
-        }
+        // Outgoing bridge transactions are permissionless burn-releases: the Merkle
+        // burn-proof verified in `commit_outgoing_transaction` is the sole authorization,
+        // so we deliberately do NOT require the owner's signature here. Requiring it made
+        // `reserve_balance` (mempool admission) reject the very transactions that `commit`
+        // accepts, diverging the mempool from consensus and breaking permissionless
+        // submission. Balance availability is still enforced by `reserve_balance` itself.
 
         // If withdrawing, must withdraw the full balance (contract deletion)
         if new_balance < self.balance {

--- a/primitives/account/src/account/bridge_contract/mod.rs
+++ b/primitives/account/src/account/bridge_contract/mod.rs
@@ -427,6 +427,22 @@ impl AccountTransactionInteraction for BridgeContract {
             )
         };
 
+        // Reject proofs that exceed the chain's configured maximum depth.
+        // An empty proof is valid (single-leaf tree where leaf == root).
+        if !outgoing_data
+            .burn_proof
+            .is_proof_depth_valid(self.chain_config.max_proof_depth)
+        {
+            log::warn!(
+                proof_depth = outgoing_data.burn_proof.proof_depth(),
+                max_depth = self.chain_config.max_proof_depth,
+                "Merkle proof exceeds maximum allowed depth"
+            );
+            return Err(AccountError::InvalidTransaction(
+                TransactionError::InvalidProof,
+            ));
+        }
+
         // Verify the merkle proof
         let merkle_root = outgoing_data
             .burn_proof
@@ -505,22 +521,17 @@ impl AccountTransactionInteraction for BridgeContract {
             .map(|n| n.nonce)
             .unwrap_or(0);
 
-        if current_nonce == receipt.nonce {
-            // Remove the nonce entry if it matches
-            store.remove_nonce(&receipt.target_address);
+        // Restore the previous nonce. If the reverted nonce was 1 (the first ever for
+        // this address), remove the entry entirely so state matches the pre-tx condition.
+        if receipt.nonce > 1 {
+            store.put_nonce(
+                &receipt.target_address,
+                BridgeNonce {
+                    nonce: receipt.nonce - 1,
+                },
+            );
         } else {
-            // If nonce doesn't match, restore the previous nonce
-            // This handles the case where multiple transactions were processed
-            if receipt.nonce > 0 {
-                store.put_nonce(
-                    &receipt.target_address,
-                    BridgeNonce {
-                        nonce: receipt.nonce - 1,
-                    },
-                );
-            } else {
-                store.remove_nonce(&receipt.target_address);
-            }
+            store.remove_nonce(&receipt.target_address);
         }
 
         // Decrement transaction count

--- a/primitives/account/src/account/bridge_contract/mod.rs
+++ b/primitives/account/src/account/bridge_contract/mod.rs
@@ -559,14 +559,17 @@ impl AccountTransactionInteraction for BridgeContract {
         _block_state: &BlockState,
         _data_store: DataStoreRead,
     ) -> Result<(), AccountError> {
+        // Only the released `value` comes from the bridge balance. The fee is paid by
+        // the burn-proof signer (see `Accounts::charge_fee_to_signer`), so it is reserved
+        // against the signer's account by the mempool, not against the bridge here.
         let needed = reserved_balance
             .balance()
-            .checked_add(transaction.total_value())
+            .checked_add(transaction.value)
             .ok_or(AccountError::InvalidCoinValue)?;
         let new_balance = self.balance.safe_sub(needed)?;
         self.can_change_balance(transaction, new_balance, true)?;
 
-        reserved_balance.reserve(self.balance, transaction.total_value())
+        reserved_balance.reserve(self.balance, transaction.value)
     }
 
     fn release_balance(
@@ -575,7 +578,7 @@ impl AccountTransactionInteraction for BridgeContract {
         reserved_balance: &mut ReservedBalance,
         _data_store: DataStoreRead,
     ) -> Result<(), AccountError> {
-        reserved_balance.release(transaction.total_value());
+        reserved_balance.release(transaction.value);
         Ok(())
     }
 }

--- a/primitives/account/src/account/bridge_contract/mod.rs
+++ b/primitives/account/src/account/bridge_contract/mod.rs
@@ -516,11 +516,6 @@ impl AccountTransactionInteraction for BridgeContract {
         // Revert nonce update in the accounts tree
         let mut store = BridgeContractStoreWrite::new(&mut data_store);
 
-        let current_nonce = store
-            .get_nonce(&receipt.target_address)
-            .map(|n| n.nonce)
-            .unwrap_or(0);
-
         // Restore the previous nonce. If the reverted nonce was 1 (the first ever for
         // this address), remove the entry entirely so state matches the pre-tx condition.
         if receipt.nonce > 1 {

--- a/primitives/account/src/account/oracle_contract.rs
+++ b/primitives/account/src/account/oracle_contract.rs
@@ -198,6 +198,24 @@ impl AccountTransactionInteraction for OracleContract {
                     // Validate that all new hashes match the contract's hash type
                     self.validate_hash_types(&hashes)?;
 
+                    // A *non-first* update may not write more hashes than the ring
+                    // buffer holds. With more than `hash_count` hashes the update
+                    // wraps over its own positions, so `removed_hashes` captures a
+                    // value written earlier *in the same update* instead of the true
+                    // pre-transaction value; the revert then restores that wrong
+                    // value and diverges the accounts-tree root on a reorg (a
+                    // consensus fork). The eviction receipt and the revert index math
+                    // both assume at most one write per position, which this
+                    // guarantees. The first-ever update is exempt: its revert clears
+                    // the buffer back to the fresh (empty) state via the
+                    // `num_hashes > current_latest` branch and never consults
+                    // `removed_hashes`, so the double-write cannot corrupt it.
+                    if self.latest_index.is_some() && hashes.len() > self.hash_count as usize {
+                        return Err(AccountError::InvalidTransaction(
+                            TransactionError::InvalidData,
+                        ));
+                    }
+
                     // Empty update: no state change, no log
                     if hashes.is_empty() {
                         return Ok(None);

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -656,7 +656,10 @@ impl Accounts {
     /// `transaction.proof`. The latter is never verified for `AccountType::Bridge`
     /// senders, so deriving the fee payer from it would let a submitter charge the
     /// fee to an arbitrary account by placing any public key in `transaction.proof`.
-    fn extract_signer_address(&self, transaction: &Transaction) -> Result<Address, AccountError> {
+    pub fn extract_signer_address(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<Address, AccountError> {
         debug_assert_eq!(transaction.sender_type, AccountType::Bridge);
 
         let outgoing_data = OutgoingBridgeTransactionData::parse(transaction)

--- a/primitives/account/src/accounts.rs
+++ b/primitives/account/src/accounts.rs
@@ -425,6 +425,34 @@ impl Accounts {
             tx_logger,
         )?;
 
+        // For outgoing bridge transactions, charge the fee to the burn-proof
+        // signer. `BridgeContract::commit_outgoing_transaction` debits only the
+        // released value from the bridge (burn proofs are permissionless), so the
+        // fee must be taken from the signer here — otherwise it is credited to the
+        // reward pot without ever being debited, inflating the total supply. On
+        // failure, revert the sender so this method stays atomic and the retry as
+        // a failed transaction starts from clean state.
+        let fee_payer =
+            if transaction.sender_type == AccountType::Bridge && transaction.fee != Coin::ZERO {
+                match self.charge_fee_to_signer(txn, transaction, tx_logger) {
+                    Ok(signer_address) => Some(signer_address),
+                    Err(e) => {
+                        sender_account
+                            .revert_outgoing_transaction(
+                                transaction,
+                                block_state,
+                                sender_receipt,
+                                sender_store.write(txn),
+                                tx_logger,
+                            )
+                            .expect("failed to revert sender account");
+                        return Err(e);
+                    }
+                }
+            } else {
+                None
+            };
+
         // Commit recipient.
         let recipient_address = &transaction.recipient;
         let mut recipient_account = Account::default();
@@ -438,8 +466,12 @@ impl Accounts {
             tx_logger,
         );
 
-        // If recipient failed, revert sender.
+        // If recipient failed, revert the fee charge (if any) and the sender.
         if let Err(e) = recipient_result {
+            if let Some(ref signer_address) = fee_payer {
+                self.restore_fee_to_signer(txn, transaction, signer_address, None, tx_logger)
+                    .expect("failed to refund fee to signer");
+            }
             sender_account
                 .revert_outgoing_transaction(
                     transaction,
@@ -463,7 +495,7 @@ impl Accounts {
             sender_receipt,
             recipient_receipt: recipient_result.unwrap(),
             pruned_account,
-            fee_payer: None, // Normal transaction, sender paid the fee
+            fee_payer,
         })
     }
 
@@ -632,6 +664,49 @@ impl Accounts {
 
         // Compute signer address from the verified proof's public key.
         let signer_address = outgoing_data.proof.compute_signer();
+
+        Ok(signer_address)
+    }
+
+    /// Charges the transaction fee to the burn-proof signer for a *successful*
+    /// outgoing bridge transaction, mirroring the failed-transaction path.
+    ///
+    /// `BridgeContract::commit_outgoing_transaction` debits only the released
+    /// `value` from the bridge, never the fee: burn proofs are submitted
+    /// permissionlessly, so the fee is charged to whoever signed the proof
+    /// (`OutgoingBridgeTransactionData.proof`, the signature bridge verification
+    /// actually checks), not to the bridge balance. Without this the fee would
+    /// still be credited to the validator reward pot while never being debited
+    /// from any account, inflating the total supply.
+    ///
+    /// Returns the signer address so it can be recorded as `fee_payer` and
+    /// refunded on revert via [`Self::restore_fee_to_signer`].
+    fn charge_fee_to_signer(
+        &self,
+        txn: &mut WriteTransactionProxy,
+        transaction: &Transaction,
+        tx_logger: &mut TransactionLog,
+    ) -> Result<Address, AccountError> {
+        let signer_address = self.extract_signer_address(transaction)?;
+
+        let mut signer_account = self.get_with_type(txn, &signer_address, AccountType::Basic)?;
+
+        if let Account::Basic(ref mut basic_account) = signer_account {
+            // Errors with InsufficientFunds if the signer cannot cover the fee.
+            basic_account.balance.safe_sub_assign(transaction.fee)?;
+            tx_logger.push_log(Log::PayFee {
+                from: signer_address.clone(),
+                fee: transaction.fee,
+            });
+        } else {
+            log::error!(
+                signer_address = %signer_address,
+                "Bridge transaction signer is not a BasicAccount"
+            );
+            return Err(AccountError::InvalidForSender);
+        }
+
+        self.put_or_prune(txn, &signer_address, signer_account);
 
         Ok(signer_address)
     }
@@ -815,6 +890,15 @@ impl Accounts {
             // Update or prune recipient.
             // The recipient account might have been created by the incoming transaction.
             self.put_or_prune(txn, recipient_address, recipient_account);
+        }
+
+        // Refund the fee to the burn-proof signer for outgoing bridge transactions
+        // (mirrors the fee charged in `try_commit_transaction`). `fee_payer` is
+        // `None` for every other transaction, so this is a no-op there. Placed
+        // between the recipient and sender reverts to invert the commit order
+        // (sender, fee, recipient).
+        if let Some(fee_payer_address) = receipt.fee_payer {
+            self.restore_fee_to_signer(txn, transaction, &fee_payer_address, None, tx_logger)?;
         }
 
         // Revert sender. It might need to be restored first if it was pruned.

--- a/primitives/account/tests/bridge_account_tests.rs
+++ b/primitives/account/tests/bridge_account_tests.rs
@@ -774,6 +774,73 @@ fn bridge_outgoing_rejects_oracle_index_out_of_bounds() {
     ));
 }
 
+/// Regression: once the oracle ring buffer wraps, valid global indices are
+/// `>= hash_count`. The old `oracle_state_index >= oracle.hashes.len()` guard
+/// rejected them, permanently locking every withdrawal. Here `hash_count = 2`
+/// and the buffer has wrapped (`latest_index = 2`), so the burn's covering state
+/// lives at global index 2; the release against index 2 must commit.
+#[test]
+fn bridge_outgoing_succeeds_with_wrapped_oracle_index() {
+    let owner = KeyPair::generate_default_csprng();
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let leaf = blake2b(&burn_data);
+    let zero = leaf.zero_of_same_type();
+    // Oracle chain: data_i = H(data_{i-1} || state_i); state_2 is the burn's leaf,
+    // so a proof covering index 2 verifies. state_0/state_1 are arbitrary.
+    let data_0 = zero.digest(&blake2b(b"state0"));
+    let data_1 = data_0.digest(&blake2b(b"state1"));
+    let data_2 = data_1.digest(&leaf);
+    // Ring buffer of size 2 after writing indices 0,1,2: pos0 = index 2, pos1 = index 1.
+    // earliest_index = 1, so index 0 is evicted and the retained window is [1, 2].
+    let oracle = OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count: 2,
+        hashes: vec![data_2, data_1],
+        latest_index: Some(2),
+    };
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 0,
+    };
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+    ]);
+
+    // Release against global oracle index 2 (== hash_count, i.e. past the wrap).
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data,
+        2,
+        &owner,
+    );
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let receipts = test
+        .commit_and_test(&[tx], &[], &bs, &mut BlockLogger::empty())
+        .expect("release against a wrapped-oracle index must commit");
+
+    assert!(
+        matches!(receipts.transactions[0], OperationReceipt::Ok(_)),
+        "release against global index >= hash_count must succeed after wrap",
+    );
+    assert_eq!(
+        test.get_complete(&bridge_addr(), None).balance(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT - RELEASE_AMOUNT),
+    );
+    assert_eq!(
+        test.get_complete(&nimiq_target(), None).balance(),
+        Coin::from_u64_unchecked(RELEASE_AMOUNT),
+    );
+}
+
 /// Merkle proof doesn't match oracle state hash → rejected.
 #[test]
 fn bridge_outgoing_rejects_wrong_merkle_proof() {

--- a/primitives/account/tests/bridge_account_tests.rs
+++ b/primitives/account/tests/bridge_account_tests.rs
@@ -533,6 +533,103 @@ fn bridge_outgoing_commit_success() {
     assert!(matches!(receipts.transactions[0], OperationReceipt::Ok(_)));
 }
 
+/// A *successful* outgoing bridge transaction with a non-zero fee must debit the
+/// fee from the burn-proof signer, not mint it. The bridge releases only `value`
+/// and the fee is still paid into the reward pot, so without a signer debit the
+/// total supply would inflate by exactly the fee. `commit_and_test` also verifies
+/// the commit/revert round-trip (state root + logs), covering the fee refund.
+#[test]
+fn bridge_outgoing_success_charges_fee_to_signer() {
+    let owner = KeyPair::generate_default_csprng();
+    let signer_address = Address::from(&owner.public);
+    let initial_signer_balance = Coin::from_u64_unchecked(10_000);
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data);
+    let bridge = BridgeContract {
+        owner: signer_address.clone(),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 0,
+    };
+    // The target is intentionally not seeded: a zero-balance account is never
+    // stored in the trie (it is created by the release and pruned again on
+    // revert), so seeding it would make the revert root-hash check spuriously
+    // fail against the pruned post-revert trie.
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+        (
+            signer_address.clone(),
+            Account::Basic(BasicAccount {
+                balance: initial_signer_balance,
+            }),
+        ),
+    ]);
+
+    // Build a signed outgoing bridge transaction with a non-zero fee. The proof
+    // in `sender_data` is signed by `owner`, so the fee payer is the owner.
+    let fee = Coin::from_u64_unchecked(10);
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        merkle_proof: AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        oracle_state_index: 0,
+    };
+    let mut bridge_data = OutgoingBridgeTransactionData {
+        burn_proof: outgoing,
+        proof: SignatureProof::default(),
+    };
+    let mut tx = Transaction::new_extended(
+        bridge_addr(),
+        AccountType::Bridge,
+        bridge_data.serialize_to_vec(),
+        nimiq_target(),
+        AccountType::Basic,
+        vec![],
+        Coin::from_u64_unchecked(RELEASE_AMOUNT),
+        fee,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+    let sig = owner.sign(&tx.serialize_content());
+    bridge_data.set_signature(SignatureProof::from_ed25519(owner.public.clone(), sig));
+    tx.sender_data = bridge_data.serialize_to_vec();
+
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let receipts = test
+        .commit_and_test(&[tx], &[], &bs, &mut BlockLogger::empty())
+        .expect("successful outgoing commit");
+
+    // The fee payer is recorded as the burn-proof signer (so revert can refund it).
+    match &receipts.transactions[0] {
+        OperationReceipt::Ok(receipt) => assert_eq!(
+            receipt.fee_payer,
+            Some(signer_address.clone()),
+            "fee payer must be the burn-proof signer",
+        ),
+        other => panic!("expected a successful receipt, got {other:?}"),
+    }
+
+    // Value leaves the bridge, the fee leaves the signer, the target gets the value.
+    assert_eq!(
+        test.get_complete(&bridge_addr(), None).balance(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT - RELEASE_AMOUNT),
+        "bridge debits exactly the released value",
+    );
+    assert_eq!(
+        test.get_complete(&signer_address, None).balance(),
+        initial_signer_balance - fee,
+        "fee is debited from the signer (no supply inflation)",
+    );
+    assert_eq!(
+        test.get_complete(&nimiq_target(), None).balance(),
+        Coin::from_u64_unchecked(RELEASE_AMOUNT),
+        "target receives the released value",
+    );
+}
+
 /// Wrong chain_id in burn data → rejected.
 #[test]
 fn bridge_outgoing_rejects_wrong_chain_id() {

--- a/primitives/account/tests/bridge_account_tests.rs
+++ b/primitives/account/tests/bridge_account_tests.rs
@@ -1,0 +1,1223 @@
+use nimiq_account::{
+    Account, BasicAccount, BlockLogger, BlockState, BridgeContract, OperationReceipt,
+    OracleContract, Receipts, RevertInfo, TransactionLog,
+};
+use nimiq_database::traits::{Database, WriteTransaction};
+use nimiq_hash::{Blake2bHasher, HashOutput, Hasher};
+use nimiq_keys::{Address, KeyPair};
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
+use nimiq_serde::Serialize;
+use nimiq_test_log::test;
+use nimiq_test_utils::accounts_revert::TestCommitRevert;
+use nimiq_transaction::{
+    account::{
+        bridge_contract::OutgoingBridgeTransactionData,
+        htlc_contract::{AnyHash, AnyHash32},
+        oracle_contract::{
+            CreationTransactionData as OracleCreationData, IncomingOracleTransactionData,
+        },
+    },
+    bridge_contract::{
+        AddressFormat, AnyMerkleProof, ChainConfig, CreationTransactionData as BridgeCreationData,
+        Endianness, OutgoingTransaction, ValidationOp, ValidationProgram,
+    },
+    SignatureProof, Transaction,
+};
+use nimiq_utils::{key_rng::SecureGenerate, merkle::MerklePath};
+
+// =====================================================================
+// Shared constants and helpers
+// =====================================================================
+
+const SOURCE_CHAIN_ID: u32 = 1;
+const RELEASE_AMOUNT: u64 = 500;
+const BURN_BLOCK_HEIGHT: u32 = 42;
+const BRIDGE_DEPOSIT: u64 = 10_000;
+
+fn nimiq_target() -> Address {
+    Address::from([0xAAu8; 20])
+}
+
+fn oracle_addr() -> Address {
+    Address::from([0x0Eu8; 20])
+}
+
+fn bridge_addr() -> Address {
+    Address::from([0x0Bu8; 20])
+}
+
+fn chain_config() -> ChainConfig {
+    ChainConfig {
+        chain_id: SOURCE_CHAIN_ID,
+        hash_function: AnyHash::Blake2b(AnyHash32::default()),
+        address_format: AddressFormat::Nimiq,
+        endianness: Endianness::LittleEndian,
+        block_time: std::time::Duration::from_secs(60),
+        validation_program: standard_program(),
+        max_proof_depth: 64,
+    }
+}
+
+/// ValidationProgram that reads all required fields from burn_data:
+///   [0..20]  target_address  [20..28] amount  [28..36] nonce
+///   [36..40] burn_block_height  [40..44] target_chain_id
+fn standard_program() -> ValidationProgram {
+    ValidationProgram::new(vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::LoadAddress,
+        ValidationOp::Store("target_address".to_string()),
+        ValidationOp::PushConst(20),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("amount".to_string()),
+        ValidationOp::PushConst(28),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("target_nonce".to_string()),
+        ValidationOp::PushConst(36),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("burn_block_height".to_string()),
+        ValidationOp::PushConst(40),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("target_chain_id".to_string()),
+    ])
+}
+
+fn make_burn_data(target: [u8; 20], amount: u64, nonce: u64, chain_id: u32) -> Vec<u8> {
+    let mut d = Vec::with_capacity(44);
+    d.extend_from_slice(&target);
+    d.extend_from_slice(&amount.to_le_bytes());
+    d.extend_from_slice(&nonce.to_le_bytes());
+    d.extend_from_slice(&BURN_BLOCK_HEIGHT.to_le_bytes());
+    d.extend_from_slice(&chain_id.to_le_bytes());
+    d
+}
+
+fn blake2b(data: &[u8]) -> AnyHash {
+    let h = Blake2bHasher::default().digest(data);
+    AnyHash::Blake2b(AnyHash32::from(<[u8; 32]>::try_from(h.as_bytes()).unwrap()))
+}
+
+/// Build an oracle whose first state-hash is derived from `burn_data`.
+/// oracle.hashes[0] = zero.digest(Blake2b(burn_data))
+fn make_single_state_oracle(burn_data: &[u8]) -> OracleContract {
+    let leaf = blake2b(burn_data);
+    let zero = leaf.zero_of_same_type();
+    let hash_0 = zero.digest(&leaf);
+    let hash_count: u16 = 10;
+    let mut hashes = vec![zero; hash_count as usize];
+    hashes[0] = hash_0;
+    OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count,
+        hashes,
+        latest_index: Some(0),
+    }
+}
+
+/// Build a signed outgoing bridge transaction.
+fn make_outgoing_tx(
+    bridge: &Address,
+    target: &Address,
+    amount: u64,
+    burn_data: Vec<u8>,
+    oracle_state_index: u64,
+    owner: &KeyPair,
+) -> Transaction {
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        merkle_proof: AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        oracle_state_index,
+    };
+    let mut bridge_data = OutgoingBridgeTransactionData {
+        burn_proof: outgoing,
+        proof: SignatureProof::default(),
+    };
+    let mut tx = Transaction::new_extended(
+        bridge.clone(),
+        AccountType::Bridge,
+        bridge_data.serialize_to_vec(),
+        target.clone(),
+        AccountType::Basic,
+        vec![],
+        Coin::from_u64_unchecked(amount),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+    let sig = owner.sign(&tx.serialize_content());
+    bridge_data.set_signature(SignatureProof::from_ed25519(owner.public.clone(), sig));
+    tx.sender_data = bridge_data.serialize_to_vec();
+    tx
+}
+
+fn commit_block(test: &TestCommitRevert, txs: &[Transaction], bs: &BlockState) -> Receipts {
+    let env = test.env();
+    let mut raw = env.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw).into();
+    let r = test
+        .commit(&mut txn, txs, &[], bs, &mut BlockLogger::empty())
+        .unwrap();
+    raw.commit();
+    r
+}
+
+fn revert_block(test: &TestCommitRevert, txs: &[Transaction], r: Receipts, bs: &BlockState) {
+    let env = test.env();
+    let mut raw = env.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw).into();
+    test.revert(
+        &mut txn,
+        txs,
+        &[],
+        bs,
+        RevertInfo::Receipts(r),
+        &mut BlockLogger::empty_reverted(),
+    )
+    .unwrap();
+    raw.commit();
+}
+
+// =====================================================================
+// Bridge: create_new_contract
+// =====================================================================
+
+/// Success path: oracle present in trie with matching hash type.
+#[test]
+fn bridge_create_success_with_matching_oracle() {
+    let owner = KeyPair::generate_default_csprng();
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data);
+
+    let test = TestCommitRevert::with_initial_state(&[(oracle_addr(), Account::Oracle(oracle))]);
+
+    let creation_data = BridgeCreationData {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+    };
+    let tx = Transaction::new_contract_creation(
+        Address::from(&owner.public),
+        AccountType::Basic,
+        vec![],
+        AccountType::Bridge,
+        creation_data.serialize_to_vec(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    let mut logger = TransactionLog::empty();
+    let account = test
+        .test_create_new_contract::<BridgeContract>(
+            &tx,
+            Coin::ZERO,
+            &BlockState::new(1, 1, Policy::max_supported_version()),
+            &mut logger,
+            false,
+        )
+        .expect("creation should succeed");
+
+    let bridge = match account {
+        Account::Bridge(b) => b,
+        _ => panic!("wrong account type"),
+    };
+    assert_eq!(bridge.owner, Address::from(&owner.public));
+    assert_eq!(bridge.oracle_address, oracle_addr());
+    assert_eq!(bridge.source_chain_id, SOURCE_CHAIN_ID);
+    assert_eq!(bridge.balance, Coin::from_u64_unchecked(BRIDGE_DEPOSIT));
+    assert_eq!(bridge.transaction_count, 0);
+}
+
+/// Oracle address doesn't exist in trie → creation rejected.
+#[test]
+fn bridge_create_rejects_when_oracle_missing() {
+    let owner = KeyPair::generate_default_csprng();
+
+    // No oracle in initial state
+    let test = TestCommitRevert::with_initial_state(&[]);
+
+    let creation_data = BridgeCreationData {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+    };
+    let tx = Transaction::new_contract_creation(
+        Address::from(&owner.public),
+        AccountType::Basic,
+        vec![],
+        AccountType::Bridge,
+        creation_data.serialize_to_vec(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    let result = test.test_create_new_contract::<BridgeContract>(
+        &tx,
+        Coin::ZERO,
+        &BlockState::new(1, 1, Policy::max_supported_version()),
+        &mut TransactionLog::empty(),
+        false,
+    );
+    assert!(result.is_err(), "creation must fail when oracle is absent");
+}
+
+/// Oracle address points to a basic account, not an oracle contract → rejected.
+#[test]
+fn bridge_create_rejects_when_oracle_addr_is_not_oracle_contract() {
+    let owner = KeyPair::generate_default_csprng();
+
+    // Put a basic account at the oracle address
+    let test = TestCommitRevert::with_initial_state(&[(
+        oracle_addr(),
+        Account::Basic(BasicAccount {
+            balance: Coin::from_u64_unchecked(1_000),
+        }),
+    )]);
+
+    let creation_data = BridgeCreationData {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+    };
+    let tx = Transaction::new_contract_creation(
+        Address::from(&owner.public),
+        AccountType::Basic,
+        vec![],
+        AccountType::Bridge,
+        creation_data.serialize_to_vec(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    let result = test.test_create_new_contract::<BridgeContract>(
+        &tx,
+        Coin::ZERO,
+        &BlockState::new(1, 1, Policy::max_supported_version()),
+        &mut TransactionLog::empty(),
+        false,
+    );
+    assert!(
+        result.is_err(),
+        "creation must fail when oracle addr is a basic account"
+    );
+}
+
+/// Oracle exists but uses a different hash type than the bridge ChainConfig → rejected.
+#[test]
+fn bridge_create_rejects_hash_type_mismatch_with_oracle() {
+    let owner = KeyPair::generate_default_csprng();
+
+    // Oracle has a Keccak256 hash stored
+    use nimiq_hash::Keccak256Hasher;
+    let keccak_hash = {
+        let h = Keccak256Hasher::default().digest(b"state");
+        AnyHash::Keccak256(AnyHash32::from(<[u8; 32]>::try_from(h.as_bytes()).unwrap()))
+    };
+    let zero = keccak_hash.zero_of_same_type();
+    let hash_count: u16 = 5;
+    let mut hashes = vec![zero.clone(); hash_count as usize];
+    hashes[0] = zero.digest(&keccak_hash);
+    let oracle = OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count,
+        hashes,
+        latest_index: Some(0),
+    };
+
+    let test = TestCommitRevert::with_initial_state(&[(oracle_addr(), Account::Oracle(oracle))]);
+
+    // Bridge ChainConfig uses Blake2b — mismatch with oracle's Keccak256
+    let creation_data = BridgeCreationData {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(), // Blake2b
+    };
+    let tx = Transaction::new_contract_creation(
+        Address::from(&owner.public),
+        AccountType::Basic,
+        vec![],
+        AccountType::Bridge,
+        creation_data.serialize_to_vec(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    let result = test.test_create_new_contract::<BridgeContract>(
+        &tx,
+        Coin::ZERO,
+        &BlockState::new(1, 1, Policy::max_supported_version()),
+        &mut TransactionLog::empty(),
+        false,
+    );
+    assert!(result.is_err(), "creation must fail when hash types differ");
+}
+
+/// Oracle exists but has no hashes yet → any hash type accepted.
+#[test]
+fn bridge_create_accepts_empty_oracle_any_hash_type() {
+    let owner = KeyPair::generate_default_csprng();
+
+    // Oracle with no hashes yet
+    let oracle = OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count: 5,
+        hashes: Vec::new(),
+        latest_index: None,
+    };
+
+    let test = TestCommitRevert::with_initial_state(&[(oracle_addr(), Account::Oracle(oracle))]);
+
+    let creation_data = BridgeCreationData {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+    };
+    let tx = Transaction::new_contract_creation(
+        Address::from(&owner.public),
+        AccountType::Basic,
+        vec![],
+        AccountType::Bridge,
+        creation_data.serialize_to_vec(),
+        Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    let result = test.test_create_new_contract::<BridgeContract>(
+        &tx,
+        Coin::ZERO,
+        &BlockState::new(1, 1, Policy::max_supported_version()),
+        &mut TransactionLog::empty(),
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "creation must succeed when oracle has no hashes yet"
+    );
+}
+
+// =====================================================================
+// Bridge: commit/revert incoming transaction
+// =====================================================================
+
+fn make_bridge_state(owner: &KeyPair) -> (TestCommitRevert, OracleContract) {
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data);
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 0,
+    };
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle.clone())),
+        (bridge_addr(), Account::Bridge(bridge)),
+    ]);
+    (test, oracle)
+}
+
+/// commit_incoming_transaction increments balance and transaction_count; revert restores both.
+#[test]
+fn bridge_incoming_commit_revert_roundtrip() {
+    let owner = KeyPair::generate_default_csprng();
+    let sender_addr = Address::from(&owner.public);
+    let deposit = Coin::from_u64_unchecked(300);
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data);
+    let bridge = BridgeContract {
+        owner: sender_addr.clone(),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 0,
+    };
+    // Sender must have enough balance to cover the deposit
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+        (
+            sender_addr.clone(),
+            Account::Basic(BasicAccount {
+                balance: Coin::from_u64_unchecked(10_000),
+            }),
+        ),
+    ]);
+
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let tx = Transaction::new_extended(
+        sender_addr,
+        AccountType::Basic,
+        vec![],
+        bridge_addr(),
+        AccountType::Bridge,
+        vec![],
+        deposit,
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    // commit_and_test commits, verifies revert is clean, and keeps the commit
+    let receipts = test
+        .commit_and_test(&[tx], &[], &bs, &mut BlockLogger::empty())
+        .expect("incoming commit should succeed");
+
+    assert!(
+        matches!(receipts.transactions[0], OperationReceipt::Ok(_)),
+        "incoming transaction must succeed"
+    );
+}
+
+// =====================================================================
+// Bridge: commit_outgoing_transaction rejection paths
+// =====================================================================
+
+fn setup_outgoing_env() -> (TestCommitRevert, KeyPair, Vec<u8>) {
+    let owner = KeyPair::generate_default_csprng();
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data);
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 0,
+    };
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+        (
+            nimiq_target(),
+            Account::Basic(BasicAccount {
+                balance: Coin::ZERO,
+            }),
+        ),
+    ]);
+    (test, owner, burn_data)
+}
+
+/// Happy path: valid outgoing tx is committed and balance decremented.
+#[test]
+fn bridge_outgoing_commit_success() {
+    let (test, owner, burn_data) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data,
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(receipts.transactions[0], OperationReceipt::Ok(_)));
+}
+
+/// Wrong chain_id in burn data → rejected.
+#[test]
+fn bridge_outgoing_rejects_wrong_chain_id() {
+    let (test, owner, _) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let wrong_chain_id = SOURCE_CHAIN_ID + 1;
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, wrong_chain_id);
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data,
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+/// Transaction recipient doesn't match burn data target address → rejected.
+#[test]
+fn bridge_outgoing_rejects_wrong_recipient() {
+    let (test, owner, burn_data) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let wrong_recipient = Address::from([0xBBu8; 20]);
+    // burn_data has [0xAA; 20] as target, but tx recipient is [0xBB; 20]
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &wrong_recipient,
+        RELEASE_AMOUNT,
+        burn_data,
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+/// Transaction value doesn't match burn data amount → rejected.
+#[test]
+fn bridge_outgoing_rejects_wrong_value() {
+    let (test, owner, burn_data) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let wrong_amount = RELEASE_AMOUNT + 1;
+    // burn_data says RELEASE_AMOUNT, but tx sends wrong_amount
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        wrong_amount,
+        burn_data,
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+/// Nonce gap: nonce=2 submitted when no prior nonce exists (expected nonce=1) → rejected.
+#[test]
+fn bridge_outgoing_rejects_nonce_gap() {
+    let owner = KeyPair::generate_default_csprng();
+    // Build oracle for nonce=2 burn data
+    let burn_data_2 = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 2, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data_2);
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 0,
+    };
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+    ]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    // No nonce=1 has been processed; submitting nonce=2 directly is a gap
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data_2,
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+/// Same nonce submitted twice → second submission rejected.
+#[test]
+fn bridge_outgoing_rejects_duplicate_nonce() {
+    let (test, owner, burn_data) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data,
+        0,
+        &owner,
+    );
+    // First submission succeeds
+    let r1 = commit_block(&test, &[tx.clone()], &bs);
+    assert!(matches!(r1.transactions[0], OperationReceipt::Ok(_)));
+    // Second identical submission must fail (nonce=1 already used)
+    let r2 = commit_block(&test, &[tx], &bs);
+    assert!(matches!(r2.transactions[0], OperationReceipt::Err(_, _)));
+}
+
+/// Oracle state index out of bounds → rejected.
+#[test]
+fn bridge_outgoing_rejects_oracle_index_out_of_bounds() {
+    let (test, owner, burn_data) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    // Oracle has only index 0; submitting index 5 is out of bounds
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data,
+        5,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+/// Merkle proof doesn't match oracle state hash → rejected.
+#[test]
+fn bridge_outgoing_rejects_wrong_merkle_proof() {
+    let (test, owner, _) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    // Use burn_data for a completely different transaction — leaf hash won't match oracle
+    let wrong_burn_data = make_burn_data([0xFFu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &Address::from([0xFFu8; 20]),
+        RELEASE_AMOUNT,
+        wrong_burn_data,
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+/// Proof depth exceeds max_proof_depth → rejected.
+#[test]
+fn bridge_outgoing_rejects_proof_depth_exceeded() {
+    let owner = KeyPair::generate_default_csprng();
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data);
+
+    // Bridge with a very tight max_proof_depth of 1
+    let mut cfg = chain_config();
+    cfg.max_proof_depth = 1;
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: cfg,
+        transaction_count: 0,
+    };
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+    ]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+
+    // Build a proof with 2 sibling nodes — exceeds max_proof_depth=1
+    use nimiq_hash::Blake2bHash;
+    use nimiq_utils::merkle::MerkleProof;
+    let dummy = Blake2bHasher::default().digest(b"a");
+    let proof =
+        MerkleProof::<Blake2bHash>::new(&[dummy.clone(), dummy.clone(), dummy.clone()], &[dummy]);
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        merkle_proof: AnyMerkleProof::Blake2b(proof),
+        oracle_state_index: 0,
+    };
+    let mut bd = OutgoingBridgeTransactionData {
+        burn_proof: outgoing,
+        proof: SignatureProof::default(),
+    };
+    let mut tx = Transaction::new_extended(
+        bridge_addr(),
+        AccountType::Bridge,
+        bd.serialize_to_vec(),
+        nimiq_target(),
+        AccountType::Basic,
+        vec![],
+        Coin::from_u64_unchecked(RELEASE_AMOUNT),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+    let sig = owner.sign(&tx.serialize_content());
+    bd.set_signature(SignatureProof::from_ed25519(owner.public.clone(), sig));
+    tx.sender_data = bd.serialize_to_vec();
+
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(matches!(
+        receipts.transactions[0],
+        OperationReceipt::Err(_, _)
+    ));
+}
+
+// =====================================================================
+// Bridge: revert_outgoing_transaction — nonce=1 direct round-trip
+// =====================================================================
+
+/// commit(nonce=1) then revert(nonce=1): nonce entry must be fully removed.
+/// Verifies the `receipt.nonce == 1 → remove_nonce` branch of the fix.
+#[test]
+fn bridge_outgoing_revert_nonce1_removes_entry() {
+    let (test, owner, burn_data) = setup_outgoing_env();
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let tx = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data,
+        0,
+        &owner,
+    );
+
+    // Commit nonce=1 then revert it
+    let receipts = commit_block(&test, &[tx.clone()], &bs);
+    assert!(matches!(receipts.transactions[0], OperationReceipt::Ok(_)));
+    revert_block(&test, &[tx.clone()], receipts, &bs);
+
+    // After revert, nonce=1 must be accepted again (entry was cleanly removed)
+    let burn_data_again = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let oracle = make_single_state_oracle(&burn_data_again);
+    // Re-build oracle state (same as initial since we're re-using same burn data)
+    // Re-submit nonce=1 — should succeed because the revert cleaned up correctly
+    let tx2 = make_outgoing_tx(
+        &bridge_addr(),
+        &nimiq_target(),
+        RELEASE_AMOUNT,
+        burn_data_again,
+        0,
+        &owner,
+    );
+    let r2 = commit_block(&test, &[tx2], &bs);
+    assert!(
+        matches!(r2.transactions[0], OperationReceipt::Ok(_)),
+        "nonce=1 should be accepted again after clean revert"
+    );
+    let _ = oracle; // suppress unused warning
+}
+
+// =====================================================================
+// Bridge: prune / restore round-trip
+// =====================================================================
+
+/// Prune/restore invariant: restored bridge has same fields as original (balance=0).
+#[test]
+fn bridge_prune_restore_roundtrip_fields() {
+    use nimiq_account::{AccountPruningInteraction, AccountReceipt};
+
+    let owner = KeyPair::generate_default_csprng();
+    let original = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::ZERO,
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config(),
+        transaction_count: 7,
+    };
+
+    assert!(original.can_be_pruned());
+
+    let test = TestCommitRevert::with_initial_state(&[]);
+    let env = test.env();
+
+    // Prune
+    let read_txn = env.read_transaction();
+    let ds = test.data_store(&bridge_addr());
+    let receipt: Option<AccountReceipt> = original.clone().prune(ds.read(&read_txn));
+    assert!(receipt.is_some());
+
+    // Restore in a write txn
+    let mut raw = env.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw).into();
+    let restored =
+        BridgeContract::restore(AccountType::Bridge, receipt.as_ref(), ds.write(&mut txn))
+            .expect("restore must succeed");
+    drop(txn);
+    raw.commit();
+
+    let bridge = match restored {
+        Account::Bridge(b) => b,
+        _ => panic!("wrong account type after restore"),
+    };
+    assert_eq!(bridge.owner, original.owner);
+    assert_eq!(bridge.oracle_address, original.oracle_address);
+    assert_eq!(bridge.source_chain_id, original.source_chain_id);
+    assert_eq!(bridge.transaction_count, original.transaction_count);
+    assert_eq!(bridge.balance, Coin::ZERO);
+
+    // Non-zero balance bridge must not be prunable
+    let rich = BridgeContract {
+        balance: Coin::from_u64_unchecked(1),
+        ..original.clone()
+    };
+    assert!(!rich.can_be_pruned());
+}
+
+// =====================================================================
+// Oracle: revert_new_contract
+// =====================================================================
+
+/// revert_new_contract must undo the deposit.
+#[test]
+fn oracle_revert_new_contract_removes_deposit() {
+    let owner = KeyPair::generate_default_csprng();
+
+    let test = TestCommitRevert::with_initial_state(&[(
+        Address::from(&owner.public),
+        Account::Basic(BasicAccount {
+            balance: Coin::from_u64_unchecked(10_000),
+        }),
+    )]);
+
+    let creation_data = OracleCreationData {
+        owner: Address::from(&owner.public),
+        hash_count: 5,
+    };
+    let tx = Transaction::new_contract_creation(
+        Address::from(&owner.public),
+        AccountType::Basic,
+        vec![],
+        AccountType::Oracle,
+        creation_data.serialize_to_vec(),
+        Coin::from_u64_unchecked(1_000),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let mut logger = TransactionLog::empty();
+
+    // keep_commit=false → commit then immediately revert and assert state is restored
+    let result =
+        test.test_create_new_contract::<OracleContract>(&tx, Coin::ZERO, &bs, &mut logger, false);
+    // If revert didn't work, the trie root check inside test_create_new_contract would panic.
+    assert!(result.is_ok(), "create+revert must both succeed");
+}
+
+// =====================================================================
+// Oracle: successful ChangeOwner revert restores old owner
+// =====================================================================
+
+fn oracle_addr_for_test() -> Address {
+    Address::from([0x01u8; 20])
+}
+
+fn make_oracle_with_owner(owner: &KeyPair) -> OracleContract {
+    OracleContract {
+        owner: Address::from(&owner.public),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count: 10,
+        hashes: Vec::new(),
+        latest_index: None,
+    }
+}
+
+fn make_change_owner_tx(
+    contract_address: Address,
+    key: &KeyPair,
+    new_owner: Address,
+) -> Transaction {
+    let data = IncomingOracleTransactionData::ChangeOwner {
+        new_owner,
+        proof: SignatureProof::default(),
+    };
+    let mut tx = Transaction::new_signaling(
+        contract_address.clone(),
+        AccountType::Oracle,
+        contract_address,
+        AccountType::Oracle,
+        Coin::ZERO,
+        data.serialize_to_vec(),
+        0,
+        NetworkId::UnitAlbatross,
+    );
+    let sig = key.sign(&tx.serialize_content());
+    let proof = SignatureProof::from_ed25519(key.public, sig);
+    tx.recipient_data =
+        IncomingOracleTransactionData::set_signature_on_data(&tx.recipient_data, proof).unwrap();
+    tx
+}
+
+/// ChangeOwner commit sets new owner; revert restores old owner.
+///
+/// `test_commit_incoming_transaction(keep_commit=false)` commits, internally
+/// asserts the revert brings the account back to `initial_account`, then
+/// returns leaving `oracle_mut` in the initial (pre-commit) state.
+/// If no panic occurs the revert is proven correct.
+#[test]
+fn oracle_change_owner_revert_restores_old_owner() {
+    let old_owner = KeyPair::generate_default_csprng();
+    let new_owner_kp = KeyPair::generate_default_csprng();
+    let new_owner_addr = Address::from(&new_owner_kp.public);
+    let old_owner_addr = Address::from(&old_owner.public);
+
+    let oracle = make_oracle_with_owner(&old_owner);
+    let contract_addr = oracle_addr_for_test();
+
+    let test = TestCommitRevert::with_initial_state(&[(
+        contract_addr.clone(),
+        Account::Oracle(oracle.clone()),
+    )]);
+
+    let tx = make_change_owner_tx(contract_addr.clone(), &old_owner, new_owner_addr.clone());
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let mut logger = TransactionLog::empty();
+    let mut oracle_mut = oracle.clone();
+
+    // keep_commit=false: the framework internally checks that after the revert
+    // oracle_mut == initial state (old owner). A panic here means revert is broken.
+    test.test_commit_incoming_transaction(&mut oracle_mut, &tx, &bs, &mut logger, false)
+        .expect("ChangeOwner commit+revert must succeed without panic");
+
+    // After keep_commit=false the framework leaves oracle_mut in the initial state.
+    assert_eq!(
+        oracle_mut.owner, old_owner_addr,
+        "after revert, owner must be the original owner"
+    );
+}
+
+// =====================================================================
+// ValidationProgram: missing opcode coverage
+// =====================================================================
+
+fn run_program(
+    ops: Vec<ValidationOp>,
+    burn_data: &[u8],
+) -> Vec<(String, nimiq_transaction::bridge_contract::StackValue)> {
+    use nimiq_transaction::bridge_contract::ValidationProgram;
+    let prog = ValidationProgram::new(ops);
+    let result = prog
+        .extract_only(burn_data)
+        .expect("program should succeed");
+    result.extracted_values.into_iter().collect()
+}
+
+/// LoadBytes: load a slice from burn_data.
+#[test]
+fn validation_op_load_bytes() {
+    let data: Vec<u8> = (0u8..32).collect();
+    // stack before LoadBytes: [offset=2, length=4] (offset pushed first, length pushed last → length is on top)
+    let ops = vec![
+        ValidationOp::PushConst(2), // offset
+        ValidationOp::PushConst(4), // length (top)
+        ValidationOp::LoadBytes,
+        ValidationOp::Store("slice".to_string()),
+    ];
+    let result = run_program(ops, &data);
+    let val = result
+        .iter()
+        .find(|(k, _)| k == "slice")
+        .map(|(_, v)| v)
+        .unwrap();
+    assert_eq!(val.as_bytes().unwrap(), vec![2u8, 3, 4, 5]);
+}
+
+/// LoadU32: reads a 4-byte little-endian u32.
+#[test]
+fn validation_op_load_u32() {
+    let value: u32 = 0x01020304;
+    let mut data = vec![0u8; 8];
+    data[2..6].copy_from_slice(&value.to_le_bytes());
+    let ops = vec![
+        ValidationOp::PushConst(2),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("val".to_string()),
+    ];
+    let result = run_program(ops, &data);
+    let v = result
+        .iter()
+        .find(|(k, _)| k == "val")
+        .unwrap()
+        .1
+        .as_u64()
+        .unwrap();
+    assert_eq!(v, value as u64);
+}
+
+/// Mod: remainder operation.
+#[test]
+fn validation_op_mod() {
+    let data = vec![0u8; 4];
+    let ops = vec![
+        ValidationOp::PushConst(10),
+        ValidationOp::PushConst(3),
+        ValidationOp::Mod,
+        ValidationOp::Store("r".to_string()),
+    ];
+    let result = run_program(ops, &data);
+    assert_eq!(
+        result
+            .iter()
+            .find(|(k, _)| k == "r")
+            .unwrap()
+            .1
+            .as_u64()
+            .unwrap(),
+        1
+    );
+}
+
+/// IsZero: 0 → 1, non-zero → 0.
+#[test]
+fn validation_op_is_zero() {
+    let data = vec![0u8; 4];
+    let ops_zero = vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::IsZero,
+        ValidationOp::Store("z".to_string()),
+    ];
+    let ops_nonzero = vec![
+        ValidationOp::PushConst(5),
+        ValidationOp::IsZero,
+        ValidationOp::Store("z".to_string()),
+    ];
+    let r1 = run_program(ops_zero, &data);
+    let r2 = run_program(ops_nonzero, &data);
+    assert_eq!(r1[0].1.as_u64().unwrap(), 1);
+    assert_eq!(r2[0].1.as_u64().unwrap(), 0);
+}
+
+/// And / Or / Not logical operations.
+#[test]
+fn validation_op_logical() {
+    let data = vec![0u8; 4];
+    // AND: 1 && 0 → 0
+    let and_ops = vec![
+        ValidationOp::PushConst(1),
+        ValidationOp::PushConst(0),
+        ValidationOp::And,
+        ValidationOp::Store("r".to_string()),
+    ];
+    // OR: 0 || 1 → 1
+    let or_ops = vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::PushConst(1),
+        ValidationOp::Or,
+        ValidationOp::Store("r".to_string()),
+    ];
+    // NOT: !0 → 1
+    let not_ops = vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::Not,
+        ValidationOp::Store("r".to_string()),
+    ];
+    assert_eq!(run_program(and_ops, &data)[0].1.as_u64().unwrap(), 0);
+    assert_eq!(run_program(or_ops, &data)[0].1.as_u64().unwrap(), 1);
+    assert_eq!(run_program(not_ops, &data)[0].1.as_u64().unwrap(), 1);
+}
+
+/// Pop discards the top stack value.
+#[test]
+fn validation_op_pop() {
+    let data = vec![0u8; 4];
+    let ops = vec![
+        ValidationOp::PushConst(99),
+        ValidationOp::PushConst(42),
+        ValidationOp::Pop,                      // remove 42
+        ValidationOp::Store("top".to_string()), // should store 99
+    ];
+    let result = run_program(ops, &data);
+    assert_eq!(result[0].1.as_u64().unwrap(), 99);
+}
+
+/// JumpIfZero: skips N operations when condition is zero.
+#[test]
+fn validation_op_jump_if_zero_taken() {
+    let data = vec![0u8; 4];
+    // Condition=0 → skip next 2 ops → Store(99) is never reached → Store(1) is
+    let ops = vec![
+        ValidationOp::PushConst(0),           // condition = 0
+        ValidationOp::JumpIfZero(2),          // skip 2 ops if zero
+        ValidationOp::PushConst(99),          // skipped
+        ValidationOp::Store("v".to_string()), // skipped
+        ValidationOp::PushConst(1),
+        ValidationOp::Store("v".to_string()),
+    ];
+    let result = run_program(ops, &data);
+    assert_eq!(
+        result[0].1.as_u64().unwrap(),
+        1,
+        "jump should have been taken"
+    );
+}
+
+#[test]
+fn validation_op_jump_if_zero_not_taken() {
+    let data = vec![0u8; 4];
+    // Condition=1 → do NOT skip → Store(99) runs
+    let ops = vec![
+        ValidationOp::PushConst(1),  // condition = 1 (non-zero)
+        ValidationOp::JumpIfZero(2), // NOT taken
+        ValidationOp::PushConst(99),
+        ValidationOp::Store("v".to_string()),
+        ValidationOp::PushConst(0), // never stored (would overwrite)
+        ValidationOp::Pop,
+    ];
+    let result = run_program(ops, &data);
+    assert_eq!(
+        result[0].1.as_u64().unwrap(),
+        99,
+        "jump should not have been taken"
+    );
+}
+
+/// Store / Load named variable round-trip.
+#[test]
+fn validation_op_store_load_roundtrip() {
+    let data = vec![0u8; 4];
+    let ops = vec![
+        ValidationOp::PushConst(77),
+        ValidationOp::Store("x".to_string()),
+        ValidationOp::Load("x".to_string()),
+        ValidationOp::Store("y".to_string()),
+    ];
+    let result = run_program(ops, &data);
+    // x should still be 77 and y should also be 77
+    let x = result
+        .iter()
+        .find(|(k, _)| k == "x")
+        .unwrap()
+        .1
+        .as_u64()
+        .unwrap();
+    let y = result
+        .iter()
+        .find(|(k, _)| k == "y")
+        .unwrap()
+        .1
+        .as_u64()
+        .unwrap();
+    assert_eq!(x, 77);
+    assert_eq!(y, 77);
+}
+
+/// extract_only errors on all four PushExpected* variants.
+#[test]
+fn extract_only_rejects_push_expected_variants() {
+    use nimiq_transaction::bridge_contract::ValidationProgram;
+    let data = vec![0u8; 4];
+    for op in [
+        ValidationOp::PushExpectedAmount,
+        ValidationOp::PushExpectedAddress,
+        ValidationOp::PushExpectedNonce,
+        ValidationOp::PushExpectedValidityHeight,
+    ] {
+        let prog = ValidationProgram::new(vec![op.clone()]);
+        assert!(
+            prog.extract_only(&data).is_err(),
+            "extract_only must reject {:?}",
+            op
+        );
+    }
+}

--- a/primitives/account/tests/bridge_advanced_tests.rs
+++ b/primitives/account/tests/bridge_advanced_tests.rs
@@ -180,12 +180,13 @@ fn bridge_reserve_and_release_balance_owner() {
     assert_eq!(reserved.balance(), Coin::ZERO);
 }
 
-/// `reserve_balance` rejects an outgoing tx whose burn-proof signature is NOT
-/// the bridge owner. This is the mempool-admission half of the intentional
-/// asymmetry: the same tx is accepted at block execution (see the
-/// permissionless test below).
+/// `reserve_balance` accepts an outgoing tx whose burn-proof signature is NOT
+/// the bridge owner. Burn-releases are permissionless — the Merkle burn-proof
+/// verified at commit is the sole authorization — so mempool admission must
+/// accept the same transactions block execution accepts. (An owner-signature
+/// check here used to diverge the mempool from consensus.)
 #[test]
-fn bridge_reserve_balance_rejects_non_owner() {
+fn bridge_reserve_balance_accepts_non_owner() {
     let owner = KeyPair::generate_default_csprng();
     let relayer = KeyPair::generate_default_csprng(); // not the owner
 
@@ -215,11 +216,11 @@ fn bridge_reserve_balance_rejects_non_owner() {
 
     let mut reserved = ReservedBalance::new(bridge_addr());
     let res = bridge.reserve_balance(&tx, &mut reserved, &bs, data_store.read(&mut db_txn));
-    assert_eq!(
-        res,
-        Err(AccountError::InvalidSignature),
-        "reserve_balance must reject a non-owner burn-proof signature"
+    assert!(
+        res.is_ok(),
+        "reserve_balance must accept a non-owner burn-proof signature: {res:?}"
     );
+    assert_eq!(reserved.balance(), Coin::from_u64_unchecked(RELEASE_AMOUNT));
 }
 
 /// `reserve_balance` rejects when the requested total exceeds the bridge balance.

--- a/primitives/account/tests/bridge_advanced_tests.rs
+++ b/primitives/account/tests/bridge_advanced_tests.rs
@@ -1,0 +1,469 @@
+use nimiq_account::{
+    Account, AccountTransactionInteraction, BasicAccount, BlockLogger, BlockState, BridgeContract,
+    OperationReceipt, Receipts, ReservedBalance,
+};
+use nimiq_database::traits::{Database, WriteTransaction};
+use nimiq_hash::{Blake2bHasher, Hasher, Keccak256Hasher, Sha256Hasher};
+use nimiq_keys::{Address, KeyPair};
+use nimiq_primitives::{
+    account::{AccountError, AccountType},
+    coin::Coin,
+    networks::NetworkId,
+    policy::Policy,
+};
+use nimiq_serde::Serialize;
+use nimiq_test_log::test;
+use nimiq_test_utils::accounts_revert::TestCommitRevert;
+use nimiq_transaction::{
+    account::{
+        bridge_contract::OutgoingBridgeTransactionData,
+        htlc_contract::{AnyHash, AnyHash32},
+    },
+    bridge_contract::{
+        AddressFormat, AnyMerkleProof, ChainConfig, Endianness, OutgoingTransaction, ValidationOp,
+        ValidationProgram,
+    },
+    SignatureProof, Transaction,
+};
+use nimiq_utils::{key_rng::SecureGenerate, merkle::MerklePath};
+
+// =====================================================================
+// Shared helpers
+// =====================================================================
+
+const SOURCE_CHAIN_ID: u32 = 1;
+const RELEASE_AMOUNT: u64 = 500;
+const BURN_BLOCK_HEIGHT: u32 = 42;
+const BRIDGE_DEPOSIT: u64 = 10_000;
+
+fn nimiq_target() -> Address {
+    Address::from([0xAAu8; 20])
+}
+fn oracle_addr() -> Address {
+    Address::from([0x0Eu8; 20])
+}
+fn bridge_addr() -> Address {
+    Address::from([0x0Bu8; 20])
+}
+
+fn standard_program() -> ValidationProgram {
+    ValidationProgram::new(vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::LoadAddress,
+        ValidationOp::Store("target_address".to_string()),
+        ValidationOp::PushConst(20),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("amount".to_string()),
+        ValidationOp::PushConst(28),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("target_nonce".to_string()),
+        ValidationOp::PushConst(36),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("burn_block_height".to_string()),
+        ValidationOp::PushConst(40),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("target_chain_id".to_string()),
+    ])
+}
+
+fn chain_config_with_hash(hash_function: AnyHash) -> ChainConfig {
+    ChainConfig {
+        chain_id: SOURCE_CHAIN_ID,
+        hash_function,
+        address_format: AddressFormat::Nimiq,
+        endianness: Endianness::LittleEndian,
+        block_time: std::time::Duration::from_secs(60),
+        validation_program: standard_program(),
+        max_proof_depth: 64,
+    }
+}
+
+fn make_burn_data(target: [u8; 20], amount: u64, nonce: u64, chain_id: u32) -> Vec<u8> {
+    let mut d = Vec::with_capacity(44);
+    d.extend_from_slice(&target);
+    d.extend_from_slice(&amount.to_le_bytes());
+    d.extend_from_slice(&nonce.to_le_bytes());
+    d.extend_from_slice(&BURN_BLOCK_HEIGHT.to_le_bytes());
+    d.extend_from_slice(&chain_id.to_le_bytes());
+    d
+}
+
+fn commit_block(test: &TestCommitRevert, txs: &[Transaction], bs: &BlockState) -> Receipts {
+    let env = test.env();
+    let mut raw = env.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw).into();
+    let r = test
+        .commit(&mut txn, txs, &[], bs, &mut BlockLogger::empty())
+        .unwrap();
+    raw.commit();
+    r
+}
+
+/// Build a signed outgoing bridge tx using an explicit Merkle-proof variant and signer.
+fn make_outgoing_tx_full(
+    amount: u64,
+    burn_data: Vec<u8>,
+    merkle_proof: AnyMerkleProof,
+    oracle_state_index: u64,
+    signer: &KeyPair,
+) -> Transaction {
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        merkle_proof,
+        oracle_state_index,
+    };
+    let mut bridge_data = OutgoingBridgeTransactionData {
+        burn_proof: outgoing,
+        proof: SignatureProof::default(),
+    };
+    let mut tx = Transaction::new_extended(
+        bridge_addr(),
+        AccountType::Bridge,
+        bridge_data.serialize_to_vec(),
+        nimiq_target(),
+        AccountType::Basic,
+        vec![],
+        Coin::from_u64_unchecked(amount),
+        Coin::ZERO,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+    let sig = signer.sign(&tx.serialize_content());
+    bridge_data.set_signature(SignatureProof::from_ed25519(signer.public.clone(), sig));
+    tx.sender_data = bridge_data.serialize_to_vec();
+    tx
+}
+
+// =====================================================================
+// reserve_balance / release_balance
+// =====================================================================
+
+/// A correctly owner-signed outgoing tx is accepted by `reserve_balance`, and
+/// `release_balance` returns the reserved amount.
+#[test]
+fn bridge_reserve_and_release_balance_owner() {
+    let owner = KeyPair::generate_default_csprng();
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config_with_hash(AnyHash::Blake2b(AnyHash32::default())),
+        transaction_count: 0,
+    };
+
+    let test =
+        TestCommitRevert::with_initial_state(&[(bridge_addr(), Account::Bridge(bridge.clone()))]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let mut db_txn = test.env().write_transaction();
+    let data_store = test.data_store(&bridge_addr());
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let tx = make_outgoing_tx_full(
+        RELEASE_AMOUNT,
+        burn_data,
+        AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        0,
+        &owner,
+    );
+
+    let mut reserved = ReservedBalance::new(bridge_addr());
+
+    // Reserve succeeds with the owner's signature.
+    let res = bridge.reserve_balance(&tx, &mut reserved, &bs, data_store.read(&mut db_txn));
+    assert!(res.is_ok(), "owner-signed reserve must succeed: {res:?}");
+    assert_eq!(reserved.balance(), Coin::from_u64_unchecked(RELEASE_AMOUNT));
+
+    // Release returns the reserved amount.
+    let rel = bridge.release_balance(&tx, &mut reserved, data_store.read(&mut db_txn));
+    assert!(rel.is_ok());
+    assert_eq!(reserved.balance(), Coin::ZERO);
+}
+
+/// `reserve_balance` rejects an outgoing tx whose burn-proof signature is NOT
+/// the bridge owner. This is the mempool-admission half of the intentional
+/// asymmetry: the same tx is accepted at block execution (see the
+/// permissionless test below).
+#[test]
+fn bridge_reserve_balance_rejects_non_owner() {
+    let owner = KeyPair::generate_default_csprng();
+    let relayer = KeyPair::generate_default_csprng(); // not the owner
+
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config_with_hash(AnyHash::Blake2b(AnyHash32::default())),
+        transaction_count: 0,
+    };
+
+    let test =
+        TestCommitRevert::with_initial_state(&[(bridge_addr(), Account::Bridge(bridge.clone()))]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let mut db_txn = test.env().write_transaction();
+    let data_store = test.data_store(&bridge_addr());
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let tx = make_outgoing_tx_full(
+        RELEASE_AMOUNT,
+        burn_data,
+        AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        0,
+        &relayer,
+    );
+
+    let mut reserved = ReservedBalance::new(bridge_addr());
+    let res = bridge.reserve_balance(&tx, &mut reserved, &bs, data_store.read(&mut db_txn));
+    assert_eq!(
+        res,
+        Err(AccountError::InvalidSignature),
+        "reserve_balance must reject a non-owner burn-proof signature"
+    );
+}
+
+/// `reserve_balance` rejects when the requested total exceeds the bridge balance.
+#[test]
+fn bridge_reserve_balance_rejects_insufficient_funds() {
+    let owner = KeyPair::generate_default_csprng();
+    let small_balance = 100u64; // less than RELEASE_AMOUNT (500)
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(small_balance),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config_with_hash(AnyHash::Blake2b(AnyHash32::default())),
+        transaction_count: 0,
+    };
+
+    let test =
+        TestCommitRevert::with_initial_state(&[(bridge_addr(), Account::Bridge(bridge.clone()))]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+    let mut db_txn = test.env().write_transaction();
+    let data_store = test.data_store(&bridge_addr());
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    let tx = make_outgoing_tx_full(
+        RELEASE_AMOUNT,
+        burn_data,
+        AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        0,
+        &owner,
+    );
+
+    let mut reserved = ReservedBalance::new(bridge_addr());
+    let res = bridge.reserve_balance(&tx, &mut reserved, &bs, data_store.read(&mut db_txn));
+    assert!(
+        matches!(res, Err(AccountError::InsufficientFunds { .. })),
+        "reserve must fail with InsufficientFunds, got {res:?}"
+    );
+}
+
+// =====================================================================
+// Permissionless burn-proof submission (block execution)
+// =====================================================================
+
+/// A valid burn proof signed by a NON-owner relayer is accepted by
+/// `commit_outgoing_transaction`. The owner-signature check is intentionally
+/// skipped at block execution to allow permissionless relaying, even though
+/// `reserve_balance` (mempool) rejects the same tx.
+#[test]
+fn bridge_permissionless_non_owner_submission_succeeds_at_commit() {
+    let owner = KeyPair::generate_default_csprng();
+    let relayer = KeyPair::generate_default_csprng(); // not the owner
+
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+    // Oracle state[0] = zero.digest(Blake2b(burn_data)); empty path => root == leaf.
+    let leaf = AnyHash::from(Blake2bHasher::default().digest(&burn_data));
+    let zero = leaf.zero_of_same_type();
+    let mut hashes = vec![zero.clone(); 10];
+    hashes[0] = zero.digest(&leaf);
+    let oracle = nimiq_account::OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count: 10,
+        hashes,
+        latest_index: Some(0),
+    };
+
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config_with_hash(AnyHash::Blake2b(AnyHash32::default())),
+        transaction_count: 0,
+    };
+
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+        (
+            nimiq_target(),
+            Account::Basic(BasicAccount {
+                balance: Coin::ZERO,
+            }),
+        ),
+    ]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+
+    // Signed by the relayer, NOT the owner. Zero fee avoids the signer-fee path.
+    let tx = make_outgoing_tx_full(
+        RELEASE_AMOUNT,
+        burn_data,
+        AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        0,
+        &relayer,
+    );
+
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(
+        matches!(receipts.transactions[0], OperationReceipt::Ok(_)),
+        "permissionless non-owner burn submission must succeed at block execution"
+    );
+}
+
+// =====================================================================
+// Non-Blake2b hash types end-to-end
+// =====================================================================
+
+#[derive(Clone, Copy)]
+enum HashKind {
+    Sha256,
+    Keccak256,
+}
+
+fn leaf_for(kind: HashKind, data: &[u8]) -> AnyHash {
+    match kind {
+        HashKind::Sha256 => AnyHash::from(Sha256Hasher::default().digest(data)),
+        HashKind::Keccak256 => AnyHash::from(Keccak256Hasher::default().digest(data)),
+    }
+}
+
+fn config_hash_for(kind: HashKind) -> AnyHash {
+    match kind {
+        HashKind::Sha256 => AnyHash::Sha256(AnyHash32::default()),
+        HashKind::Keccak256 => AnyHash::Keccak256(AnyHash32::default()),
+    }
+}
+
+fn empty_path_for(kind: HashKind) -> AnyMerkleProof {
+    match kind {
+        HashKind::Sha256 => AnyMerkleProof::Sha256Path(MerklePath::empty()),
+        HashKind::Keccak256 => AnyMerkleProof::Keccak256Path(MerklePath::empty()),
+    }
+}
+
+/// Runs a full successful outgoing-transaction commit for a given hash type,
+/// proving the leaf-hash / oracle-state / proof machinery is hash-agnostic.
+fn run_outgoing_success_for(kind: HashKind) {
+    let owner = KeyPair::generate_default_csprng();
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+
+    // Oracle state[0] = zero.digest(H(burn_data)) for the chosen hash type.
+    let leaf = leaf_for(kind, &burn_data);
+    let zero = leaf.zero_of_same_type();
+    let mut hashes = vec![zero.clone(); 10];
+    hashes[0] = zero.digest(&leaf);
+    let oracle = nimiq_account::OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count: 10,
+        hashes,
+        latest_index: Some(0),
+    };
+
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config_with_hash(config_hash_for(kind)),
+        transaction_count: 0,
+    };
+
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+        (
+            nimiq_target(),
+            Account::Basic(BasicAccount {
+                balance: Coin::ZERO,
+            }),
+        ),
+    ]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+
+    let tx = make_outgoing_tx_full(RELEASE_AMOUNT, burn_data, empty_path_for(kind), 0, &owner);
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(
+        matches!(receipts.transactions[0], OperationReceipt::Ok(_)),
+        "outgoing commit must succeed for the selected hash type"
+    );
+}
+
+#[test]
+fn bridge_outgoing_sha256_end_to_end() {
+    run_outgoing_success_for(HashKind::Sha256);
+}
+
+#[test]
+fn bridge_outgoing_keccak256_end_to_end() {
+    run_outgoing_success_for(HashKind::Keccak256);
+}
+
+/// Sanity check that a mismatched proof variant (Blake2b path against a
+/// Keccak-configured bridge) is rejected rather than silently mis-verified.
+#[test]
+fn bridge_outgoing_rejects_mismatched_proof_variant() {
+    let owner = KeyPair::generate_default_csprng();
+    let burn_data = make_burn_data([0xAAu8; 20], RELEASE_AMOUNT, 1, SOURCE_CHAIN_ID);
+
+    let leaf = leaf_for(HashKind::Keccak256, &burn_data);
+    let zero = leaf.zero_of_same_type();
+    let mut hashes = vec![zero.clone(); 10];
+    hashes[0] = zero.digest(&leaf);
+    let oracle = nimiq_account::OracleContract {
+        owner: Address::from([0x01u8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count: 10,
+        hashes,
+        latest_index: Some(0),
+    };
+
+    let bridge = BridgeContract {
+        owner: Address::from(&owner.public),
+        oracle_address: oracle_addr(),
+        balance: Coin::from_u64_unchecked(BRIDGE_DEPOSIT),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config_with_hash(config_hash_for(HashKind::Keccak256)),
+        transaction_count: 0,
+    };
+
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_addr(), Account::Oracle(oracle)),
+        (bridge_addr(), Account::Bridge(bridge)),
+        (
+            nimiq_target(),
+            Account::Basic(BasicAccount {
+                balance: Coin::ZERO,
+            }),
+        ),
+    ]);
+    let bs = BlockState::new(1, 1, Policy::max_supported_version());
+
+    // Bridge expects Keccak256, but the proof is a Blake2b path → compute_root
+    // returns an error (variant mismatch).
+    let tx = make_outgoing_tx_full(
+        RELEASE_AMOUNT,
+        burn_data,
+        AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        0,
+        &owner,
+    );
+    let receipts = commit_block(&test, &[tx], &bs);
+    assert!(
+        matches!(receipts.transactions[0], OperationReceipt::Err(_, _)),
+        "mismatched proof variant must be rejected"
+    );
+}

--- a/primitives/account/tests/bridge_contract_integration_test.rs
+++ b/primitives/account/tests/bridge_contract_integration_test.rs
@@ -30,6 +30,7 @@ fn create_test_chain_config(chain_id: u32) -> ChainConfig {
         endianness: Endianness::LittleEndian,
         block_time: std::time::Duration::from_secs(60),
         validation_program: ValidationProgram::empty(),
+        max_proof_depth: 64,
     }
 }
 
@@ -425,6 +426,7 @@ fn test_chain_specific_address_validation() {
         endianness: Endianness::LittleEndian,
         block_time: std::time::Duration::from_secs(60),
         validation_program: nimiq_transaction::bridge_contract::ValidationProgram::empty(),
+        max_proof_depth: 64,
     };
 
     let nimiq_recipient = RecipientData {
@@ -442,6 +444,7 @@ fn test_chain_specific_address_validation() {
         endianness: Endianness::BigEndian,
         block_time: std::time::Duration::from_secs(12),
         validation_program: nimiq_transaction::bridge_contract::ValidationProgram::empty(),
+        max_proof_depth: 64,
     };
 
     let ethereum_recipient = RecipientData {
@@ -459,6 +462,7 @@ fn test_chain_specific_address_validation() {
         endianness: Endianness::BigEndian,
         block_time: std::time::Duration::from_secs(600),
         validation_program: nimiq_transaction::bridge_contract::ValidationProgram::empty(),
+        max_proof_depth: 64,
     };
 
     let bitcoin_recipient = RecipientData {
@@ -477,6 +481,7 @@ fn test_chain_specific_address_validation() {
         endianness: Endianness::LittleEndian,
         block_time: std::time::Duration::from_secs(30),
         validation_program: nimiq_transaction::bridge_contract::ValidationProgram::empty(),
+        max_proof_depth: 64,
     };
 
     let custom_recipient = RecipientData {

--- a/primitives/account/tests/bridge_contract_integration_test.rs
+++ b/primitives/account/tests/bridge_contract_integration_test.rs
@@ -1,6 +1,8 @@
 use nimiq_account::{
-    Account, BasicAccount, BlockLogger, BlockState, BridgeContract, TransactionOperationReceipt,
+    Account, AccountTransactionInteraction, BasicAccount, BlockLogger, BlockState, BridgeContract,
+    ReservedBalance, TransactionOperationReceipt,
 };
+use nimiq_database::traits::Database;
 use nimiq_hash::{Blake2bHash, Blake2bHasher, Hasher};
 use nimiq_keys::{Address, KeyPair, SecureGenerate};
 use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
@@ -638,4 +640,80 @@ fn fee_for_failed_outgoing_tx_is_charged_to_sender_data_signer() {
         accounts.get_complete(&victim_address, None).balance(),
         initial_victim_balance,
     );
+}
+
+/// Regression test: an outgoing bridge burn-release reserves only `value` against
+/// the bridge balance, NOT `value + fee`. The fee is paid by the burn-proof signer and
+/// is reserved against the signer by the mempool (`reserve_bridge_signer_fee`), not
+/// against the bridge here. Before the fix `reserve_balance` reserved `total_value`,
+/// which both over-reserved the bridge and left the signer fee unreserved.
+#[test]
+fn reserve_balance_excludes_fee_for_bridge() {
+    let signer = KeyPair::generate_default_csprng();
+    let signer_address = Address::from(&signer.public);
+    let bridge_address = Address::from([3u8; 20]);
+    let recipient_address = Address::from([4u8; 20]);
+    let source_chain_id = 1;
+
+    let bridge_contract = BridgeContract {
+        owner: signer_address.clone(),
+        oracle_address: Address::from([2u8; 20]),
+        balance: Coin::from_u64_unchecked(1000),
+        source_chain_id,
+        chain_config: create_test_chain_config(source_chain_id),
+        transaction_count: 0,
+    };
+
+    let accounts = TestCommitRevert::with_initial_state(&[(
+        bridge_address.clone(),
+        Account::Bridge(bridge_contract.clone()),
+    )]);
+
+    // Outgoing bridge transaction with value = 100 and a non-zero fee = 10.
+    let outgoing_tx = OutgoingTransaction {
+        burn_transaction_data: vec![0u8; 32],
+        merkle_proof: AnyMerkleProof::Blake2b(MerkleProof::<Blake2bHash>::new(&[], &[])),
+        oracle_state_index: 0,
+    };
+    let mut bridge_data = OutgoingBridgeTransactionData {
+        burn_proof: outgoing_tx,
+        proof: SignatureProof::default(),
+    };
+
+    let value = Coin::from_u64_unchecked(100);
+    let fee = Coin::from_u64_unchecked(10);
+
+    let mut transaction = Transaction::new_extended(
+        bridge_address.clone(),
+        AccountType::Bridge,
+        bridge_data.serialize_to_vec(),
+        recipient_address,
+        AccountType::Basic,
+        vec![],
+        value,
+        fee,
+        1,
+        NetworkId::UnitAlbatross,
+    );
+    let signer_proof =
+        SignatureProof::from_ed25519(signer.public, signer.sign(&transaction.serialize_content()));
+    bridge_data.set_signature(signer_proof);
+    transaction.sender_data = bridge_data.serialize_to_vec();
+
+    let block_state = BlockState::new(1, 1, Policy::max_supported_version());
+    let mut db_txn = accounts.env().write_transaction();
+    let data_store = accounts.data_store(&bridge_address);
+    let mut reserved_balance = ReservedBalance::new(bridge_address.clone());
+
+    bridge_contract
+        .reserve_balance(
+            &transaction,
+            &mut reserved_balance,
+            &block_state,
+            data_store.read(&mut db_txn),
+        )
+        .expect("reserve_balance should succeed");
+
+    // Only `value` is reserved against the bridge — not `value + fee`.
+    assert_eq!(reserved_balance.balance(), value);
 }

--- a/primitives/account/tests/bridge_contract_test.rs
+++ b/primitives/account/tests/bridge_contract_test.rs
@@ -15,6 +15,7 @@ fn test_bridge_account_type() {
         endianness: Endianness::LittleEndian,
         block_time: std::time::Duration::from_secs(60),
         validation_program: nimiq_transaction::bridge_contract::ValidationProgram::empty(),
+        max_proof_depth: 64,
     };
 
     let bridge_contract = BridgeContract {
@@ -52,6 +53,7 @@ fn test_bridge_account_serialization() {
         endianness: Endianness::LittleEndian,
         block_time: std::time::Duration::from_secs(60),
         validation_program: nimiq_transaction::bridge_contract::ValidationProgram::empty(),
+        max_proof_depth: 64,
     };
 
     let bridge_contract = BridgeContract {

--- a/primitives/account/tests/bridge_security_tests.rs
+++ b/primitives/account/tests/bridge_security_tests.rs
@@ -1,0 +1,359 @@
+use nimiq_account::{
+    Account, BlockLogger, BlockState, BridgeContract, OperationReceipt, OracleContract, Receipts,
+    RevertInfo,
+};
+use nimiq_database::traits::{Database, WriteTransaction};
+use nimiq_hash::{Blake2bHasher, HashOutput, Hasher};
+use nimiq_keys::{Address, KeyPair};
+use nimiq_primitives::{account::AccountType, coin::Coin, networks::NetworkId, policy::Policy};
+use nimiq_serde::Serialize;
+use nimiq_test_log::test;
+use nimiq_test_utils::accounts_revert::TestCommitRevert;
+use nimiq_transaction::{
+    account::{
+        bridge_contract::OutgoingBridgeTransactionData,
+        htlc_contract::{AnyHash, AnyHash32},
+    },
+    bridge_contract::{
+        AddressFormat, AnyMerkleProof, ChainConfig, CreationTransactionData, Endianness,
+        OutgoingTransaction, ValidationOp, ValidationProgram,
+    },
+    SignatureProof, Transaction,
+};
+use nimiq_utils::{key_rng::SecureGenerate, merkle::MerklePath};
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+const SOURCE_CHAIN_ID: u32 = 1;
+const RELEASE_AMOUNT: u64 = 100;
+const BURN_BLOCK_HEIGHT: u32 = 42;
+
+fn target_address() -> Address {
+    Address::from([5u8; 20])
+}
+
+fn target_address_bytes() -> [u8; 20] {
+    [5u8; 20]
+}
+
+/// Returns a ValidationProgram that reads all required fields from burn_data:
+///   [0..20]  target_address
+///   [20..28] amount (u64 LE)
+///   [28..36] target_nonce (u64 LE)
+///   [36..40] burn_block_height (u32 LE)
+///   [40..44] target_chain_id (u32 LE)
+fn standard_validation_program() -> ValidationProgram {
+    ValidationProgram::new(vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::LoadAddress,
+        ValidationOp::Store("target_address".to_string()),
+        ValidationOp::PushConst(20),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("amount".to_string()),
+        ValidationOp::PushConst(28),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("target_nonce".to_string()),
+        ValidationOp::PushConst(36),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("burn_block_height".to_string()),
+        ValidationOp::PushConst(40),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("target_chain_id".to_string()),
+    ])
+}
+
+fn make_chain_config(program: ValidationProgram) -> ChainConfig {
+    ChainConfig {
+        chain_id: SOURCE_CHAIN_ID,
+        hash_function: AnyHash::Blake2b(AnyHash32::default()),
+        address_format: AddressFormat::Nimiq,
+        endianness: Endianness::LittleEndian,
+        block_time: std::time::Duration::from_secs(60),
+        validation_program: program,
+        max_proof_depth: 64,
+    }
+}
+
+/// Encode burn_data for a given nonce.
+fn make_burn_data(nonce: u64) -> Vec<u8> {
+    let mut data = Vec::with_capacity(44);
+    data.extend_from_slice(&target_address_bytes());
+    data.extend_from_slice(&RELEASE_AMOUNT.to_le_bytes());
+    data.extend_from_slice(&nonce.to_le_bytes());
+    data.extend_from_slice(&BURN_BLOCK_HEIGHT.to_le_bytes());
+    data.extend_from_slice(&SOURCE_CHAIN_ID.to_le_bytes());
+    data
+}
+
+/// Compute AnyHash::Blake2b over raw bytes.
+fn blake2b_hash(data: &[u8]) -> AnyHash {
+    let h = Blake2bHasher::default().digest(data);
+    AnyHash::Blake2b(AnyHash32::from(<[u8; 32]>::try_from(h.as_bytes()).unwrap()))
+}
+
+/// Build the oracle contract with exactly two chained state-hashes so that both
+/// nonce=1 and nonce=2 outgoing transactions can be verified.
+///
+/// oracle.hashes[0] = zero.digest(leaf_hash_1)
+/// oracle.hashes[1] = oracle.hashes[0].digest(leaf_hash_2)
+fn make_oracle_for_two_txs() -> (OracleContract, AnyHash, AnyHash) {
+    let burn_data_1 = make_burn_data(1);
+    let burn_data_2 = make_burn_data(2);
+
+    let leaf_hash_1 = blake2b_hash(&burn_data_1);
+    let leaf_hash_2 = blake2b_hash(&burn_data_2);
+
+    let zero_hash = leaf_hash_1.zero_of_same_type();
+    let oracle_hash_0 = zero_hash.digest(&leaf_hash_1);
+    let oracle_hash_1 = oracle_hash_0.digest(&leaf_hash_2);
+
+    let hash_count: u16 = 10;
+    let mut hashes = vec![zero_hash; hash_count as usize];
+    hashes[0] = oracle_hash_0;
+    hashes[1] = oracle_hash_1;
+
+    let oracle = OracleContract {
+        owner: Address::from([0x0Eu8; 20]),
+        balance: Coin::from_u64_unchecked(1_000),
+        hash_count,
+        hashes,
+        latest_index: Some(1),
+    };
+
+    (oracle, leaf_hash_1, leaf_hash_2)
+}
+
+/// Construct a signed outgoing bridge transaction.
+///
+/// `oracle_state_index=0` for nonce=1, `oracle_state_index=1` for nonce=2.
+fn make_outgoing_tx(
+    bridge_address: &Address,
+    nonce: u64,
+    oracle_state_index: u64,
+    owner_keypair: &KeyPair,
+) -> Transaction {
+    let burn_data = make_burn_data(nonce);
+
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        // Empty MerklePath → compute_root_from_hash returns leaf unchanged, so
+        // merkle_root == leaf_hash == Blake2b(burn_data). This is what the oracle stores.
+        merkle_proof: AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        oracle_state_index,
+    };
+
+    // Build bridge_data with default (zero) proof first — this is what gets signed.
+    let mut bridge_data = OutgoingBridgeTransactionData {
+        burn_proof: outgoing,
+        proof: SignatureProof::default(),
+    };
+
+    let amount = Coin::from_u64_unchecked(RELEASE_AMOUNT);
+    let mut tx = Transaction::new_extended(
+        bridge_address.clone(),
+        AccountType::Bridge,
+        bridge_data.serialize_to_vec(), // sender_data with zeroed proof
+        target_address(),
+        AccountType::Basic,
+        vec![],
+        amount,
+        Coin::ZERO, // zero fee avoids signer-deduction path
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    // Sign over tx content (which already has zeroed proof in sender_data).
+    // This matches what verify_transaction_signature does before checking the sig.
+    let sig = owner_keypair.sign(&tx.serialize_content());
+    let sig_proof = SignatureProof::from_ed25519(owner_keypair.public.clone(), sig);
+
+    // Set the real signature and update sender_data.
+    bridge_data.set_signature(sig_proof);
+    tx.sender_data = bridge_data.serialize_to_vec();
+
+    tx
+}
+
+/// Commit `transactions` to the trie (persisting the result) and return the receipts.
+fn commit_block(
+    test: &TestCommitRevert,
+    transactions: &[Transaction],
+    block_state: &BlockState,
+) -> Receipts {
+    let env = test.env();
+    let mut raw_txn = env.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw_txn).into();
+    let receipts = test
+        .commit(
+            &mut txn,
+            transactions,
+            &[],
+            block_state,
+            &mut BlockLogger::empty(),
+        )
+        .expect("commit_block failed");
+    raw_txn.commit();
+    receipts
+}
+
+/// Revert `transactions` from the trie (persisting the revert) using the supplied receipts.
+fn revert_block(
+    test: &TestCommitRevert,
+    transactions: &[Transaction],
+    receipts: Receipts,
+    block_state: &BlockState,
+) {
+    let env = test.env();
+    let mut raw_txn = env.write_transaction();
+    let mut txn: nimiq_trie::WriteTransactionProxy = (&mut raw_txn).into();
+    test.revert(
+        &mut txn,
+        transactions,
+        &[],
+        block_state,
+        RevertInfo::Receipts(receipts),
+        &mut BlockLogger::empty_reverted(),
+    )
+    .expect("revert_block failed");
+    raw_txn.commit();
+}
+
+#[test]
+fn test_nonce_revert_opens_replay_attack() {
+    let owner_keypair = KeyPair::generate_default_csprng();
+    let owner_address = Address::from(&owner_keypair.public);
+    let oracle_address = Address::from([0x0Eu8; 20]);
+    let bridge_address = Address::from([0x0Bu8; 20]);
+
+    let (oracle, _, _) = make_oracle_for_two_txs();
+    let chain_config = make_chain_config(standard_validation_program());
+
+    let bridge = BridgeContract {
+        owner: owner_address.clone(),
+        oracle_address: oracle_address.clone(),
+        balance: Coin::from_u64_unchecked(10_000),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config,
+        transaction_count: 0,
+    };
+
+    let test = TestCommitRevert::with_initial_state(&[
+        (oracle_address.clone(), Account::Oracle(oracle)),
+        (bridge_address.clone(), Account::Bridge(bridge)),
+    ]);
+
+    let block_state = BlockState::new(1, 1, Policy::max_supported_version());
+
+    let tx1 = make_outgoing_tx(&bridge_address, 1, 0, &owner_keypair);
+    let tx2 = make_outgoing_tx(&bridge_address, 2, 1, &owner_keypair);
+
+    // Step 1: commit nonce=1 — must succeed.
+    let receipts1 = commit_block(&test, &[tx1.clone()], &block_state);
+    assert!(
+        matches!(receipts1.transactions[0], OperationReceipt::Ok(_)),
+        "tx nonce=1 should be committed successfully"
+    );
+
+    // Step 2: commit nonce=2 — must succeed.
+    let receipts2 = commit_block(&test, &[tx2.clone()], &block_state);
+    assert!(
+        matches!(receipts2.transactions[0], OperationReceipt::Ok(_)),
+        "tx nonce=2 should be committed successfully"
+    );
+
+    // Step 3: revert nonce=2.
+    // should restore nonce to 1
+    revert_block(&test, &[tx2.clone()], receipts2, &block_state);
+
+    // Step 4: attempt to replay nonce=1.
+    // Expected (correct): OperationReceipt::Err — nonce=1 was already processed.
+    // Actual (buggy):     OperationReceipt::Ok  — nonce was wiped, replay succeeds.
+    let receipts_replay = commit_block(&test, &[tx1.clone()], &block_state);
+
+    assert!(
+        matches!(receipts_replay.transactions[0], OperationReceipt::Err(_, _)),
+        "REPLAY ATTACK CONFIRMED: nonce=1 was accepted again after reverting nonce=2. \
+         The nonce revert logic removes the entry instead of restoring it to the previous value."
+    );
+}
+
+#[test]
+fn test_large_amount_in_burn_data_returns_error() {
+    // Amount one unit above Coin::MAX_SAFE_VALUE.
+    let oversize_amount = Coin::MAX_SAFE_VALUE + 1; // 9_007_199_254_740_992u64
+
+    let program = standard_validation_program();
+    let chain_config = make_chain_config(program);
+
+    let mut burn_data = make_burn_data(1);
+    // Overwrite the amount field (bytes 20..28) with the oversize value.
+    burn_data[20..28].copy_from_slice(&oversize_amount.to_le_bytes());
+
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        merkle_proof: AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        oracle_state_index: 0,
+    };
+
+    // Must return an error and not panic.
+    assert!(
+        outgoing.parse_burn_data(&chain_config).is_err(),
+        "oversized amount must be rejected with an error, not a panic"
+    );
+}
+
+#[test]
+fn test_assert_in_validation_program_permanently_locks_funds() {
+    // ValidationProgram with all required stores PLUS a final Assert.
+    // A bridge operator might add this for "extra on-chain validation".
+    let locked_program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::LoadAddress,
+        ValidationOp::Store("target_address".to_string()),
+        ValidationOp::PushConst(20),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("amount".to_string()),
+        ValidationOp::PushConst(28),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("target_nonce".to_string()),
+        ValidationOp::PushConst(36),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("burn_block_height".to_string()),
+        ValidationOp::PushConst(40),
+        ValidationOp::LoadU32(Endianness::LittleEndian),
+        ValidationOp::Store("target_chain_id".to_string()),
+        // "Sanity check" assertion that looks harmless but breaks extraction-only mode.
+        ValidationOp::PushConst(1), // push true
+        ValidationOp::Assert,       // assert top of stack is non-zero
+    ]);
+
+    let chain_config = make_chain_config(locked_program.clone());
+
+    //  Creation must be rejected when the program is incompatible.
+    let creation_data = CreationTransactionData {
+        owner: Address::from([1u8; 20]),
+        oracle_address: Address::from([2u8; 20]),
+        source_chain_id: SOURCE_CHAIN_ID,
+        chain_config: chain_config.clone(),
+    };
+    assert!(
+        creation_data.verify().is_err(),
+        "Bridge creation must be rejected when the ValidationProgram contains Assert"
+    );
+
+    // parse_burn_data fails for ALL burn proofs — funds are permanently locked.
+    let burn_data = make_burn_data(1);
+    let outgoing = OutgoingTransaction {
+        burn_transaction_data: burn_data,
+        merkle_proof: AnyMerkleProof::Blake2bPath(MerklePath::empty()),
+        oracle_state_index: 0,
+    };
+
+    let result = outgoing.parse_burn_data(&chain_config);
+    assert!(
+        result.is_err(),
+        "parse_burn_data must fail when the ValidationProgram contains Assert"
+    );
+}

--- a/primitives/account/tests/oracle_contract.rs
+++ b/primitives/account/tests/oracle_contract.rs
@@ -564,6 +564,81 @@ fn it_reverts_update_after_multiple_wraps() {
     );
 }
 
+/// Regression: a *non-first* update carrying more hashes than `hash_count` wraps
+/// over its own ring positions, so `removed_hashes` captures a value written
+/// earlier in the same update. The revert then restores that wrong value instead
+/// of the true prior one, diverging the accounts-tree root on a reorg (consensus
+/// fork). Such an update must be rejected. Concretely, with `hash_count = 3` and a
+/// full buffer, a follow-up 4-hash update evicts position 0 twice; before the fix
+/// the revert would restore `data_3` there instead of `data_0`.
+#[test]
+fn oracle_rejects_non_first_update_exceeding_hash_count() {
+    let mut rng = test_rng(true);
+    let key = KeyPair::generate(&mut rng);
+    let contract_addr = Address([1u8; 20]);
+
+    let oracle = OracleContract {
+        balance: Coin::from_u64_unchecked(1000),
+        owner: Address::from(&key.public),
+        hash_count: 3,
+        hashes: Vec::new(),
+        latest_index: None,
+    };
+    let accounts = TestCommitRevert::with_initial_state(&[
+        (
+            Address::from(&key.public),
+            Account::Basic(BasicAccount {
+                balance: Coin::from_u64_unchecked(10_000),
+            }),
+        ),
+        (contract_addr.clone(), Account::Oracle(oracle.clone())),
+    ]);
+    let block_state = BlockState::new(1, 1, Policy::max_supported_version());
+
+    // Fill the buffer to capacity (a first update of exactly hash_count is allowed),
+    // so every position holds real data and the next update is *non-first*.
+    let mut oracle = oracle;
+    let fill = make_update_transaction(
+        contract_addr.clone(),
+        &key,
+        vec![make_hash(1), make_hash(2), make_hash(3)],
+    );
+    accounts
+        .test_commit_incoming_transaction(
+            &mut oracle,
+            &fill,
+            &block_state,
+            &mut TransactionLog::empty(),
+            true,
+        )
+        .expect("initial fill of exactly hash_count hashes must succeed");
+    assert_eq!(oracle.latest_index, Some(2));
+
+    // A follow-up update of 4 hashes (> hash_count = 3) would wrap over its own
+    // positions and corrupt the revert; it must be rejected before any mutation.
+    let too_many = make_update_transaction(
+        contract_addr,
+        &key,
+        vec![make_hash(4), make_hash(5), make_hash(6), make_hash(7)],
+    );
+    let result = accounts.test_commit_incoming_transaction(
+        &mut oracle,
+        &too_many,
+        &block_state,
+        &mut TransactionLog::empty(),
+        false,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(AccountError::InvalidTransaction(
+                TransactionError::InvalidData
+            ))
+        ),
+        "a non-first update exceeding hash_count must be rejected, got {result:?}",
+    );
+}
+
 #[test]
 fn it_can_change_owner() {
     let (accounts, mut oracle_contract, key_1, key_2) = init_tree();

--- a/primitives/src/policy/upgrades/v3.rs
+++ b/primitives/src/policy/upgrades/v3.rs
@@ -9,3 +9,8 @@ pub const VERSION: u16 = 3;
 
 // --- Changes shipping in v3 -------------------------------------------------
 // Add one `pub const MY_CHANGE: u16 = VERSION;` line per change below.
+
+/// Bridge and oracle contracts for cross-chain asset transfers. Transactions
+/// involving `AccountType::Bridge` or `AccountType::Oracle` are invalid in
+/// blocks before this version.
+pub const BRIDGE_ORACLE_CONTRACTS: u16 = VERSION;

--- a/primitives/transaction/src/account/bridge_contract/core.rs
+++ b/primitives/transaction/src/account/bridge_contract/core.rs
@@ -147,6 +147,10 @@ pub struct ChainConfig {
     /// Validation program for burn transactions
     /// Defines how to parse and validate burn transactions from the source chain
     pub validation_program: ValidationProgram,
+    /// Maximum allowed Merkle proof depth (number of sibling nodes).
+    /// Bounds the work required to verify a proof and prevents DoS via
+    /// artificially deep proofs. A depth of 64 covers trees with 2^64 leaves.
+    pub max_proof_depth: u32,
 }
 
 /// Represents a verified state hash from the Nimiq Oracle Contract.
@@ -519,7 +523,8 @@ impl OutgoingTransaction {
             .extracted_values
             .get("amount")
             .ok_or(BridgeError::InvalidRecipientData)?;
-        let amount = Coin::from_u64_unchecked(amount_value.as_u64()?);
+        let amount =
+            Coin::try_from(amount_value.as_u64()?).map_err(|_| BridgeError::InvalidAmount)?;
 
         let address_value = result
             .extracted_values
@@ -836,15 +841,13 @@ impl MerkleProofValidator {
 
     /// Validates the structure of a Merkle proof.
     ///
-    /// Checks that the proof depth does not exceed the maximum allowed
-    /// and that the proof is not empty.
+    /// Checks that the proof depth does not exceed the maximum allowed.
+    /// An empty proof is valid: it represents a single-leaf tree where the
+    /// leaf hash is the root (no siblings needed).
     ///
     pub fn validate_proof_structure(&self, proof: &AnyMerkleProof) -> Result<(), BridgeError> {
         if proof.len() > self.max_proof_depth as usize {
             return Err(BridgeError::ProofDepthExceeded);
-        }
-        if proof.is_empty() {
-            return Err(BridgeError::InvalidMerkleProof);
         }
         Ok(())
     }

--- a/primitives/transaction/src/account/bridge_contract/core.rs
+++ b/primitives/transaction/src/account/bridge_contract/core.rs
@@ -1509,6 +1509,28 @@ pub struct ValidationProgram {
     pub operations: Vec<ValidationOp>,
 }
 
+/// Computes the byte range `offset..offset + len` into a buffer of size `data_len`,
+/// rejecting any range that overflows or falls outside the buffer.
+///
+/// `offset` and `len` originate from attacker-controlled burn data, so the
+/// addition is done with `checked_add`: a plain `offset + len` can wrap (release
+/// builds do not enable overflow checks) and satisfy a naive `> data_len` guard
+/// while the real range is out of bounds, panicking on the subsequent slice.
+fn checked_data_range(
+    offset: u64,
+    len: u64,
+    data_len: usize,
+) -> Result<std::ops::Range<usize>, BridgeError> {
+    let end = offset
+        .checked_add(len)
+        .ok_or(BridgeError::InvalidDataLength)?;
+    if end > data_len as u64 {
+        return Err(BridgeError::InvalidDataLength);
+    }
+    // `end <= data_len`, which is a `usize`, so both bounds fit in `usize`.
+    Ok(offset as usize..end as usize)
+}
+
 impl ValidationProgram {
     /// Creates a new validation program with the given operations
     pub fn new(operations: Vec<ValidationOp>) -> Self {
@@ -1538,70 +1560,49 @@ impl ValidationProgram {
             }
 
             ValidationOp::LoadBytes => {
-                let length = ctx.pop_u64()? as usize;
-                let offset = ctx.pop_u64()? as usize;
-                let burn_tx_data = ctx.burn_tx_data();
+                let length = ctx.pop_u64()?;
+                let offset = ctx.pop_u64()?;
+                let data = ctx.burn_tx_data();
+                let range = checked_data_range(offset, length, data.len())?;
 
-                if offset + length > burn_tx_data.len() {
-                    return Err(BridgeError::InvalidDataLength);
-                }
-
-                let bytes = burn_tx_data[offset..offset + length].to_vec();
+                let bytes = data[range].to_vec();
                 ctx.stack_mut().push(StackValue::Bytes(bytes));
             }
 
             ValidationOp::LoadU64(endianness) => {
-                let offset = ctx.pop_u64()? as usize;
-                let burn_tx_data = ctx.burn_tx_data();
+                let offset = ctx.pop_u64()?;
+                let data = ctx.burn_tx_data();
+                let range = checked_data_range(offset, 8, data.len())?;
 
-                if offset + 8 > burn_tx_data.len() {
-                    return Err(BridgeError::InvalidDataLength);
-                }
-
-                let value = endianness_conversion::parse_u64(
-                    &burn_tx_data[offset..offset + 8],
-                    *endianness,
-                )?;
+                let value = endianness_conversion::parse_u64(&data[range], *endianness)?;
                 ctx.stack_mut().push(StackValue::U64(value));
             }
 
             ValidationOp::LoadU32(endianness) => {
-                let offset = ctx.pop_u64()? as usize;
-                let burn_tx_data = ctx.burn_tx_data();
+                let offset = ctx.pop_u64()?;
+                let data = ctx.burn_tx_data();
+                let range = checked_data_range(offset, 4, data.len())?;
 
-                if offset + 4 > burn_tx_data.len() {
-                    return Err(BridgeError::InvalidDataLength);
-                }
-
-                let value = endianness_conversion::parse_u32(
-                    &burn_tx_data[offset..offset + 4],
-                    *endianness,
-                )?;
+                let value = endianness_conversion::parse_u32(&data[range], *endianness)?;
                 ctx.stack_mut().push(StackValue::U32(value));
             }
 
             ValidationOp::LoadAddress => {
-                let offset = ctx.pop_u64()? as usize;
-                let burn_tx_data = ctx.burn_tx_data();
+                let offset = ctx.pop_u64()?;
+                let data = ctx.burn_tx_data();
+                let range = checked_data_range(offset, 20, data.len())?;
 
-                if offset + 20 > burn_tx_data.len() {
-                    return Err(BridgeError::InvalidDataLength);
-                }
-
-                let bytes = burn_tx_data[offset..offset + 20].to_vec();
+                let bytes = data[range].to_vec();
                 ctx.stack_mut().push(StackValue::Bytes(bytes));
             }
 
             ValidationOp::LoadEvmU64 => {
-                let offset = ctx.pop_u64()? as usize;
-                let burn_tx_data = ctx.burn_tx_data();
-
-                if offset + 32 > burn_tx_data.len() {
-                    return Err(BridgeError::InvalidDataLength);
-                }
+                let offset = ctx.pop_u64()?;
+                let data = ctx.burn_tx_data();
+                let range = checked_data_range(offset, 32, data.len())?;
 
                 let mut evm_bytes = [0u8; 32];
-                evm_bytes.copy_from_slice(&burn_tx_data[offset..offset + 32]);
+                evm_bytes.copy_from_slice(&data[range]);
                 let value = crate::bridge_contract::decode_arithmetic::bytes32_to_u64(&evm_bytes)?;
                 ctx.stack_mut().push(StackValue::U64(value));
             }

--- a/primitives/transaction/src/account/bridge_contract/mod.rs
+++ b/primitives/transaction/src/account/bridge_contract/mod.rs
@@ -3,7 +3,7 @@
 // This module contains all bridge contract functionality for cross-chain asset transfers.
 // The main implementation is in bridge_contract.rs, with transaction data structures in structs.rs
 
-use nimiq_primitives::account::AccountType;
+use nimiq_primitives::{account::AccountType, policy::upgrades};
 
 use crate::{
     account::AccountTransactionVerification, Transaction, TransactionError, TransactionFlags,
@@ -23,9 +23,18 @@ pub struct BridgeContractVerifier {}
 impl AccountTransactionVerification for BridgeContractVerifier {
     fn verify_incoming_transaction(
         transaction: &Transaction,
-        _protocol_version: u16,
+        protocol_version: u16,
     ) -> Result<(), TransactionError> {
         assert_eq!(transaction.recipient_type, AccountType::Bridge);
+
+        // Bridge contracts only activate with the v3 fork.
+        if protocol_version < upgrades::v3::BRIDGE_ORACLE_CONTRACTS {
+            warn!(
+                ?transaction,
+                "Bridge contracts are not enabled in this protocol version",
+            );
+            return Err(TransactionError::InvalidForRecipient);
+        }
 
         if transaction
             .flags
@@ -56,9 +65,18 @@ impl AccountTransactionVerification for BridgeContractVerifier {
 
     fn verify_outgoing_transaction(
         transaction: &Transaction,
-        _protocol_version: u16,
+        protocol_version: u16,
     ) -> Result<(), TransactionError> {
         assert_eq!(transaction.sender_type, AccountType::Bridge);
+
+        // Bridge contracts only activate with the v3 fork.
+        if protocol_version < upgrades::v3::BRIDGE_ORACLE_CONTRACTS {
+            warn!(
+                ?transaction,
+                "Bridge contracts are not enabled in this protocol version",
+            );
+            return Err(TransactionError::InvalidForSender);
+        }
 
         // Parse and verify the outgoing data from sender_data
         let data = OutgoingBridgeTransactionData::parse(transaction)?;

--- a/primitives/transaction/src/account/bridge_contract/structs.rs
+++ b/primitives/transaction/src/account/bridge_contract/structs.rs
@@ -2,7 +2,7 @@ use nimiq_keys::Address;
 use nimiq_serde::{Deserialize, Serialize};
 
 use super::core::{ChainConfig, OutgoingTransaction};
-use crate::{SignatureProof, Transaction, TransactionError};
+use crate::{account::htlc_contract::AnyHash, SignatureProof, Transaction, TransactionError};
 
 /// Data used to create bridge contracts.
 ///
@@ -37,6 +37,18 @@ impl CreationTransactionData {
         if self.chain_config.chain_id != self.source_chain_id {
             warn!("Chain config chain_id does not match source_chain_id");
             return Err(TransactionError::InvalidData);
+        }
+        // The release path (extract_burn_transaction_hash and AnyMerkleProof)
+        // supports only Blake2b, Sha256 and Keccak256. A bridge configured with any
+        // other hash function could accept deposits but never process a burn-proof
+        // release, permanently locking user funds. The match is exhaustive so a
+        // newly added AnyHash variant forces an explicit support decision here.
+        match self.chain_config.hash_function {
+            AnyHash::Blake2b(_) | AnyHash::Sha256(_) | AnyHash::Keccak256(_) => {}
+            AnyHash::Sha512(_) => {
+                warn!("Invalid creation data: Sha512 hash_function is not supported by the bridge release path");
+                return Err(TransactionError::InvalidData);
+            }
         }
         // Reject programs that contain Assert or PushExpected* operations.
         // These require a ValidationContext (full execution mode) and cause

--- a/primitives/transaction/src/account/bridge_contract/structs.rs
+++ b/primitives/transaction/src/account/bridge_contract/structs.rs
@@ -38,6 +38,22 @@ impl CreationTransactionData {
             warn!("Chain config chain_id does not match source_chain_id");
             return Err(TransactionError::InvalidData);
         }
+        // Reject programs that contain Assert or PushExpected* operations.
+        // These require a ValidationContext (full execution mode) and cause
+        // parse_burn_data → extract_only to always fail, permanently locking funds.
+        for op in &self.chain_config.validation_program.operations {
+            match op {
+                super::core::ValidationOp::Assert
+                | super::core::ValidationOp::PushExpectedAmount
+                | super::core::ValidationOp::PushExpectedAddress
+                | super::core::ValidationOp::PushExpectedNonce
+                | super::core::ValidationOp::PushExpectedValidityHeight => {
+                    warn!("Validation program contains an operation incompatible with extraction-only mode");
+                    return Err(TransactionError::InvalidData);
+                }
+                _ => {}
+            }
+        }
         Ok(())
     }
 }

--- a/primitives/transaction/src/account/oracle_contract.rs
+++ b/primitives/transaction/src/account/oracle_contract.rs
@@ -1,5 +1,5 @@
 use nimiq_keys::Address;
-use nimiq_primitives::account::AccountType;
+use nimiq_primitives::{account::AccountType, policy::upgrades};
 use nimiq_serde::{Deserialize, DeserializeError, Serialize};
 
 use crate::{
@@ -13,9 +13,18 @@ pub struct OracleContractVerifier {}
 impl AccountTransactionVerification for OracleContractVerifier {
     fn verify_incoming_transaction(
         transaction: &Transaction,
-        _protocol_version: u16,
+        protocol_version: u16,
     ) -> Result<(), TransactionError> {
         assert_eq!(transaction.recipient_type, AccountType::Oracle);
+
+        // Oracle contracts only activate with the v3 fork.
+        if protocol_version < upgrades::v3::BRIDGE_ORACLE_CONTRACTS {
+            warn!(
+                "Oracle contracts are not enabled in this protocol version. The offending transaction is the following:\n{:?}",
+                transaction
+            );
+            return Err(TransactionError::InvalidForRecipient);
+        }
 
         if transaction
             .flags
@@ -49,9 +58,18 @@ impl AccountTransactionVerification for OracleContractVerifier {
 
     fn verify_outgoing_transaction(
         transaction: &Transaction,
-        _protocol_version: u16,
+        protocol_version: u16,
     ) -> Result<(), TransactionError> {
         assert_eq!(transaction.sender_type, AccountType::Oracle);
+
+        // Oracle contracts only activate with the v3 fork.
+        if protocol_version < upgrades::v3::BRIDGE_ORACLE_CONTRACTS {
+            warn!(
+                "Oracle contracts are not enabled in this protocol version. The offending transaction is the following:\n{:?}",
+                transaction
+            );
+            return Err(TransactionError::InvalidForSender);
+        }
 
         if !transaction.sender_data.is_empty() {
             warn!(

--- a/primitives/transaction/tests/bridge_oracle_contract_verify.rs
+++ b/primitives/transaction/tests/bridge_oracle_contract_verify.rs
@@ -8,7 +8,7 @@ use nimiq_primitives::{
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_transaction::{
     account::{
-        htlc_contract::{AnyHash, AnyHash32},
+        htlc_contract::{AnyHash, AnyHash32, AnyHash64},
         oracle_contract::CreationTransactionData as OracleCreationData,
         AccountTransactionVerification,
     },
@@ -126,6 +126,61 @@ fn bridge_creation_is_version_gated() {
             assert_eq!(result, Ok(()));
         }
     });
+}
+
+/// A bridge configured with `hash_function = Sha512` must be rejected at creation:
+/// Sha512 has no `AnyMerkleProof` variant and `extract_burn_transaction_hash`
+/// returns `UnsupportedHashFunction`, so such a bridge could accept deposits but
+/// never process a burn-proof release — a permanent fund lock.
+#[test]
+fn bridge_creation_rejects_unsupported_hash_function() {
+    let make_tx = |hash_function: AnyHash| {
+        let data = BridgeCreationData {
+            owner: Address::from(&key_pair().public),
+            oracle_address: Address::from([4u8; 20]),
+            source_chain_id: 1,
+            chain_config: ChainConfig {
+                chain_id: 1,
+                hash_function,
+                address_format: AddressFormat::Ethereum,
+                endianness: Endianness::LittleEndian,
+                block_time: std::time::Duration::from_secs(60),
+                validation_program: ValidationProgram::empty(),
+                max_proof_depth: 64,
+            },
+        };
+        Transaction::new_contract_creation(
+            Address::from([1u8; 20]),
+            AccountType::Basic,
+            vec![],
+            AccountType::Bridge,
+            data.serialize_to_vec(),
+            1000.try_into().unwrap(),
+            0.try_into().unwrap(),
+            1,
+            NetworkId::UnitAlbatross,
+        )
+    };
+
+    // Sha512 is unsupported by the release path → rejected at an activated version.
+    let sha512_tx = make_tx(AnyHash::Sha512(AnyHash64::from([0u8; 64])));
+    assert_eq!(
+        AccountType::verify_incoming_transaction(&sha512_tx, ACTIVATION),
+        Err(TransactionError::InvalidData),
+    );
+
+    // The three supported hash functions are accepted at an activated version.
+    for supported in [
+        AnyHash::Blake2b(AnyHash32::from([0u8; 32])),
+        AnyHash::Sha256(AnyHash32::from([0u8; 32])),
+        AnyHash::Keccak256(AnyHash32::from([0u8; 32])),
+    ] {
+        let tx = make_tx(supported);
+        assert_eq!(
+            AccountType::verify_incoming_transaction(&tx, ACTIVATION),
+            Ok(()),
+        );
+    }
 }
 
 #[test]

--- a/primitives/transaction/tests/bridge_oracle_contract_verify.rs
+++ b/primitives/transaction/tests/bridge_oracle_contract_verify.rs
@@ -1,0 +1,185 @@
+mod common;
+
+use common::for_each_protocol_version;
+use nimiq_keys::{Address, KeyPair, PrivateKey};
+use nimiq_primitives::{
+    account::AccountType, networks::NetworkId, policy::upgrades, transaction::TransactionError,
+};
+use nimiq_serde::{Deserialize, Serialize};
+use nimiq_transaction::{
+    account::{
+        htlc_contract::{AnyHash, AnyHash32},
+        oracle_contract::CreationTransactionData as OracleCreationData,
+        AccountTransactionVerification,
+    },
+    bridge_contract::{
+        AddressFormat, ChainConfig, CreationTransactionData as BridgeCreationData, Endianness,
+        ValidationProgram,
+    },
+    SignatureProof, Transaction,
+};
+
+const ACTIVATION: u16 = upgrades::v3::BRIDGE_ORACLE_CONTRACTS;
+
+fn key_pair() -> KeyPair {
+    KeyPair::from(
+        PrivateKey::deserialize_from_vec(
+            &hex::decode("9d5bd02379e7e45cf515c788048f5cf3c454ffabd3e83bd1d7667716c325c3c0")
+                .unwrap(),
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn oracle_creation_is_version_gated() {
+    let data = OracleCreationData {
+        owner: Address::from(&key_pair().public),
+        hash_count: 5,
+    };
+
+    let tx = Transaction::new_contract_creation(
+        Address::from([1u8; 20]),
+        AccountType::Basic,
+        vec![],
+        AccountType::Oracle,
+        data.serialize_to_vec(),
+        1000.try_into().unwrap(),
+        0.try_into().unwrap(),
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    for_each_protocol_version(|v| {
+        let result = AccountType::verify_incoming_transaction(&tx, v);
+        if v < ACTIVATION {
+            assert_eq!(result, Err(TransactionError::InvalidForRecipient));
+        } else {
+            assert_eq!(result, Ok(()));
+        }
+    });
+}
+
+#[test]
+fn oracle_outgoing_is_version_gated() {
+    let key_pair = key_pair();
+
+    let mut tx = Transaction::new_extended(
+        Address::from([2u8; 20]),
+        AccountType::Oracle,
+        vec![],
+        Address::from([3u8; 20]),
+        AccountType::Basic,
+        vec![],
+        1000.try_into().unwrap(),
+        0.try_into().unwrap(),
+        1,
+        NetworkId::UnitAlbatross,
+    );
+    let signature = key_pair.sign(&tx.serialize_content());
+    tx.proof = SignatureProof::from_ed25519(key_pair.public, signature).serialize_to_vec();
+
+    for_each_protocol_version(|v| {
+        let result = AccountType::verify_outgoing_transaction(&tx, v);
+        if v < ACTIVATION {
+            assert_eq!(result, Err(TransactionError::InvalidForSender));
+        } else {
+            assert_eq!(result, Ok(()));
+        }
+    });
+}
+
+#[test]
+fn bridge_creation_is_version_gated() {
+    let data = BridgeCreationData {
+        owner: Address::from(&key_pair().public),
+        oracle_address: Address::from([4u8; 20]),
+        source_chain_id: 1,
+        chain_config: ChainConfig {
+            chain_id: 1,
+            hash_function: AnyHash::Keccak256(AnyHash32::from([0u8; 32])),
+            address_format: AddressFormat::Ethereum,
+            endianness: Endianness::LittleEndian,
+            block_time: std::time::Duration::from_secs(60),
+            validation_program: ValidationProgram::empty(),
+            max_proof_depth: 64,
+        },
+    };
+
+    let tx = Transaction::new_contract_creation(
+        Address::from([1u8; 20]),
+        AccountType::Basic,
+        vec![],
+        AccountType::Bridge,
+        data.serialize_to_vec(),
+        1000.try_into().unwrap(),
+        0.try_into().unwrap(),
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    for_each_protocol_version(|v| {
+        let result = AccountType::verify_incoming_transaction(&tx, v);
+        if v < ACTIVATION {
+            assert_eq!(result, Err(TransactionError::InvalidForRecipient));
+        } else {
+            assert_eq!(result, Ok(()));
+        }
+    });
+}
+
+#[test]
+fn bridge_incoming_transfer_is_version_gated() {
+    // A regular transfer to a bridge contract (user locking funds).
+    let tx = Transaction::new_extended(
+        Address::from([1u8; 20]),
+        AccountType::Basic,
+        vec![],
+        Address::from([2u8; 20]),
+        AccountType::Bridge,
+        vec![],
+        1000.try_into().unwrap(),
+        0.try_into().unwrap(),
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    for_each_protocol_version(|v| {
+        let result = AccountType::verify_incoming_transaction(&tx, v);
+        if v < ACTIVATION {
+            assert_eq!(result, Err(TransactionError::InvalidForRecipient));
+        } else {
+            assert_eq!(result, Ok(()));
+        }
+    });
+}
+
+#[test]
+fn bridge_outgoing_is_version_gated() {
+    // Empty sender_data fails to parse as OutgoingBridgeTransactionData, but
+    // the version gate must fire before any parsing is attempted.
+    let tx = Transaction::new_extended(
+        Address::from([2u8; 20]),
+        AccountType::Bridge,
+        vec![],
+        Address::from([3u8; 20]),
+        AccountType::Basic,
+        vec![],
+        1000.try_into().unwrap(),
+        0.try_into().unwrap(),
+        1,
+        NetworkId::UnitAlbatross,
+    );
+
+    for_each_protocol_version(|v| {
+        let result = AccountType::verify_outgoing_transaction(&tx, v);
+        if v < ACTIVATION {
+            assert_eq!(result, Err(TransactionError::InvalidForSender));
+        } else {
+            assert!(matches!(
+                result,
+                Err(TransactionError::InvalidSerialization(_))
+            ));
+        }
+    });
+}

--- a/primitives/transaction/tests/validation_operations_test.rs
+++ b/primitives/transaction/tests/validation_operations_test.rs
@@ -444,6 +444,7 @@ fn test_chain_config_with_validation_program() {
         endianness: Endianness::BigEndian,
         block_time: std::time::Duration::from_secs(12),
         validation_program,
+        max_proof_depth: 64,
     };
 
     // Verify the validation program is stored correctly

--- a/primitives/transaction/tests/validation_operations_test.rs
+++ b/primitives/transaction/tests/validation_operations_test.rs
@@ -450,3 +450,105 @@ fn test_chain_config_with_validation_program() {
     // Verify the validation program is stored correctly
     assert_eq!(chain_config.validation_program.operations.len(), 4);
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for the `Load*` bounds-check integer overflow (audit finding
+// "High — Integer overflow in Load* bounds checks").
+//
+// The offset/length operands are popped from the stack and, on the outgoing
+// burn-proof path, originate from fully attacker-controlled burn data. A naive
+// `offset + N > data.len()` guard wraps on overflow (release builds don't enable
+// overflow-checks) and lets an out-of-bounds slice through to a panic, which
+// halts every node re-executing the block. Each opcode must return an error
+// instead of panicking. These run through `extract_only`, the exact path used by
+// permissionless burn-proof submission.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_bytes_offset_plus_length_overflow_is_rejected_not_panic() {
+    // offset + length overflows u64 (u64::MAX - 3 + 100), so a wrapping guard
+    // would compute a small "end" and slip an out-of-bounds slice through.
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(u64::MAX - 3),
+        ValidationOp::PushConst(100),
+        ValidationOp::LoadBytes,
+    ]);
+    let burn_tx_data = vec![0u8; 64];
+    assert!(program.extract_only(&burn_tx_data).is_err());
+}
+
+#[test]
+fn load_u64_offset_overflow_is_rejected_not_panic() {
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(u64::MAX),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+    ]);
+    let burn_tx_data = vec![0u8; 64];
+    assert!(program.extract_only(&burn_tx_data).is_err());
+}
+
+#[test]
+fn load_u32_offset_overflow_is_rejected_not_panic() {
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(u64::MAX),
+        ValidationOp::LoadU32(Endianness::BigEndian),
+    ]);
+    let burn_tx_data = vec![0u8; 64];
+    assert!(program.extract_only(&burn_tx_data).is_err());
+}
+
+#[test]
+fn load_address_offset_overflow_is_rejected_not_panic() {
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(u64::MAX),
+        ValidationOp::LoadAddress,
+    ]);
+    let burn_tx_data = vec![0u8; 64];
+    assert!(program.extract_only(&burn_tx_data).is_err());
+}
+
+#[test]
+fn load_evm_u64_offset_overflow_is_rejected_not_panic() {
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(u64::MAX),
+        ValidationOp::LoadEvmU64,
+    ]);
+    let burn_tx_data = vec![0u8; 64];
+    assert!(program.extract_only(&burn_tx_data).is_err());
+}
+
+#[test]
+fn load_just_past_end_boundary_is_rejected() {
+    // Data is 8 bytes; a u64 read at offset 1 needs bytes [1..9] — one past the
+    // end. No overflow here, just an ordinary out-of-range read that must fail.
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(1),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+    ]);
+    let burn_tx_data = vec![0u8; 8];
+    assert!(program.extract_only(&burn_tx_data).is_err());
+}
+
+#[test]
+fn load_within_bounds_still_succeeds_after_fix() {
+    // Guard against an over-tight bound: a legitimate in-range read of exactly
+    // the last available bytes must still succeed and extract the right value.
+    let program = ValidationProgram::new(vec![
+        ValidationOp::PushConst(0),
+        ValidationOp::LoadU64(Endianness::LittleEndian),
+        ValidationOp::Store("value".to_string()),
+    ]);
+    let burn_tx_data = 42u64.to_le_bytes().to_vec(); // exactly 8 bytes
+    let result = program
+        .extract_only(&burn_tx_data)
+        .expect("in-range load must succeed");
+    assert_eq!(
+        result
+            .extracted_values
+            .get("value")
+            .expect("value was stored")
+            .as_u64()
+            .expect("value is a u64"),
+        42
+    );
+}


### PR DESCRIPTION
  Protocol gating
  - Gate all bridge/oracle contract transactions behind the v3 protocol upgrade, so they are invalid in pre-v3 blocks.

  Fund-lock prevention (creation-time validation)
  - Reject bridge creation with a hash function the release path can't process (e.g. Sha512), which would otherwise accept deposits that can never be released.
  - Reject ValidationPrograms containing extraction-incompatible opcodes (Assert/PushExpected*) at creation, which would otherwise permanently lock deposited funds.

  Node-crash / DoS hardening
  - Fix integer overflow in the validation-VM Load* bounds checks, where an attacker-controlled offset + length could wrap, pass the check, and panic every node re-executing the block.
  - Prevent a node crash from an oversized burn amount by using a checked Coin conversion instead of a panicking unchecked one.
  - Enforce a maximum Merkle proof depth on withdrawals (the limit was dead code), closing an unbounded-proof DoS; also accept valid single-leaf empty proofs.

  Consensus / state-integrity
  - Reject oracle ring-buffer updates exceeding hash_count, which corrupted the revert path and could fork the accounts-tree root on a reorg.
  - Use the global oracle index (not the physical ring-buffer length) when validating withdrawals, preventing every withdrawal from being permanently locked once the buffer wraps.
  - Fix a nonce replay/double-spend where reverting an outgoing transaction deleted the nonce instead of restoring the previous value, letting a processed nonce be replayed after a reorg. 
  - Build MerklePath from per-recursion tentative paths, fixing incorrect proof construction.

  Mempool ↔ consensus consistency
  - Drop the owner-signature requirement from mempool admission of burn-releases (they are permissionless), so the mempool no longer rejects transactions consensus accepts.

  Fee model (signer-pays)
  - Charge the withdrawal fee to the burn-proof signer on a successful release; it was previously uncollected while still credited to the reward pot, inflating total supply.
  - Reserve the burn-release fee against the signer (not the bridge) at mempool admission, so a signer that cannot pay is rejected up front instead of aborting block production at commit.
  - Skip fee deduction for zero-fee permissionless burn submissions.

  Performance
  - Reuse the already-fetched epoch transactions in get_keccak256_proof instead of scanning the whole epoch a second time per request.

  Test coverage
  - Add comprehensive functional coverage for bridge/oracle contracts and integration tests for the mempool signer-fee reservation (reserve/release/rebuild).


## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
