### PR TITLE
Web client: validate `seedNodes` input instead of panicking

### DIFF
--- a/web-client/src/client/bls_cache.rs
+++ b/web-client/src/client/bls_cache.rs
@@ -82,8 +82,8 @@ impl BlsCache {
             {
                 let mut keys = self.keys.borrow_mut();
                 for js_key in &js_keys {
-                    let value: BlsKeyEntry =
-                        serde_wasm_bindgen::from_value(js_key.clone()).unwrap();
+                    let value: BlsKeyEntry = serde_wasm_bindgen::from_value(js_key.clone())
+                        .map_err(|e| Error::UnexpectedJsType("BlsKeyEntry", e.into()))?;
                     let public_key = PublicKey::trusted_deserialize(&value.public_key);
                     keys.push(LazyPublicKey::from(public_key));
                 }

--- a/web-client/src/common/client_configuration.rs
+++ b/web-client/src/common/client_configuration.rs
@@ -128,13 +128,17 @@ impl ClientConfiguration {
     /// Sets the list of seed nodes that are used to connect to the Nimiq Albatross network.
     ///
     /// Each array entry must be a proper Multiaddr format string.
+    ///
+    /// Throws when an entry cannot be deserialized as a string.
     #[wasm_bindgen(js_name = seedNodes)]
     #[allow(clippy::boxed_local)]
-    pub fn seed_nodes(&mut self, seeds: Box<[JsValue]>) {
+    pub fn seed_nodes(&mut self, seeds: Box<[JsValue]>) -> Result<(), JsError> {
         self.seed_nodes = seeds
             .iter()
-            .map(|seed| serde_wasm_bindgen::from_value(seed.clone()).unwrap())
-            .collect::<Vec<String>>();
+            .map(|seed| serde_wasm_bindgen::from_value::<String>(seed.clone()))
+            .collect::<Result<Vec<String>, _>>()
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
     }
 
     /// Sets the log level that is used when logging to the console.

--- a/web-client/tests/wasm.rs
+++ b/web-client/tests/wasm.rs
@@ -11,9 +11,11 @@ use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{Network, Topic};
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::policy;
+use nimiq_web_client::common::client_configuration::ClientConfiguration;
 use nimiq_zkp_component::ZKPComponent;
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -103,4 +105,28 @@ async fn gossipsub_web_env() {
     log::info!("Received Gossipsub message: {:?}", received_message);
 
     assert_eq!(received_message, test_message);
+}
+
+#[wasm_bindgen_test]
+fn seed_nodes_rejects_non_string_entries() {
+    let mut config = ClientConfiguration::new();
+
+    let bad: Box<[JsValue]> = Box::new([
+        JsValue::from_str("/dns4/x.example/tcp/443/wss"),
+        JsValue::from(42_u32),
+    ]);
+    assert!(config.seed_nodes(bad).is_err());
+
+    let good: Box<[JsValue]> = Box::new([
+        JsValue::from_str("/dns4/x.example/tcp/443/wss"),
+        JsValue::from_str("/dns4/y.example/tcp/443/wss"),
+    ]);
+    assert!(config.seed_nodes(good).is_ok());
+    assert_eq!(
+        config.seed_nodes,
+        vec![
+            "/dns4/x.example/tcp/443/wss".to_string(),
+            "/dns4/y.example/tcp/443/wss".to_string(),
+        ]
+    );
 }


### PR DESCRIPTION
## What's in this pull request?
`ClientConfiguration::seedNodes()` in the WASM web client unwrapped the result of deserializing each array element as a `String`.

This PR also fixes a similar issue in the `BlsCache`.

- `seedNodes` now returns `Result<(), JsError>` and propagates the deserialization error.
- `BlsCache::init` maps the deserialization error to `idb::Error::UnexpectedJsType("BlsKeyEntry", e.into())` so it flows through the existing `Result<(), Error>` return.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
