### PR TITLE
Add protocol-upgrade signaling dashboard (web client)

### DIFF
--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -241,6 +241,30 @@ impl From<&nimiq_account::Validator> for PlainValidator {
     }
 }
 
+/// JSON-compatible and human-readable format of a validator that is elected for the current
+/// epoch, together with the number of validator slots assigned to it.
+///
+/// Unlike {@link PlainValidator}, this reflects the slot distribution that was fixed at the most
+/// recent election block. The number of slots is the metric used on-chain to evaluate support for
+/// protocol upgrades.
+#[derive(serde::Serialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub struct PlainElectedValidator {
+    /// The validator's address, in user-friendly format.
+    address: String,
+    /// The number of validator slots assigned to this validator in the current epoch.
+    num_slots: u16,
+}
+
+impl From<&nimiq_primitives::slots_allocation::Validator> for PlainElectedValidator {
+    fn from(validator: &nimiq_primitives::slots_allocation::Validator) -> PlainElectedValidator {
+        PlainElectedValidator {
+            address: validator.address.to_user_friendly_address(),
+            num_slots: validator.num_slots(),
+        }
+    }
+}
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(typescript_type = "PlainAccount")]
@@ -260,4 +284,7 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "(PlainValidator | undefined)[]")]
     pub type PlainValidatorArrayType;
+
+    #[wasm_bindgen(typescript_type = "PlainElectedValidator[]")]
+    pub type PlainElectedValidatorArrayType;
 }

