### PR TITLE
tendermint: allow late proposals to finish an aggregation

### DIFF
--- a/tendermint/src/states/aggregate.rs
+++ b/tendermint/src/states/aggregate.rs
@@ -42,12 +42,15 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             .state
             .round_proposals
             .entry(self.state.current_round)
-            .or_default();
+            .or_default()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
 
         // Go over the proposals known to the node for this round.
         // As they are the only ones that can result in an action all others can be ignored.
         // Those which bear any chance of reaching a result will be requested during aggregation acquisition.
-        for proposal_hash in proposals.keys().cloned() {
+        for proposal_hash in proposals {
             let proposal_contributor_count =
                 current_best.contributors_for(Some(&proposal_hash)).len();
             // If there are not enough votes, continue with the next
@@ -71,12 +74,33 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                 proposal = ?proposal_hash,
                 "Aggregation resulted in Block polka",
             );
-            self.on_polka(proposal_hash);
+            match round_and_step.1 {
+                Step::Prevote => {
+                    self.update_valid(round_and_step.0, proposal_hash.clone());
+                    self.on_polka(proposal_hash);
 
-            // Reset timeout.
-            self.timeout = None;
-            // Yield state.
-            return Some(Return::Update(self.state.clone()));
+                    // Reset timeout.
+                    self.timeout = None;
+                    // Yield state.
+                    return Some(Return::Update(self.state.clone()));
+                }
+                Step::Precommit => {
+                    let proposal = self
+                        .state
+                        .known_proposals
+                        .get(&proposal_hash)
+                        .expect("proposal must be known")
+                        .clone();
+                    let decision =
+                        self.build_decision(proposal, current_best.clone(), round_and_step.0);
+
+                    self.timeout = None;
+                    return Some(Return::Decision(decision));
+                }
+                Step::Propose => {
+                    panic!("current_step must not be Step::Propose when calling aggregate()")
+                }
+            }
         }
 
         // Also check the vote for None as it could be conclusive.
@@ -141,8 +165,9 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
     /// action to advance to the next state while having seen 2f+1 votes for the known proposal with `proposal_hash`
     /// as its hash.
     ///
-    /// As precommit aggregations with 2f+1 votes result in a decision being produced and as those are produced
-    /// while polling ongoing aggregations that match arm is unreachable!() here.
+    /// As precommit aggregations with 2f+1 votes result in a decision being produced, this only handles
+    /// the prevote-to-precommit transition. Fresh precommit polkas are handled in `poll_aggregations`,
+    /// while cached ones are handled directly in `aggregate`.
     ///
     /// This cannot fail.
     fn on_polka(&mut self, proposal_hash: TProtocol::ProposalHash) {

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -215,6 +215,30 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             .is_some()
     }
 
+    /// Updates `valid` if `proposal_hash` forms a newer known prevote polka.
+    pub(crate) fn update_valid(&mut self, round: u32, proposal_hash: TProtocol::ProposalHash) {
+        if self.state.valid.is_none() || self.state.valid.as_ref().unwrap().0 < round {
+            self.state.valid = Some((round, proposal_hash));
+        }
+    }
+
+    /// Builds a decision from a known proposal and a conclusive precommit aggregation.
+    pub(crate) fn build_decision(
+        &self,
+        proposal: TProtocol::Proposal,
+        aggregation: TProtocol::Aggregation,
+        round: u32,
+    ) -> TProtocol::Decision {
+        let inherent = self
+            .state
+            .inherents
+            .get(&proposal.inherent_hash())
+            .expect("proposal inherent must be known");
+
+        self.protocol
+            .create_decision(proposal, inherent.clone(), aggregation, round)
+    }
+
     /// Creates an aggregation for a given `id`. If that aggregation does already exist,
     /// as indicated by the presence of `id` in `self.aggregation_senders` it has no effect.
     ///
@@ -586,7 +610,8 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                 .or_insert_with(|| {
                     *should_export_state = true;
                     aggregate
-                });
+                })
+                .clone();
 
             // Get the total weight for the aggregate. It will be used for more comparisons later.
             let total_contributor_count = best_vote.all_contributors().len();
@@ -601,33 +626,16 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                                 // If it is an improvement over `valid`, replace it.
                                 // Note that this might happen for any given round. This instance might have already voted None.
                                 // Thus setting `valid` and setting `locked` happens in different places.
