### PR TITLE
Add checkpoints to pico sync fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,6 +4436,7 @@ dependencies = [
  "nimiq-blockchain-interface",
  "nimiq-blockchain-proxy",
  "nimiq-consensus",
+ "nimiq-genesis",
  "nimiq-mempool",
  "nimiq-network-interface",
  "nimiq-network-libp2p",

--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -475,6 +475,13 @@ impl Blockchain {
         // Check if this block is an election block.
         let is_election_block = macro_block.is_election();
         if is_election_block {
+            // Verify the hardcoded checkpoint (if any) against our own chain.
+            nimiq_genesis::verify_election_checkpoint(
+                this.network_id,
+                macro_block.block_number(),
+                &block_hash,
+            );
+
             this.state.election_head = macro_block.clone();
             this.state.election_head_hash = block_hash.clone();
             this.state.previous_slots = this.state.current_slots.take();

--- a/blockchain/src/blockchain/macro_sync.rs
+++ b/blockchain/src/blockchain/macro_sync.rs
@@ -155,6 +155,13 @@ impl Blockchain {
             this.state.macro_head_hash = block_hash.clone();
 
             if is_election_block {
+                // Verify the hardcoded checkpoint (if any) against our own chain.
+                nimiq_genesis::verify_election_checkpoint(
+                    this.network_id,
+                    macro_block.block_number(),
+                    &block_hash,
+                );
+
                 this.state.election_head = macro_block.clone();
                 this.state.election_head_hash = block_hash.clone();
 

--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -385,6 +385,10 @@ impl Blockchain {
             this.state.macro_head_hash = block_hash.clone();
 
             if is_election_block {
+                // The hardcoded checkpoint is intentionally not verified on this live extend path
+                // (nor on rebranch): checkpoints always reference a *past* election block, which
+                // full nodes verify during history-sync catch-up, and a live-tip election event
+                // cannot cross a past checkpoint. See `nimiq_genesis::verify_election_checkpoint`.
                 this.state.election_head = macro_block.clone();
                 this.state.election_head_hash = block_hash.clone();
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -39,6 +39,7 @@ nimiq-blockchain = { workspace = true, optional = true }
 nimiq-blockchain-interface = { workspace = true }
 nimiq-blockchain-proxy = { workspace = true, default-features = false }
 nimiq-bls = { workspace = true }
+nimiq-genesis = { workspace = true }
 nimiq-hash = { workspace = true }
 nimiq-keys = { workspace = true }
 nimiq-light-blockchain = { workspace = true }
@@ -56,7 +57,6 @@ hex = "0.4"
 
 nimiq-bls = { workspace = true }
 nimiq-database = { workspace = true }
-nimiq-genesis = { workspace = true }
 nimiq-genesis-builder = { workspace = true }
 nimiq-keys = { workspace = true }
 nimiq-network-mock = { workspace = true }

--- a/consensus/src/sync/light/sync.rs
+++ b/consensus/src/sync/light/sync.rs
@@ -5,24 +5,27 @@ use std::{
 
 use futures::{future::BoxFuture, FutureExt};
 use nimiq_block::Block;
+use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_genesis::HardcodedElection;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{
     network::{CloseReason, Network, SubscribeEvents},
     request::RequestError,
 };
+use nimiq_primitives::policy::Policy;
 use nimiq_utils::{spawn, stream::FuturesUnordered};
-#[cfg(feature = "full")]
 use parking_lot::RwLock;
 
+#[cfg(feature = "full")]
+use crate::messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk};
 use crate::{
     messages::BlockError,
-    sync::sync_interface::{EpochIds, MacroSync, PeerMacroRequests},
-};
-#[cfg(feature = "full")]
-use crate::{
-    messages::{HistoryChunk, HistoryChunkError, RequestHistoryChunk},
-    sync::{peer_list::PeerList, sync_queue::SyncQueue},
+    sync::{
+        peer_list::PeerList,
+        sync_interface::{EpochIds, MacroSync},
+        sync_queue::SyncQueue,
+    },
 };
 
 #[cfg(feature = "full")]
@@ -40,9 +43,31 @@ pub struct ValidityChunkRequest {
     pub last_chunk_items: Option<usize>,
 }
 
-#[cfg(feature = "full")]
-/// Validity sync queue pending size
+/// Sync queue pending size (max in-flight block / chunk requests per queue).
 const PENDING_SIZE: usize = 5;
+
+/// Error returned by the `macro_block_queue` request function. Both variants are **retryable**:
+/// `SyncQueue` fails the request over to another peer. A peer returning a block that does not match
+/// the requested hash (`BlockError::ResponseHashMismatch`) is the only provably-malicious case, and
+/// it is instead surfaced as a successful-but-erroneous output so the consumer can ban that specific
+/// peer — never converted into this (retryable) error.
+#[derive(Debug)]
+pub(crate) enum MacroBlockError {
+    /// Transport-level request error (timeout, connection closed, ...).
+    Request(RequestError),
+    /// Remote block-level error other than a hash mismatch (e.g. the peer does not have the block
+    /// it was asked for). The responder is not at fault; retry from another peer.
+    Block(BlockError),
+}
+
+impl std::fmt::Display for MacroBlockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MacroBlockError::Request(error) => write!(f, "request error: {error}"),
+            MacroBlockError::Block(error) => write!(f, "block error: {error}"),
+        }
+    }
+}
 
 /// The LightMacroSync is one type of MacroSync and it is essentially a stream,
 /// that operates on a per peer basis, emitting peers either as Outdated or Good.
@@ -58,21 +83,44 @@ pub struct LightMacroSync<TNetwork: Network> {
     pub(crate) network: Arc<TNetwork>,
     /// Stream for peer joined and peer left events
     pub(crate) network_event_rx: SubscribeEvents<TNetwork::PeerId>,
-    /// Used to track the macro requests on a per peer basis
-    pub(crate) peer_requests: HashMap<TNetwork::PeerId, PeerMacroRequests>,
     /// The stream for epoch ids requests
     pub(crate) epoch_ids_stream:
         FuturesUnordered<BoxFuture<'static, Option<EpochIds<TNetwork::PeerId>>>>,
-    /// Block requests
-    pub(crate) block_headers: FuturesUnordered<
-        BoxFuture<
-            'static,
-            (
-                Result<Result<Block, BlockError>, RequestError>,
-                TNetwork::PeerId,
-            ),
-        >,
+
+    /// Hardcoded election block to bootstrap from on the pico sync fallback path; `None` for
+    /// light/full sync (which sync the election chain from genesis and only verify the checkpoint).
+    /// When set and the chain is still behind it, the checkpoint election block is fetched through
+    /// `macro_block_queue` and seeded via `apply_macro_block` (see `add_peer`).
+    pub(crate) bootstrap_checkpoint: Option<HardcodedElection>,
+
+    /// Bounded, ordered, failover queue for fetching macro (election) block headers: the checkpoint
+    /// seed, the forward catch-up after it, and the full-node `previous_slots` recovery block all go
+    /// through here. Requests are bounded (`PENDING_SIZE`), responses applied in request (epoch)
+    /// order, and a timed-out block is re-requested from another peer instead of stalling. Its peer
+    /// pool is maintained via `macro_block_queue.add_peer`/`remove_peer`.
+    pub(crate) macro_block_queue: SyncQueue<
+        TNetwork,
+        Blake2bHash,
+        (Blake2bHash, Result<Block, BlockError>, TNetwork::PeerId),
+        MacroBlockError,
+        (),
     >,
+
+    /// Macro block hashes currently queued or in flight in `macro_block_queue`. Deduplicates
+    /// overlapping `epoch_ids` (and seed requests) from multiple peers; entries are removed once the
+    /// block is applied or its request is exhausted.
+    pub(crate) in_flight_macro_blocks: HashSet<Blake2bHash>,
+
+    /// Peers waiting for `macro_block_queue` to advance our head to their reported target block
+    /// number. Once reached they are re-queried for epoch ids (emitting `Good` when nothing is
+    /// left, or enqueuing the next epochs if the tip moved). Drives the checkpoint seed and forward
+    /// catch-up.
+    pub(crate) waiting_macro_peers: HashMap<TNetwork::PeerId, u32>,
+
+    /// Peers to re-query once a specific queued block resolves, keyed by that block's hash. Used for
+    /// the full-node `previous_slots` recovery fetch, whose `update_previous_slots` apply does not
+    /// advance the head (so `waiting_macro_peers` can't drive it).
+    pub(crate) pending_followup_requests: HashMap<Blake2bHash, Vec<TNetwork::PeerId>>,
 
     #[cfg(feature = "full")]
     /// The validity (history chunks) queue
@@ -108,7 +156,54 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         network: Arc<TNetwork>,
         network_event_rx: SubscribeEvents<TNetwork::PeerId>,
         full_sync_threshold: u32,
+        bootstrap_checkpoint: Option<HardcodedElection>,
     ) -> Self {
+        // A hardcoded checkpoint must point at an election block; otherwise the pico bootstrap seed
+        // branch (gated on `block.is_election()` in `apply_macro_block`) never fires and the chain
+        // would silently fail to seed. Catch a release-time misconfiguration early.
+        //
+        // NOTE: this only validates the *height*. The `hash` and `block_number` are hand-pasted per
+        // release and MUST come from the same block — they cannot be cross-checked here without the
+        // block itself. If they disagree, the fetched (by-hash) block won't match the seed condition
+        // and the pico bootstrap silently fails to seed (it no longer bans peers — see `apply_macro_block`).
+        debug_assert!(
+            bootstrap_checkpoint
+                .as_ref()
+                .is_none_or(|cp| Policy::is_election_block_at(cp.block_number)),
+            "bootstrap checkpoint must be an election block"
+        );
+
+        // Queue for all macro-block fetches (seed, forward catch-up, previous_slots recovery).
+        // Ungated (used by light/pico too). The queue owns its peer pool, maintained via
+        // `macro_block_queue.add_peer`/`remove_peer` (same pattern as `validity_queue`).
+        let macro_block_queue = SyncQueue::with_verification(
+            Arc::clone(&network),
+            Vec::<(Blake2bHash, Option<_>)>::new(),
+            Arc::new(RwLock::new(PeerList::default())),
+            PENDING_SIZE,
+            move |block_hash, network, peer_id| {
+                async move {
+                    match Self::request_macro_block(network, peer_id, block_hash.clone()).await {
+                        // Transport failure: retry from another peer.
+                        Err(error) => Err(MacroBlockError::Request(error)),
+                        // A hash mismatch is provably the responder's fault: surface it (not
+                        // retryable) so the consumer bans that specific peer.
+                        Ok(Err(error @ BlockError::ResponseHashMismatch)) => {
+                            Ok((block_hash, Err(error), peer_id))
+                        }
+                        // Any other remote block error (e.g. the peer simply does not have the
+                        // block it was asked for) is not this peer's fault: retry from another peer
+                        // rather than disconnecting an honest failover target.
+                        Ok(Err(error)) => Err(MacroBlockError::Block(error)),
+                        Ok(Ok(block)) => Ok((block_hash, Ok(block), peer_id)),
+                    }
+                }
+                .boxed()
+            },
+            |_, _, _| true,
+            (),
+        );
+
         #[cfg(feature = "full")]
         let peers = Arc::new(RwLock::new(PeerList::default()));
 
@@ -138,11 +233,14 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             blockchain,
             network,
             network_event_rx,
-            peer_requests: HashMap::new(),
             epoch_ids_stream: FuturesUnordered::new(),
             #[cfg(feature = "full")]
             full_sync_threshold,
-            block_headers: Default::default(),
+            bootstrap_checkpoint,
+            macro_block_queue,
+            in_flight_macro_blocks: HashSet::new(),
+            waiting_macro_peers: HashMap::new(),
+            pending_followup_requests: HashMap::new(),
             #[cfg(feature = "full")]
             validity_requests: None,
             #[cfg(feature = "full")]
@@ -154,13 +252,18 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         }
     }
 
-    pub fn remove_peer_requests(&mut self, peer_id: TNetwork::PeerId) {
-        self.peer_requests.remove(&peer_id);
+    pub fn remove_peer(&mut self, peer_id: TNetwork::PeerId) {
+        // Drop the peer from the macro-block fetch pool so the queue stops requesting/failing over
+        // to it, and forget any pending "waiting for our head to reach its target" bookkeeping.
+        // `pending_followup_requests` entries are left to drain on block resolution (the re-query is
+        // `has_peer`-guarded), so no scrub is needed here.
+        self.macro_block_queue.remove_peer(&peer_id);
+        self.waiting_macro_peers.remove(&peer_id);
     }
 
     pub fn disconnect_peer(&mut self, peer_id: TNetwork::PeerId, reason: CloseReason) {
-        // Remove all pending peer requests (if any)
-        self.remove_peer_requests(peer_id);
+        // Remove all pending peer bookkeeping (if any)
+        self.remove_peer(peer_id);
         let network = Arc::clone(&self.network);
         // We disconnect from this peer
         spawn(Box::pin({
@@ -169,17 +272,47 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             }
         }));
     }
+
+    /// Starts epoch-id macro sync with a peer.
+    pub(crate) fn request_epoch_ids_from(&mut self, peer_id: TNetwork::PeerId) {
+        let future =
+            Self::request_epoch_ids(self.blockchain.clone(), Arc::clone(&self.network), peer_id)
+                .boxed();
+        self.epoch_ids_stream.push(future);
+    }
 }
 
 impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for LightMacroSync<TNetwork> {
     const MAX_REQUEST_EPOCHS: u16 = 1000; // TODO: Use other value
 
     fn add_peer(&mut self, peer_id: TNetwork::PeerId) {
+        // Make the peer available to the macro-block fetch queue (idempotent) so it can serve
+        // election blocks and act as a failover target.
+        self.macro_block_queue.add_peer(peer_id);
+
+        // If we have a hardcoded checkpoint and have not reached it yet (pico sync fallback path),
+        // bootstrap from it instead of re-syncing the whole election chain from genesis (infeasible
+        // for pico/browser clients): enqueue the checkpoint election block (deduplicated; the
+        // request layer verifies the response matches the hash). The queue applies it first via
+        // `apply_macro_block`, which seeds the chain; once our head reaches the checkpoint the
+        // tip-follow loop re-queries this peer for epoch ids to sync forward.
+        if let Some(checkpoint) = &self.bootstrap_checkpoint
+            && self.blockchain.read().block_number() < checkpoint.block_number
+        {
+            let hash = checkpoint.hash.clone();
+            let target = checkpoint.block_number;
+            // Only request the checkpoint if it isn't already in flight; otherwise this peer just
+            // joins the queue's pool as a failover target and waits for our head to reach it.
+            if self.in_flight_macro_blocks.insert(hash.clone()) {
+                info!(%peer_id, "Requesting checkpoint block from peer");
+                self.macro_block_queue.add_ids(vec![(hash, Some(peer_id))]);
+            }
+            self.waiting_macro_peers.insert(peer_id, target);
+            return;
+        }
+
         info!(%peer_id, "Requesting epoch ids from peer");
-        let future =
-            Self::request_epoch_ids(self.blockchain.clone(), Arc::clone(&self.network), peer_id)
-                .boxed();
-        self.epoch_ids_stream.push(future);
+        self.request_epoch_ids_from(peer_id);
     }
 
     fn fallback(&mut self, _peers: Vec<TNetwork::PeerId>) {

--- a/consensus/src/sync/light/sync_requests.rs
+++ b/consensus/src/sync/light/sync_requests.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use futures::FutureExt;
 use nimiq_block::Block;
 use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
@@ -15,7 +14,7 @@ use crate::{
     messages::{BlockError, MacroChain, MacroChainError, RequestMacroChain},
     sync::{
         light::LightMacroSync,
-        sync_interface::{EpochIds, MacroSync, MacroSyncReturn, PeerMacroRequests},
+        sync_interface::{EpochIds, MacroSync, MacroSyncReturn},
     },
 };
 
@@ -126,32 +125,6 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         }
     }
 
-    /// Adds a request for a single macro block to the block headers queue.
-    /// This is useful for fetching a specific block during sync.
-    #[cfg(feature = "full")]
-    pub(crate) fn request_single_macro_block(
-        &mut self,
-        peer_id: TNetwork::PeerId,
-        block_hash: Blake2bHash,
-    ) {
-        let mut peer_requests = PeerMacroRequests::new();
-        let network = Arc::clone(&self.network);
-
-        peer_requests.push_request(block_hash.clone());
-
-        self.block_headers.push(
-            async move {
-                (
-                    Self::request_macro_block(network, peer_id, block_hash).await,
-                    peer_id,
-                )
-            }
-            .boxed(),
-        );
-
-        self.peer_requests.insert(peer_id, peer_requests);
-    }
-
     /// Creates block header requests for election blocks and an optional checkpoint
     /// received from a peer.
     pub(crate) fn request_macro_headers(
@@ -220,53 +193,48 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             return Some(MacroSyncReturn::Good(epoch_ids.sender));
         }
 
-        let mut peer_requests = PeerMacroRequests::new();
+        // The highest block this peer reports: once our head reaches it, the peer is fully synced
+        // from our side. Drives the tip-follow re-request in `poll_macro_block_queue`. A checkpoint
+        // (a later, non-election macro block) is always higher than the last election block.
+        //
+        // A peer reporting a nonsensically large epoch number yields a `u32::MAX` target it has no
+        // hope of reaching, so it just sits in `waiting_macro_peers` until it disconnects. Harmless:
+        // it never gets emitted, but it also wastes nothing (it is requested no blocks).
+        let target_block_number = if let Some(checkpoint) = &epoch_ids.checkpoint {
+            checkpoint.block_number
+        } else {
+            Policy::election_block_of(epoch_ids.last_epoch_number() as u32).unwrap_or(u32::MAX)
+        };
 
-        log::trace!(%epoch_ids.sender,
-            "Creating a new set of requests",
-        );
+        log::trace!(%epoch_ids.sender, "Queueing macro block requests");
 
-        // Request the election blocks
+        // Enqueue the election blocks (and optional checkpoint) into the shared, bounded,
+        // failover-capable macro block queue. Deduplicate against blocks already in flight so
+        // overlapping epoch_ids from multiple peers don't request the same block twice. The sender
+        // is passed as the preferred peer; the queue fails over to others on timeout.
+        let mut ids = Vec::new();
         for block_hash in epoch_ids.ids {
-            let network = Arc::clone(&self.network);
-            let peer_id = epoch_ids.sender;
-
-            log::trace!(
-                %block_hash,
-                "Pushing a new block request",
-            );
-
-            peer_requests.push_request(block_hash.clone());
-
-            self.block_headers.push(
-                async move {
-                    (
-                        Self::request_macro_block(network, peer_id, block_hash).await,
-                        peer_id,
-                    )
-                }
-                .boxed(),
-            );
+            if self.in_flight_macro_blocks.insert(block_hash.clone()) {
+                ids.push((block_hash, Some(epoch_ids.sender)));
+            }
         }
-
-        // Request the checkpoint (if any)
         if let Some(checkpoint) = &epoch_ids.checkpoint {
-            let block_hash = checkpoint.clone().hash;
-            let network = Arc::clone(&self.network);
-            let peer_id = epoch_ids.sender;
-            peer_requests.push_request(block_hash.clone());
-            self.block_headers.push(
-                async move {
-                    (
-                        Self::request_macro_block(network, peer_id, block_hash).await,
-                        peer_id,
-                    )
-                }
-                .boxed(),
-            );
+            let block_hash = checkpoint.hash.clone();
+            if self.in_flight_macro_blocks.insert(block_hash.clone()) {
+                ids.push((block_hash, Some(epoch_ids.sender)));
+            }
         }
 
-        self.peer_requests.insert(epoch_ids.sender, peer_requests);
+        // If everything this peer reported is already in flight (driven by another peer) and we
+        // have already reached its target, it is fully synced now: emit it as good. Otherwise wait
+        // until the queue advances our head to its target (see `poll_macro_block_queue`).
+        if ids.is_empty() && target_block_number <= our_block_number {
+            return Some(MacroSyncReturn::Good(epoch_ids.sender));
+        }
+
+        self.waiting_macro_peers
+            .insert(epoch_ids.sender, target_block_number);
+        self.macro_block_queue.add_ids(ids);
 
         None
     }

--- a/consensus/src/sync/light/sync_stream.rs
+++ b/consensus/src/sync/light/sync_stream.rs
@@ -1,14 +1,17 @@
 use std::{
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{Stream, StreamExt};
+// `BlockError` from `nimiq_block` (block-level verification errors) is aliased to avoid clashing
+// with `crate::messages::BlockError` (the request-response error used elsewhere in this file).
+use nimiq_block::{Block, BlockError as BlockVerifyError};
 #[cfg(feature = "full")]
 use nimiq_blockchain::Blockchain;
-use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_blockchain_interface::{AbstractBlockchain, PushError};
 use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_hash::Blake2bHash;
 use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{CloseReason, Network, NetworkEvent};
 #[cfg(feature = "full")]
@@ -22,6 +25,36 @@ use crate::{
     },
 };
 
+/// Outcome of attempting to apply a single fetched macro/election block to the chain.
+enum ApplyOutcome {
+    /// The block was applied (Extended/Known/Ignored, or `previous_slots` updated for full nodes).
+    Pushed,
+    /// The block is below our current head; the peer that provided it is outdated.
+    OutdatedPeer,
+    /// The block is valid but does not extend our chain right now — its predecessor is missing (an
+    /// earlier block in the sequence could not be fetched) or it is on a fork. The peer relayed a
+    /// hash-matching block, so this is not misbehavior: skip it rather than banning the peer.
+    Unfit,
+    /// The block is intrinsically invalid; the responding peer must be banned.
+    Ban,
+}
+
+/// Whether a failed macro-block push reflects the block not fitting our chain *right now* (a missing
+/// or diverging predecessor) rather than the block being intrinsically invalid. In the former case
+/// the peer that served a hash-matching block is not at fault and must not be banned.
+fn is_unfitting_push_error(error: &PushError) -> bool {
+    matches!(
+        error,
+        PushError::Orphan
+            | PushError::InvalidSuccessor
+            | PushError::InvalidPredecessor
+            | PushError::InvalidFork
+            | PushError::InvalidBlock(
+                BlockVerifyError::InvalidParentElectionHash | BlockVerifyError::InvalidBlockNumber
+            )
+    )
+}
+
 impl<TNetwork: Network> LightMacroSync<TNetwork> {
     // This function is the one that starts the LightMacroSync process,
     // by adding peers into the MacroSync component.
@@ -34,7 +67,7 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
             match result {
                 Ok(NetworkEvent::PeerLeft(peer_id)) => {
                     // Remove the peer from internal data structures.
-                    self.remove_peer_requests(peer_id);
+                    self.remove_peer(peer_id);
                 }
                 Ok(NetworkEvent::PeerJoined(peer_id, _)) => {
                     // Query if that peer provides the necessary services for syncing
@@ -90,10 +123,22 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
                                 .clone();
                             drop(blockchain_rg);
 
-                            self.request_single_macro_block(
-                                epoch_ids.sender,
-                                previous_election_block,
-                            );
+                            // Fetch the predecessor election block through the macro block queue and
+                            // re-query this peer once it has been applied (`update_previous_slots`
+                            // does not advance the head, so the tip-follow loop can't drive it).
+                            if self
+                                .in_flight_macro_blocks
+                                .insert(previous_election_block.clone())
+                            {
+                                self.macro_block_queue.add_ids(vec![(
+                                    previous_election_block.clone(),
+                                    Some(epoch_ids.sender),
+                                )]);
+                            }
+                            self.pending_followup_requests
+                                .entry(previous_election_block)
+                                .or_default()
+                                .push(epoch_ids.sender);
 
                             continue;
                         }
@@ -178,160 +223,215 @@ impl<TNetwork: Network> LightMacroSync<TNetwork> {
         Poll::Pending
     }
 
-    /// Polls for macro block headers received in response to previous requests.
-    fn poll_macro_blocks(
+    /// Applies a single fetched macro/election block to the chain and returns the outcome. Used by
+    /// `poll_macro_block_queue` for every macro block (seed, forward catch-up, `previous_slots`).
+    /// Does not disconnect peers or touch request bookkeeping — the caller acts on the outcome.
+    fn apply_macro_block(&self, block: Block) -> ApplyOutcome {
+        // Check if the block is still valid for us or if it is outdated before trying to apply it
+        let push_result = match self.blockchain {
+            #[cfg(feature = "full")]
+            BlockchainProxy::Full(ref full_blockchain) => {
+                let blockchain = full_blockchain.upgradable_read();
+
+                let latest_block_number = blockchain.block_number();
+                // Get the block number of the election block before the current election block.
+                let current_election_block_number = blockchain.election_head().block_number();
+                let previous_election_block_number = if current_election_block_number > 0 {
+                    Some(Policy::election_block_before(current_election_block_number))
+                } else {
+                    None
+                };
+
+                // If the block matches the previous election block, we use it to update the
+                // `previous_slots`. Otherwise, check if it's outdated / push the macro block.
+                if previous_election_block_number == Some(block.block_number()) {
+                    Blockchain::update_previous_slots(blockchain, block.clone())
+                } else if block.block_number() < latest_block_number {
+                    return ApplyOutcome::OutdatedPeer;
+                } else {
+                    Blockchain::push_macro(blockchain, block.clone())
+                }
+            }
+            BlockchainProxy::Light(ref light_blockchain) => {
+                let blockchain = light_blockchain.upgradable_read();
+
+                let latest_block_number = blockchain.block_number();
+
+                // Bootstrap checkpoint (pico sync fallback): the checkpoint election block has no
+                // on-chain predecessor yet, so it must be seeded via push_pico_election rather than
+                // push_macro (which would fail macro-successor verification). The response hash was
+                // already verified against the requested checkpoint hash, so matching the block
+                // number identifies the seed block. push_pico_election is idempotent (returns
+                // Known/Ignored) if another peer already seeded the chain.
+                if let Some(checkpoint) = &self.bootstrap_checkpoint
+                    && blockchain.block_number() < checkpoint.block_number
+                    && block.is_election()
+                    && block.block_number() == checkpoint.block_number
+                {
+                    LightBlockchain::push_pico_election(blockchain, block.clone())
+                } else if block.block_number() < latest_block_number {
+                    return ApplyOutcome::OutdatedPeer;
+                } else {
+                    LightBlockchain::push_macro(blockchain, block.clone())
+                }
+            }
+        };
+
+        match push_result {
+            Ok(push_result) => {
+                log::debug!(
+                    block_number = block.block_number(),
+                    ?push_result,
+                    "Pushed a macro block",
+                );
+                ApplyOutcome::Pushed
+            }
+            // The block doesn't extend our chain (missing predecessor or fork). The serving peer is
+            // not at fault — skip the block instead of banning it.
+            Err(error) if is_unfitting_push_error(&error) => {
+                log::debug!(
+                    block_number = block.block_number(),
+                    ?error,
+                    "Skipping macro block that does not extend our chain",
+                );
+                ApplyOutcome::Unfit
+            }
+            Err(error) => {
+                log::warn!(
+                    block_number = block.block_number(),
+                    ?error,
+                    "Failed to push macro block",
+                );
+                ApplyOutcome::Ban
+            }
+        }
+    }
+
+    /// Polls the bounded, failover macro block queue (the checkpoint seed, the forward catch-up, and
+    /// the full-node `previous_slots` recovery block all flow through here). Applies fetched blocks
+    /// in request order; a misbehaving peer is banned while others keep fetching via failover, and a
+    /// fully-exhausted block is logged and left to be re-requested later (no wedge). After draining,
+    /// it advances the tip-follow loop (re-querying peers whose reported target our head has reached,
+    /// for seed + forward) and resolves any `previous_slots` follow-ups. Never emits a
+    /// `MacroSyncReturn` itself (always `Poll::Pending`); peer transitions happen via re-queried
+    /// epoch ids or `disconnect_peer`.
+    fn poll_macro_block_queue(
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<MacroSyncReturn<TNetwork::PeerId>>> {
-        while let Poll::Ready(Some(result)) = self.block_headers.poll_next_unpin(cx) {
+        // Set when a block exhausts its retries across all peers. The successors of an exhausted
+        // block may still be in flight (`PENDING_SIZE` ahead), so we cannot decide recovery in the
+        // `Err` arm itself — those successors will resolve and be skipped as `Unfit` (missing
+        // predecessor), emptying the queue without ever advancing the head. We therefore recover
+        // once, after the drain loop, if an exhaustion left the queue empty.
+        let mut fetch_exhausted = false;
+        while let Poll::Ready(Some(result)) = self.macro_block_queue.poll_next_unpin(cx) {
             match result {
-                (Ok(Ok(block)), peer_id) => {
+                Ok((hash, Ok(block), peer_id)) => {
+                    self.in_flight_macro_blocks.remove(&hash);
+
                     if !block.is_macro() {
-                        // We received a non macro block during the macro sync process.
-                        log::warn!(%peer_id,
-                            "Banning peer due to a non expected response",
-                        );
+                        log::warn!(%peer_id, "Banning peer due to a non macro block response");
                         self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
-                        return Poll::Ready(None);
+                        self.resolve_followups(&hash);
+                        continue;
                     }
 
-                    if let Some(peer_requests) = self.peer_requests.get_mut(&peer_id) {
-                        if !peer_requests.update_request(block) {
-                            // We received a block we were not expecting from this peer
-                            log::warn!(%peer_id,
-                                "Banning peer due to a non expected response",
-                            );
+                    match self.apply_macro_block(block) {
+                        // Applied normally; a backward `previous_slots` block that went stale because
+                        // a forward push already advanced the head (and set previous_slots); or a
+                        // block that doesn't fit our chain (missing predecessor / fork). None of
+                        // these is peer misbehavior — re-query the follow-up peers to finish them.
+                        ApplyOutcome::Pushed | ApplyOutcome::OutdatedPeer | ApplyOutcome::Unfit => {
+                            self.resolve_followups(&hash);
+                        }
+                        ApplyOutcome::Ban => {
+                            log::warn!(%peer_id, "Banning peer that served an invalid macro block");
                             self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
-                            return Poll::Ready(None);
+                            self.resolve_followups(&hash);
                         }
-
-                        if peer_requests.is_ready() {
-                            log::trace!(%peer_id, "All pending requests are ready");
-
-                            while let Some((_, block)) = peer_requests.pop_request() {
-                                let block = block.expect("At this point the queue should be ready");
-
-                                // Check if the block is still valid for us or if it is outdated before trying to apply it
-                                let push_result = match self.blockchain {
-                                    #[cfg(feature = "full")]
-                                    BlockchainProxy::Full(ref full_blockchain) => {
-                                        let blockchain = full_blockchain.upgradable_read();
-
-                                        let latest_block_number = blockchain.block_number();
-                                        // Get the block number of the election block before the current election block.
-                                        let current_election_block_number =
-                                            blockchain.election_head().block_number();
-                                        let previous_election_block_number =
-                                            if current_election_block_number > 0 {
-                                                Some(Policy::election_block_before(
-                                                    current_election_block_number,
-                                                ))
-                                            } else {
-                                                None
-                                            };
-
-                                        // If the block matches the previous election block, we use it to update the `previous_slots`.
-                                        // Otherwise, check if it's outdated / push the macro block.
-                                        if previous_election_block_number
-                                            == Some(block.block_number())
-                                        {
-                                            Blockchain::update_previous_slots(
-                                                blockchain,
-                                                block.clone(),
-                                            )
-                                        } else if block.block_number() < latest_block_number {
-                                            // The peer is outdated, so we emit it, and we remove it
-                                            self.peer_requests.remove(&peer_id);
-                                            return Poll::Ready(Some(MacroSyncReturn::Outdated(
-                                                peer_id,
-                                            )));
-                                        } else {
-                                            Blockchain::push_macro(blockchain, block.clone())
-                                        }
-                                    }
-                                    BlockchainProxy::Light(ref light_blockchain) => {
-                                        let blockchain = light_blockchain.upgradable_read();
-
-                                        let latest_block_number = blockchain.block_number();
-
-                                        if block.block_number() < latest_block_number {
-                                            // The peer is outdated, so we emit it, and we remove it
-                                            self.peer_requests.remove(&peer_id);
-                                            return Poll::Ready(Some(MacroSyncReturn::Outdated(
-                                                peer_id,
-                                            )));
-                                        }
-
-                                        LightBlockchain::push_macro(blockchain, block.clone())
-                                    }
-                                };
-
-                                match push_result {
-                                    Ok(push_result) => {
-                                        log::debug!(
-                                            block_number = block.block_number(),
-                                            ?push_result,
-                                            "Pushed a macro block",
-                                        );
-                                    }
-                                    Err(error) => {
-                                        log::warn!(
-                                            block_number = block.block_number(),
-                                            ?error,
-                                            %peer_id,
-                                            "Banning peer because failed to push macro block",
-                                        );
-                                        // We failed applying a block from this peer, so we disconnect it
-                                        self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
-                                        return Poll::Ready(None);
-                                    }
-                                }
-                            }
-                            //  At this point we applied all the pending requests from this peer
-                            self.peer_requests.remove(&peer_id);
-
-                            // Re-request epoch ids after applying these blocks in order to know if we are up to date with this peer
-                            // or if there is more to sync
-                            // Request epoch ids with our updated state from this peer
-                            let future = Self::request_epoch_ids(
-                                self.blockchain.clone(),
-                                Arc::clone(&self.network),
-                                peer_id,
-                            )
-                            .boxed();
-                            self.epoch_ids_stream.push(future);
-                        }
-                    } else {
-                        // If we don't have any pending requests from this peer, we proceed requesting epoch ids
-                        let future = Self::request_epoch_ids(
-                            self.blockchain.clone(),
-                            Arc::clone(&self.network),
-                            peer_id,
-                        )
-                        .boxed();
-                        self.epoch_ids_stream.push(future);
                     }
                 }
-                // A peer that replies with a block other than the requested one is either
-                // buggy or malicious; either way we ban it
-                (Ok(Err(BlockError::ResponseHashMismatch)), peer_id) => {
+                // A hash mismatch is the responder's fault (it returned a block other than the one
+                // requested) — ban it. The request function only ever surfaces this block error;
+                // every other remote block error is retried via failover (see `MacroBlockError`),
+                // so an honest peer that merely lacks the block is not disconnected.
+                Ok((hash, Err(BlockError::ResponseHashMismatch), peer_id)) => {
+                    self.in_flight_macro_blocks.remove(&hash);
                     log::warn!(%peer_id, "Banning peer that replied with a block other than the requested one");
                     self.disconnect_peer(peer_id, CloseReason::MaliciousPeer);
+                    self.resolve_followups(&hash);
                 }
-                (Ok(Err(error)), peer_id) => {
-                    trace!(%error, %peer_id, "Received a response for a failed request on the remote side");
-                    // If a block request fails, we disconnect from this peer
-                    self.disconnect_peer(peer_id, CloseReason::Error);
+                // Unreachable in practice (the request function only surfaces `ResponseHashMismatch`),
+                // but handle defensively without disconnecting the peer.
+                Ok((hash, Err(error), peer_id)) => {
+                    self.in_flight_macro_blocks.remove(&hash);
+                    trace!(%error, %peer_id, "Unexpected remote block error; skipping");
+                    self.resolve_followups(&hash);
                 }
-                (Err(error), peer_id) => {
-                    trace!(?error, %peer_id, "Failed block request");
-                    // If a block request fails, we disconnect from this peer
-                    self.disconnect_peer(peer_id, CloseReason::Error);
+                // All retry attempts across all peers were exhausted for this block. Don't ban or
+                // disconnect (honest peers may simply not have it yet); drop it from the in-flight
+                // set so it can be re-requested. Recovery is deferred to after the drain loop (see
+                // `fetch_exhausted`): the successors already in flight will resolve and be skipped
+                // as `Unfit`, so deciding here would miss the mid-sequence case.
+                Err(hash) => {
+                    self.in_flight_macro_blocks.remove(&hash);
+                    log::warn!(%hash, "Could not fetch macro block from any peer after retries");
+                    self.resolve_followups(&hash);
+                    fetch_exhausted = true;
+                }
+            }
+        }
+
+        // Tip-follow loop: re-query peers whose reported target our head has now reached. They are
+        // then emitted `Good` ("nothing new") or report the moving tip and enqueue the next epochs.
+        let head = self.blockchain.read().block_number();
+        let satisfied: Vec<_> = self
+            .waiting_macro_peers
+            .iter()
+            .filter(|&(_, &target)| target <= head)
+            .map(|(peer_id, _)| *peer_id)
+            .collect();
+        for peer_id in satisfied {
+            self.waiting_macro_peers.remove(&peer_id);
+            if self.network.has_peer(peer_id) {
+                self.request_epoch_ids_from(peer_id);
+            }
+        }
+
+        // Recover from an exhausted fetch that left us unable to advance: a block was exhausted and
+        // the queue is now empty (its successors, if any, resolved and were skipped as `Unfit`).
+        // The peers still in `waiting_macro_peers` are blocked on a head that will never arrive on
+        // its own, so re-add them (re-seeding or re-requesting epoch ids as appropriate for our
+        // current head) to recover instead of wedging until a new peer joins. Gating on
+        // `fetch_exhausted` (rather than emptiness alone) keeps a misconfigured checkpoint — which
+        // only ever skips via `Unfit`, never `Err` — silently failing to seed rather than looping.
+        if fetch_exhausted && self.macro_block_queue.is_empty() {
+            let waiting: Vec<_> = self.waiting_macro_peers.drain().map(|(p, _)| p).collect();
+            for peer_id in waiting {
+                if self.network.has_peer(peer_id) {
+                    self.add_peer(peer_id);
                 }
             }
         }
 
         Poll::Pending
+    }
+
+    /// Re-queries the `previous_slots` follow-up peers registered for a just-finished queued block
+    /// (no-op for forward/seed blocks, which never register one). Whatever the outcome — applied,
+    /// stale, unfitting, or unfetchable — the waiting peer is re-queried for epoch ids: it is then
+    /// emitted `Good` once `previous_slots` is set, `Outdated` if it is now behind, or it re-requests
+    /// the block. An honest peer is never disconnected for a fetch we could not complete.
+    fn resolve_followups(&mut self, hash: &Blake2bHash) {
+        let Some(peers) = self.pending_followup_requests.remove(hash) else {
+            return;
+        };
+        for peer_id in peers {
+            if self.network.has_peer(peer_id) {
+                self.request_epoch_ids_from(peer_id);
+            }
+        }
     }
 }
 
@@ -344,7 +444,7 @@ impl<TNetwork: Network> Stream for LightMacroSync<TNetwork> {
     /// progresses syncing in steps. It checks for:
     /// - Peer join/leave events
     /// - Epoch ID responses
-    /// - Macro block headers
+    /// - Macro block headers (seed, forward catch-up, previous_slots)
     /// - Validity window chunks
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Poll::Ready(o) = self.poll_network_events(cx) {
@@ -355,7 +455,7 @@ impl<TNetwork: Network> Stream for LightMacroSync<TNetwork> {
             return Poll::Ready(o);
         }
 
-        if let Poll::Ready(o) = self.poll_macro_blocks(cx) {
+        if let Poll::Ready(o) = self.poll_macro_block_queue(cx) {
             return Poll::Ready(o);
         }
         #[cfg(feature = "full")]
@@ -384,8 +484,12 @@ mod tests {
     use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
     use nimiq_blockchain_proxy::BlockchainProxy;
     use nimiq_database::{mdbx::MdbxDatabase, traits::WriteTransaction};
+    use nimiq_genesis::HardcodedElection;
     use nimiq_light_blockchain::LightBlockchain;
-    use nimiq_network_interface::{network::Network, request::request_handler};
+    use nimiq_network_interface::{
+        network::Network,
+        request::{request_handler, Handle},
+    };
     use nimiq_network_mock::{MockHub, MockNetwork};
     use nimiq_primitives::{networks::NetworkId, policy::Policy};
     use nimiq_test_log::test;
@@ -394,7 +498,7 @@ mod tests {
     use parking_lot::RwLock;
 
     use crate::{
-        messages::{RequestBlock, RequestHistoryChunk, RequestMacroChain},
+        messages::{BlockError, RequestBlock, RequestHistoryChunk, RequestMacroChain},
         sync::{light::LightMacroSync, sync_interface::MacroSyncReturn},
     };
 
@@ -458,6 +562,7 @@ mod tests {
                 Arc::clone(&net1),
                 net1.subscribe_events(),
                 0,
+                None,
             );
 
             spawn_request_handlers(&net2, &chain2.clone());
@@ -507,6 +612,7 @@ mod tests {
                 Arc::clone(&net1),
                 net1.subscribe_events(),
                 0,
+                None,
             );
 
             spawn_request_handlers(&net2, &chain2.clone());
@@ -555,6 +661,7 @@ mod tests {
                 Arc::clone(&net1),
                 net1.subscribe_events(),
                 0,
+                None,
             );
 
             spawn_request_handlers(&net2, &chain2.clone());
@@ -596,6 +703,7 @@ mod tests {
                 Arc::clone(&net1),
                 net1.subscribe_events(),
                 0,
+                None,
             );
 
             spawn_request_handlers(&net2, &chain2.clone());
@@ -681,6 +789,7 @@ mod tests {
                 Arc::clone(&net1),
                 net1.subscribe_events(),
                 0,
+                None,
             );
 
             spawn_request_handlers(&net2, &chain2.clone());
@@ -701,5 +810,576 @@ mod tests {
 
         test(0).await;
         test(1).await;
+    }
+
+    /// A pico/light client configured with a hardcoded checkpoint bootstraps by fetching the
+    /// checkpoint election block (by hash), seeding the chain to it via `push_pico_election`
+    /// (its predecessor is never on-chain), and then syncing forward from there.
+    ///
+    /// The checkpoint is the *epoch-2* election block, so the epoch-1 election block (its
+    /// predecessor) is never on the fresh client's chain. That is what makes the seed branch
+    /// load-bearing: a plain `push_macro` would fail macro-successor verification.
+    #[test(tokio::test)]
+    async fn it_bootstraps_from_checkpoint() {
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net2 = Arc::new(hub.new_network());
+
+        // Server: a full chain spanning three full epochs, so its head is the epoch-3 election
+        // block and the epoch-2 election block (the checkpoint) has an on-chain predecessor the
+        // client will never fetch.
+        let chain2 = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain2) = chain2 {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain2,
+                Policy::batches_per_epoch() as usize * 3,
+                1,
+                0,
+            );
+        }
+        assert_eq!(
+            chain2.read().block_number(),
+            Policy::blocks_per_epoch() * 3 + Policy::genesis_block_number()
+        );
+
+        // The checkpoint points at the epoch-2 election block: a fresh client must seed to it
+        // (its epoch-1 predecessor is not on-chain) and then sync forward to the epoch-3 head.
+        let cp_block = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let checkpoint = HardcodedElection {
+            block_number: cp_block.block_number(),
+            hash: cp_block.hash(),
+        };
+
+        // Client: fresh light chain at genesis, configured to bootstrap from the checkpoint.
+        let chain1 = light_blockchain();
+        assert!(chain1.read().block_number() < checkpoint.block_number);
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            Some(checkpoint),
+        );
+
+        spawn_request_handlers(&net2, &chain2.clone());
+        net1.dial_mock(&net2);
+
+        // On a fresh genesis chain `add_peer` requests *only* the checkpoint block (epoch-2),
+        // whose predecessor (epoch-1) is not on-chain. Without the seed branch in
+        // `apply_macro_block`, `push_macro` would reject it (failed macro-successor verification)
+        // and ban the peer, so no `Good` would ever be emitted. Reaching the epoch-3 head also
+        // proves forward sync continues after the seed.
+        match sync.next().await {
+            Some(MacroSyncReturn::Good(_)) => {
+                assert_eq!(chain1.read().block_number(), chain2.read().block_number());
+                assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
+            }
+            res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+        }
+    }
+
+    /// When several peers are available before the chain is seeded, the checkpoint block is
+    /// requested from each of them. The first response seeds the chain; a later response for the
+    /// same (now on-chain or behind) block must be handled gracefully (`push_pico_election` /
+    /// `push_macro` return `Known`/`Ignored`, or the peer is emitted as `Outdated`) and never
+    /// treated as a malicious block.
+    #[test(tokio::test)]
+    async fn it_bootstraps_from_checkpoint_with_multiple_peers() {
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net2 = Arc::new(hub.new_network());
+        let net3 = Arc::new(hub.new_network());
+
+        // Two server endpoints serving the same three-epoch chain; checkpoint = epoch-2 election.
+        let chain2 = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain2) = chain2 {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain2,
+                Policy::batches_per_epoch() as usize * 3,
+                1,
+                0,
+            );
+        }
+
+        let cp_block = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let checkpoint = HardcodedElection {
+            block_number: cp_block.block_number(),
+            hash: cp_block.hash(),
+        };
+
+        let chain1 = light_blockchain();
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            Some(checkpoint),
+        );
+
+        spawn_request_handlers(&net2, &chain2.clone());
+        spawn_request_handlers(&net3, &chain2.clone());
+        net1.dial_mock(&net2);
+        net1.dial_mock(&net3);
+
+        // Drive until a peer reports a successful (`Good`) sync. A second peer whose checkpoint
+        // block is now behind the seeded chain may legitimately be emitted as `Outdated`; that is
+        // fine. A wrongly-banned peer would instead terminate the stream with `None` and fail here.
+        loop {
+            match sync.next().await {
+                Some(MacroSyncReturn::Good(_)) => break,
+                Some(MacroSyncReturn::Outdated(_)) => continue,
+                res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+            }
+        }
+        assert_eq!(chain1.read().block_number(), chain2.read().block_number());
+        assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
+    }
+
+    /// Forward catch-up after the checkpoint spans many epochs (more than the queue's
+    /// `PENDING_SIZE` window), so the election blocks are fetched in bounded, ordered batches
+    /// through `macro_block_queue` and applied in epoch order until the head is reached.
+    #[test(tokio::test)]
+    async fn it_syncs_many_epochs_from_checkpoint_via_queue() {
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net2 = Arc::new(hub.new_network());
+
+        // Server: eight full epochs (head = epoch-8 election block).
+        let chain2 = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain2) = chain2 {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain2,
+                Policy::batches_per_epoch() as usize * 8,
+                1,
+                0,
+            );
+        }
+
+        // Checkpoint = epoch-2 election block; forward sync then covers epochs 3..=8, i.e. six
+        // election blocks, more than `PENDING_SIZE` (5) in flight at once.
+        let cp_block = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let checkpoint = HardcodedElection {
+            block_number: cp_block.block_number(),
+            hash: cp_block.hash(),
+        };
+
+        let chain1 = light_blockchain();
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            Some(checkpoint),
+        );
+
+        spawn_request_handlers(&net2, &chain2.clone());
+        net1.dial_mock(&net2);
+
+        match sync.next().await {
+            Some(MacroSyncReturn::Good(_)) => {
+                assert_eq!(chain1.read().block_number(), chain2.read().block_number());
+                assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
+            }
+            res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+        }
+    }
+
+    /// Several peers report the same multi-epoch chain. The forward election blocks must be fetched
+    /// once (deduplicated across peers via `in_flight_macro_blocks`), applied in epoch order, and
+    /// every peer eventually resolved (`Good`/`Outdated`) without any being wrongly banned (which
+    /// would terminate the stream with `None`).
+    #[test(tokio::test)]
+    async fn it_syncs_many_epochs_from_checkpoint_with_multiple_peers() {
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net2 = Arc::new(hub.new_network());
+        let net3 = Arc::new(hub.new_network());
+
+        let chain2 = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain2) = chain2 {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain2,
+                Policy::batches_per_epoch() as usize * 8,
+                1,
+                0,
+            );
+        }
+
+        let cp_block = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let checkpoint = HardcodedElection {
+            block_number: cp_block.block_number(),
+            hash: cp_block.hash(),
+        };
+
+        let chain1 = light_blockchain();
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            Some(checkpoint),
+        );
+
+        spawn_request_handlers(&net2, &chain2.clone());
+        spawn_request_handlers(&net3, &chain2.clone());
+        net1.dial_mock(&net2);
+        net1.dial_mock(&net3);
+
+        // A peer whose checkpoint/epochs are behind the seeded chain may legitimately be emitted as
+        // `Outdated`; a wrongly-banned peer would instead terminate the stream with `None`.
+        loop {
+            match sync.next().await {
+                Some(MacroSyncReturn::Good(_)) => break,
+                Some(MacroSyncReturn::Outdated(_)) => continue,
+                res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+            }
+        }
+        assert_eq!(chain1.read().block_number(), chain2.read().block_number());
+        assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
+    }
+
+    /// A peer that answers epoch ids but cannot serve block requests must not stall or fail the
+    /// sync: the bounded queue fails each block over to another peer. Here `net3` only handles
+    /// `RequestMacroChain` (no `RequestBlock`), so blocks preferred to it are re-requested from the
+    /// fully-serving `net2`, and the sync still reaches the head.
+    #[test(tokio::test)]
+    async fn it_fails_over_when_a_peer_serves_no_blocks() {
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net2 = Arc::new(hub.new_network());
+        let net3 = Arc::new(hub.new_network());
+
+        let chain2 = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain2) = chain2 {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain2,
+                Policy::batches_per_epoch() as usize * 5,
+                1,
+                0,
+            );
+        }
+
+        let cp_block = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let checkpoint = HardcodedElection {
+            block_number: cp_block.block_number(),
+            hash: cp_block.hash(),
+        };
+
+        let chain1 = light_blockchain();
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            Some(checkpoint),
+        );
+
+        // net2 serves everything; net3 answers only epoch ids (no `RequestBlock` handler), so block
+        // requests preferred to net3 fail fast and must fail over to net2. Dial net3 first so its
+        // epoch ids tend to arrive first and it is preferred for the (failing) block requests.
+        spawn_request_handlers(&net2, &chain2.clone());
+        spawn(request_handler(
+            &net3,
+            net3.receive_requests::<RequestMacroChain>(),
+            &chain2.clone(),
+        ));
+        net1.dial_mock(&net3);
+        net1.dial_mock(&net2);
+
+        loop {
+            match sync.next().await {
+                Some(MacroSyncReturn::Good(_)) => break,
+                Some(MacroSyncReturn::Outdated(_)) => continue,
+                res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+            }
+        }
+        assert_eq!(chain1.read().block_number(), chain2.read().block_number());
+        assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
+    }
+
+    /// Mid-sequence fetch exhaustion during forward sync must not wedge the client. A single peer
+    /// withholds one mid-sequence election block (epoch 5) for the first `max_tries` requests, so it
+    /// exhausts its retries while its successors (epochs 6..=8) are already in flight. Those
+    /// successors then resolve and are skipped as `Unfit` (their predecessor, epoch 5, never
+    /// applied), draining the queue without advancing the head — the queue is *not* empty at the
+    /// moment exhaustion fires, so the recovery in the `Err` arm alone would miss it. The post-drain
+    /// recovery must re-add the waiting peer, whose retry now serves epoch 5, letting the sync reach
+    /// the head. Without that recovery this test hangs.
+    #[test(tokio::test)]
+    async fn it_recovers_from_mid_sequence_exhaustion() {
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net2 = Arc::new(hub.new_network());
+
+        // Server: eight full epochs (head = epoch-8 election block).
+        let chain2 = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain2) = chain2 {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain2,
+                Policy::batches_per_epoch() as usize * 8,
+                1,
+                0,
+            );
+        }
+
+        // Checkpoint = epoch-2 election block; forward sync then covers epochs 3..=8.
+        let cp_block = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let checkpoint = HardcodedElection {
+            block_number: cp_block.block_number(),
+            hash: cp_block.hash(),
+        };
+
+        // The mid-sequence block we withhold: the epoch-5 election block.
+        let withheld_hash = chain2
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 5 + Policy::genesis_block_number(),
+                false,
+            )
+            .unwrap()
+            .hash();
+
+        let chain1 = light_blockchain();
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            Some(checkpoint),
+        );
+
+        // net2 serves epoch ids normally, but its custom `RequestBlock` handler answers
+        // `TargetHashNotFound` for the withheld block until it has been requested `max_tries` times
+        // (4 for a single peer), then serves it like any other block.
+        spawn(request_handler(
+            &net2,
+            net2.receive_requests::<RequestMacroChain>(),
+            &chain2.clone(),
+        ));
+        let chain_for_blocks = chain2.clone();
+        let net2_blocks = Arc::clone(&net2);
+        spawn(async move {
+            let mut requests = net2_blocks.receive_requests::<RequestBlock>();
+            let mut withheld_attempts = 0u32;
+            while let Some((msg, request_id, peer_id)) = requests.next().await {
+                let response = if msg.hash == withheld_hash && withheld_attempts < 4 {
+                    withheld_attempts += 1;
+                    Err(BlockError::TargetHashNotFound)
+                } else {
+                    Handle::<MockNetwork, _>::handle(&msg, peer_id, &chain_for_blocks)
+                };
+                net2_blocks
+                    .respond::<RequestBlock>(request_id, response)
+                    .await
+                    .ok();
+            }
+        });
+        net1.dial_mock(&net2);
+
+        match sync.next().await {
+            Some(MacroSyncReturn::Good(_)) => {
+                assert_eq!(chain1.read().block_number(), chain2.read().block_number());
+                assert_eq!(chain1.read().head_hash(), chain2.read().head_hash());
+            }
+            res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+        }
+    }
+
+    /// A full node with `previous_slots = None` connects to two peers at once: a shorter one at the
+    /// node's own head (empty epoch ids → triggers the backward `previous_slots` fetch) and a longer
+    /// one (→ forward fetch). Both fetches share `macro_block_queue`. Regardless of which resolves
+    /// first, the node must reach the longer head with correct `previous_slots` and emit `Good` —
+    /// exercising the previous_slots / forward interleaving + the follow-up re-query.
+    #[test(tokio::test)]
+    async fn it_sets_previous_slots_while_forward_syncing() {
+        let chain1 = blockchain();
+        let mut hub = MockHub::default();
+        let net1 = Arc::new(hub.new_network());
+        let net_short = Arc::new(hub.new_network());
+        let net_long = Arc::new(hub.new_network());
+
+        // Long server: three full epochs (head = epoch-3 election block).
+        let chain_long = blockchain();
+        let producer = BlockProducer::new(signing_key(), voting_key());
+        if let BlockchainProxy::Full(ref chain_long) = chain_long {
+            produce_macro_blocks_with_txns(
+                &producer,
+                chain_long,
+                Policy::batches_per_epoch() as usize * 3,
+                1,
+                0,
+            );
+        }
+
+        // The epoch-1 and epoch-2 election blocks, reused to build the short server and the client
+        // so their election blocks are byte-identical to the long server's.
+        let epoch1 = chain_long
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+        let epoch2 = chain_long
+            .read()
+            .get_block_at(
+                Policy::blocks_per_epoch() * 2 + Policy::genesis_block_number(),
+                true,
+            )
+            .unwrap();
+
+        // Short server: the same chain truncated to two epochs (head = epoch-2 election block).
+        let chain_short = blockchain();
+        if let BlockchainProxy::Full(ref chain_short) = chain_short {
+            assert_eq!(
+                Blockchain::push_macro(chain_short.upgradable_read(), epoch1.clone()),
+                Ok(PushResult::Extended),
+            );
+            assert_eq!(
+                Blockchain::push_macro(chain_short.upgradable_read(), epoch2.clone()),
+                Ok(PushResult::Extended),
+            );
+        }
+
+        // Client: at epoch-2 with `previous_slots` cleared and the epoch-1 block removed, so the
+        // backward fetch is genuinely required (its predecessor is not on-chain).
+        if let BlockchainProxy::Full(ref chain1) = chain1 {
+            assert_eq!(
+                Blockchain::push_macro(chain1.upgradable_read(), epoch1.clone()),
+                Ok(PushResult::Extended),
+            );
+            assert_eq!(
+                Blockchain::push_macro(chain1.upgradable_read(), epoch2.clone()),
+                Ok(PushResult::Extended),
+            );
+            let mut chain1_wg = chain1.write();
+            let mut txn = chain1_wg.write_transaction();
+            chain1_wg.chain_store.remove_chain_info(
+                &mut txn,
+                &epoch1.hash(),
+                epoch1.block_number(),
+            );
+            txn.commit();
+            chain1_wg.state.previous_slots = None;
+        }
+
+        let mut sync = LightMacroSync::<MockNetwork>::new(
+            chain1.clone(),
+            Arc::clone(&net1),
+            net1.subscribe_events(),
+            0,
+            None,
+        );
+
+        spawn_request_handlers(&net_short, &chain_short.clone());
+        spawn_request_handlers(&net_long, &chain_long.clone());
+        net1.dial_mock(&net_short);
+        net1.dial_mock(&net_long);
+
+        // The short peer (synced with our epoch-2 head) may legitimately be emitted `Good` once
+        // `previous_slots` is set, before the forward sync to epoch-3 completes; keep driving until
+        // our head reaches the long server's.
+        loop {
+            match sync.next().await {
+                Some(MacroSyncReturn::Good(_)) | Some(MacroSyncReturn::Outdated(_)) => {
+                    if chain1.read().head_hash() == chain_long.read().head_hash() {
+                        break;
+                    }
+                }
+                res => panic!("Unexpected MacroSyncReturn: {res:?}"),
+            }
+        }
+        assert_eq!(
+            chain1.read().previous_validators(),
+            chain_long.read().previous_validators()
+        );
+    }
+
+    /// A macro-block push that fails because the block doesn't fit our chain (missing predecessor
+    /// or fork) must be classified as non-malicious, while an intrinsically invalid block must not.
+    /// This is what keeps the queue from banning a peer that merely relayed a hash-matching block
+    /// whose predecessor we failed to fetch.
+    #[test]
+    fn unfitting_push_errors_are_not_treated_as_malicious() {
+        use nimiq_block::BlockError;
+        use nimiq_blockchain_interface::PushError;
+
+        use super::is_unfitting_push_error;
+
+        // Block doesn't extend our chain right now — the serving peer is not at fault.
+        for error in [
+            PushError::Orphan,
+            PushError::InvalidSuccessor,
+            PushError::InvalidPredecessor,
+            PushError::InvalidFork,
+            PushError::InvalidBlock(BlockError::InvalidParentElectionHash),
+            PushError::InvalidBlock(BlockError::InvalidBlockNumber),
+        ] {
+            assert!(
+                is_unfitting_push_error(&error),
+                "{error:?} should be treated as unfitting (no ban)"
+            );
+        }
+
+        // Intrinsically invalid block — the peer must be banned.
+        for error in [
+            PushError::InvalidBlock(BlockError::InvalidJustification),
+            PushError::InvalidBlock(BlockError::BodyHashMismatch),
+            PushError::InvalidBlock(BlockError::InvalidSeed),
+            PushError::DuplicateTransaction,
+        ] {
+            assert!(
+                !is_unfitting_push_error(&error),
+                "{error:?} should be treated as a ban"
+            );
+        }
     }
 }

