### PR TITLE
tendermint: reject non-disjoint contributor sets in aggregate verification

### DIFF
--- a/tendermint/src/states/aggregate.rs
+++ b/tendermint/src/states/aggregate.rs
@@ -53,11 +53,15 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             // If there are not enough votes, continue with the next
             if proposal_contributor_count < TProtocol::TWO_F_PLUS_ONE {
                 // The vote can improve if there is a proposal with < 2f+1 votes currently where also
-                // all of the other votes combined do not exceed f
-                can_improve |=
-                    total_contributors - proposal_contributor_count < TProtocol::F_PLUS_ONE;
+                // all of the other votes combined do not exceed f.
+                // Contributor sets across buckets are disjoint (enforced at verification time), so
+                // these counts never exceed the total. Use saturating arithmetic regardless so a
+                // malformed aggregate that slipped through cannot underflow the count
+                can_improve |= total_contributors.saturating_sub(proposal_contributor_count)
+                    < TProtocol::F_PLUS_ONE;
                 // Keep the remaining contributor count accurate.
-                remaining_contributor_count -= proposal_contributor_count;
+                remaining_contributor_count =
+                    remaining_contributor_count.saturating_sub(proposal_contributor_count);
                 continue;
             }
 
@@ -92,14 +96,17 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
         }
 
         // Keep the remaining contributor count accurate.
-        remaining_contributor_count -= none_contributor_count;
+        remaining_contributor_count =
+            remaining_contributor_count.saturating_sub(none_contributor_count);
 
         // If none of the proposals checked can improve to 2f+1 there is the additional chance, that there might be an unknown proposal
         // which can (or already has) reached 2f+1 votes. As it is unknown it can not be voted for, but it should have been requested thus
         // waiting for the timeout could lead to receiving that proposal.
         // Only if neither known proposals can improve, nor is there enough vote power left to reach a conclusion the timeout is skipped.
 
