### PR TITLE
Make `Validators::hash` panic-free and verify block-by-hash requests

### DIFF
--- a/consensus/src/consensus/head_requests.rs
+++ b/consensus/src/consensus/head_requests.rs
@@ -18,7 +18,7 @@ use nimiq_network_interface::{
 };
 use nimiq_utils::{spawn, stream::FuturesUnordered};
 
-use crate::messages::{BlockError, RequestBlock, RequestHead, ResponseHead};
+use crate::messages::{BlockError, RequestHead, ResponseHead};
 
 /// Requests the head blocks for a set of peers.
 /// Calculates the number of known/unknown blocks and a vector of unknown blocks.
@@ -100,35 +100,6 @@ impl<TNetwork: Network + 'static> HeadRequests<TNetwork> {
             .request::<RequestHead>(RequestHead {}, peer_id)
             .await
     }
-
-    /// Requests a block by hash from the specified peer, optionally including the body.
-    ///
-    /// Verifies that the returned block matches the requested hash.
-    async fn request_block(
-        network: Arc<TNetwork>,
-        peer_id: TNetwork::PeerId,
-        hash: Blake2bHash,
-        include_body: bool,
-    ) -> Result<Result<Block, BlockError>, RequestError> {
-        network
-            .request::<RequestBlock>(
-                RequestBlock {
-                    hash: hash.clone(),
-                    include_body,
-                },
-                peer_id,
-            )
-            .await
-            .map(|block_res| {
-                // Modify response if the block received does not correspond to the one requested.
-                Ok(block_res.and_then(|mut block| {
-                    if block.hash_cached() != hash {
-                        return Err(BlockError::ResponseHashMismatch);
-                    }
-                    Ok(block)
-                }))
-            })?
-    }
 }
 
 impl<TNetwork: Network + 'static> Future for HeadRequests<TNetwork> {
