### PR TITLE
consensus: validate proven transactions against the requested hashes

### DIFF
--- a/consensus/src/consensus/consensus_proxy.rs
+++ b/consensus/src/consensus/consensus_proxy.rs
@@ -25,8 +25,8 @@ use nimiq_network_interface::{
 use nimiq_primitives::{key_nibbles::KeyNibbles, policy::Policy};
 use nimiq_serde::{Deserialize, Serialize};
 use nimiq_transaction::{
-    historic_transaction::HistoricTransaction, ControlTransaction, ControlTransactionTopic,
-    Transaction, TransactionTopic,
+    historic_transaction::{HistoricTransaction, RawTransactionHash},
+    ControlTransaction, ControlTransactionTopic, Transaction, TransactionTopic,
 };
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::wrappers::BroadcastStream;
@@ -311,6 +311,18 @@ impl<N: Network> ConsensusProxy<N> {
 
         let mut verified_transactions = HashMap::new();
 
+        // Map of the transaction hashes we are requesting to their (optionally) requested block
+        // number. This is used to ensure that a peer only answers with transactions that we
+        // actually asked for. A proof merely attests that a transaction is part of the chain
+        // history (it carries no notion of which hashes were requested), so without this check a
+        // malicious peer could answer a lookup for transaction A with a perfectly valid inclusion
+        // proof for an unrelated transaction B that genuinely is in the chain, and we would accept
+        // B as the result for A.
+        let requested_transactions: HashMap<RawTransactionHash, Option<u32>> = receipts
+            .iter()
+            .map(|(hash, block_number)| (RawTransactionHash::from(hash.clone()), *block_number))
+            .collect();
+
         let full_node_cutoff = election_head.block_number() - Policy::blocks_per_epoch() + 1;
         let can_query_full_nodes = receipts
             .iter()
@@ -490,7 +502,26 @@ impl<N: Network> ConsensusProxy<N> {
 
                         if verification_result {
                             for tx in response.proof.history {
-                                verified_transactions.insert(tx.tx_hash(), tx);
+                                let tx_hash = tx.tx_hash();
+
+                                // Only accept transactions that we actually requested. This
+                                // prevents a peer from substituting a valid proof for an unrelated
+                                // transaction in response to our lookup.
+                                let Some(&requested_block_number) =
+                                    requested_transactions.get(&tx_hash)
+                                else {
+                                    log::warn!(peer = %peer_id, tx_hash = %*tx_hash, "Peer returned a proof for a transaction we did not request; ignoring it");
+                                    continue;
+                                };
+
+                                // If the lookup was bound to a specific block number, the proven
+                                // transaction must have occurred in exactly that block.
+                                if requested_block_number.is_some_and(|bn| tx.block_number != bn) {
+                                    log::warn!(peer = %peer_id, tx_hash = %*tx_hash, expected = ?requested_block_number, got = tx.block_number, "Peer returned a proof for a requested transaction but in an unexpected block; ignoring it");
+                                    continue;
+                                }
+
+                                verified_transactions.insert(tx_hash, tx);
                             }
                         } else {
                             // The proof didn't verify so we continue with another peer

--- a/consensus/tests/consensus_proxy.rs
+++ b/consensus/tests/consensus_proxy.rs
@@ -1,12 +1,16 @@
 use std::{str::FromStr, sync::Arc};
 
-use nimiq_blockchain::{BlockProducer, Blockchain, BlockchainConfig};
+use futures::StreamExt;
+use nimiq_blockchain::{interface::HistoryInterface, BlockProducer, Blockchain, BlockchainConfig};
 use nimiq_blockchain_proxy::BlockchainProxy;
-use nimiq_consensus::{sync::syncer_proxy::SyncerProxy, BlsCache, Consensus};
+use nimiq_consensus::{
+    messages::RequestTransactionsProof, sync::syncer_proxy::SyncerProxy, BlsCache, Consensus,
+};
 use nimiq_database::mdbx::MdbxDatabase;
+use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, KeyPair, PrivateKey};
-use nimiq_network_interface::network::Network;
-use nimiq_network_mock::MockHub;
+use nimiq_network_interface::{network::Network, request::Handle};
+use nimiq_network_mock::{MockHub, MockNetwork};
 use nimiq_primitives::{networks::NetworkId, policy::Policy};
 use nimiq_test_log::test;
 use nimiq_test_utils::blockchain::{
@@ -121,4 +125,130 @@ async fn test_request_transactions_by_address() {
         // There should be one basic transaction in each micro block of the first batch
         Policy::blocks_per_batch() - 1
     );
+}
+
+/// Regression test for a transaction-proof integrity issue: a proof attests only that a transaction
+/// is part of the chain history, it carries no notion of *which* transactions were requested. A
+/// malicious peer can therefore answer a lookup for transaction `A` with a perfectly valid
+/// inclusion proof for an unrelated transaction `B` that genuinely is in the chain.
+///
+/// `prove_transactions_from_receipts` must discard any proven transaction whose hash (or, when a
+/// block number was requested, whose block number) does not match what we actually asked for.
+#[test(tokio::test)]
+async fn test_rejects_proof_for_unrequested_transaction() {
+    let mut hub = MockHub::default();
+
+    // Create a node with a full (finalized) epoch. Each micro block of the first batch has one tx.
+    let blockchain = Arc::new(RwLock::new(
+        Blockchain::new(
+            MdbxDatabase::new_volatile(Default::default()).unwrap(),
+            BlockchainConfig::default(),
+            NetworkId::UnitAlbatross,
+            Arc::new(OffsetTime::new()),
+        )
+        .unwrap(),
+    ));
+
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    fill_micro_blocks_with_txns(&producer, &blockchain, 1, 1);
+    let num_macro_blocks = (Policy::batches_per_epoch() + 1) as usize;
+    produce_macro_blocks(&producer, &blockchain, num_macro_blocks);
+
+    // Pick a real transaction `B` from the first micro block. The malicious peer will serve a
+    // genuine inclusion proof for `B` no matter which transaction is actually requested.
+    let block_b = Policy::genesis_block_number() + 1;
+    let tx_b = blockchain
+        .read()
+        .history_store
+        .get_block_transactions(block_b, None)
+        .into_iter()
+        .find(|tx| matches!(tx.data, HistoricTransactionData::Basic(_)))
+        .expect("first micro block should contain a basic transaction");
+    let hash_b: Blake2bHash = tx_b.tx_hash().into();
+
+    // The malicious peer's network. We deliberately do NOT spawn a full consensus on it, so we can
+    // install our own handler that always proves `B`, regardless of what was requested.
+    let malicious_net = Arc::new(hub.new_network());
+    {
+        let mut requests = malicious_net.receive_requests::<RequestTransactionsProof>();
+        let malicious_net = Arc::clone(&malicious_net);
+        let blockchain = Arc::clone(&blockchain);
+        let hash_b = hash_b.clone();
+        tokio::spawn(async move {
+            while let Some((_request, request_id, peer_id)) = requests.next().await {
+                // Ignore the requested hashes and always answer with a valid proof for `B`.
+                let response = <RequestTransactionsProof as Handle<
+                    MockNetwork,
+                    Arc<RwLock<Blockchain>>,
+                >>::handle(
+                    &RequestTransactionsProof {
+                        hashes: vec![hash_b.clone()],
+                        block_number: None,
+                    },
+                    peer_id,
+                    &blockchain,
+                );
+                malicious_net
+                    .respond::<RequestTransactionsProof>(request_id, response)
+                    .await
+                    .ok();
+            }
+        });
+    }
+
+    // The victim node shares the same blockchain (so the chain-binding checks pass) and queries the
+    // malicious peer.
+    let victim_net = Arc::new(hub.new_network());
+    let blockchain_proxy = BlockchainProxy::from(&blockchain);
+    let zkp_prover = ZKPComponent::new(blockchain_proxy.clone(), Arc::clone(&victim_net), None)
+        .await
+        .proxy();
+    let syncer = SyncerProxy::new_history(
+        blockchain_proxy.clone(),
+        Arc::clone(&victim_net),
+        Arc::new(Mutex::new(BlsCache::new_test())),
+        victim_net.subscribe_events(),
+    )
+    .await;
+    let consensus = Consensus::from_network(
+        blockchain_proxy.clone(),
+        Arc::clone(&victim_net),
+        syncer,
+        zkp_prover,
+    );
+    let consensus_proxy = consensus.proxy();
+    malicious_net.dial_mock(&victim_net);
+
+    // 1. Ask for an unrelated hash without a block number (the web client `getTransaction` path).
+    //    The peer answers with a valid proof for `B`, which must be rejected.
+    let unrelated_hash = Blake2bHash::default();
+    assert_ne!(unrelated_hash, hash_b);
+    let result = consensus_proxy
+        .prove_transactions_from_receipts(vec![(unrelated_hash, None)], 1)
+        .await
+        .expect("request should succeed");
+    assert!(
+        result.is_empty(),
+        "peer substituted an unrelated transaction for the requested one"
+    );
+
+    // 2. Ask for `B`'s hash but bound to the wrong block number. The proof for `B` (in its real
+    //    block) must be rejected because the requested block number does not match.
+    let wrong_block = block_b + 1;
+    let result = consensus_proxy
+        .prove_transactions_from_receipts(vec![(hash_b.clone(), Some(wrong_block))], 1)
+        .await
+        .expect("request should succeed");
+    assert!(
+        result.is_empty(),
+        "peer proof was accepted for a mismatching block number"
+    );
+
+    // 3. Sanity check: a correct lookup for `B` (right hash, right block) still succeeds.
+    let result = consensus_proxy
+        .prove_transactions_from_receipts(vec![(hash_b.clone(), Some(block_b))], 1)
+        .await
+        .expect("request should succeed");
+    assert_eq!(result.len(), 1);
+    assert_eq!(Blake2bHash::from(result[0].tx_hash()), hash_b);
 }


### PR DESCRIPTION
`prove_transactions_from_receipts` verified a peer's `HistoryTreeProof` against the returned block's history root and checked that the block was on the expected chain, but then inserted every transaction from `response.proof.history` keyed by its own `tx_hash()` without checking it against the requested hashes. A proof only attests Merkle inclusion in the chain history; it carries no notion of which hashes were requested. A malicious proof-serving peer could therefore answer a lookup for transaction A with a valid proof for an unrelated transaction B that genuinely is in the chain, and the client would accept B as the result for A (e.g. the web client's `getTransaction`, which queries with `min_peers=1`).

Build a map of the requested hashes to their optionally requested block number and only accept proven transactions whose hash is in that set; when a block number was requested, also require the proven transaction's block number to match. Mismatching transactions are dropped, so a substituted transaction now results in "not found" instead of a spoofed answer.

Add a regression test.