--- a/web-client/src/client/lib.rs
+++ b/web-client/src/client/lib.rs
@@ -39,9 +39,9 @@ use web_sys::MessageEvent;
 use crate::{
     client::{
         account::{
-            PlainAccount, PlainAccountArrayType, PlainAccountType, PlainStaker,
-            PlainStakerArrayType, PlainStakerType, PlainValidator, PlainValidatorArrayType,
-            PlainValidatorType,
+            PlainAccount, PlainAccountArrayType, PlainAccountType, PlainElectedValidator,
+            PlainElectedValidatorArrayType, PlainStaker, PlainStakerArrayType, PlainStakerType,
+            PlainValidator, PlainValidatorArrayType, PlainValidatorType,
         },
         block::{PlainBlock, PlainBlockType},
         bls_cache::BlsCache,
@@ -554,6 +554,29 @@ impl Client {
         let addresses = Client::unpack_addresses(addresses)?;
         let plain_validators = self.get_plain_validators(addresses).await?;
         Ok(serde_wasm_bindgen::to_value(&plain_validators)?.into())
+    }
+
+    /// Returns the validators elected for the current epoch, together with the number of validator
+    /// slots assigned to each of them.
+    ///
+    /// The slot distribution is fixed for the duration of an epoch and is the metric used on-chain
+    /// to evaluate support for protocol upgrades. Combine this with {@link Client.getValidators} to
+    /// relate slot counts to each validator's stake and signal data.
+    ///
+    /// Throws if the elected validators are not available (e.g. before consensus is established).
+    #[wasm_bindgen(js_name = getElectedValidators)]
+    pub async fn get_elected_validators(&self) -> Result<PlainElectedValidatorArrayType, JsError> {
+        let consensus_proxy = self.inner.consensus_proxy();
+        let blockchain = consensus_proxy.blockchain.read();
+        let validators = blockchain
+            .current_validators()
+            .ok_or_else(|| JsError::new("No elected validators available"))?;
+        let elected: Vec<PlainElectedValidator> = validators
+            .validators
+            .iter()
+            .map(PlainElectedValidator::from)
+            .collect();
+        Ok(serde_wasm_bindgen::to_value(&elected)?.into())
     }
 
     /// Sends a transaction to the network and returns {@link PlainTransactionDetails}.

--- a/web-client/upgrade-dashboard/Dockerfile
+++ b/web-client/upgrade-dashboard/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+#
+# Toolchain image to build the Nimiq web-client WASM locally, without installing
+# Rust / Node / wasm tooling on the host. Used by docker-compose.yml ("build" service).
+#
+# It only sets up the toolchain; the repo is bind-mounted at run time and the build
+# writes back to web-client/dist on the host.
+FROM rust:1-bookworm
+
+# clang provides the WebAssembly backend that cc-rs uses to compile C dependencies
+# (e.g. clear_on_drop) to wasm32. Debian's clang ships the wasm target; Apple clang on
+# macOS does not, which is why building directly on the host fails.
+# nodejs/npm + yarn (via corepack) are needed by build.sh's launcher/lib steps (tsup),
+# so that the full dist is regenerated consistently. They live only in this image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang nodejs npm \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g yarn
+
+RUN rustup target add wasm32-unknown-unknown
+
+# Pin wasm-bindgen-cli to the version locked in Cargo.lock (matches CI).
+ARG WASM_BINDGEN_VERSION=0.2.118
+RUN cargo install --locked wasm-bindgen-cli@${WASM_BINDGEN_VERSION}
+
+WORKDIR /repo/web-client

--- a/web-client/upgrade-dashboard/README.md
+++ b/web-client/upgrade-dashboard/README.md
@@ -1,0 +1,71 @@
+# Protocol Upgrade Signaling Dashboard
+
+A small, read-only browser dashboard that shows whether validators are signaling support
+for the next protocol upgrade. It displays the two on-chain thresholds — **% of active
+stake** and **% of slots** signaling the target version — and an explorable, filterable
+list of all validators.
+
+It is a trustless [web client](../) (`@nimiq/core`, WASM) running as a light client in pico
+sync mode, so it needs no node or RPC server — just the built WASM in `../dist`.
+
+## How it works
+
+The upgrade activates on-chain only when **both** of these reach
+`Policy::UPGRADE_MIN_SUPPORT` (80%), evaluated at macro-block proposal time
+(`validator/src/tendermint.rs`):
+
+- `supporting_stake ≥ 80%` of total active stake, and
+- `supporting_slots ≥ 80%` of `Policy::SLOTS`.
+
+The dashboard mirrors this exactly:
+
+- **Target version** = current head `version + 1`.
+- A validator **supports** the upgrade iff the first two bytes (big-endian) of its
+  `signalData` decode to the target version (the JS equivalent of `Policy::supports_upgrade`).
+- **Stake** is summed over the staking contract's active validators
+  (`client.getAccount(STAKING_CONTRACT).activeValidators`).
+- **Slots** are summed over the validators elected for the current epoch
+  (`client.getElectedValidators()`, added on this branch — see
+  `web-client/src/client/lib.rs`).
+
+This dashboard relies on the locally built WASM, which must include the
+`getElectedValidators()` method added on this branch.
+
+## Build & run with Docker (recommended — no host tooling)
+
+Everything runs in containers; you do **not** need Rust, Node or any wasm tooling on your
+machine. Run both commands from the **repository root**.
+
+```sh
+# 1. Build web-client/dist (one-shot). First run compiles the wasm toolchain + client,
+#    so it takes a while; subsequent runs are cached in Docker volumes.
+docker compose -f web-client/upgrade-dashboard/docker-compose.yml run --rm build
+
+# 2. Serve it.
+docker compose -f web-client/upgrade-dashboard/docker-compose.yml up serve
+```
+
+Then open <http://localhost:8000/upgrade-dashboard/>.
+
+The build only rebuilds the `web` target (main + worker wasm) and reuses the committed
+launcher, so it never invokes Node. See `Dockerfile` and `docker-compose.yml` here.
+
+## Build & run natively (alternative)
+
+If you do have the wasm toolchain, from the `web-client` directory:
+
+```sh
+./scripts/build.sh --only web,types   # build the dist (includes getElectedValidators)
+npx serve .                           # then open /upgrade-dashboard/
+```
+
+(An HTTP server is required either way — ES modules will not load over `file://`.)
+
+## Network
+
+By default the dashboard connects to the built-in default network (`MainAlbatross`) using
+**pico** sync. Query parameters:
+
+- `?network=testalbatross` (or `devalbatross`) — target another network. For non-default
+  networks you usually also need seed nodes; set `SEED_NODES` in `dashboard.js`.
+- `?sync=light` — use light sync instead of pico.

--- a/web-client/upgrade-dashboard/dashboard.js
+++ b/web-client/upgrade-dashboard/dashboard.js
@@ -1,0 +1,297 @@
+import init, * as Nimiq from '../dist/web/index.js';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// The staking contract lives at a fixed address on every Nimiq PoS network.
+const STAKING_CONTRACT_ADDRESS = 'NQ77 0000 0000 0000 0000 0000 0000 0000 0001';
+
+// Minimum support (in percent) required for BOTH stake and slots to trigger an upgrade.
+// Mirrors `Policy::UPGRADE_MIN_SUPPORT` (primitives/src/policy.rs).
+const UPGRADE_MIN_SUPPORT = 80;
+
+// 1 NIM = 100000 Luna.
+const LUNA_PER_NIM = 1e5;
+
+// Re-fetch the (network-bound) validator data at most this often, in ms.
+const REFRESH_INTERVAL_MS = 20_000;
+
+// Optionally connect to a non-default network via `?network=testalbatross` (+ optional seeds),
+// and/or pick a sync mode via `?sync=pico`. Without query params the client uses its built-in
+// default network (MainAlbatross) and default sync mode (light). Light is the most widely
+// supported mode by network peers; pico may fail to find peers on networks that don't serve it.
+const params = new URLSearchParams(location.search);
+const NETWORK = params.get('network');
+const SYNC_MODE = params.get('sync'); // 'light' (default) | 'pico'
+const SEED_NODES = [
+    // For a custom network you typically need explicit seeds, e.g.:
+    // "/dns4/seed1.pos.nimiq-testnet.com/tcp/8443/wss",
+];
+
+// ---------------------------------------------------------------------------
+// State + small DOM helpers
+// ---------------------------------------------------------------------------
+
+const $ = (id) => document.getElementById(id);
+
+const state = {
+    targetVersion: null,
+    rows: [],            // [{ address, stake, numSlots, signaled, supports }]
+    totalStake: 0,       // Luna, over active validators
+    supportingStake: 0,
+    totalSlots: 0,       // over elected validators
+    supportingSlots: 0,
+    sortKey: 'numSlots',
+    sortDir: -1,         // -1 desc, 1 asc
+    refreshing: false,
+    lastRefresh: 0,
+};
+
+const nim = (luna) => Math.round(luna / LUNA_PER_NIM).toLocaleString();
+const pct = (part, total) => (total > 0 ? (part / total) * 100 : 0);
+// Integer comparison mirroring the on-chain check: part*100 >= total*MIN.
+const meets = (part, total) => part * 100 >= total * UPGRADE_MIN_SUPPORT;
+
+// Decode the protocol version a validator signals: the first two bytes (big-endian u16)
+// of the signal_data hash. This is the JS equivalent of `Policy::supports_upgrade`.
+function signaledVersion(signalData) {
+    if (!signalData) return null;
+    const hex = signalData.startsWith('0x') ? signalData.slice(2) : signalData;
+    if (hex.length < 4) return null;
+    const v = parseInt(hex.slice(0, 4), 16);
+    return Number.isNaN(v) ? null : v;
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+init().then(async () => {
+    const config = new Nimiq.ClientConfiguration();
+    config.logLevel('info');
+    config.syncMode(SYNC_MODE || 'pico'); // pico by default; override with ?sync=light
+    if (NETWORK) {
+        config.network(NETWORK);
+        if (SEED_NODES.length) config.seedNodes(SEED_NODES);
+    }
+
+    const client = await Nimiq.Client.create(config.build());
+    window.client = client; // prevent GC / allow poking from the console
+
+    client.addConsensusChangedListener((cstate) => {
+        const el = $('consensus');
+        el.textContent = cstate;
+        el.classList.toggle('connecting', cstate === 'connecting');
+        el.classList.toggle('syncing', cstate === 'syncing');
+        el.classList.toggle('established', cstate === 'established');
+        if (cstate === 'established') refreshData(client, true);
+    });
+
+    client.addPeerChangedListener((_id, _reason, numPeers) => {
+        $('peers').textContent = numPeers;
+    });
+
+    let lastEpoch = null;
+    client.addHeadChangedListener(async () => {
+        const head = await updateHead(client);
+        if (!head) return;
+        // Refresh on every new epoch (validator set / slots change), otherwise throttle.
+        if (head.epoch !== lastEpoch) {
+            lastEpoch = head.epoch;
+            refreshData(client);
+        } else if (Date.now() - state.lastRefresh > REFRESH_INTERVAL_MS) {
+            refreshData(client);
+        }
+    });
+
+    // Periodic refresh so newly included signal transactions show up even on quiet chains.
+    setInterval(() => {
+        if (Date.now() - state.lastRefresh > REFRESH_INTERVAL_MS) refreshData(client);
+    }, REFRESH_INTERVAL_MS);
+
+    // Controls
+    $('refresh').addEventListener('click', () => refreshData(client, true));
+    $('search').addEventListener('input', renderTable);
+    $('filter').addEventListener('change', renderTable);
+    document.querySelectorAll('#validators th').forEach((th, i) => {
+        const keys = ['address', 'stake', 'stake', 'numSlots', 'numSlots', 'signaled', 'supports'];
+        th.addEventListener('click', () => {
+            const key = keys[i];
+            state.sortDir = state.sortKey === key ? -state.sortDir : -1;
+            state.sortKey = key;
+            renderTable();
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+// Cheap, local read of the head block: updates header + target version.
+async function updateHead(client) {
+    let head;
+    try {
+        head = await client.getHeadBlock();
+    } catch (e) {
+        return null;
+    }
+    state.targetVersion = head.version + 1;
+    $('block').textContent = head.height;
+    $('epoch').textContent = head.epoch;
+    $('version').textContent = head.version;
+    $('target-version').textContent = state.targetVersion;
+    return head;
+}
+
+// Network-bound refresh of validators, stake and slots. Guarded against overlap.
+async function refreshData(client, force = false) {
+    if (state.refreshing) return;
+    if (!force && !(await client.isConsensusEstablished())) return;
+    state.refreshing = true;
+    try {
+        const head = await updateHead(client);
+        if (!head) return;
+        const target = state.targetVersion;
+
+        // Stake side: the staking contract's active validators (address -> active stake in Luna).
+        const staking = await client.getAccount(STAKING_CONTRACT_ADDRESS);
+        const stakeByAddress = new Map(staking.activeValidators);
+
+        // Slots side: the validators elected for the current epoch (address -> slot count).
+        const elected = await client.getElectedValidators();
+        const slotsByAddress = new Map(elected.map((v) => [v.address, v.numSlots]));
+
+        // Signal data per validator (union of both sets).
+        const addresses = [...new Set([...stakeByAddress.keys(), ...slotsByAddress.keys()])];
+        const validators = await client.getValidators(addresses);
+        const signalByAddress = new Map();
+        addresses.forEach((addr, i) => {
+            const v = validators[i];
+            signalByAddress.set(addr, v ? signaledVersion(v.signalData) : null);
+        });
+
+        // Aggregate, mirroring tendermint.rs: stake over active_validators, slots over current_validators.
+        let totalStake = 0, supportingStake = 0, totalSlots = 0, supportingSlots = 0;
+        for (const [addr, balance] of stakeByAddress) {
+            totalStake += balance;
+            if (signalByAddress.get(addr) === target) supportingStake += balance;
+        }
+        for (const [addr, numSlots] of slotsByAddress) {
+            totalSlots += numSlots;
+            if (signalByAddress.get(addr) === target) supportingSlots += numSlots;
+        }
+
+        state.rows = addresses.map((addr) => {
+            const signaled = signalByAddress.get(addr);
+            return {
+                address: addr,
+                stake: stakeByAddress.get(addr) ?? 0,
+                numSlots: slotsByAddress.get(addr) ?? 0,
+                signaled,
+                supports: signaled === target,
+            };
+        });
+        Object.assign(state, { totalStake, supportingStake, totalSlots, supportingSlots });
+        state.lastRefresh = Date.now();
+        $('updated').textContent = new Date(state.lastRefresh).toLocaleTimeString();
+
+        renderMetrics();
+        renderTable();
+    } catch (e) {
+        console.error('Refresh failed:', e);
+    } finally {
+        state.refreshing = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function renderMetrics() {
+    const { supportingStake, totalStake, supportingSlots, totalSlots, targetVersion } = state;
+    const stakePct = pct(supportingStake, totalStake);
+    const slotsPct = pct(supportingSlots, totalSlots);
+    const stakeOk = meets(supportingStake, totalStake);
+    const slotsOk = meets(supportingSlots, totalSlots);
+
+    setMetric('stake', stakePct, stakeOk,
+        `${nim(supportingStake)} of ${nim(totalStake)} NIM active stake`);
+    setMetric('slots', slotsPct, slotsOk,
+        `${supportingSlots} of ${totalSlots} slots`);
+
+    const verdict = $('verdict');
+    if (totalStake === 0 || totalSlots === 0) {
+        verdict.className = 'verdict pending';
+        verdict.textContent = 'Waiting for validator data…';
+    } else if (stakeOk && slotsOk) {
+        verdict.className = 'verdict ready';
+        verdict.textContent = `✓ Upgrade to version ${targetVersion} would activate — both stake and slots meet the ${UPGRADE_MIN_SUPPORT}% threshold.`;
+    } else {
+        verdict.className = 'verdict not-ready';
+        const missing = [!stakeOk && 'stake', !slotsOk && 'slots'].filter(Boolean).join(' and ');
+        verdict.textContent = `✗ Upgrade to version ${targetVersion} not yet supported — ${missing} below ${UPGRADE_MIN_SUPPORT}%.`;
+    }
+}
+
+function setMetric(prefix, percentage, ok, detail) {
+    $(`${prefix}-pct`).textContent = percentage.toFixed(1);
+    const bar = $(`${prefix}-bar`);
+    bar.style.width = `${Math.min(percentage, 100)}%`;
+    bar.classList.toggle('ok', ok);
+    $(`${prefix}-detail`).textContent = detail;
+    const badge = $(`${prefix}-badge`);
+    badge.textContent = ok ? `✓ meets ${UPGRADE_MIN_SUPPORT}%` : `✗ below ${UPGRADE_MIN_SUPPORT}%`;
+    badge.className = `card-badge ${ok ? 'ok' : 'no'}`;
+}
+
+function renderTable() {
+    const body = $('validators-body');
+    const query = $('search').value.trim().toUpperCase().replace(/\s/g, '');
+    const filter = $('filter').value;
+    const target = state.targetVersion;
+
+    let rows = state.rows.filter((r) => {
+        if (query && !r.address.replace(/\s/g, '').includes(query)) return false;
+        if (filter === 'supporting') return r.supports;
+        if (filter === 'other') return r.signaled !== null && !r.supports;
+        if (filter === 'none') return r.signaled === null;
+        return true;
+    });
+
+    const { sortKey, sortDir } = state;
+    rows.sort((a, b) => {
+        let av = a[sortKey], bv = b[sortKey];
+        if (sortKey === 'address') return sortDir * String(av).localeCompare(String(bv));
+        av = av ?? -1; bv = bv ?? -1; // nulls (no signal) sort last on desc
+        return sortDir * (av - bv);
+    });
+
+    $('count').textContent = `${rows.length} of ${state.rows.length} validators`;
+
+    if (!rows.length) {
+        body.innerHTML = '<tr><td colspan="7" class="muted">No matching validators.</td></tr>';
+        return;
+    }
+
+    body.innerHTML = rows.map((r) => {
+        const stakeShare = pct(r.stake, state.totalStake).toFixed(2);
+        const slotShare = pct(r.numSlots, state.totalSlots).toFixed(2);
+        let tag;
+        if (r.supports) tag = '<span class="tag ok">✓ yes</span>';
+        else if (r.signaled !== null) tag = '<span class="tag other">other</span>';
+        else tag = '<span class="tag no">no</span>';
+        const signaled = r.signaled === null ? '–' : r.signaled;
+        return `<tr class="${r.supports ? 'supporting' : ''}">
+            <td class="addr" title="${r.address}">${r.address}</td>
+            <td class="num">${nim(r.stake)}</td>
+            <td class="num">${stakeShare}%</td>
+            <td class="num">${r.numSlots}</td>
+            <td class="num">${slotShare}%</td>
+            <td class="num">${signaled}</td>
+            <td>${tag}</td>
+        </tr>`;
+    }).join('');
+}

--- a/web-client/upgrade-dashboard/docker-compose.yml
+++ b/web-client/upgrade-dashboard/docker-compose.yml
@@ -1,0 +1,49 @@
+name: nimiq-upgrade-dashboard
+
+# Build and serve the upgrade-signaling dashboard entirely in containers — no Rust,
+# Node or wasm tooling needed on the host.
+#
+#   # 1. Build web-client/dist (with the new getElectedValidators method). One-shot.
+#   docker compose -f web-client/upgrade-dashboard/docker-compose.yml run --rm build
+#
+#   # 2. Serve it, then open http://localhost:8000/upgrade-dashboard/
+#   docker compose -f web-client/upgrade-dashboard/docker-compose.yml up serve
+
+services:
+  # Rust -> WASM build. Rebuilds the `web` target AND regenerates the launcher + lib so the
+  # whole dist is internally consistent (the launcher/lib are gitignored build artifacts).
+  # --skip-wasm-opt avoids binaryen (and its x86_64-only download) — fine for local use.
+  build:
+    build:
+      context: .
+    image: nimiq-webclient-wasm-builder
+    working_dir: /repo/web-client
+    environment:
+      # cc-rs already prefers clang for wasm targets; set it explicitly to be safe.
+      CC_wasm32_unknown_unknown: clang
+      CARGO_TARGET_DIR: /repo/target
+      # extras' test devDep (vitest) wants node >=20; the build only needs tsup (fine on 18),
+      # so skip the engine check during `yarn install`.
+      YARN_IGNORE_ENGINES: "true"
+    command: ["./scripts/build.sh", "--only", "web", "--skip-wasm-opt"]
+    volumes:
+      - ../../:/repo                                  # repo root -> /repo (dist writes back to host)
+      - cargo-registry:/usr/local/cargo/registry      # cache crate downloads between runs
+      - cargo-git:/usr/local/cargo/git
+      - wasm-target:/repo/target                       # cache build artifacts (and keep host target clean)
+      - extras-node-modules:/repo/web-client/extras/node_modules  # keep node_modules off the host
+
+  # Static file server with correct .mjs / .wasm MIME types (Caddy handles both natively).
+  serve:
+    image: caddy:2-alpine
+    command: ["caddy", "file-server", "--root", "/srv", "--listen", ":80", "--browse"]
+    ports:
+      - "8000:80"
+    volumes:
+      - ../../web-client:/srv:ro
+
+volumes:
+  cargo-registry:
+  cargo-git:
+  wasm-target:
+  extras-node-modules:

--- a/web-client/upgrade-dashboard/index.html
+++ b/web-client/upgrade-dashboard/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nimiq Protocol Upgrade Signaling</title>
+  </head>
+  <body>
+    <script type="module" src="./dashboard.js"></script>
+
+    <header>
+      <h1>Protocol Upgrade Signaling</h1>
+      <div class="status-line">
+        <span>Consensus: <strong id="consensus" class="connecting">connecting</strong></span>
+        <span>Peers: <strong id="peers">0</strong></span>
+        <span>Block: <strong id="block">-</strong></span>
+        <span>Epoch: <strong id="epoch">-</strong></span>
+        <span>Version: <strong id="version">-</strong> &rarr; Target <strong id="target-version">-</strong></span>
+        <span class="muted">Updated: <span id="updated">never</span></span>
+      </div>
+    </header>
+
+    <!-- Overall verdict: upgrade activates only when BOTH metrics reach the threshold. -->
+    <div id="verdict" class="verdict pending">
+      Waiting for consensus&hellip;
+    </div>
+
+    <section class="metrics">
+      <div class="card">
+        <div class="card-title">Active stake signaling</div>
+        <div class="card-value"><span id="stake-pct">–</span><span class="pct">%</span></div>
+        <div class="bar"><div class="bar-fill" id="stake-bar"></div><div class="threshold"></div></div>
+        <div class="card-detail" id="stake-detail">&nbsp;</div>
+        <div class="card-badge" id="stake-badge">&nbsp;</div>
+      </div>
+      <div class="card">
+        <div class="card-title">Slots signaling</div>
+        <div class="card-value"><span id="slots-pct">–</span><span class="pct">%</span></div>
+        <div class="bar"><div class="bar-fill" id="slots-bar"></div><div class="threshold"></div></div>
+        <div class="card-detail" id="slots-detail">&nbsp;</div>
+        <div class="card-badge" id="slots-badge">&nbsp;</div>
+      </div>
+    </section>
+
+    <section class="controls">
+      <input type="search" id="search" placeholder="Filter by address&hellip;" />
+      <select id="filter">
+        <option value="all">All validators</option>
+        <option value="supporting">Signaling target version</option>
+        <option value="other">Signaling other version</option>
+        <option value="none">Not signaling</option>
+      </select>
+      <button id="refresh">Refresh</button>
+      <span class="muted" id="count">&nbsp;</span>
+    </section>
+
+    <table id="validators">
+      <thead>
+        <tr>
+          <th>Validator</th>
+          <th class="num">Stake (NIM)</th>
+          <th class="num">Stake %</th>
+          <th class="num">Slots</th>
+          <th class="num">Slot %</th>
+          <th class="num">Signaled</th>
+          <th>Supports target</th>
+        </tr>
+      </thead>
+      <tbody id="validators-body">
+        <tr><td colspan="7" class="muted">No data yet.</td></tr>
+      </tbody>
+    </table>
+
+    <style>
+      :root {
+        --bg: #0d1117; --fg: #e6edf3; --muted: #8b949e; --card: #161b22;
+        --border: #30363d; --accent: #0582ca; --ok: #2ea043; --no: #c9510c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        font-family: system-ui, sans-serif; margin: 0; padding: 24px 32px;
+        background: var(--bg); color: var(--fg); line-height: 1.45;
+      }
+      h1 { font-size: 22px; margin: 0 0 8px; }
+      .status-line { display: flex; flex-wrap: wrap; gap: 18px; font-size: 14px; }
+      .muted { color: var(--muted); }
+      #consensus.connecting { color: firebrick; }
+      #consensus.syncing { color: orange; }
+      #consensus.established { color: var(--ok); }
+
+      .verdict {
+        margin: 20px 0; padding: 14px 18px; border-radius: 8px; font-weight: 600;
+        border: 1px solid var(--border);
+      }
+      .verdict.pending { background: #1c2128; color: var(--muted); }
+      .verdict.ready { background: rgba(46,160,67,.15); color: #56d364; border-color: var(--ok); }
+      .verdict.not-ready { background: rgba(201,81,12,.12); color: #e0823d; border-color: var(--no); }
+
+      .metrics { display: flex; gap: 20px; flex-wrap: wrap; }
+      .card {
+        flex: 1 1 280px; background: var(--card); border: 1px solid var(--border);
+        border-radius: 10px; padding: 18px 20px;
+      }
+      .card-title { color: var(--muted); font-size: 13px; text-transform: uppercase; letter-spacing: .04em; }
+      .card-value { font-size: 44px; font-weight: 700; line-height: 1.1; margin: 6px 0 12px; }
+      .card-value .pct { font-size: 22px; color: var(--muted); margin-left: 2px; }
+      .bar {
+        position: relative; height: 12px; background: #21262d; border-radius: 6px; overflow: hidden;
+      }
+      .bar-fill { height: 100%; width: 0%; background: var(--accent); transition: width .4s ease; }
+      .bar-fill.ok { background: var(--ok); }
+      /* 80% threshold marker */
+      .threshold { position: absolute; top: -2px; bottom: -2px; left: 80%; width: 2px; background: #f0c674; }
+      .card-detail { margin-top: 10px; font-size: 14px; color: var(--muted); }
+      .card-badge { margin-top: 6px; font-size: 13px; font-weight: 600; }
+      .card-badge.ok { color: #56d364; }
+      .card-badge.no { color: #e0823d; }
+
+      .controls { display: flex; gap: 12px; align-items: center; margin: 26px 0 12px; flex-wrap: wrap; }
+      .controls input, .controls select, .controls button {
+        background: var(--card); color: var(--fg); border: 1px solid var(--border);
+        border-radius: 6px; padding: 7px 10px; font-size: 14px;
+      }
+      .controls input { min-width: 240px; }
+      .controls button { cursor: pointer; }
+      .controls button:hover { border-color: var(--accent); }
+
+      table { width: 100%; border-collapse: collapse; font-size: 14px; }
+      th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); }
+      th { color: var(--muted); font-weight: 600; cursor: pointer; user-select: none; }
+      th.num, td.num { text-align: right; font-variant-numeric: tabular-nums; }
+      td.addr { font-family: ui-monospace, monospace; font-size: 12px; white-space: nowrap; }
+      tr.supporting td { background: rgba(46,160,67,.06); }
+      .tag { padding: 1px 8px; border-radius: 10px; font-size: 12px; font-weight: 600; }
+      .tag.ok { background: rgba(46,160,67,.18); color: #56d364; }
+      .tag.no { background: rgba(139,148,158,.18); color: var(--muted); }
+      .tag.other { background: rgba(240,198,116,.18); color: #f0c674; }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
## What

A simple, **read-only** browser dashboard that shows whether validators are signaling support for the next protocol upgrade: the two on-chain thresholds (**% of active stake** and **% of slots** signaling the target version) plus a filterable validator explorer.

It lives in `web-client/upgrade-dashboard/` as a vanilla HTML + ES-modules page on top of the `@nimiq/core` web client (light client, pico sync) — no node or RPC server required.

## Web client change

Adds `Client.getElectedValidators()` (`web-client/src/client/lib.rs`, `web-client/src/client/account.rs`), returning the current epoch's elected validators with their slot counts (`{ address, numSlots }`). The web client already exposes per-validator `signalData` and `totalStake`, but not slot counts — and slots are one of the two on-chain upgrade thresholds. Implemented via the existing `blockchain.current_validators()` accessor; purely additive.

## How the metrics mirror the chain

- **Target version** = head `version + 1`.
- A validator **supports** the upgrade iff the first two bytes (big-endian) of its `signalData` decode to the target version — the JS equivalent of `Policy::supports_upgrade`.
- **Stake** is summed over the staking contract's active validators; **slots** over the elected validators.
- Both are compared against `Policy::UPGRADE_MIN_SUPPORT` (80%), matching the upgrade trigger in `validator/src/tendermint.rs`.

## Build & run

Fully containerized (nothing installed on the host); see `web-client/upgrade-dashboard/README.md`:

```sh
docker compose -f web-client/upgrade-dashboard/docker-compose.yml run --rm build
docker compose -f web-client/upgrade-dashboard/docker-compose.yml up serve
# open http://localhost:8000/upgrade-dashboard/
```

A native `./scripts/build.sh` + static-serve path is documented too.

## Notes

- Read-only; submitting signals and historical/trend views are out of scope.
- Verified end-to-end against mainnet: pico sync establishes and the validator table + metrics populate (0% there, since no mainnet validator signals the next version — as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
