### PR TITLE
Time: patch `gloo-timers` locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,8 +2050,6 @@ dependencies = [
 [[package]]
 name = "gloo-timers"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ opt-level = 2
 [patch.crates-io]
 ark-ec = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
 ark-ff = { git = "https://github.com/paberr/algebra", branch = "pb/0.4" }
+gloo-timers = { path = "patches/gloo-timers" }
 
 [workspace.package]
 version = "1.7.1"

--- a/patches/gloo-timers/Cargo.toml
+++ b/patches/gloo-timers/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "gloo-timers"
+description = "Convenience crate for working with JavaScript timers"
+version = "0.4.0"
+authors = ["Rust and WebAssembly Working Group"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rustwasm/gloo/tree/master/crates/timers"
+homepage = "https://github.com/rustwasm/gloo"
+categories = ["api-bindings", "asynchronous", "wasm"]
+rust-version = { workspace = true }
+
+[package.metadata.docs.rs]
+features = ["futures"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+futures-core = { version = "0.3", optional = true }
+futures-channel = { version = "0.3", optional = true }
+
+[features]
+default = []
+futures = ["futures-core", "futures-channel"]

--- a/patches/gloo-timers/Cargo.toml
+++ b/patches/gloo-timers/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/timers"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
-rust-version = { workspace = true }
+rust-version = "1.82"
 
 [package.metadata.docs.rs]
 features = ["futures"]

--- a/patches/gloo-timers/src/callback.rs
+++ b/patches/gloo-timers/src/callback.rs
@@ -1,0 +1,222 @@
+//! Callback-style timer APIs.
+
+use js_sys::Function;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsCast, JsValue};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = "setTimeout", catch)]
+    fn set_timeout(handler: &Function, timeout: i32) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(js_name = "setInterval", catch)]
+    fn set_interval(handler: &Function, timeout: i32) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(js_name = "clearTimeout")]
+    fn clear_timeout(handle: JsValue) -> JsValue;
+
+    #[wasm_bindgen(js_name = "clearInterval")]
+    fn clear_interval(handle: JsValue) -> JsValue;
+}
+
+/// A scheduled timeout.
+///
+/// See `Timeout::new` for scheduling new timeouts.
+///
+/// Once scheduled, you can [`drop`] the [`Timeout`] to clear it or [`forget`](Timeout::forget) to leak it. Once forgotten, the interval will keep running forever.
+/// This pattern is known as Resource Acquisition Is Initialization (RAII).
+#[derive(Debug)]
+#[must_use = "timeouts cancel on drop; either call `forget` or `drop` explicitly"]
+pub struct Timeout {
+    id: Option<JsValue>,
+    closure: Option<Closure<dyn FnMut()>>,
+}
+
+impl Drop for Timeout {
+    /// Disposes of the timeout, dually cancelling this timeout by calling
+    /// `clearTimeout` directly.
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            clear_timeout(id);
+        }
+    }
+}
+
+impl Timeout {
+    /// Schedule a timeout to invoke `callback` in `millis` milliseconds from
+    /// now.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::callback::Timeout;
+    ///
+    /// let timeout = Timeout::new(1_000, move || {
+    ///     // Do something...
+    /// });
+    /// ```
+    pub fn new<F>(millis: u32, callback: F) -> Timeout
+    where
+        F: 'static + FnOnce(),
+    {
+        let closure = Closure::once(callback);
+
+        let id = set_timeout(
+            closure.as_ref().unchecked_ref::<js_sys::Function>(),
+            millis as i32,
+        )
+        .unwrap_throw();
+
+        Timeout {
+            id: Some(id),
+            closure: Some(closure),
+        }
+    }
+
+    /// Forgets this resource without clearing the timeout.
+    ///
+    /// Returns the identifier returned by the original `setTimeout` call, and
+    /// therefore you can still cancel the timeout by calling `clearTimeout`
+    /// directly (perhaps via `web_sys::clear_timeout_with_handle`).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::callback::Timeout;
+    ///
+    /// // We definitely want to do stuff, and aren't going to ever cancel this
+    /// // timeout.
+    /// Timeout::new(1_000, || {
+    ///     // Do stuff...
+    /// }).forget();
+    /// ```
+    pub fn forget(mut self) -> JsValue {
+        let id = self.id.take().unwrap_throw();
+        self.closure.take().unwrap_throw().forget();
+        id
+    }
+
+    /// Cancel this timeout so that the callback is not invoked after the time
+    /// is up.
+    ///
+    /// The scheduled callback is returned.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::callback::Timeout;
+    ///
+    /// let timeout = Timeout::new(1_000, || {
+    ///     // Do stuff...
+    /// });
+    ///
+    /// // If actually we didn't want to set a timer, then cancel it.
+    /// if nevermind() {
+    ///     timeout.cancel();
+    /// }
+    /// # fn nevermind() -> bool { true }
+    /// ```
+    pub fn cancel(mut self) -> Closure<dyn FnMut()> {
+        self.closure.take().unwrap_throw()
+    }
+}
+
+/// A scheduled interval.
+///
+/// See `Interval::new` for scheduling new intervals.
+///
+/// Once scheduled, you can [`drop`] the [`Interval`] to clear it or [`forget`](Interval::forget) to leak it. Once forgotten, the interval will keep running forever.
+/// This pattern is known as Resource Acquisition Is Initialization (RAII).
+#[derive(Debug)]
+#[must_use = "intervals cancel on drop; either call `forget` or `drop` explicitly"]
+pub struct Interval {
+    id: Option<JsValue>,
+    closure: Option<Closure<dyn FnMut()>>,
+}
+
+impl Drop for Interval {
+    /// Disposes of the interval, dually cancelling this interval by calling
+    /// `clearInterval` directly.
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            clear_interval(id);
+        }
+    }
+}
+
+impl Interval {
+    /// Schedule an interval to invoke `callback` every `millis` milliseconds.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::callback::Interval;
+    ///
+    /// let interval = Interval::new(1_000, move || {
+    ///     // Do something...
+    /// });
+    /// ```
+    pub fn new<F>(millis: u32, callback: F) -> Interval
+    where
+        F: 'static + FnMut(),
+    {
+        let closure = Closure::wrap(Box::new(callback) as Box<dyn FnMut()>);
+
+        let id = set_interval(
+            closure.as_ref().unchecked_ref::<js_sys::Function>(),
+            millis as i32,
+        )
+        .unwrap_throw();
+
+        Interval {
+            id: Some(id),
+            closure: Some(closure),
+        }
+    }
+
+    /// Forget this resource without clearing the interval.
+    ///
+    /// Returns the identifier returned by the original `setInterval` call, and
+    /// therefore you can still cancel the interval by calling `clearInterval`
+    /// directly (perhaps via `web_sys::clear_interval_with_handle`).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::callback::Interval;
+    ///
+    /// // We want to do stuff every second, indefinitely.
+    /// Interval::new(1_000, || {
+    ///     // Do stuff...
+    /// }).forget();
+    /// ```
+    pub fn forget(mut self) -> JsValue {
+        let id = self.id.take().unwrap_throw();
+        self.closure.take().unwrap_throw().forget();
+        id
+    }
+
+    /// Cancel this interval so that the callback is no longer periodically
+    /// invoked.
+    ///
+    /// The scheduled callback is returned.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::callback::Interval;
+    ///
+    /// let interval = Interval::new(1_000, || {
+    ///     // Do stuff...
+    /// });
+    ///
+    /// // If we don't want this interval to run anymore, then cancel it.
+    /// if nevermind() {
+    ///     interval.cancel();
+    /// }
+    /// # fn nevermind() -> bool { true }
+    /// ```
+    pub fn cancel(mut self) -> Closure<dyn FnMut()> {
+        self.closure.take().unwrap_throw()
+    }
+}

