### PR TITLE
Fix non-terminating loop in MMR proof verification

### DIFF
--- a/primitives/mmr/src/mmr/position.rs
+++ b/primitives/mmr/src/mmr/position.rs
@@ -154,8 +154,10 @@ fn all_ones(num: usize) -> bool {
 /// Important: This uses 1-based indexing.
 fn move_left(index: usize) -> usize {
     let bit_length = bit_length(index);
-    let most_significant_bits = 1 << (bit_length - 1); // 2^(l - 1)
-    index - (most_significant_bits as usize - 1)
+    // `1usize`, not a bare `1`: as `i32` the shift wraps for `bit_length >= 33` under release,
+    // making `index_to_height` loop forever
+    let most_significant_bits = 1usize << (bit_length - 1); // 2^(l - 1)
+    index - (most_significant_bits - 1)
 }
 
 /// To calculate the height for any index, we move left in the tree (on the same height)

--- a/primitives/mmr/src/mmr/proof.rs
+++ b/primitives/mmr/src/mmr/proof.rs
@@ -81,6 +81,12 @@ impl<H: Merge + Clone> Proof<H> {
         let positions: Result<Vec<(Position, H)>, Error> = leaves
             .iter()
             .map(|(index, value)| {
+                // Reject out-of-range leaf numbers before the Position arithmetic, which does
+                // not terminate for huge inputs. A tree never has more leaves than nodes, so
+                // this never refuses a valid leaf
+                if *index >= self.mmr_size {
+                    return Err(Error::ProveInvalidLeaves);
+                }
                 let pos = Position::from(leaf_number_to_index(*index));
                 // Make sure that we only ever prove leaf nodes.
                 if pos.index >= self.mmr_size {
@@ -336,6 +342,35 @@ mod tests {
         mmr::{utils::test_utils::TestHash, MerkleMountainRange},
         store::{memory::MemoryStore, Store},
     };
+
+    #[test]
+    fn calculate_root_rejects_out_of_range_leaf_index() {
+        use std::{sync::mpsc, thread, time::Duration};
+
+        // A leaf number with the top bit set used to wedge `calculate_root`: under release
+        // (overflow-checks off) `leaf_number_to_index` -> `Position::from` -> `index_to_height`
+        // never terminated. Run it on a worker thread so a regression surfaces as a timeout
+        // instead of hanging the whole test binary.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let leaf: usize = 1;
+            let leaves = [(0x8000_0000_0000_0000usize, &leaf)];
+            let proof: Proof<TestHash> = Proof {
+                mmr_size: 4,
+                nodes: vec![TestHash(42)],
+            };
+            let _ = tx.send(proof.calculate_root(&leaves));
+        });
+        match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok(result) => assert_eq!(result, Err(Error::ProveInvalidLeaves)),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                panic!("calculate_root did not return within 10s: non-terminating loop")
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("worker thread panicked before returning")
+            }
+        }
+    }
 
     #[test]
     fn it_correctly_constructs_proofs() {


### PR DESCRIPTION
## Problem

`Proof::calculate_root` mapped every caller-supplied leaf number to a tree
`Position` before validating it: `Position::from(leaf_number_to_index(*index))`
ran ahead of the `pos.index >= self.mmr_size` bounds check. For a crafted leaf
number, `index_to_height`/`move_left` never terminate under the release profile
(`overflow-checks` off), pinning the thread.

These leaf numbers are attacker-controlled: `HistoryTreeProof.positions` is
plain-deserialized from a peer's `ResponseTransactionsProof` and reaches
`calculate_root` before any other validation. The existing `MAX_MMR_SIZE` guard
only bounds `self.mmr_size`, not the leaf indices.

## Fix

- `calculate_root`: reject out-of-range leaf numbers (`*index >= self.mmr_size`)
  before the `Position` arithmetic. A tree never has more leaves than nodes, so
  this never refuses a valid leaf.
- `move_left`: type the shift base as `usize` instead of the `i32` the bare
  literal defaulted to (byte-identical for every valid index `< 2^31`; also
  fixes a latent correctness bug for trees exceeding ~2^31 nodes).
