### PR TITLE
validator: cache hash-to-`G1` points in the Handel verifiers

### DIFF
--- a/bls/src/types/aggregate_public_key.rs
+++ b/bls/src/types/aggregate_public_key.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use ark_ff::Zero;
-use ark_mnt6_753::G2Projective;
+use ark_mnt6_753::{G1Projective, G2Projective};
 use nimiq_hash::Hash;
 
 use crate::{AggregateSignature, PublicKey, SigHash};
@@ -58,6 +58,13 @@ impl AggregatePublicKey {
     /// Verifies an aggregate signature, over the same message, given the hash of that message.
     pub fn verify_hash(&self, hash: SigHash, signature: &AggregateSignature) -> bool {
         self.0.verify_hash(hash, &signature.0)
+    }
+
+    /// Verifies an aggregate signature given the `G1` point the message hashes to. Verifying many
+    /// aggregates against the same message (e.g. Handel aggregation of a single vote) only needs
+    /// the hash-to-curve computed once, which can then be reused across all the verifications.
+    pub fn verify_g1(&self, hash_curve: G1Projective, signature: &AggregateSignature) -> bool {
+        self.0.verify_g1(hash_curve, &signature.0)
     }
 }
 

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -2,7 +2,8 @@ use std::fmt;
 
 use ark_ec::{AffineRepr, Group};
 use ark_ff::{One, PrimeField, ToConstraintField};
-use ark_mnt6_753::{Fq, G1Affine, G1Projective};
+pub use ark_mnt6_753::G1Projective;
+use ark_mnt6_753::{Fq, G1Affine};
 use nimiq_hash::{blake2s::Blake2xParameters, HashOutput};
 
 use crate::{CompressedSignature, SigHash};

--- a/validator/src/aggregation/tendermint/verifier.rs
+++ b/validator/src/aggregation/tendermint/verifier.rs
@@ -1,14 +1,15 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use nimiq_bls::AggregatePublicKey;
+use nimiq_bls::{AggregatePublicKey, G1Projective, Signature};
 use nimiq_collections::bitset::BitSet;
 use nimiq_handel::{
     identity::IdentityRegistry,
     verifier::{VerificationResult, Verifier},
 };
-use nimiq_hash::Hash;
+use nimiq_hash::{Blake2sHash, Hash};
 use nimiq_primitives::{TendermintIdentifier, TendermintVote};
+use parking_lot::Mutex;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::task;
 
@@ -18,6 +19,10 @@ use super::contribution::TendermintContribution;
 pub(crate) struct TendermintVerifier<I: IdentityRegistry> {
     identity_registry: Arc<I>,
     id: TendermintIdentifier,
+    /// Caches, per proposal hash, the `G1` point its vote hashes to. The `id` is fixed for the
+    /// verifier, so the same proposal recurs across the many contributions of a round and the
+    /// hash-to-curve only needs to be computed once per distinct proposal.
+    hash_curves: Mutex<HashMap<Option<Blake2sHash>, G1Projective>>,
 }
 
 impl<I: IdentityRegistry> TendermintVerifier<I> {
@@ -25,6 +30,7 @@ impl<I: IdentityRegistry> TendermintVerifier<I> {
         Self {
             identity_registry,
             id,
+            hash_curves: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -64,19 +70,26 @@ impl<I: IdentityRegistry + Sync + Send + 'static> Verifier for TendermintVerifie
                 }
             }
 
-            // create a thread that is allowed to block for this specific proposals hash contributions.
-            let vote = TendermintVote {
-                id: self.id.clone(),
-                proposal_hash: hash.clone(),
-            };
+            // Hash the vote to its `G1` point, reusing the cached point for this proposal hash.
+            let hash_curve = *self
+                .hash_curves
+                .lock()
+                .entry(hash.clone())
+                .or_insert_with(|| {
+                    let vote = TendermintVote {
+                        id: self.id.clone(),
+                        proposal_hash: hash.clone(),
+                    };
+                    Signature::hash_to_g1(vote.hash())
+                });
 
-            params.push((aggregated_public_key, vote, multi_sig.clone()));
+            params.push((aggregated_public_key, hash_curve, multi_sig.clone()));
         }
         let result = task::spawn_blocking(move || {
             params
                 .into_par_iter()
-                .map(|(aggregated_public_key, vote, contribution)| {
-                    if aggregated_public_key.verify_hash(vote.hash(), &contribution.signature) {
+                .map(|(aggregated_public_key, hash_curve, contribution)| {
+                    if aggregated_public_key.verify_g1(hash_curve, &contribution.signature) {
                         Ok(())
                     } else {
                         Err(())

--- a/validator/src/aggregation/verifier.rs
+++ b/validator/src/aggregation/verifier.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use nimiq_bls::AggregatePublicKey;
+use nimiq_bls::{AggregatePublicKey, G1Projective, Signature};
 use nimiq_handel::{
     identity::IdentityRegistry,
     verifier::{VerificationResult, Verifier},
@@ -11,14 +11,15 @@ use nimiq_hash::Blake2sHash;
 use super::skip_block::SignedSkipBlockMessage;
 
 pub struct MultithreadedVerifier<I: IdentityRegistry> {
-    message_hash: Blake2sHash,
+    /// The `G1` point the message hashes to, precomputed once instead of on every contribution.
+    hash_curve: G1Projective,
     identity_registry: Arc<I>,
 }
 
 impl<I: IdentityRegistry> MultithreadedVerifier<I> {
     pub fn new(message_hash: Blake2sHash, identity_registry: Arc<I>) -> Self {
         Self {
-            message_hash,
+            hash_curve: Signature::hash_to_g1(message_hash),
             identity_registry,
         }
     }
@@ -39,9 +40,7 @@ impl<I: IdentityRegistry + Sync + Send + 'static> Verifier for MultithreadedVeri
             }
         }
 
-        if aggregated_public_key
-            .verify_hash(self.message_hash.clone(), &contribution.proof.signature)
-        {
+        if aggregated_public_key.verify_g1(self.hash_curve, &contribution.proof.signature) {
             VerificationResult::Ok
         } else {
             VerificationResult::Forged


### PR DESCRIPTION
The skip-block and Tendermint verifiers re-derived `hash_to_g1` of the (fixed) message on every contribution of a round. Precompute/memoize the `G1` point per message and verify through the new `AggregatePublicKey::verify_g1`.