--- a/patches/gloo-timers/src/future.rs
+++ b/patches/gloo-timers/src/future.rs
@@ -1,0 +1,162 @@
+//! `Future`- and `Stream`-backed timers APIs.
+
+use crate::callback::{Interval, Timeout};
+
+use futures_channel::{mpsc, oneshot};
+use futures_core::stream::Stream;
+use std::convert::TryFrom;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use wasm_bindgen::prelude::*;
+
+/// A scheduled timeout as a `Future`.
+///
+/// See `TimeoutFuture::new` for scheduling new timeouts.
+///
+/// Once scheduled, if you change your mind and don't want the timeout to fire,
+/// you can `drop` the future.
+///
+/// A timeout future will never resolve to `Err`. Its only failure mode is when
+/// the timeout is so long that it is effectively infinite and never fires.
+///
+/// # Example
+///
+/// ```no_run
+/// use gloo_timers::future::TimeoutFuture;
+/// use futures_util::future::{select, Either};
+/// use wasm_bindgen_futures::spawn_local;
+///
+/// spawn_local(async {
+///     match select(TimeoutFuture::new(1_000), TimeoutFuture::new(2_000)).await {
+///         Either::Left((val, b)) => {
+///             // Drop the `2_000` ms timeout to cancel its timeout.
+///             drop(b);
+///         }
+///         Either::Right((a, val)) => {
+///             panic!("the `1_000` ms timeout should have won this race");
+///         }
+///     }
+/// });
+/// ```
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled or spawned"]
+pub struct TimeoutFuture {
+    _inner: Timeout,
+    rx: oneshot::Receiver<()>,
+}
+
+impl TimeoutFuture {
+    /// Create a new timeout future.
+    ///
+    /// Remember that futures do nothing unless polled or spawned, so either
+    /// pass this future to `wasm_bindgen_futures::spawn_local` or use it inside
+    /// another future.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gloo_timers::future::TimeoutFuture;
+    /// use wasm_bindgen_futures::spawn_local;
+    ///
+    /// spawn_local(async {
+    ///     TimeoutFuture::new(1_000).await;
+    ///     // Do stuff after one second...
+    /// });
+    /// ```
+    pub fn new(millis: u32) -> TimeoutFuture {
+        let (tx, rx) = oneshot::channel();
+        let inner = Timeout::new(millis, move || {
+            // if the receiver was dropped we do nothing.
+            tx.send(()).unwrap_throw();
+        });
+        TimeoutFuture { _inner: inner, rx }
+    }
+}
+
+/// Waits until the specified duration has elapsed.
+///
+/// # Panics
+///
+/// This function will panic if the specified [`Duration`] cannot be casted into a u32 in
+/// milliseconds.
+///
+/// # Example
+///
+/// ```compile_fail
+/// use std::time::Duration;
+/// use gloo_timers::future::sleep;
+///
+/// sleep(Duration::from_secs(1)).await;
+/// ```
+pub fn sleep(dur: Duration) -> TimeoutFuture {
+    let millis = u32::try_from(dur.as_millis())
+        .expect_throw("failed to cast the duration into a u32 with Duration::as_millis.");
+
+    TimeoutFuture::new(millis)
+}
+
+impl Future for TimeoutFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        Future::poll(Pin::new(&mut self.rx), cx).map(|t| t.unwrap_throw())
+    }
+}
+/// A scheduled interval as a `Stream`.
+///
+/// See `IntervalStream::new` for scheduling new intervals.
+///
+/// Once scheduled, if you want to stop the interval from continuing to fire,
+/// you can `drop` the stream.
+///
+/// An interval stream will never resolve to `Err`.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled or spawned"]
+pub struct IntervalStream {
+    receiver: mpsc::UnboundedReceiver<()>,
+    _inner: Interval,
+}
+
+impl IntervalStream {
+    /// Create a new interval stream.
+    ///
+    /// Remember that streams do nothing unless polled or spawned, so either
+    /// spawn this stream via `wasm_bindgen_futures::spawn_local` or use it inside
+    /// another stream or future.
+    ///
+    /// # Example
+    ///
+    /// ```compile_fail
+    /// use futures_util::stream::StreamExt;
+    /// use gloo_timers::future::IntervalStream;
+    /// use wasm_bindgen_futures::spawn_local;
+    ///
+    /// spawn_local(async {
+    ///     IntervalStream::new(1_000).for_each(|_| {
+    ///         // Do stuff every one second...
+    ///     }).await;
+    /// });
+    /// ```
+    pub fn new(millis: u32) -> IntervalStream {
+        let (sender, receiver) = mpsc::unbounded();
+        let inner = Interval::new(millis, move || {
+            // if the receiver was dropped we do nothing.
+            sender.unbounded_send(()).unwrap_throw();
+        });
+
+        IntervalStream {
+            receiver,
+            _inner: inner,
+        }
+    }
+}
+
+impl Stream for IntervalStream {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        Stream::poll_next(Pin::new(&mut self.receiver), cx)
+    }
+}