--- a/consensus/src/sync/light/validity_window.rs
+++ b/consensus/src/sync/light/validity_window.rs
@@ -532,6 +532,7 @@ mod tests {
             Arc::clone(&network),
             network.subscribe_events(),
             0,
+            None,
         );
 
         let peer_id = network.peer_id();

--- a/consensus/src/sync/sync_queue.rs
+++ b/consensus/src/sync/sync_queue.rs
@@ -297,12 +297,10 @@ where
         true
     }
 
-    #[cfg(feature = "full")]
     pub fn add_peer(&mut self, peer_id: TNetwork::PeerId) -> bool {
         self.peers.write().add_peer(peer_id)
     }
 
-    #[cfg(feature = "full")]
     pub fn remove_peer(&mut self, peer_id: &TNetwork::PeerId) {
         self.peers.write().remove_peer(peer_id);
     }
@@ -336,7 +334,6 @@ where
     }
 
     /// Checks if there are no more items to request and all request responses have been processed and returned.
-    #[cfg(feature = "full")]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/consensus/src/sync/syncer_proxy.rs
+++ b/consensus/src/sync/syncer_proxy.rs
@@ -17,7 +17,9 @@ use std::{
 
 use futures::{Stream, StreamExt};
 use nimiq_block::Block;
+use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_blockchain_proxy::BlockchainProxy;
+use nimiq_genesis::NetworkInfo;
 use nimiq_light_blockchain::LightBlockchain;
 use nimiq_network_interface::network::{Network, SubscribeEvents};
 #[cfg(feature = "full")]
@@ -121,12 +123,18 @@ impl<TNetwork: Network> MacroSync<TNetwork::PeerId> for EitherSyncer<TNetwork> {
             }
         }
 
