### PR TITLE
rpc-client: Remove unwanted debug log

### DIFF
--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -525,7 +525,6 @@ impl HandleSubcommand for TransactionCommand {
                 retire_stake,
                 tx_commons,
             } => {
-                eprintln! {"a {sender_wallet:?}\n{staker_wallet:?}\n{retire_stake:?}\n{tx_commons:?}"};
                 if tx_commons.dry {
                     let tx = client
                         .consensus


### PR DESCRIPTION
Remove unwanted debug log in the `rpc-client`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
