### PR TITLE
Reject overflowing `validate_keys` slot total with `checked_add`

### DIFF
--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -527,4 +527,46 @@ mod test {
 
         assert_eq!(new_hash, old_hash);
     }
+
+    /// Verifies that `validate_keys()` rejects a validator set whose slot total
+    /// would wrap around `u16` to exactly `Policy::SLOTS`.
+    ///
+    /// Regression test for the u16 accumulation overflow (finding C1, poc3): with
+    /// overflow checks disabled (release profile), a plain `u16 += ` accumulator could
+    /// wrap to `Policy::SLOTS` and let a malformed set pass validation while still
+    /// mismatching the `usize` total computed in `hash()`, re-opening the crash on the
+    /// gossip path. `validate_keys` now uses `checked_add`, which rejects on overflow.
+    #[test]
+    fn validate_keys_rejects_u16_wrapping_slot_total() {
+        use nimiq_keys::SecureGenerate;
+
+        let compressed = nimiq_bls::KeyPair::generate_default_csprng()
+            .public_key
+            .compress();
+
+        // Two validators whose true total slot count is 65535 + 513 = 66048, which
+        // wraps to exactly Policy::SLOTS (512) in u16 arithmetic
+        let validator_a = Validator::new(
+            nimiq_keys::Address::default(),
+            compressed.clone(),
+            SchnorrPublicKey::default(),
+            0..u16::MAX, // 65535 slots
+        );
+        let validator_b = Validator::new(
+            nimiq_keys::Address::default(),
+            compressed,
+            SchnorrPublicKey::default(),
+            0..(Policy::SLOTS + 1), // 513 slots; 65535 + 513 = 66048 ≡ 512 (mod 2^16)
+        );
+        let validators = Validators::new(vec![validator_a, validator_b]);
+
+        // Sanity check: this is exactly the case that wraps a u16 to Policy::SLOTS
+        let true_total: usize = validators.iter().map(|v| v.num_slots() as usize).sum();
+        assert_eq!(true_total, Policy::SLOTS as usize + (1 << 16));
+        assert_eq!(true_total as u16, Policy::SLOTS);
+
+        // `checked_add` must reject it (a plain `u16 +=` accumulator would have wrapped
+        // to Policy::SLOTS and passed)
+        assert!(validators.validate_keys().is_err());
+    }
 }

--- a/primitives/src/slots_allocation.rs
+++ b/primitives/src/slots_allocation.rs
@@ -224,7 +224,15 @@ impl Validators {
                 .voting_key
                 .uncompress()
                 .ok_or(InvalidValidatorsError)?;
-            total_slots += validator.num_slots();
+            // Use `checked_add` so a crafted validator set cannot silently wrap the
+            // running total around `u16` (overflow checks are disabled in the release
+            // profile). Any overflow implies far more than `Policy::SLOTS` slots, so the
+            // set is invalid; rejecting here prevents a wrapped total from slipping
+            // through and later mismatching the `usize` total computed in
+            // `Validators::hash()`
+            total_slots = total_slots
+                .checked_add(validator.num_slots())
+                .ok_or(InvalidValidatorsError)?;
         }
 
         // Check structural invariants that would cause panics in Hash implementation


### PR DESCRIPTION
## What's in this pull request?

`Validators::validate_keys` accumulated the total slot count in a `u16` with a plain `+=`. With overflow checks disabled (the case in `[profile.release]`), a crafted validator set whose slot sum wraps around `u16` to exactly `Policy::SLOTS` would pass this check, while `Validators::hash` (which sums the slots as `usize`) sees the true total, fails its `assert_eq!`, and panics. Since the block hash is computed before verification on several sync/request paths, this re-opens the election-macro-block crash even after the gossip path was guarded.

Accumulate with `checked_add` and reject on overflow. This is correct in isolation regardless of how many validators a peer could supply or the platform's pointer width: any overflow implies far more than `Policy::SLOTS` slots, so the set is invalid. Keeps slot counts in their natural `u16` type.

Add a regression test covering the `u16` wraparound case.

_Stacked PR — based on `viquezcl/empty_trieproof`; please merge the base chain in order._

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
