### PR TITLE
network-libp2p: rate limit inbound DHT PutRecord per peer

### DIFF
--- a/network-libp2p/src/rate_limiting.rs
+++ b/network-libp2p/src/rate_limiting.rs
@@ -41,6 +41,10 @@ impl RateLimitConfig {
 pub(crate) enum RateLimitId {
     Request(RequestType),
     Gossipsub(TopicHash),
+    /// Inbound DHT `PutRecord` requests. Rate limited per peer so a single peer
+    /// cannot flood the swarm task with record verifications.
+    #[cfg(feature = "kad")]
+    DhtPutRecord,
 }
 
 /// Holds the expiration time for a given peer and request type. This struct defines the ordering for the btree set.
@@ -417,6 +421,37 @@ mod tests {
         assert!(
             observed_pre_expiry_disconnect,
             "the test must exercise at least one disconnect that happens before the rate limit expires",
+        );
+    }
+
+    #[cfg(feature = "kad")]
+    #[test]
+    fn dht_put_rate_limit_is_enforced_per_peer() {
+        let config = RateLimitConfig {
+            max_requests: 3,
+            time_window: Duration::from_secs(60),
+        };
+        let peer_id = PeerId::random();
+        let mut rate_limits = RateLimits::default();
+
+        // The first `max_requests` puts from a peer are allowed.
+        for _ in 0..config.max_requests {
+            assert!(
+                !rate_limits.exceeds_rate_limit(peer_id, RateLimitId::DhtPutRecord, &config),
+                "puts within the limit must be allowed",
+            );
+        }
+
+        // Any further put within the same window is dropped.
+        assert!(
+            rate_limits.exceeds_rate_limit(peer_id, RateLimitId::DhtPutRecord, &config),
+            "puts exceeding the limit must be dropped",
+        );
+
+        // The limit is tracked per peer, so a different peer is unaffected.
+        assert!(
+            !rate_limits.exceeds_rate_limit(PeerId::random(), RateLimitId::DhtPutRecord, &config),
+            "a different peer must have its own independent rate limit",
         );
     }
 }

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -42,6 +42,8 @@ use tokio::sync::{broadcast, mpsc};
 
 #[cfg(feature = "metrics")]
 use crate::network_metrics::NetworkMetrics;
+#[cfg(feature = "kad")]
+use crate::rate_limiting::RateLimitConfig;
 use crate::{
     autonat::NatStatus,
     behaviour, dht,
@@ -67,6 +69,19 @@ struct EventInfo<'a> {
     #[cfg(feature = "metrics")]
     metrics: &'a Arc<NetworkMetrics>,
 }
+
+/// Per-peer rate limit for inbound DHT `PutRecord` requests.
+///
+/// The window matches the Kademlia replication interval configured in
+/// [`Config::new`] (60s). The limit is deliberately generous: the DHT holds at
+/// most a few hundred validator records (`Policy::SLOTS`), so legitimate
+/// replication and caching pushes from a single peer stay well below it, while
+/// a malicious peer is capped to roughly one verification per second.
+#[cfg(feature = "kad")]
+const DHT_PUT_RATE_LIMIT: RateLimitConfig = RateLimitConfig {
+    max_requests: 64,
+    time_window: Duration::from_secs(60),
+};
 
 #[cfg(feature = "kad")]
 fn store_dht_record<K>(
@@ -774,11 +789,27 @@ fn handle_dht_bootstrap(
 
 #[cfg(feature = "kad")]
 fn handle_dht_inbound_put(
-    _source: PeerId,
+    source: PeerId,
     _connection: ConnectionId,
     record: Record,
     event_info: EventInfo,
 ) {
+    // Rate limit inbound puts per peer before doing any verification work, so a
+    // single peer cannot starve the swarm task with record verifications.
+    if event_info.rate_limiting.exceeds_rate_limit(
+        source,
+        RateLimitId::DhtPutRecord,
+        &DHT_PUT_RATE_LIMIT,
+    ) {
+        debug!(
+            %source,
+            max_requests = %DHT_PUT_RATE_LIMIT.max_requests,
+            time_window = ?DHT_PUT_RATE_LIMIT.time_window,
+            "Dropping DHT PutRecord - rate limit exceeded",
+        );
+        return;
+    }
+
     // Verify incoming record
     let dht_record = match event_info.dht_verifier.verify(&record) {
         Ok(record) => record,


### PR DESCRIPTION
Every inbound Kademlia PutRecord ran dht::Verifier::verify directly on the single swarm task, which for validator records takes the global blockchain read lock and traverses the staking-contract trie before an Ed25519 check. There was no per-peer or per-protocol bound on this path, so a peer could flood the swarm task with verifications and degrade processing of other libp2p events.

Add a DhtPutRecord variant to RateLimitId and enforce a per-peer rate limit (64 requests / 60s, aligned with the Kademlia replication interval) in handle_dht_inbound_put before any verification work, mirroring the existing gossipsub and request-response rate limiting. The source PeerId is now used instead of being discarded.

## What's in this pull request?

...

## Pull request checklist

- [ ] All tests pass. The project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have resolved all `clippy` and `rustfmt` warnings.