--- a/patches/gloo-timers/src/future.rs
+++ b/patches/gloo-timers/src/future.rs
@@ -69,7 +69,7 @@ impl TimeoutFuture {
         let (tx, rx) = oneshot::channel();
         let inner = Timeout::new(millis, move || {
             // if the receiver was dropped we do nothing.
-            tx.send(()).unwrap_throw();
+            let _ = tx.send(());
         });
         TimeoutFuture { _inner: inner, rx }
     }
@@ -101,7 +101,13 @@ impl Future for TimeoutFuture {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        Future::poll(Pin::new(&mut self.rx), cx).map(|t| t.unwrap_throw())
+        match Future::poll(Pin::new(&mut self.rx), cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(()),
+            // Invariance where the sender is dropped without firing (ranile/gloo#570).
+            // The timer can never fire now, so park permanently.
+            Poll::Ready(Err(_)) => Poll::Pending,
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 /// A scheduled interval as a `Stream`.
@@ -143,7 +149,7 @@ impl IntervalStream {
         let (sender, receiver) = mpsc::unbounded();
         let inner = Interval::new(millis, move || {
             // if the receiver was dropped we do nothing.
-            sender.unbounded_send(()).unwrap_throw();
+            let _ = sender.unbounded_send(());
         });
 
         IntervalStream {

--- a/patches/gloo-timers/src/lib.rs
+++ b/patches/gloo-timers/src/lib.rs
@@ -1,0 +1,66 @@
+/*!
+
+Working with timers on the Web: `setTimeout` and `setInterval`.
+
+These APIs come in two flavors:
+
+1. a callback style (that more directly mimics the JavaScript APIs), and
+2. a `Future`s and `Stream`s API.
+
+## Timeouts
+
+Timeouts fire once after a period of time (measured in milliseconds).
+
+### Timeouts with a Callback Function
+
+```no_run
+use gloo_timers::callback::Timeout;
+
+let timeout = Timeout::new(1_000, move || {
+    // Do something after the one second timeout is up!
+});
+
+// Since we don't plan on cancelling the timeout, call `forget`.
+timeout.forget();
+```
+
+### Timeouts as `Future`s
+
+With the `futures` feature enabled, a `future` module containing futures-based
+timers is exposed.
+
+*/
+#![cfg_attr(feature = "futures", doc = "```no_run")]
+#![cfg_attr(not(feature = "futures"), doc = "```ignore")]
+/*!
+use gloo_timers::future::TimeoutFuture;
+use wasm_bindgen_futures::spawn_local;
+
+// Spawn the `timeout` future on the local thread. If we just dropped it, then
+// the timeout would be cancelled with `clearTimeout`.
+spawn_local(async {
+    TimeoutFuture::new(1_000).await;
+    // Do something here after the one second timeout is up!
+});
+```
+
+## Intervals
+
+Intervals fire repeatedly every *n* milliseconds.
+
+### Intervals with a Callback Function
+
+TODO
+
+### Intervals as `Stream`s
+
+TODO
+
+ */
+
+#![deny(missing_docs, missing_debug_implementations)]
+
+pub mod callback;
+
+#[cfg(feature = "futures")]
+pub mod future;

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
+# Patched locally. See issue nimiq/core-rs-albatross#3844 and ranile/gloo#570.
+# Currently vendored via `patches/gloo-timers`; remove once the fix is upstream.
 gloo-timers = { version = "0.4", features = ["futures"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 pin-project-lite = "0.2.17"


### PR DESCRIPTION
## What's in this pull request?
Patch `gloo-timers` locally as a mitigation of a panic that surfaced in the `web-client` until this has been [solved upstream](https://github.com/ranile/gloo/issues/570). The code path that causes the panic is described in [this issue](https://github.com/nimiq/core-rs-albatross/issues/3844).

1st commit in this PR is bringing in the `gloo-timers` crate into our workspace.
2nd commit is the change that gracefully handles the `Err` invariant.

This closes #3844.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
