### PR TITLE
Better empty trie proof handling

### DIFF
--- a/consensus/src/messages/handlers.rs
+++ b/consensus/src/messages/handlers.rs
@@ -746,6 +746,9 @@ impl<N: Network> Handle<N, Arc<RwLock<Blockchain>>> for RequestTrieProof {
         blockchain: &Arc<RwLock<Blockchain>>,
     ) -> Result<ResponseTrieProof, ResponseTrieProofError> {
         // Validate request.
+        if self.keys.is_empty() {
+            return Err(ResponseTrieProofError::EmptyKeys);
+        }
         if self.keys.len() > Self::MAX_KEYS {
             return Err(ResponseTrieProofError::TooManyKeys);
         }

--- a/consensus/src/messages/mod.rs
+++ b/consensus/src/messages/mod.rs
@@ -606,6 +606,8 @@ pub struct ResponseTrieProof {
 pub enum ResponseTrieProofError {
     #[error("incomplete trie")]
     IncompleteTrie,
+    #[error("empty keys")]
+    EmptyKeys,
     #[error("too many keys")]
     TooManyKeys,
     #[error("duplicate keys")]

--- a/consensus/tests/request_handlers.rs
+++ b/consensus/tests/request_handlers.rs
@@ -103,6 +103,19 @@ fn transaction_receipts_request_without_index_returns_empty_list() {
 }
 
 #[test]
+fn trie_proof_request_rejects_empty_keys() {
+    let blockchain = blockchain_with_accounts();
+
+    let response = <RequestTrieProof as Handle<MockNetwork, Arc<RwLock<Blockchain>>>>::handle(
+        &RequestTrieProof { keys: vec![] },
+        MockPeerId(0),
+        &blockchain,
+    );
+
+    assert!(matches!(response, Err(ResponseTrieProofError::EmptyKeys)));
+}
+
+#[test]
 fn trie_proof_request_rejects_duplicate_missing_keys() {
     let blockchain = blockchain_with_accounts();
     let absent_key: KeyNibbles = "deadbeefdeadbeefdeadbeef01".parse().unwrap();

--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -1198,6 +1198,13 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         txn: &MdbxReadTransaction,
         mut keys: Vec<&KeyNibbles>,
     ) -> Result<TrieProof, IncompleteTrie> {
+        if keys.is_empty() {
+            return Ok(TrieProof::new(
+                vec![self.get_root(txn).unwrap().into()],
+                Default::default(),
+            ));
+        }
+
         // We sort the keys in post-order.
         keys.sort_by(|&k1, &k2| k1.post_order_cmp(k2));
 
@@ -1776,6 +1783,27 @@ mod tests {
         let proof = trie.get_proof(&txn, vec![&key_4]).unwrap();
         assert_eq!(proof.nodes.len(), 2);
         assert!(proof.verify(&trie.root_hash_assert(&txn)));
+    }
+
+    #[test]
+    fn get_proof_accepts_empty_key_sets() {
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let trie = MerkleRadixTrie::new(&env, TestTrie);
+        let mut raw_txn = env.write_transaction();
+        let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
+
+        let key: KeyNibbles = "cfb986f5a".parse().unwrap();
+        trie.put(&mut txn, &key, 9u8).expect("complete trie");
+        trie.update_root(&mut txn).expect("complete trie");
+
+        let proof = trie.get_proof(&txn, Vec::new()).unwrap();
+        assert_eq!(proof.nodes.len(), 1);
+        assert!(proof.verify(&trie.root_hash_assert(&txn)));
+
+        let proof_values = proof
+            .verify_values(&trie.root_hash_assert(&txn), &[])
+            .unwrap();
+        assert!(proof_values.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What's in this pull request?

Avoid panics when an empty trie proof is requested. `RequestTrieProof::handle` now rejects a request that carries no keys up front (new `ResponseTrieProofError::EmptyKeys`) instead of proceeding into proof construction with an empty key set.

Adds a regression test asserting that a `RequestTrieProof` with empty keys is rejected.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