+        // For the pico sync fallback, bootstrap from the hardcoded checkpoint (if the network has
+        // one) instead of re-syncing the whole election chain from genesis.
+        let checkpoint =
+            NetworkInfo::from_network_id(pico.blockchain.read().network_id()).checkpoint();
+
         log::info!("Initializing Light Macro Sync");
         let mut light_macro_sync = LightMacroSync::new(
             pico.blockchain.clone(),
             Arc::clone(&pico.network),
             network_event_rx,
             0, // Since the light sync does not keep state, we ignore the threshold.
+            checkpoint,
         );
 
         for peer_id in peers {
@@ -266,6 +274,7 @@ impl<N: Network> SyncerProxy<N> {
             Arc::clone(&network),
             network_event_rx,
             full_sync_threshold,
+            None, // Full nodes do not bootstrap from a checkpoint.
         );
 
         // Return the Full node variant of the SyncerProxy.
@@ -311,7 +320,8 @@ impl<N: Network> SyncerProxy<N> {
             blockchain_proxy.clone(),
             Arc::clone(&network),
             network_event_rx,
-            0, // Since the light sync does not keep state, we ignore the threshold.
+            0,    // Since the light sync does not keep state, we ignore the threshold.
+            None, // Light nodes sync the election chain from genesis; they only verify the checkpoint.
         );
 
         // Return the constructed Light node variant of the SyncerProxy.

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4"
+log = { workspace = true }
 serde = "1.0"
 url = "2.5"
 

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -1,3 +1,5 @@
-pub use networks::{NetworkId, NetworkInfo};
+pub use networks::{
+    checkpoint_mismatch, verify_election_checkpoint, HardcodedElection, NetworkId, NetworkInfo,
+};
 
 pub mod networks;

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "genesis-override")]
 use std::path::Path;
