### PR TITLE
account: gate revert_jail_validator deactivation log on newly_deactivated

### DIFF
--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -501,10 +501,13 @@ impl StakingContract {
         // Update validator entry.
         store.put_validator(validator_address, validator);
 
-        tx_logger.push_log(Log::DeactivateValidator {
-            validator_address: validator_address.clone(),
-            inactive_from: inactive_from.expect("must have inactivation block number"),
-        });
+        // Mirror the conditional log emission in `jail_validator`.
+        if receipt.newly_deactivated {
+            tx_logger.push_log(Log::DeactivateValidator {
+                validator_address: validator_address.clone(),
+                inactive_from: inactive_from.expect("must have inactivation block number"),
+            });
+        }
         tx_logger.push_log(Log::JailValidator {
             validator_address: validator_address.clone(),
             event_block: jailed_from,

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -1957,6 +1957,8 @@ fn can_jail_twice() {
         .contains_key(&jailed_setup.validator_address));
 
     // Revert the second jail.
+    let mut revert_logs = vec![];
+    let mut inherent_logger = InherentLogger::new(&mut revert_logs);
     jailed_setup
         .staking_contract
         .revert_inherent(
@@ -1964,9 +1966,20 @@ fn can_jail_twice() {
             &second_jail_block_state,
             receipt,
             data_store.write(&mut db_txn),
-            &mut InherentLogger::empty(),
+            &mut inherent_logger,
         )
         .expect("Failed to revert inherent");
+
+    // The revert must mirror the commit logs: since the validator was already
+    // inactive, no `DeactivateValidator` log is emitted on either side.
+    assert_eq!(
+        revert_logs,
+        vec![Log::JailValidator {
+            validator_address: jailed_setup.validator_address.clone(),
+            event_block: second_jail_block_state.number,
+            newly_jailed: false
+        },]
+    );
 
     let validator = jailed_setup
         .staking_contract


### PR DESCRIPTION
Mirror the conditional `DeactivateValidator` log emission from `jail_validator` so reverting a jail of an already-inactive validator no longer emits a phantom log.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
