### PR TITLE
validator: fix version-upgrade trigger

### DIFF
--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -276,6 +276,44 @@ impl Blockchain {
             return Ok(());
         }
 
+        // If this block triggers a version upgrade, it must be an election block with enough
+        // support. The support check mirrors the proposer-side check in
+        // `TendermintProtocol::create_proposal` and gates the same `VersionUpgrade` inherent applied
+        // during `commit_accounts`: without it a malicious proposer could bump the version with
+        // insufficient support and thereby deactivate most of the active validators.
+        let new_version = macro_block.header.version;
+        if Some(new_version) == self.state.current_version().checked_add(1) {
+            // The network only accepts a version increase on election blocks: proposing one on a
+            // checkpoint block would halt the chain. Reject it here too as defense in depth, even
+            // though `Block::verify_immediate_successor` already rejects a version bump on a
+            // non-election block.
+            if !macro_block.is_election() {
+                warn!(
+                    %macro_block,
+                    new_version,
+                    reason = "Version upgrade on a non-election block",
+                    "Rejecting block"
+                );
+                return Err(PushError::InvalidBlock(BlockError::InvalidVersionUpgrade));
+            }
+
+            let validators = self
+                .current_validators()
+                .expect("Current validators must be present");
+            let data_store = self.get_staking_contract_store();
+            let data_store_read = data_store.read(txn);
+            if !staking_contract.supports_version_upgrade(&data_store_read, validators, new_version)
+            {
+                warn!(
+                    %macro_block,
+                    new_version,
+                    reason = "Version upgrade lacks sufficient support",
+                    "Rejecting block"
+                );
+                return Err(PushError::InvalidBlock(BlockError::InvalidVersionUpgrade));
+            }
+        }
+
         let reward_transactions =
             self.create_reward_transactions(&macro_block.header, &staking_contract);
 

--- a/primitives/account/src/account/staking_contract/mod.rs
+++ b/primitives/account/src/account/staking_contract/mod.rs
@@ -244,6 +244,42 @@ impl StakingContract {
             .sum()
     }
 
+    /// Returns whether an upgrade to `new_version` has enough support to be triggered.
+    ///
+    /// An upgrade requires at least `Policy::UPGRADE_MIN_SUPPORT` percent of *both*:
+    /// - the elected slots of the current epoch (`validators`), and
+    /// - the active stake,
+    ///
+    /// to signal support for `new_version`. Both conditions are needed: the slot threshold ensures
+    /// the current committee can finalize the version-bumped election block, while the stake
+    /// threshold bounds how much of the active set gets deactivated by the upgrade.
+    /// This predicate is the single source of truth shared by the block proposer and the block
+    /// validation, keeping both sides symmetric.
+    ///
+    /// IMPORTANT: This is a fairly expensive function, iterating over all validators.
+    pub fn supports_version_upgrade<T: DataStoreReadOps + DataStoreIterOps>(
+        &self,
+        data_store: &T,
+        validators: &Validators,
+        new_version: u16,
+    ) -> bool {
+        let support_check = |data| Policy::supports_upgrade(data, new_version);
+
+        // `Policy::UPGRADE_MIN_SUPPORT` of the elected slots must support the upgrade.
+        let supporting_slots = self.get_supporting_slots(data_store, validators, support_check);
+        if u64::from(supporting_slots) * 100
+            < u64::from(Policy::SLOTS) * Policy::UPGRADE_MIN_SUPPORT
+        {
+            return false;
+        }
+
+        // `Policy::UPGRADE_MIN_SUPPORT` of the active stake must support the upgrade.
+        let supporting_stake = self.get_supporting_stake(data_store, support_check);
+        let total_active_stake = self.get_active_stake();
+        u64::from(supporting_stake) * 100
+            >= u64::from(total_active_stake) * Policy::UPGRADE_MIN_SUPPORT
+    }
+
     /// Deactivates validators that did not support the upgrade.
     /// The support is determined by a function over the signal data.
     /// IMPORTANT: This is a fairly expensive function, iterating over all validators.

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -3389,6 +3389,13 @@ fn version_upgrade_works() {
         "Supporting slots are counted correctly"
     );
 
