### PR TITLE
Trie: reject ROOT-keyed entries in apply_diff

### DIFF
--- a/primitives/trie/src/trie.rs
+++ b/primitives/trie/src/trie.rs
@@ -489,6 +489,16 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         key: &KeyNibbles,
         missing_range: &Option<ops::RangeFrom<KeyNibbles>>,
     ) -> Result<bool, MerkleRadixTrieError> {
+        // The root node is loaded below and the descent loop's invariant is
+        // `node.key != key`; the ROOT key would violate that on the first
+        // iteration. Reject it cleanly so `apply_diff` returns an error
+        // instead of panicking on an attacker-supplied diff entry.
+        if key.is_empty() {
+            return Err(MerkleRadixTrieError::InvalidChunk(
+                "diff key must not be the root key",
+            ));
+        }
+
         let mut node = self
             .get_root(txn)
             .expect("The Merkle Radix Trie didn't have a root node!");
@@ -497,9 +507,6 @@ impl<T: TrieTable> MerkleRadixTrie<T> {
         let mut new_stump = false;
         // Descend down the tree and collect nodes to be updated.
         loop {
-            // This function should only be called with keys in the missing range.
-            assert_ne!(&node.key, key);
-
             // Check that the key we are trying to update can exist in this part of the tree.
             if !node.key.is_prefix_of(key) {
                 return Err(MerkleRadixTrieError::ChildDoesNotExist);
@@ -2323,6 +2330,32 @@ mod tests {
         assert!(trie
             .put_chunk(&mut txn, KeyNibbles::ROOT, malicious_chunk, expected_hash)
             .is_err());
+    }
+
+    #[test]
+    fn apply_diff_with_root_key_returns_error_instead_of_panicking() {
+        // A ROOT-keyed entry in a TrieDiff used to reach
+        // `update_within_missing_part_raw` and panic on the descent loop's
+        // `assert_ne!(&node.key, key)`; `apply_diff` must return an error.
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let trie = MerkleRadixTrie::new_incomplete(&env, TestTrie);
+        let mut raw_txn = env.write_transaction();
+        let mut txn: WriteTransactionProxy = (&mut raw_txn).into();
+        assert!(!trie.is_complete(&txn));
+
+        let mut diff_map = BTreeMap::new();
+        diff_map.insert(KeyNibbles::ROOT, Some(vec![1, 2, 3]));
+        match trie.apply_diff(&mut txn, TrieDiff(diff_map)) {
+            Err(MerkleRadixTrieError::InvalidChunk(_)) => {}
+            other => panic!("expected InvalidChunk(_), got {:?}", other),
+        }
+
+        let mut diff_map = BTreeMap::new();
+        diff_map.insert(KeyNibbles::ROOT, None);
+        match trie.apply_diff(&mut txn, TrieDiff(diff_map)) {
+            Err(MerkleRadixTrieError::InvalidChunk(_)) => {}
+            other => panic!("expected InvalidChunk(_), got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A malicious peer could include the ROOT key (empty `KeyNibbles`) in a `TrieDiff` response and crash a syncing node via an `assert_ne!(&node.key, key)` panic deep inside `MerkleRadixTrie::update_within_missing_part_raw`. On an incomplete trie the ROOT key falls in the missing range, so `apply_diff` routes it to `update_within_missing_part_raw`, which loads the root node and then asserts the descent-loop invariant `node.key != key` — both ROOT, panic.

Replace the descent-loop assertion with an early empty-key guard at the function entry that returns `MerkleRadixTrieError::InvalidChunk("diff key must not be the root key")`. After the guard the loop invariant is trivially preserved, so the inner `assert_ne!` is removed.

This matches the style of the earlier "Trie: reject ROOT-keyed items in `put_chunk`" fix, which handled the same class of issue at a different entry point.

## Severity

LOW (defense-in-depth). `DiffRequestComponent` already validates a diff's `TreeProof` against the signed block's `diff_root()` before passing it to `apply_diff` and evicts peers on mismatch (see "Consensus: evict peers returning diffs with invalid tree-proof"). A legitimate block never produces a diff containing the ROOT key, so this primarily hardens the trie boundary rather than closing a live remote attack vector.

## Notes

- `remove_within_missing_part_raw` carries the same `assert_ne!` pattern but is only reachable via `revert_diff` replaying `RevertTrieDiff`s we produced ourselves. Reverts are assumed to never fail, so that assertion is left untouched.
- The new `Err` propagates cleanly through `commit_incomplete` → `commit_accounts` → block push, which already handles the error with a `warn!()` and block rejection — no node crash.

_Stacked PR — based on `jsdanielh/slots`; please merge the base chain in order._

## Test plan

- [x] `cargo test -p nimiq-trie -- apply_diff_with_root_key_returns_error_instead_of_panicking` — new regression test passes (would panic on `albatross` without the fix).
- [x] `cargo test -p nimiq-trie` — full suite green.
- [x] `cargo test -p nimiq-primitives -p nimiq-account` — downstream callers green.
- [x] `cargo clippy -p nimiq-trie --all-targets` — no new warnings introduced.