-use std::{env, sync::OnceLock};
+use std::{
+    env,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        OnceLock,
+    },
+};
 
 use nimiq_block::Block;
 use nimiq_bls::{LazyPublicKey as BlsLazyPublicKey, PublicKey as BlsPublicKey};
@@ -22,6 +28,28 @@ struct GenesisData {
     hash: Blake2bHash,
     accounts: Option<&'static [u8]>,
 }
+
+/// A hardcoded, per-network reference to a recent trusted election block.
+///
+/// Pico clients use it as a sync anchor on the sync fallback: they fetch the block by `hash` (the
+/// hash commits to the full election header, so a matching block is the trusted block) and seed
+/// their chain to it instead of re-syncing from genesis. Other clients (light/full/history) do not
+/// sync from it but verify it against their own chain.
+///
+/// This is intentionally distinct from `nimiq_consensus::messages::Checkpoint` (a transient
+/// macro-sync hint): this one is a release-time hardcoded anchor, and lives in this low-level
+/// crate to avoid a dependency cycle.
+#[derive(Clone, Debug)]
+pub struct HardcodedElection {
+    /// Block height of the checkpoint election block.
+    pub block_number: u32,
+    /// Blake2b hash of the checkpoint election block.
+    pub hash: Blake2bHash,
+}
+
+/// Set once if a hardcoded checkpoint has been found NOT to match the local chain.
+/// Surfaced as the `checkpoint_mismatch` metric.
+static CHECKPOINT_MISMATCH: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone, Debug)]
 pub struct NetworkInfo {
@@ -55,6 +83,12 @@ impl NetworkInfo {
         &self.genesis.hash
     }
 
+    /// The hardcoded checkpoint (a recent trusted election block) for this network, if any.
+    #[inline]
+    pub fn checkpoint(&self) -> Option<HardcodedElection> {
+        checkpoint_for_network(self.network_id)
+    }
+
     #[inline]
     pub fn genesis_accounts(&self) -> Option<Vec<TrieItem>> {
         self.genesis.accounts.as_ref().map(|accounts| {
@@ -70,6 +104,89 @@ impl NetworkInfo {
 
     pub fn from_network_id(network_id: NetworkId) -> &'static Self {
         network(network_id).unwrap_or_else(|| panic!("No such network ID: {network_id}"))
+    }
+}
+
+/// Returns the hardcoded checkpoint election block for a network, if one has been set.
+///
+/// Refreshed each release: paste the latest election block's `(block_number, hash)` from a
+/// trusted, fully-synced node. Networks with ephemeral genesis (dev/unit) or no checkpoint
+/// yet return `None`, in which case clients behave exactly as without checkpoints.
+fn checkpoint_for_network(network_id: NetworkId) -> Option<HardcodedElection> {
+    // The match is the scaffold real arms get added to per release; until then it only has the
+    // catch-all, which clippy would otherwise suggest collapsing away.
+    #[allow(clippy::match_single_binding)]
+    match network_id {
+        // Example (fill in per release):
+        // NetworkId::MainAlbatross => Some(HardcodedElection {
+        //     block_number: 3_456_000,
+        //     hash: "0000…".parse().expect("valid checkpoint hash"),
+        // }),
+        _ => None,
+    }
+}
+
+/// Whether a hardcoded checkpoint has been found NOT to match the local chain.
+pub fn checkpoint_mismatch() -> bool {
+    CHECKPOINT_MISMATCH.load(Ordering::Relaxed)
+}
+
+/// Outcome of comparing a just-committed election block against the hardcoded checkpoint.
+#[derive(Debug, PartialEq, Eq)]
+enum CheckpointCheck {
+    /// Block is at the checkpoint height and the hash matches.
+    Match,
+    /// Block is at the checkpoint height but the hash differs.
+    Mismatch,
+    /// Block is not at the checkpoint height; nothing to check.
+    NotApplicable,
+}
+
+/// Pure comparison of a committed election block against a checkpoint (no logging or metric
+/// side effects, so it can be unit-tested directly).
+fn check_against_checkpoint(
+    checkpoint: &HardcodedElection,
+    block_number: u32,
+    hash: &Blake2bHash,
+) -> CheckpointCheck {
+    if block_number != checkpoint.block_number {
+        CheckpointCheck::NotApplicable
+    } else if *hash == checkpoint.hash {
+        CheckpointCheck::Match
+    } else {
+        CheckpointCheck::Mismatch
+    }
+}
+
+/// Verifies a just-committed election block against the network's hardcoded checkpoint, if any.
+///
+/// Non-pico clients call this from the blockchain election-commit paths. When the committed
+/// block is at the checkpoint height but its hash differs, it logs an error and flags the
+/// `checkpoint_mismatch` metric — meaning either this client is on a different chain or the
+/// bundled checkpoint is wrong. It never panics; a missing checkpoint or a non-matching height
+/// is a no-op.
+pub fn verify_election_checkpoint(network_id: NetworkId, block_number: u32, hash: &Blake2bHash) {
+    let Some(checkpoint) = checkpoint_for_network(network_id) else {
+        return;
+    };
+    match check_against_checkpoint(&checkpoint, block_number, hash) {
+        CheckpointCheck::NotApplicable => {}
+        CheckpointCheck::Match => {
+            log::info!(
+                "Hardcoded checkpoint at block #{block_number} verified against the local chain"
+            );
+        }
+        CheckpointCheck::Mismatch => {
+            log::error!(
+                "Hardcoded checkpoint at block #{} does NOT match the local chain (expected {}, \
+                 got {}). This client may be on a different chain, or the bundled checkpoint is \
+                 incorrect.",
+                block_number,
+                checkpoint.hash,
+                hash,
+            );
+            CHECKPOINT_MISMATCH.store(true, Ordering::Relaxed);
+        }
     }
 }
 
@@ -230,4 +347,45 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
         }
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn checkpoint() -> HardcodedElection {
+        HardcodedElection {
+            block_number: 100,
+            hash: Blake2bHash::from([1u8; 32]),
+        }
+    }
+
+    #[test]
+    fn detects_matching_checkpoint() {
+        let cp = checkpoint();
+        assert_eq!(
+            check_against_checkpoint(&cp, cp.block_number, &cp.hash),
+            CheckpointCheck::Match
+        );
+    }
+
+    #[test]
+    fn detects_mismatched_checkpoint() {
+        let cp = checkpoint();
+        let other = Blake2bHash::from([2u8; 32]);
+        assert_eq!(
+            check_against_checkpoint(&cp, cp.block_number, &other),
+            CheckpointCheck::Mismatch
+        );
+    }
+
+    #[test]
+    fn ignores_other_heights() {
+        let cp = checkpoint();
+        // A different height is a no-op even if the hash happens to match.
+        assert_eq!(
+            check_against_checkpoint(&cp, cp.block_number + 1, &cp.hash),
+            CheckpointCheck::NotApplicable
+        );
+    }
 }

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -113,15 +113,14 @@ impl NetworkInfo {
 /// trusted, fully-synced node. Networks with ephemeral genesis (dev/unit) or no checkpoint
 /// yet return `None`, in which case clients behave exactly as without checkpoints.
 fn checkpoint_for_network(network_id: NetworkId) -> Option<HardcodedElection> {
-    // The match is the scaffold real arms get added to per release; until then it only has the
-    // catch-all, which clippy would otherwise suggest collapsing away.
-    #[allow(clippy::match_single_binding)]
     match network_id {
-        // Example (fill in per release):
-        // NetworkId::MainAlbatross => Some(HardcodedElection {
-        //     block_number: 3_456_000,
-        //     hash: "0000…".parse().expect("valid checkpoint hash"),
-        // }),
+        // Election block #52401600 (2026-06-01), refreshed per release from a trusted node.
+        NetworkId::MainAlbatross => Some(HardcodedElection {
+            block_number: 52_401_600,
+            hash: "70fb730260deea0950e3f0f448d5eaadb252e36fe808ab2782dddaabdd3e6de5"
+                .parse()
+                .expect("valid checkpoint hash"),
+        }),
         _ => None,
     }
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -121,7 +121,7 @@ full-consensus = [
     "nimiq-network-libp2p/kad",
 ]
 logging = ["nimiq-log", "serde_json", "tokio", "tracing-subscriber"]
-loki = ["logging", "tracing-loki"]
+loki = ["logging", "tracing-loki", "nimiq-utils/spawn"]
 metrics-server = [
     "nimiq-metrics-server",
     "nimiq-network-libp2p/metrics",

--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -74,6 +74,13 @@ impl LightBlockchain {
 
         // If it's an election block, you have more steps.
         if block.is_election() {
+            // Verify the hardcoded checkpoint (if any) against our own chain.
+            nimiq_genesis::verify_election_checkpoint(
+                this.network_id,
+                block.block_number(),
+                &block_hash,
+            );
+
             this.election_head = block.unwrap_macro_ref().clone();
 
             this.current_validators = block.validators();

--- a/metrics-server/Cargo.toml
+++ b/metrics-server/Cargo.toml
@@ -41,6 +41,7 @@ nimiq-blockchain = { workspace = true, features = ["metrics"] }
 nimiq-blockchain-interface = { workspace = true }
 nimiq-blockchain-proxy = { workspace = true, features = ["full"] }
 nimiq-consensus = { workspace = true, features = ["full"] }
+nimiq-genesis = { workspace = true }
 nimiq-mempool = { workspace = true, features = ["metrics"] }
 nimiq-network-interface = { workspace = true }
 nimiq-network-libp2p = { workspace = true, features = ["metrics"] }

--- a/metrics-server/src/lib.rs
+++ b/metrics-server/src/lib.rs
@@ -108,6 +108,15 @@ pub fn start_metrics_server<TNetwork: Network>(
     ConsensusMetrics::register(nimiq_registry, consensus_proxy);
     NetworkMetrics::register(nimiq_registry, network);
 
+    // Checkpoint verification status (set by the blockchain checkpoint check in nimiq-genesis).
+    let checkpoint_mismatch =
+        NumericClosureMetric::new_gauge(Box::new(|| nimiq_genesis::checkpoint_mismatch() as i64));
+    nimiq_registry.register(
+        "checkpoint_mismatch",
+        "1 if the hardcoded checkpoint does not match the local chain, otherwise 0",
+        checkpoint_mismatch,
+    );
+
     if let Some(mempool) = mempool {
         MempoolMetrics::register(nimiq_registry, mempool);
     }


### PR DESCRIPTION
Adds a hash + block-number checkpoint to the network config. Pico clients can use it as a fallback during sync; other clients only log a mismatch (to verify the checkpoint) rather than failing.

Checkpoint verification happens during the blockchain push, checkpoint fetches are deduplicated, and light-client macro block requests go through a `SyncQueue` to avoid request floods.

The mainnet checkpoint is set to election block #52401600 (2026-06-01).

Stacked on top of #remove-zkp.
