### PR TITLE
Trie: reject equal-length keys in TrieProofNode::child_index

### DIFF
--- a/primitives/src/trie/trie_proof.rs
+++ b/primitives/src/trie/trie_proof.rs
@@ -213,7 +213,36 @@ mod tests {
     use nimiq_test_log::test;
 
     use super::*;
-    use crate::trie::trie_node::TrieNode;
+    use crate::trie::{trie_node::TrieNode, trie_proof_node::TrieProofNode};
+
+    #[test]
+    fn verify_rejects_proof_with_duplicate_keys() {
+        let key_leaf: KeyNibbles = "001".parse().unwrap();
+        let key_branch: KeyNibbles = "00".parse().unwrap();
+
+        let leaf = TrieNode::new_leaf(key_leaf.clone(), vec![42]);
+
+        let mut branch = TrieNode::new_empty(key_branch.clone());
+        branch.put_child(&key_leaf, leaf.hash_assert()).unwrap();
+
+        let mut root = TrieNode::new_empty(KeyNibbles::ROOT);
+        root.put_child(&key_branch, branch.hash_assert()).unwrap();
+
+        let branch_proof_node: TrieProofNode = branch.into();
+        let root_proof_node: TrieProofNode = root.clone().into();
+
+        let proof = TrieProof::new(
+            vec![
+                branch_proof_node.clone(),
+                branch_proof_node,
+                root_proof_node,
+            ],
+            Default::default(),
+        );
+
+        let root_hash = root.hash_assert();
+        assert!(!proof.verify(&root_hash));
+    }
 
     // We're going to construct proofs based on this tree:
     //

--- a/primitives/src/trie/trie_proof_node.rs
+++ b/primitives/src/trie/trie_proof_node.rs
@@ -80,18 +80,17 @@ impl TrieProofNode {
         self.children.iter().any(|c| c.is_some())
     }
     pub fn child_index(&self, child_prefix: &KeyNibbles) -> Result<usize, MerkleRadixTrieError> {
-        if !self.key.is_prefix_of(child_prefix) {
+        if !self.key.is_prefix_of(child_prefix) || self.key.len() == child_prefix.len() {
             error!(
-                "Child's prefix {} is not a prefix of the node with key {}!",
+                "Child's prefix {} is not a strict prefix of the node with key {}!",
                 child_prefix, self.key,
             );
             return Err(MerkleRadixTrieError::WrongPrefix);
         }
 
-        // Key length has to be smaller or equal to the child prefix length, so this will only panic
-        // when `child_prefix` has the same length as `self.key()`.
-        // PITODO: return error instead of unwrapping
-        Ok(child_prefix.get(self.key.len()).unwrap())
+        child_prefix
+            .get(self.key.len())
+            .ok_or(MerkleRadixTrieError::WrongPrefix)
     }
 
     pub fn child(&self, child_prefix: &KeyNibbles) -> Result<&TrieNodeChild, MerkleRadixTrieError> {


### PR DESCRIPTION
## What's in this pull request?

`TrieProofNode::child_index` computed a child's branch index as `child_prefix.get(self.key.len()).unwrap()`. When `child_prefix` has the *same* length as `self.key` (rather than being a strict prefix), that index is out of bounds and the `unwrap()` panics. This is reachable from `TrieProof::verify` on a proof supplied by an untrusted peer that contains equal-length / duplicate keys.

Require the node key to be a *strict* prefix of the child (reject when `self.key.len() == child_prefix.len()`) and propagate `MerkleRadixTrieError::WrongPrefix` instead of unwrapping the optional nibble.

Adds a regression test that builds a proof with duplicate nodes and asserts `verify` returns `false` instead of panicking.

_Stacked PR — based on `stefan/staking-databuilder-coin-bounds`; please merge that base first._

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