+    // Only half of the active stake supports version 2, so the upgrade is not supported even though
+    // some slots back it.
+    assert!(
+        !staking_contract.supports_version_upgrade(&data_store_read, &validators, 2),
+        "Version 2 upgrade lacks the required stake support"
+    );
+
     // Check that the inherent correctly deactivates unsupporting validators.
     let inherent = Inherent::VersionUpgrade { new_version: 2 };
     let mut logs = vec![];

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -87,6 +87,9 @@ pub enum BlockError {
     #[error("Incorrect reward transactions")]
     InvalidRewardTransactions,
 
+    #[error("Version upgrade lacks sufficient support")]
+    InvalidVersionUpgrade,
+
     #[error("Skip block contains a non empty body")]
     InvalidSkipBlockBody,
 

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -232,46 +232,30 @@ where
         // Check if we want to upgrade the version.
         // This assumes we only ever upgrade to the latest version
         // and don't queue multiple upgrades.
-        let version = if blockchain.state().current_version() + 1 == Policy::max_supported_version()
+        // The version can only ever increase at election blocks (see `Block::verify_immediate_successor`),
+        // so we must not bump it on checkpoint macro blocks, which would be rejected by the network
+        let version = if Policy::is_election_block_at(self.block_height)
+            && blockchain.state().current_version() + 1 == Policy::max_supported_version()
         {
+            let new_version = blockchain.state().current_version() + 1;
             let staking_contract = blockchain
                 .get_staking_contract_if_complete(None)
                 .expect("Staking Contract must be complete to create a macro proposal");
             let data_store = blockchain.get_staking_contract_store();
             let txn = blockchain.read_transaction();
             let data_store_read = &data_store.read(&txn);
+            let validators = blockchain
+                .current_validators()
+                .expect("There need to be validators present");
 
-            // Calculate support for upgrade.
-            let support_check =
-                |data| Policy::supports_upgrade(data, blockchain.state().current_version() + 1);
-            let supporting_stake =
-                staking_contract.get_supporting_stake(data_store_read, support_check);
-            let total_active_stake = staking_contract.get_active_stake();
-            let supporting_slots = staking_contract.get_supporting_slots(
-                data_store_read,
-                blockchain
-                    .current_validators()
-                    .expect("There need to be validators present"),
-                support_check,
-            );
-
-            // We propose an upgraded block version only if:
-            // - `Policy::UPGRADE_MIN_SUPPORT` of the stake supports the upgrade.
-            // - `Policy::UPGRADE_MIN_SUPPORT` slots support the upgrade.
-            if supporting_slots * 100 >= Policy::SLOTS * Policy::UPGRADE_MIN_SUPPORT as u16
-                && u64::from(supporting_stake) * 100
-                    >= u64::from(total_active_stake) * Policy::UPGRADE_MIN_SUPPORT
-            {
-                info!(
-                    supporting_slots,
-                    %supporting_stake, %total_active_stake, "Triggering version upgrade"
-                );
-                Some(blockchain.state().current_version() + 1)
+            // We propose an upgraded block version only if the upgrade has enough support.
+            // The same predicate is enforced on the validation side (see
+            // `Blockchain::verify_block_state_pre_commit`), keeping both sides symmetric.
+            if staking_contract.supports_version_upgrade(data_store_read, validators, new_version) {
+                info!(new_version, "Triggering version upgrade");
+                Some(new_version)
             } else {
-                info!(
-                    supporting_slots,
-                    %supporting_stake, %total_active_stake, "Version upgrade does not have enough support"
-                );
+                info!(new_version, "Version upgrade does not have enough support");
                 None
             }
         } else {

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use nimiq_account::{Account, StakingContractStoreWrite, TransactionLog};
-use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_block::BlockError;
+use nimiq_blockchain_interface::{AbstractBlockchain, PushError};
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_database::traits::WriteTransaction;
 use nimiq_hash::Blake2bHash;
@@ -393,17 +394,135 @@ async fn it_triggers_version_upgrades() {
         .expect("Should have created proposal");
     assert_eq!(proposal.0.proposal.0.version, 1);
 
-    // Case 2: Elected validator threshold reached, but stake threshold not.
+    // Case 2: The elected slots support the upgrade (validator1 holds them all), but only half of
+    // the active stake does, so the stake threshold is not reached.
     signal_support(&temp_producer, &validator1, Some(2));
     let proposal = interface
         .create_proposal(0)
         .expect("Should have created proposal");
     assert_eq!(proposal.0.proposal.0.version, 1);
 
-    // Case 3: Both thresholds reached.
+    // Case 3: Both the elected slots and the active stake support the upgrade.
     signal_support(&temp_producer, &validator2, Some(2));
     let proposal = interface
         .create_proposal(0)
         .expect("Should have created proposal");
     assert_eq!(proposal.0.proposal.0.version, 2);
+}
+
+#[test(tokio::test)]
+async fn it_does_not_trigger_version_upgrades_on_checkpoint_blocks() {
+    // Move to just before the first checkpoint (non-election) macro block
+    let temp_producer = TemporaryBlockProducer::default();
+    for _ in 0..Policy::blocks_per_batch() - 1 {
+        let block = temp_producer.next_block(vec![], false);
+        temp_producer
+            .push(block)
+            .expect("Should be able to push block");
+    }
+
+    // Initialize a TendermintProtocol.
+    let blockchain = Arc::clone(&temp_producer.blockchain);
+    let current_validators = blockchain.read().current_validators().unwrap().clone();
+    let proposal_height = blockchain.read().head().block_number() + 1;
+    assert!(
+        Policy::is_macro_block_at(proposal_height)
+            && !Policy::is_election_block_at(proposal_height),
+        "Test setup assumes the next macro block is a checkpoint block"
+    );
+    assert_eq!(
+        current_validators.num_validators(),
+        1,
+        "Test setup assumes one validator"
+    );
+    assert_eq!(
+        blockchain.read().state().current_version(),
+        1,
+        "Test assumes current version"
+    );
+    assert_eq!(
+        Policy::max_supported_version(),
+        2,
+        "Test assumes max supported version"
+    );
+    let validator1 = current_validators.validators[0].address.clone();
+    let hub = MockHub::default();
+    let nw: Arc<Network> = TestNetwork::build_network(0, Default::default(), &mut Some(hub)).await;
+    let val_net = Arc::new(ValidatorNetworkImpl::new(nw));
+    let interface = TendermintProtocol::new(
+        Arc::clone(&blockchain),
+        val_net,
+        temp_producer.producer.clone(),
+        current_validators,
+        0,
+        NetworkId::UnitAlbatross,
+        proposal_height,
+    );
+
+    // Setup second validator with same stake and signal full support from both
+    let validator2 = create_validator(&temp_producer);
+    signal_support(&temp_producer, &validator1, Some(2));
+    signal_support(&temp_producer, &validator2, Some(2));
+
+    // Even with both thresholds reached, a checkpoint block must keep the current version,
+    // since the network only accepts version increases on election blocks
+    let proposal = interface
+        .create_proposal(0)
+        .expect("Should have created proposal");
+    assert_eq!(proposal.0.proposal.0.version, 1);
+}
+
+/// The validation side must reject an election block that bumps the version without sufficient
+/// support, mirroring the proposer-side check (otherwise a malicious proposer could force the
+/// upgrade and deactivate most of the active validators).
+#[test(tokio::test)]
+async fn it_rejects_unsupported_version_upgrade_blocks() {
+    // Move to before the next election block.
+    let temp_producer = TemporaryBlockProducer::default();
+    for _ in 0..Policy::blocks_per_epoch() - 1 {
+        let block = temp_producer.next_block(vec![], false);
+        temp_producer
+            .push(block)
+            .expect("Should be able to push block");
+    }
+
+    let blockchain = Arc::clone(&temp_producer.blockchain);
+    let validator1 = blockchain.read().current_validators().unwrap().validators[0]
+        .address
+        .clone();
+
+    // Add a second validator with the same stake and let only the elected validator1 signal
+    // support. This yields full slot support but only half of the active stake, below the
+    // `UPGRADE_MIN_SUPPORT` threshold, so the upgrade is not supported.
+    let _validator2 = create_validator(&temp_producer);
+    signal_support(&temp_producer, &validator1, Some(2));
+
+    // Forcefully craft an election block that bumps the version despite the missing support.
+    let proposal = {
+        let bc = blockchain.read();
+        temp_producer
+            .producer
+            .next_macro_block_proposal(
+                &bc,
+                bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
+                0,
+                vec![],
+                Some(2),
+            )
+            .expect("Should have created proposal")
+    };
+    assert!(proposal.is_election());
+    assert_eq!(proposal.header.version, 2);
+
+    // The network must reject the proposal because the upgrade lacks sufficient support.
+    let result = blockchain
+        .read()
+        .verify_macro_block_proposal(proposal, 0, None);
+    assert!(
+        matches!(
+            result,
+            Err(PushError::InvalidBlock(BlockError::InvalidVersionUpgrade))
+        ),
+        "Expected InvalidVersionUpgrade, got {result:?}"
+    );
 }


### PR DESCRIPTION
Only bump the block version on election blocks: the network rejects a version increase on checkpoint blocks, so proposing one there would halt the chain at the first checkpoint after the threshold is crossed.

Also gauge support by active stake alone, dropping the elected-slot check (a stale snapshot) so the trigger matches the set that `deactivate_unsupporting_validators` acts on.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