@@ -159,8 +130,13 @@ impl<TNetwork: Network + 'static> Future for HeadRequests<TNetwork> {
                             self.head_blocks.push(
                                 async move {
                                     (
-                                        Self::request_block(network, peer_id, hash, include_body)
-                                            .await,
+                                        crate::sync::request_block(
+                                            network,
+                                            peer_id,
+                                            hash,
+                                            include_body,
+                                        )
+                                        .await,
                                         peer_id,
                                     )
                                 }

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -18,7 +18,7 @@ use nimiq_zkp_component::{
 };
 
 use crate::{
-    messages::{BlockError, MacroChain, MacroChainError, RequestBlock, RequestMacroChain},
+    messages::{BlockError, MacroChain, MacroChainError, RequestMacroChain},
     sync::{
         light::LightMacroSync,
         sync_interface::{EpochIds, MacroSync, MacroSyncReturn, PeerMacroRequests},
@@ -305,16 +305,8 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         peer_id: TNetwork::PeerId,
         hash: Blake2bHash,
     ) -> Result<Result<Block, BlockError>, RequestError> {
-        // We will only request macro blocks, so we always need the body
-        network
-            .request::<RequestBlock>(
-                RequestBlock {
-                    hash,
-                    include_body: false,
-                },
-                peer_id,
-            )
-            .await
+        // Macro sync only needs the header, so the body is not requested
+        crate::sync::request_block(network, peer_id, hash, false).await
     }
 
     /// Sends a macro chain request to a peer, using the provided locators and maximum number of epochs.

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -16,9 +16,12 @@ use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent};
 use nimiq_primitives::policy::Policy;
 use nimiq_zkp_component::types::ZKPRequestEvent::{OutdatedProof, Proof};
 
-use crate::sync::{
-    light::LightMacroSync,
-    sync_interface::{MacroSync, MacroSyncReturn},
+use crate::{
+    messages::BlockError,
+    sync::{
+        light::LightMacroSync,
+        sync_interface::{MacroSync, MacroSyncReturn},
+    },
 };
 
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
@@ -420,6 +423,12 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                         .boxed();
                         self.epoch_ids_stream.push(future);
                     }
+                }
+                // A peer that replies with a block other than the requested one is either
+                // buggy or malicious; either way we ban it
+                (Ok(Err(BlockError::ResponseHashMismatch)), peer_id) => {
+                    log::warn!(%peer_id, "Banning peer that replied with a block other than the requested one");
+                    self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
                 }
                 (Ok(Err(error)), peer_id) => {
                     trace!(%error, %peer_id, "Received a response for a failed request on the remote side");

--- a/consensus/src/sync/live/block_queue/block_request_component.rs
+++ b/consensus/src/sync/live/block_queue/block_request_component.rs
@@ -18,7 +18,7 @@ use nimiq_network_interface::{
     network::{Network, NetworkEvent},
     request::RequestError,
 };
-use nimiq_primitives::{policy::Policy, slots_allocation::Validators};
+use nimiq_primitives::{networks::NetworkId, policy::Policy, slots_allocation::Validators};
 use nimiq_utils::spawn;
 use parking_lot::RwLock;
 use thiserror::Error;
@@ -110,7 +110,8 @@ pub struct SyncQueueError {
 /// The public interface allows to request blocks, which are not immediately returned.
 /// The blocks instead are returned by polling the component.
 pub struct BlockRequestComponent<N: Network> {
-    sync_queue: SyncQueue<N, MissingBlockRequest, MissingBlockResponse<N>, MissingBlockError, ()>, // requesting missing blocks from peers
+    sync_queue:
+        SyncQueue<N, MissingBlockRequest, MissingBlockResponse<N>, MissingBlockError, NetworkId>, // requesting missing blocks from peers
     peers: Arc<RwLock<PeerList<N>>>,
     include_body: bool,
     /// Pending requests.
@@ -120,7 +121,7 @@ pub struct BlockRequestComponent<N: Network> {
 impl<N: Network> BlockRequestComponent<N> {
     const NUM_PENDING_BLOCKS: usize = 5;
 
-    pub fn new(network: Arc<N>, include_body: bool) -> Self {
+    pub fn new(network: Arc<N>, network_id: NetworkId, include_body: bool) -> Self {
         let peers = Arc::new(RwLock::new(PeerList::default()));
         let mut network_event_rx = network.subscribe_events();
 
@@ -172,7 +173,7 @@ impl<N: Network> BlockRequestComponent<N> {
                     }
                     .boxed()
                 },
-                |request, response, _| {
+                |request, response, network_id| {
                     // We check general consistency for the response:
                     // 1. Check that the blocks end on target block or macro block
                     // 2. Verify macro block signature (last block)
@@ -203,6 +204,23 @@ impl<N: Network> BlockRequestComponent<N> {
                                 has_body = block.has_body(),
                                 include_body = request.include_body,
                                 "Received block with body where none was expected or vice versa",
+                            );
+                            return false;
+                        }
+
+                        // Verify the header before the chain is hashed below, to cheaply reject
+                        // malformed blocks (wrong network/version, oversized extra data, or — for
+                        // election blocks — an invalid validator set) without buffering them.
+                        // `max_timestamp` is `u64::MAX` because these are historical blocks
+                        // requested by hash/height: the future-drift check is only meaningful for
+                        // live blocks and is re-applied with the real clock at push time
+                        if let Err(error) =
+                            block.verify_header(*network_id, block.is_skip(), u64::MAX)
+                        {
+                            log::error!(
+                                %block,
+                                %error,
+                                "Received missing block with an invalid header"
                             );
                             return false;
                         }
@@ -270,7 +288,7 @@ impl<N: Network> BlockRequestComponent<N> {
 
                     true
                 },
-                (),
+                network_id,
             ),
             peers,
             include_body,

--- a/consensus/src/sync/live/block_queue/block_request_component.rs
+++ b/consensus/src/sync/live/block_queue/block_request_component.rs
@@ -242,16 +242,24 @@ impl<N: Network> BlockRequestComponent<N> {
                         return false;
                     }
 
-                    // Check that the last block is valid.
-                    // The last block must be the target block or a macro block.
+                    // Check that the last block is valid. If it is at the target height it must
+                    // be the requested target block, i.e. its hash must match the requested one
+                    // (this holds for both macro and micro target blocks). Otherwise it must be
+                    // an intermediate macro block below the target that serves as a valid
+                    // stopping point; the rest of the chain up to the target is fetched by
+                    // follow-up requests.
                     let last_block = blocks.last_mut().unwrap(); // cannot be empty
                     let block_hash = last_block.hash_cached();
-                    if !(last_block.is_macro()
-                        || (last_block.block_number() == request.target_block_number
-                            && block_hash == request.target_block_hash))
-                    {
+                    let valid_last_block =
+                        if last_block.block_number() == request.target_block_number {
+                            block_hash == request.target_block_hash
+                        } else {
+                            last_block.is_macro()
+                        };
+                    if !valid_last_block {
                         log::error!(
                             request.target_block_number,
+                            last_block = last_block.block_number(),
                             %block_hash,
                             %request.target_block_hash,
                             "Received invalid missing blocks (invalid target block)"

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -123,8 +123,9 @@ impl<N: Network> BlockQueue<N> {
         let current_macro_height = Policy::last_macro_block(blockchain.read().block_number());
         let blockchain_rx = blockchain.read().notifier_as_stream();
         let fork_rx = blockchain.read().fork_notifier_as_stream();
+        let network_id = blockchain.read().network_id();
         let request_component =
-            BlockRequestComponent::new(Arc::clone(&network), config.include_body);
+            BlockRequestComponent::new(Arc::clone(&network), network_id, config.include_body);
 
         Self {
             config,

--- a/consensus/src/sync/mod.rs
+++ b/consensus/src/sync/mod.rs
@@ -1,5 +1,13 @@
 //! Synchronization logic for different types of sync in the consensus layer.
 
+use std::sync::Arc;
+
+use nimiq_block::Block;
+use nimiq_hash::Blake2bHash;
+use nimiq_network_interface::{network::Network, request::RequestError};
+
+use crate::messages::{BlockError, RequestBlock};
+
 #[cfg(feature = "full")]
 pub mod history;
 pub mod light;
@@ -10,3 +18,33 @@ pub mod sync_interface;
 mod sync_queue;
 pub mod syncer;
 pub mod syncer_proxy;
+
+/// Requests a block by hash from the given peer, optionally including the body.
+///
+/// Verifies that the returned block matches the requested hash, returning
+/// `BlockError::ResponseHashMismatch` otherwise, so a peer cannot answer a
+/// request with a different block than the one we asked for.
+pub(crate) async fn request_block<TNetwork: Network>(
+    network: Arc<TNetwork>,
+    peer_id: TNetwork::PeerId,
+    hash: Blake2bHash,
+    include_body: bool,
+) -> Result<Result<Block, BlockError>, RequestError> {
+    network
+        .request::<RequestBlock>(
+            RequestBlock {
+                hash: hash.clone(),
+                include_body,
+            },
+            peer_id,
+        )
+        .await
+        .map(|block_res| {
+            Ok(block_res.and_then(|mut block| {
+                if block.hash_cached() != hash {
+                    return Err(BlockError::ResponseHashMismatch);
+                }
+                Ok(block)
+            }))
+        })?
+}

--- a/consensus/src/sync/pico/sync_requests.rs
+++ b/consensus/src/sync/pico/sync_requests.rs
@@ -10,8 +10,7 @@ use nimiq_network_interface::{
 
 use crate::{
     messages::{
-        BlockError, MacroChain, MacroChainError, RequestBlock, RequestHead, RequestMacroChain,
-        ResponseHead,
+        BlockError, MacroChain, MacroChainError, RequestHead, RequestMacroChain, ResponseHead,
     },
     sync::{pico::PicoMacroSync, sync_interface::PeerMacroRequests},
 };
@@ -93,16 +92,8 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
         peer_id: TNetwork::PeerId,
         hash: Blake2bHash,
     ) -> Result<Result<Block, BlockError>, RequestError> {
-        // We will only request macro blocks, so we always need the body
-        network
-            .request::<RequestBlock>(
-                RequestBlock {
-                    hash,
-                    include_body: false,
-                },
-                peer_id,
-            )
-            .await
+        // Macro sync only needs the header, so the body is not requested
+        crate::sync::request_block(network, peer_id, hash, false).await
     }
 
     /// Requests the macro chain to the given peer.

--- a/consensus/src/sync/pico/sync_stream.rs
+++ b/consensus/src/sync/pico/sync_stream.rs
@@ -11,9 +11,12 @@ use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent};
 use nimiq_primitives::policy::Policy;
 
-use crate::sync::{
-    pico::PicoMacroSync,
-    sync_interface::{MacroSync, MacroSyncReturn},
+use crate::{
+    messages::BlockError,
+    sync::{
+        pico::PicoMacroSync,
+        sync_interface::{MacroSync, MacroSyncReturn},
+    },
 };
 
 impl<TNetwork: Network> PicoMacroSync<TNetwork> {
@@ -230,6 +233,12 @@ impl<TNetwork: Network> PicoMacroSync<TNetwork> {
                         let future = Self::request_head(Arc::clone(&self.network), peer_id).boxed();
                         self.head_stream.push(future);
                     }
+                }
+                // A peer that replies with a block other than the requested one is either
+                // buggy or malicious; either way we ban it
+                (Ok(Err(BlockError::ResponseHashMismatch)), peer_id) => {
+                    log::warn!(%peer_id, "Banning peer that replied with a block other than the requested one");
+                    self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
                 }
                 (Ok(Err(error)), peer_id) => {
                     trace!(%error, %peer_id, "Received a response for a failed request on the remote side");

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -528,6 +528,41 @@ mod test {
         assert_eq!(new_hash, old_hash);
     }
 
+    /// Verifies that `Validators::hash()` does not panic when the validator set has
+    /// an invalid total slot count, and that `validate_keys()` rejects it.
+    ///
+    /// Regression test for the election-macro-block crash (finding C1): on the
+    /// sync/request paths (`Blockchain::push`, `LightBlockchain::push`,
+    /// `push_history_sync`, `push_zkp`) the block hash is computed *before*
+    /// verification, so an unconditional assertion in `hash()` would crash the node
+    /// on a single malformed block. Before the fix, `hash()` asserted
+    /// `total_slots == Policy::SLOTS` and would panic here.
+    #[test]
+    fn hash_with_wrong_slot_total_does_not_panic() {
+        use nimiq_hash::{Blake2sHash, Hash};
+        use nimiq_keys::SecureGenerate;
+
+        let compressed = nimiq_bls::KeyPair::generate_default_csprng()
+            .public_key
+            .compress();
+
+        // Wrong total slot count: Policy::SLOTS + 1 is neither equal to
+        // Policy::SLOTS nor a multiple of PK_TREE_BREADTH
+        let validator = Validator::new(
+            nimiq_keys::Address::default(),
+            compressed,
+            SchnorrPublicKey::default(),
+            0..(Policy::SLOTS + 1),
+        );
+        let validators = Validators::new(vec![validator]);
+
+        // Must not panic even though the slot total is invalid
+        let _hash: Blake2sHash = validators.hash();
+
+        // And the malformed set must be rejected during verification
+        assert!(validators.validate_keys().is_err());
+    }
+
     /// Verifies that `validate_keys()` rejects a validator set whose slot total
     /// would wrap around `u16` to exactly `Policy::SLOTS`.
     ///

--- a/primitives/src/slots_allocation.rs
+++ b/primitives/src/slots_allocation.rs
@@ -260,14 +260,6 @@ impl Hash for Validators {
     /// This function is meant to calculate the public key tree "off-circuit". Generating the public key
     /// tree with this function guarantees that it is compatible with the ZK circuit.
     fn hash<H: HashOutput>(&self) -> H {
-        let total_slots: usize = self.iter().map(|v| v.num_slots() as usize).sum();
-
-        // Checking that the number of slots is equal to the expected number of validator slots.
-        assert_eq!(total_slots, Policy::SLOTS as usize);
-
-        // Checking that the number of slots is a multiple of the number of leaves.
-        assert_eq!(total_slots % PK_TREE_BREADTH, 0);
-
         // Use the raw compressed key bytes directly instead of decompressing to
         // G2Projective and re-serializing. For valid keys, the canonical compressed
         // serialization is a fixed-point of the uncompress -> serialize_compressed


### PR DESCRIPTION
## What's in this pull request?

Fixes a node-crash vulnerability: a single malformed election macro block from an untrusted peer could panic a full or light node *before* the block was rejected. Also tightens the block-by-hash sync request paths.

- **`Validators::hash` is now panic-free.** It asserted that the validator set's total slot count equals `Policy::SLOTS` and is a multiple of `PK_TREE_BREADTH`. The block/header hash is computed *before* verification on several sync/request paths (`Blockchain::push`, `LightBlockchain::push`, `push_history_sync`, `push_zkp`, and the Tendermint proposal path), so a malformed set could trip these assertions and crash the node. The assertions are removed: the function is already total for any input (the chunking yields `PK_TREE_BREADTH` in-bounds slices and `merkle_tree_construct` always receives exactly `PK_TREE_BREADTH` leaves). For valid sets the output is byte-for-byte identical, so there is **no consensus impact**; malformed sets now produce a deterministic hash that fails verification. Structural validity is still enforced by `validate_keys` during verification.

- **Header verification on the requested missing-blocks path.** `BlockRequestComponent` verified chain-linking and the last macro block's signature but never ran `verify_header`. It now header-verifies each received block *before* the chain is hashed, rejecting malformed blocks (wrong network/version, oversized extra data, or an invalid validator set) at the sync-queue level.

- **Received blocks must match the requested hash.** The missing-blocks terminal check now enforces the hash at the target height (previously skipped for macro targets via an `is_macro()` short-circuit). A single shared `request_block` helper that verifies the returned block's hash now backs `HeadRequests` and the light/pico macro-sync requests, replacing three near-duplicate copies and adding the missing check to the macro-sync paths.

_Stacked PR — based on `pb/apply-diff-reject-root-key`; this is the final PR in the series; please merge the base chain in order._

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