-        if !can_improve && total_contributors - remaining_contributor_count >= TProtocol::F_PLUS_ONE
+        if !can_improve
+            && total_contributors.saturating_sub(remaining_contributor_count)
+                >= TProtocol::F_PLUS_ONE
         {
             // Vote against all proposals, as None has 2f+1 votes.
             log::debug!(?round_and_step, "Aggregation resulted in None polka",);

--- a/validator/src/aggregation/tendermint/verifier.rs
+++ b/validator/src/aggregation/tendermint/verifier.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use nimiq_bls::AggregatePublicKey;
+use nimiq_collections::bitset::BitSet;
 use nimiq_handel::{
     identity::IdentityRegistry,
     verifier::{VerificationResult, Verifier},
@@ -39,7 +40,20 @@ impl<I: IdentityRegistry + Sync + Send + 'static> Verifier for TendermintVerifie
         // I.e once f contributions are against the proposal this node signed, it is already known that that proposal is not going to pass.
         // Likewise once a proposal has 2f+1 valid contributions it passed and no other contributions are needed.
         let mut params = Vec::new();
+        // Tracks the signers seen across all proposal buckets so far. A given slot may only
+        // contribute to a single bucket: the same slot in two buckets means the validator signed
+        // conflicting votes (equivocation) or the aggregate is malformed. Either way the
+        // contributor sets are no longer disjoint, which would break the union/sum invariant the
+        // Tendermint state machine relies on (`aggregate()`) and underflow its contributor
+        // arithmetic. Reject such contributions outright
+        let mut seen_signers = BitSet::new();
         for (hash, multi_sig) in &contribution.contributions {
+            // Reject the contribution if this bucket overlaps any previously seen bucket
+            if seen_signers.intersection_size(&multi_sig.signers) > 0 {
+                return VerificationResult::Forged;
+            }
+            seen_signers |= multi_sig.signers.clone();
+
             // Create  the aggregated public key for this specific proposal hash's contributions.
             let mut aggregated_public_key = AggregatePublicKey::new();
             for signer in multi_sig.signers.iter() {
@@ -79,5 +93,133 @@ impl<I: IdentityRegistry + Sync + Send + 'static> Verifier for TendermintVerifie
             Ok(()) => VerificationResult::Ok,
             Err(()) => VerificationResult::Forged,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, sync::Arc};
+
+    use nimiq_bls::KeyPair as BlsKeyPair;
+    use nimiq_handel::verifier::{VerificationResult, Verifier};
+    use nimiq_hash::Blake2sHash;
+    use nimiq_keys::{Address, Ed25519PublicKey};
+    use nimiq_primitives::{
+        networks::NetworkId, slots_allocation::ValidatorsBuilder, TendermintIdentifier,
+        TendermintStep, TendermintVote,
+    };
+    use nimiq_utils::key_rng::SecureGenerate;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::TendermintVerifier;
+    use crate::aggregation::{
+        registry::ValidatorRegistry, tendermint::contribution::TendermintContribution,
+    };
+
+    /// Builds a registry with two single-slot validators (slot 0 and slot 1), returning it
+    /// alongside their voting key pairs and a shared aggregation identifier.
+    fn setup() -> (
+        Arc<ValidatorRegistry>,
+        BlsKeyPair,
+        BlsKeyPair,
+        TendermintIdentifier,
+    ) {
+        let mut rng = StdRng::from_rng(&mut rand::rng());
+        let kp0 = BlsKeyPair::generate(&mut rng);
+        let kp1 = BlsKeyPair::generate(&mut rng);
+
+        // `ValidatorsBuilder` assigns slots in address order and `START_ADDRESS < END_ADDRESS`,
+        // so `kp0` gets slot 0 and `kp1` gets slot 1.
+        let mut builder = ValidatorsBuilder::new();
+        builder.push(
+            Address::START_ADDRESS,
+            kp0.public_key,
+            Ed25519PublicKey::default(),
+        );
+        builder.push(
+            Address::END_ADDRESS,
+            kp1.public_key,
+            Ed25519PublicKey::default(),
+        );
+        let registry = Arc::new(ValidatorRegistry::new(builder.build()));
+
+        let id = TendermintIdentifier {
+            network: NetworkId::UnitAlbatross,
+            block_number: 1,
+            round_number: 0,
+            step: TendermintStep::PreVote,
+        };
+
+        (registry, kp0, kp1, id)
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        // The verifier uses `tokio::task::spawn_blocking`, so it needs a Tokio context
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    /// A contribution where the same slot appears in two different proposal buckets (the validator
+    /// equivocated, or the aggregate was crafted) must be rejected, even though each bucket
+    /// signature is individually valid. This guards the contributor-count arithmetic in
+    /// `nimiq_tendermint::Tendermint::aggregate` against underflow on non-disjoint contributor sets
+    #[test]
+    fn rejects_contribution_with_overlapping_buckets() {
+        let (registry, kp0, _kp1, id) = setup();
+        let verifier = TendermintVerifier::new(registry, id.clone());
+
+        let proposal = Blake2sHash::from([1u8; 32]);
+        let vote_proposal = TendermintVote {
+            proposal_hash: Some(proposal),
+            id: id.clone(),
+        };
+        let vote_none = TendermintVote {
+            proposal_hash: None,
+            id,
+        };
+
+        // Slot 0 signs BOTH the proposal and None: two individually valid bucket signatures.
+        let proposal_bucket =
+            TendermintContribution::from_vote(vote_proposal, &kp0.secret_key, 0..1);
+        let none_bucket = TendermintContribution::from_vote(vote_none, &kp0.secret_key, 0..1);
+
+        // Merge them so slot 0 ends up in both buckets of a single contribution.
+        let mut overlapping = proposal_bucket;
+        overlapping.contributions.extend(none_bucket.contributions);
+
+        assert_eq!(
+            block_on(verifier.verify(&overlapping)),
+            VerificationResult::Forged,
+        );
+    }
+
+    /// A contribution with disjoint buckets and valid signatures must verify. This confirms the
+    /// rejection above is caused by the bucket overlap, not by invalid signatures.
+    #[test]
+    fn accepts_contribution_with_disjoint_buckets() {
+        let (registry, kp0, kp1, id) = setup();
+        let verifier = TendermintVerifier::new(registry, id.clone());
+
+        let proposal = Blake2sHash::from([1u8; 32]);
+        let vote_proposal = TendermintVote {
+            proposal_hash: Some(proposal),
+            id: id.clone(),
+        };
+        let vote_none = TendermintVote {
+            proposal_hash: None,
+            id,
+        };
+
+        // Slot 0 votes for the proposal, slot 1 votes for None: disjoint buckets.
+        let proposal_bucket =
+            TendermintContribution::from_vote(vote_proposal, &kp0.secret_key, 0..1);
+        let none_bucket = TendermintContribution::from_vote(vote_none, &kp1.secret_key, 1..2);
+
+        let mut disjoint = proposal_bucket;
+        disjoint.contributions.extend(none_bucket.contributions);
+
+        assert_eq!(block_on(verifier.verify(&disjoint)), VerificationResult::Ok,);
     }
 }


### PR DESCRIPTION
`Tendermint::aggregate` subtracts each proposal bucket's count from the contributor union assuming the buckets are disjoint, but nothing on the receive path enforced that: `TendermintVerifier::verify` only checks each bucket's BLS signature. A contribution where one slot signs two votes (equivocation) makes the per-bucket counts exceed the union and underflows the `usize` subtractions.

Reject overlapping buckets in `TendermintVerifier::verify` (as `Forged`, so the sender is banned), use `saturating_sub` in `aggregate` as defense-in-depth, and add regression tests for the overlapping and disjoint cases.
