### PR TITLE
web-client: build the `types` target in the upgrade-dashboard compose

### DIFF
--- a/web-client/upgrade-dashboard/docker-compose.yml
+++ b/web-client/upgrade-dashboard/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # extras' test devDep (vitest) wants node >=20; the build only needs tsup (fine on 18),
       # so skip the engine check during `yarn install`.
       YARN_IGNORE_ENGINES: "true"
-    command: ["./scripts/build.sh", "--only", "web", "--skip-wasm-opt"]
+    command: ["./scripts/build.sh", "--only", "web,types", "--skip-wasm-opt"]
     volumes:
       - ../../:/repo                                  # repo root -> /repo (dist writes back to host)
       - cargo-registry:/usr/local/cargo/registry      # cache crate downloads between runs


### PR DESCRIPTION
build-lib.sh always runs and its --dts-only step type-checks the extras lib, which imports from `@nimiq/core` (link:../dist). That resolves to dist/types/bundler.d.ts, which re-exports dist/types/wasm — a gitignored artifact only produced by build.sh's `types` target. With `--only web` the types target was skipped, so the file was missing and the lib type build failed with TS2305 ("@nimiq/core has no exported member ...").

Include `types` in the build so the dist is internally consistent.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
