### PR TITLE
web-client: download wasm-opt for the host platform

### DIFF
--- a/web-client/scripts/build.sh
+++ b/web-client/scripts/build.sh
@@ -98,23 +98,40 @@ then
     BINARYEN_VERSION=129
     BINARYEN_FOLDER="binaryen-version_$BINARYEN_VERSION"
 
-    # Test if correct wasm-opt is already downloaded
-    if [ -f "$BINARYEN_FOLDER/wasm-opt" ]; then
-        export PATH="$PATH:$(pwd)/$BINARYEN_FOLDER"
+    # Determine the binaryen release asset for the current platform
+    case "$(uname -s)" in
+        Linux)  BINARYEN_OS="linux" ;;
+        Darwin) BINARYEN_OS="macos" ;;
+        *) echo "Error: no automatic wasm-opt download for OS '$(uname -s)'." >&2
+           echo "Install binaryen $BINARYEN_VERSION manually and put wasm-opt on your PATH." >&2
+           exit 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64) BINARYEN_ARCH="x86_64" ;;
+        # binaryen names its arm64 assets "arm64" for macOS but "aarch64" for linux
+        arm64|aarch64) [ "$BINARYEN_OS" = "macos" ] && BINARYEN_ARCH="arm64" || BINARYEN_ARCH="aarch64" ;;
+        *) echo "Error: no automatic wasm-opt download for architecture '$(uname -m)'." >&2
+           echo "Install binaryen $BINARYEN_VERSION manually and put wasm-opt on your PATH." >&2
+           exit 1 ;;
+    esac
+
+    BINARYEN_ASSET="$BINARYEN_FOLDER-$BINARYEN_ARCH-$BINARYEN_OS"
+
+    # Test if wasm-opt is already downloaded
+    if [ -f "$BINARYEN_FOLDER/bin/wasm-opt" ]; then
+        export PATH="$PATH:$(pwd)/$BINARYEN_FOLDER/bin"
     else
-        echo "Downloading wasm-opt $BINARYEN_VERSION..."
+        echo "Downloading wasm-opt $BINARYEN_VERSION ($BINARYEN_ARCH-$BINARYEN_OS)..."
         # Download release from GitHub
-        curl https://github.com/WebAssembly/binaryen/releases/download/version_$BINARYEN_VERSION/$BINARYEN_FOLDER-x86_64-linux.tar.gz --location --output binaryen.tar.gz
+        curl "https://github.com/WebAssembly/binaryen/releases/download/version_$BINARYEN_VERSION/$BINARYEN_ASSET.tar.gz" --location --output binaryen.tar.gz
         # Extract archive
-        tar -xvzf binaryen.tar.gz
+        tar -xzf binaryen.tar.gz
         # Delete archive
         rm binaryen.tar.gz
-        # Move wasm-opt binary to root of extracted folder and delete everything else
-        mv ./$BINARYEN_FOLDER/bin/wasm-opt ./$BINARYEN_FOLDER/wasm-opt
-        rm -rf ./$BINARYEN_FOLDER/bin
-        rm -rf ./$BINARYEN_FOLDER/include
-        rm -rf ./$BINARYEN_FOLDER/lib
-        export PATH="$PATH:$(pwd)/$BINARYEN_FOLDER"
+        # Keep bin/ and lib/ together: the macOS wasm-opt resolves libbinaryen.dylib via @loader_path/../lib
+        rm -rf "./$BINARYEN_FOLDER/include"
+        export PATH="$PATH:$(pwd)/$BINARYEN_FOLDER/bin"
     fi
 fi
 


### PR DESCRIPTION
The build script always fetched the `x86_64-linux` `binaryen` release, so it installed an unrunnable binary on macOS and Linux arm64. Detect OS/arch via `uname` and pick the matching asset, and keep `bin/` + `lib/` together since the macOS `wasm-opt` loads `libbinaryen.dylib` via `@loader_path/../lib`.


## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