-                                if self.state.valid.is_none()
-                                    || self.state.valid.as_ref().unwrap().0 < round_and_step.0
-                                {
-                                    self.state.valid =
-                                        Some((round_and_step.0, proposal_hash.clone()));
-                                }
+                                self.update_valid(round_and_step.0, proposal_hash.clone());
                             }
                             Step::Precommit => {
                                 // The proposal exists and is valid. 2f+1 precommits have been seen.
                                 log::debug!(?round_and_step, "Aggregation produced decision value",);
-
-                                // Get the inherent
-                                let inherent = self
-                                    .state
-                                    .inherents
-                                    .get(&proposal.inherent_hash())
-                                    .expect("");
-
-                                // Produce a decision
-                                let decision = self.protocol.create_decision(
+                                return Some(self.build_decision(
                                     proposal.clone(),
-                                    inherent.clone(),
                                     best_vote.clone(),
                                     round_and_step.0,
-                                );
-
-                                return Some(decision);
+                                ));
                             }
                             _ => panic!("Aggregations must not have Step::Propose"),
                         };
@@ -777,11 +785,15 @@ impl<TProtocol: Protocol> Stream for Tendermint<TProtocol> {
         };
 
         // If the state machine did not return Poll::Pending its return must be returned as it might be the result
-        if state_machine_return.is_some() {
-            if let Some(Return::Update(_)) = &state_machine_return {
-                self.state_return_pending = false;
+        if let Some(state_machine_return) = state_machine_return {
+            match &state_machine_return {
+                Return::Decision(_) => self.decision = true,
+                Return::Update(_) => self.state_return_pending = false,
+                Return::ProposalAccepted(_)
+                | Return::ProposalIgnored(_)
+                | Return::ProposalRejected(_) => {}
             }
-            return Poll::Ready(state_machine_return);
+            return Poll::Ready(Some(state_machine_return));
         }
 
         // If the state machine did return Poll::Pending there might have been a state change prior to it, that makes a state

--- a/tendermint/tests/detailed.rs
+++ b/tendermint/tests/detailed.rs
@@ -774,6 +774,55 @@ async fn it_progresses_with_no_proposal() {
     assert_eq!(update.current_round, 1);
 }
 
+#[test(tokio::test)]
+async fn late_known_precommit_polka_produces_decision() {
+    let (validator, mut observe_receiver) = create_validator(vec![false], vec![]);
+    let (mut proposal_sender, proposal_receiver) = mpsc::channel(10);
+
+    let mut tendermint = Tendermint::new(
+        validator.clone(),
+        None,
+        ReceiverStream::new(proposal_receiver).boxed(),
+        stream::iter(vec![]).boxed(),
+    );
+
+    let update = await_state(&mut tendermint).await;
+    assert_eq!(update.votes.get(&(0, Step::Prevote)), Some(&None));
+
+    let _update = expect_state(&mut tendermint);
+    expect_observe_aggregate(&mut observe_receiver);
+
+    aggregate(
+        &validator,
+        (0, Step::Prevote),
+        vec![(Some(99), 0..Validator::TWO_F_PLUS_ONE)],
+    );
+    let _update = expect_state(&mut tendermint);
+
+    let update = await_state(&mut tendermint).await;
+    assert_eq!(update.votes.get(&(0, Step::Precommit)), Some(&None));
+
+    let _update = expect_state(&mut tendermint);
+    expect_observe_aggregate(&mut observe_receiver);
+
+    aggregate(
+        &validator,
+        (0, Step::Precommit),
+        vec![(Some(99), 0..Validator::TWO_F_PLUS_ONE)],
+    );
+    let _update = expect_state(&mut tendermint);
+
+    send_proposal(&mut proposal_sender, 99, 0, None, true);
+    let proposal = expect_proposal(&mut tendermint, Acceptance::Accept);
+    assert_eq!(proposal.0, 99);
+
+    let decision = expect_decision(&mut tendermint);
+    assert_eq!(decision.round, 0);
+    assert_eq!(decision.proposal, TestProposal(99));
+    assert_eq!(decision.inherents, TestInherent(99));
+    assert_eq!(decision.sig.len(), Validator::TWO_F_PLUS_ONE);
+}
+
 // The first proposer does not send a proposal but the second one does.
 #[test(tokio::test)]
 async fn it_skips_ahead() {


### PR DESCRIPTION
Whenever a node sees a finished aggregation (2f+1 votes) for an unknown proposal it enters a timeout window during which the proposal can still arrive. Before this change a late Pre-Commit hit an unreachable panic and crashed the node; a late Pre-Vote did not panic but failed to set the valid round correctly.

Re-assess the outcome correctly in that window for both cases, and add a test that a decision can still be reached with a late proposal.
