### PR TITLE
fix: reject all-zero default public key as a signature signer

### DIFF
--- a/keys/src/public_key.rs
+++ b/keys/src/public_key.rs
@@ -19,6 +19,14 @@ impl Ed25519PublicKey {
     pub const SIZE: usize = 32;
 
     pub fn verify(&self, signature: &Ed25519Signature, data: &[u8]) -> bool {
+        // The all-zero (default) public key is a low-order curve point for which the
+        // all-zero signature satisfies the (cofactored, ZIP-215) verification equation
+        // for *any* message. Accepting it would turn the default `SignatureProof` into a
+        // universal wildcard, so we reject it explicitly as a signer.
+        if self.as_bytes() == &[0u8; Ed25519PublicKey::SIZE] {
+            return false;
+        }
+
         if let Ok(vk) = ed25519_zebra::VerificationKey::try_from(self.0) {
             vk.verify(&signature.0, data).is_ok()
         } else {

--- a/keys/tests/mod.rs
+++ b/keys/tests/mod.rs
@@ -55,6 +55,18 @@ fn falsify_wrong_signature() {
 }
 
 #[test]
+fn it_rejects_the_default_public_key() {
+    // The all-zero (default) public key is a low-order curve point for which the all-zero
+    // signature used to verify against any message, making it a universal wildcard. It must
+    // now be rejected as a signer regardless of the message.
+    let public_key = Ed25519PublicKey::default();
+    let signature = Ed25519Signature::default();
+    assert!(!public_key.verify(&signature, b""));
+    assert!(!public_key.verify(&signature, b"any message"));
+    assert!(!public_key.verify(&signature, b"another message"));
+}
+
+#[test]
 fn verify_rfc8032_test_vectors() {
     struct TestVector<'a, 'b, 'c, 'd> {
         private: &'a str,

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -255,6 +255,16 @@ pub fn verify_transaction_signature(
     transaction: &Transaction,
     sig_proof: &SignatureProof,
 ) -> Result<(), TransactionError> {
+    // Reject the all-zero (default) public key as a signer. It is a verification wildcard
+    // (see `SignatureProof::is_default_public_key`)
+    if sig_proof.is_default_public_key() {
+        warn!(
+            ?transaction,
+            "Rejecting staking transaction signed with the default (all-zero) public key",
+        );
+        return Err(TransactionError::InvalidProof);
+    }
+
     // If we are verifying the signature on an incoming transaction, then we need to reset the
     // signature field first.
     let tx = {

--- a/primitives/transaction/src/signature_proof.rs
+++ b/primitives/transaction/src/signature_proof.rs
@@ -93,6 +93,16 @@ impl SignatureProof {
         self.compute_signer() == *address
     }
 
+    /// Returns whether this proof's public key is the all-zero (default) Ed25519 key.
+    ///
+    /// That key is a low-order curve point for which the all-zero signature verifies
+    /// against any message (see [`nimiq_keys::Ed25519PublicKey::verify`]), making the
+    /// default `SignatureProof` a verification wildcard. It must never be accepted as a
+    /// signer.
+    pub fn is_default_public_key(&self) -> bool {
+        self.public_key == PublicKey::Ed25519(Ed25519PublicKey::default())
+    }
+
     pub fn verify(&self, message: &[u8]) -> bool {
         if self.webauthn_fields.is_some() {
             self.verify_webauthn(message)

--- a/primitives/transaction/tests/staking_contract_verify.rs
+++ b/primitives/transaction/tests/staking_contract_verify.rs
@@ -523,6 +523,38 @@ fn create_staker() {
 }
 
 #[test]
+fn it_rejects_staking_transaction_with_default_signer() {
+    let keypair = ed25519_key_pair(STAKER_PRIVATE_KEY);
+
+    // A correctly signed create-staker transaction is accepted.
+    let tx = make_signed_incoming_tx(
+        IncomingStakingTransactionData::CreateStaker {
+            delegation: None,
+            proof: SignatureProof::default(),
+        },
+        Policy::MINIMUM_STAKE,
+        &keypair,
+        None,
+    );
+    assert_eq!(AccountType::verify_incoming_transaction(&tx), Ok(()));
+
+    // Replacing the embedded staking proof with the all-zero default proof models the
+    // transaction a malicious block producer would forge to create a staker owned by the
+    // all-zero (wildcard) key. The default proof must be rejected as a signer.
+    let mut forged = tx;
+    forged.recipient_data = IncomingStakingTransactionData::set_signature_on_data(
+        &forged.recipient_data,
+        SignatureProof::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        AccountType::verify_incoming_transaction(&forged),
+        Err(TransactionError::InvalidProof)
+    );
+}
+
+#[test]
 fn stake() {
     let keypair = ed25519_key_pair(STAKER_PRIVATE_KEY);
 


### PR DESCRIPTION
The all-zero default `SignatureProof` (all-zero Ed25519 key + all-zero signature) is a low-order point that verifies against any message under ZIP-215, acting as a universal wildcard. Because staking transactions are double-signed, a malicious block producer could swap the staking and transaction proofs to forge a create-staker/create-validator owned by the all-zero key.

Reject the all-zero key in `Ed25519PublicKey::verify` (root cause) and in `verify_transaction_signature` (defense in depth). This is stage 1 of a two-stage fix; stage 2 will introduce domain separation between the staking and transaction proofs.
