### PR TITLE
feat(primitives): add per-fork upgrade activation registry

### DIFF
--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -9,6 +9,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::networks::NetworkId;
 
+pub mod upgrades;
+
 /// Global policy
 static GLOBAL_POLICY: OnceCell<Policy> = OnceCell::new();
 

--- a/primitives/src/policy/upgrades.rs
+++ b/primitives/src/policy/upgrades.rs
@@ -1,0 +1,27 @@
+//! Per-fork activation registries.
+//!
+//! Each `vN` submodule lists every consensus-affecting change that ships in
+//! protocol version `N`. To gate code on a change, compare the *block's*
+//! version (`block.version()`) against the change's constant:
+//!
+//! ```ignore
+//! use nimiq_primitives::policy::upgrades;
+//!
+//! if block.version() >= upgrades::v2::HASH_CHANGE {
+//!     // new behaviour
+//! }
+//! ```
+//!
+//! Conventions for contributors:
+//! - Register a change by adding one `pub const MY_CHANGE: u16 = VERSION;` line
+//!   to the current fork's `vN` module. One line per change keeps merge
+//!   conflicts minimal.
+//! - Always gate with `>=` (active from version `N` onward), never `==` — an
+//!   `==` check would silently turn the change off again once the next fork
+//!   ships.
+//! - If a change slips to a later fork, move its line to that version's module.
+//!   Because the value is `VERSION` (not a literal), it auto-corrects.
+
+pub mod v2;
+pub mod v3;
+// pub mod v4;  // uncomment when the v4 fork opens

--- a/primitives/src/policy/upgrades/v2.rs
+++ b/primitives/src/policy/upgrades/v2.rs
@@ -1,0 +1,14 @@
+//! Consensus changes shipping in protocol version 2.
+//!
+//! Register every fork change here on its own line. The value is always
+//! [`VERSION`] — never a literal — so a change that slips to a later fork is a
+//! one-line move to that version's module.
+
+/// The protocol version every change in this module activates in.
+pub const VERSION: u16 = 2;
+
+// --- Changes shipping in v2 -------------------------------------------------
+// Add one `pub const MY_CHANGE: u16 = VERSION;` line per change below.
+
+// pub const HASH_CHANGE: u16 = VERSION;
+// pub const STAKING_CHANGE_XX: u16 = VERSION;

--- a/primitives/src/policy/upgrades/v3.rs
+++ b/primitives/src/policy/upgrades/v3.rs
@@ -1,0 +1,11 @@
+//! Consensus changes shipping in protocol version 3.
+//!
+//! Register every fork change here on its own line. The value is always
+//! [`VERSION`] — never a literal — so a change that slips to a later fork is a
+//! one-line move to that version's module.
+
+/// The protocol version every change in this module activates in.
+pub const VERSION: u16 = 3;
+
+// --- Changes shipping in v3 -------------------------------------------------
+// Add one `pub const MY_CHANGE: u16 = VERSION;` line per change below.


### PR DESCRIPTION
Adds a `policy::upgrades` module where each `vN` submodule declares the changes shipping in protocol version `N` as named constants. Call sites gate behaviour with a plain comparison:

```rust
if block.version() >= upgrades::v2::V2_CHANGE { ... }
```

Scaffolds the v2 and v3 registries.