### PR TITLE
rpc-client: fix inverted `--previous-penalized` flag for penalized-slots

### DIFF
--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -296,12 +296,12 @@ impl HandleSubcommand for BlockchainCommand {
                 if previous_penalized {
                     println!(
                         "{:#?}",
-                        client.blockchain.get_current_penalized_slots().await?
+                        client.blockchain.get_previous_penalized_slots().await?
                     )
                 } else {
                     println!(
                         "{:#?}",
-                        client.blockchain.get_previous_penalized_slots().await?
+                        client.blockchain.get_current_penalized_slots().await?
                     )
                 }
             }


### PR DESCRIPTION
Fix inverted `--previous-penalized` flag for penalized-slots

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
