### PR TITLE
rpc-client: add CLI subcommands for missing RPC methods

### DIFF
--- a/rpc-client/src/subcommands/accounts_subcommands.rs
+++ b/rpc-client/src/subcommands/accounts_subcommands.rs
@@ -62,6 +62,12 @@ pub enum AccountCommand {
         address: Address,
     },
 
+    /// Removes an imported account from the wallet.
+    Remove {
+        /// The account's address.
+        address: Address,
+    },
+
     /// Signs a message using the specified account. The account must already be unlocked.
     Sign {
         /// The message to be signed.
@@ -147,6 +153,9 @@ impl HandleSubcommand for AccountCommand {
             }
             AccountCommand::IsUnlocked { address } => {
                 println!("{:#?}", client.wallet.is_account_unlocked(address).await?);
+            }
+            AccountCommand::Remove { address } => {
+                println!("{:#?}", client.wallet.remove_account(address).await?);
             }
             AccountCommand::Sign {
                 message,

--- a/rpc-client/src/subcommands/blockchain_subcommands.rs
+++ b/rpc-client/src/subcommands/blockchain_subcommands.rs
@@ -11,6 +11,9 @@ use crate::Client;
 
 #[derive(Debug, Parser)]
 pub enum BlockchainCommand {
+    /// Returns the network ID the client is connected to.
+    NetworkId {},
+
     /// Returns the block number for the current head.
     BlockNumber {},
 
@@ -101,6 +104,21 @@ pub enum BlockchainCommand {
         /// If set true only the hash of the transactions will be fetched. Otherwise the full transactions will be retrieved.
         #[clap(short = 'h')]
         just_hash: bool,
+    },
+
+    /// Returns the transaction references (transaction hash and block number) for a given address.
+    /// Similar to `transactions-by-address`, but only returns the hash and block number of each transaction.
+    TransactionReferencesByAddress {
+        /// The address to query by.
+        address: Address,
+
+        /// Max number of transaction references to fetch. If absent it defaults to 500.
+        #[clap(long)]
+        max: Option<u16>,
+
+        /// A transaction to start at.
+        #[clap(long)]
+        start_at: Option<Blake2bHash>,
     },
 
     /// Returns the information for the slot owner at the given block height and offset. The
@@ -199,6 +217,9 @@ impl HandleSubcommand for BlockchainCommand {
                 }?;
                 println!("{block:#?}")
             }
+            BlockchainCommand::NetworkId {} => {
+                println!("{:#?}", client.blockchain.get_network_id().await?)
+            }
             BlockchainCommand::BlockNumber {} => {
                 println!("{:#?}", client.blockchain.get_block_number().await?)
             }
@@ -291,6 +312,19 @@ impl HandleSubcommand for BlockchainCommand {
                             .await?
                     )
                 }
+            }
+            BlockchainCommand::TransactionReferencesByAddress {
+                address,
+                max,
+                start_at,
+            } => {
+                println!(
+                    "{:#?}",
+                    client
+                        .blockchain
+                        .get_transaction_references_by_address(address, max, start_at)
+                        .await?
+                )
             }
             BlockchainCommand::PenalizedSlots { previous_penalized } => {
                 if previous_penalized {

--- a/rpc-client/src/subcommands/mempool_subcommands.rs
+++ b/rpc-client/src/subcommands/mempool_subcommands.rs
@@ -1,6 +1,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use clap::Parser;
+use nimiq_hash::Blake2bHash;
 use nimiq_rpc_client::MempoolInterface;
 
 use super::accounts_subcommands::HandleSubcommand;
@@ -30,6 +31,12 @@ pub enum MempoolCommand {
 
     /// Returns the minimum fee per byte of the local mempool.
     MinFeePerByte {},
+
+    /// Returns a transaction from the local mempool given its hash.
+    MempoolTransaction {
+        /// The hash of the transaction to fetch from the local mempool.
+        hash: Blake2bHash,
+    },
 }
 
 #[async_trait]
@@ -65,6 +72,12 @@ impl HandleSubcommand for MempoolCommand {
             }
             MempoolCommand::MinFeePerByte {} => {
                 println!("{:#?}", client.mempool.get_min_fee_per_byte().await?);
+            }
+            MempoolCommand::MempoolTransaction { hash } => {
+                println!(
+                    "{:#?}",
+                    client.mempool.get_transaction_from_mempool(hash).await?
+                );
             }
         }
         Ok(client)

--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -127,6 +127,18 @@ pub enum PolicyCommand {
         block_number: u32,
     },
 
+    /// Returns the first block after the reporting window of a given block number has ended.
+    BlockAfterReportingWindow {
+        /// The block number.
+        block_number: u32,
+    },
+
+    /// Returns the first block after the jail period of a given block number has ended.
+    BlockAfterJail {
+        /// The block number.
+        block_number: u32,
+    },
+
     /// Returns the supply at a given time (as Unix time) in Lunas (1 NIM = 100,000 Lunas). It is
     /// calculated using the following formula:
     /// Supply (t) = Genesis_supply + Initial_supply_velocity / Supply_decay * (1 - 2^(- Supply_decay * t))
@@ -245,6 +257,21 @@ impl HandleSubcommand for PolicyCommand {
                 println!(
                     "{:#?}",
                     client.policy.get_first_batch_of_epoch(block_number).await?
+                );
+            }
+            PolicyCommand::BlockAfterReportingWindow { block_number } => {
+                println!(
+                    "{:#?}",
+                    client
+                        .policy
+                        .get_block_after_reporting_window(block_number)
+                        .await?
+                );
+            }
+            PolicyCommand::BlockAfterJail { block_number } => {
+                println!(
+                    "{:#?}",
+                    client.policy.get_block_after_jail(block_number).await?
                 );
             }
             PolicyCommand::SupplyAt {

--- a/rpc-client/src/subcommands/transactions_subcommands.rs
+++ b/rpc-client/src/subcommands/transactions_subcommands.rs
@@ -54,6 +54,22 @@ pub enum TransactionCommand {
         tx_commons: TxCommonWithValue,
     },
 
+    /// Sends a basic transaction, with an arbitrary data field, from the wallet `sender_wallet` to a
+    /// basic `recipient`.
+    BasicWithData {
+        /// Transaction will be sent from this address. The sender wallet must be unlocked prior to this action.
+        sender_wallet: Address,
+
+        /// Recipient for this transaction. This must be a basic account.
+        recipient: Address,
+
+        /// The arbitrary data (in hex) to be included in the transaction.
+        data: String,
+
+        #[clap(flatten)]
+        tx_commons: TxCommonWithValue,
+    },
+
     /* Staker transactions */
     /// Sends a `new_staker` transaction to the network. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee.
@@ -340,6 +356,12 @@ pub enum TransactionCommand {
         /// The transaction to be sent in hex string format.
         raw_tx: String,
     },
+
+    /// Returns whether the consensus is established.
+    IsConsensusEstablished {},
+
+    /// Returns the status of the sync process.
+    SyncStatus {},
 }
 
 impl TransactionCommand {
@@ -379,6 +401,40 @@ impl HandleSubcommand for TransactionCommand {
                         .send_basic_transaction(
                             sender_wallet,
                             recipient,
+                            tx_commons.value,
+                            tx_commons.common_tx_fields.fee,
+                            tx_commons.common_tx_fields.validity_start_height,
+                        )
+                        .await?;
+                    println!("{txid:#?}");
+                }
+            }
+            TransactionCommand::BasicWithData {
+                sender_wallet,
+                recipient,
+                data,
+                tx_commons,
+            } => {
+                if tx_commons.common_tx_fields.dry {
+                    let tx = client
+                        .consensus
+                        .create_basic_transaction_with_data(
+                            sender_wallet,
+                            recipient,
+                            data,
+                            tx_commons.value,
+                            tx_commons.common_tx_fields.fee,
+                            tx_commons.common_tx_fields.validity_start_height,
+                        )
+                        .await?;
+                    println!("{tx:#?}");
+                } else {
+                    let txid = client
+                        .consensus
+                        .send_basic_transaction_with_data(
+                            sender_wallet,
+                            recipient,
+                            data,
                             tx_commons.value,
                             tx_commons.common_tx_fields.fee,
                             tx_commons.common_tx_fields.validity_start_height,
@@ -842,6 +898,12 @@ impl HandleSubcommand for TransactionCommand {
             TransactionCommand::GetRawTransactionInfo { raw_tx } => {
                 let tx = client.consensus.get_raw_transaction_info(raw_tx).await?;
                 println!("{tx:#?}");
+            }
+            TransactionCommand::IsConsensusEstablished {} => {
+                println!("{:#?}", client.consensus.is_consensus_established().await?);
+            }
+            TransactionCommand::SyncStatus {} => {
+                println!("{:#?}", client.consensus.get_sync_status().await?);
             }
             TransactionCommand::SendRawTransaction { raw_tx } => {
                 let tx = client.consensus.send_raw_transaction(raw_tx).await?;

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -22,6 +22,18 @@ pub enum ValidatorCommand {
     /// Returns the address of the local validator.
     ValidatorAddress {},
 
+    /// Adds a voting key that will be used when the key expected by the chain changes.
+    AddVotingKey {
+        /// The BLS secret key to be added.
+        secret_key: String,
+    },
+
+    /// Returns whether the local validator is currently elected.
+    IsValidatorElected {},
+
+    /// Returns whether the local validator is currently synced.
+    IsValidatorSynced {},
+
     /// Sends a transaction to the network to create this validator. You need to provide the address of a basic
     /// account (the sender wallet) to pay the transaction fee and the validator deposit. The sender wallet must be unlocked
     /// prior to this command.
@@ -111,6 +123,17 @@ pub enum ValidatorCommand {
         tx_commons: TxCommon,
     },
 
+    /// Sends a transaction to retire this validator. You need to provide the address of a basic
+    /// account (the sender wallet) to pay the transaction fee.
+    /// The sender wallet must be unlocked prior to this command.
+    RetireValidator {
+        /// The fee will be paid from this address. This wallet must be already unlocked.
+        sender_wallet: Address,
+
+        #[clap(flatten)]
+        tx_commons: TxCommon,
+    },
+
     /// Sends a transaction to delete this validator. The transaction fee will be paid from the
     /// validator deposit that is being returned.
     DeleteValidator {
@@ -128,6 +151,19 @@ impl HandleSubcommand for ValidatorCommand {
         match self {
             ValidatorCommand::ValidatorAddress {} => {
                 println!("{:#?}", client.validator.get_address().await?);
+            }
+
+            ValidatorCommand::AddVotingKey { secret_key } => {
+                client.validator.add_voting_key(secret_key).await?;
+                println!("Voting key added");
+            }
+
+            ValidatorCommand::IsValidatorElected {} => {
+                println!("{:#?}", client.validator.is_validator_elected().await?);
+            }
+
+            ValidatorCommand::IsValidatorSynced {} => {
+                println!("{:#?}", client.validator.is_validator_synced().await?);
             }
 
             ValidatorCommand::SetAutoReactivateValidator {
@@ -282,6 +318,36 @@ impl HandleSubcommand for ValidatorCommand {
                             sender_wallet,
                             validator_address,
                             signing_secret_key,
+                            tx_commons.fee,
+                            tx_commons.validity_start_height,
+                        )
+                        .await?;
+                    println!("{txid:#?}");
+                }
+            }
+
+            ValidatorCommand::RetireValidator {
+                sender_wallet,
+                tx_commons,
+            } => {
+                let validator_address = client.validator.get_address().await?.data;
+                if tx_commons.dry {
+                    let tx = client
+                        .consensus
+                        .create_retire_validator_transaction(
+                            sender_wallet,
+                            validator_address,
+                            tx_commons.fee,
+                            tx_commons.validity_start_height,
+                        )
+                        .await?;
+                    println!("{tx:#?}");
+                } else {
+                    let txid = client
+                        .consensus
+                        .send_retire_validator_transaction(
+                            sender_wallet,
+                            validator_address,
                             tx_commons.fee,
                             tx_commons.validity_start_height,
                         )


### PR DESCRIPTION
Wire up the 15 `rpc-interface` methods that had no `rpc-client` command: `network-id`, `transaction-references-by-address`, `block-after-reporting-window`, `block-after-jail`, `mempool-transaction`, `account remove`, `validator add-voting-key/is-elected/is-synced/retire`, `basic-with-data`, `is-consensus-established` and `sync-status`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
