### PR TITLE
blockchain: compute reward recipients from the in-flight txn

### DIFF
--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -431,7 +431,7 @@ impl BlockProducer {
 
         // Calculate the reward transactions.
         let reward_transactions =
-            blockchain.create_reward_transactions(macro_header, &staking_contract);
+            blockchain.create_reward_transactions(macro_header, &staking_contract, txn_option);
 
         // Create the body for the macro block.
         Ok(MacroBody {

--- a/blockchain/src/blockchain/inherents.rs
+++ b/blockchain/src/blockchain/inherents.rs
@@ -142,7 +142,7 @@ impl Blockchain {
         let mut inherents: Vec<Inherent> = if let Some(body) = macro_block.body.as_ref() {
             body.transactions.iter().map(Inherent::from).collect()
         } else {
-            self.create_reward_transactions(&macro_block.header, &self.get_staking_contract())
+            self.create_reward_transactions(&macro_block.header, &self.get_staking_contract(), None)
                 .iter()
                 .map(Inherent::from)
                 .collect()
@@ -160,6 +160,7 @@ impl Blockchain {
         &self,
         macro_header: &MacroHeader,
         staking_contract: &StakingContract,
+        txn_option: Option<&MdbxReadTransaction>,
     ) -> Vec<RewardTransaction> {
         let prev_macro_info = &self.state.macro_info;
 
@@ -221,10 +222,17 @@ impl Blockchain {
         // accept the inherent.
         let mut burned_reward = Coin::ZERO;
 
-        // Load the staking contract before iterating over the validator slots
-        let staking_contract = self.get_staking_contract();
+        // Read validators/recipient accounts from the SAME txn the caller used, so uncommitted
+        // changes earlier in this batch during a rebranch are reflected.
         let data_store = self.get_staking_contract_store();
-        let txn = self.read_transaction();
+        let owned_read_txn;
+        let txn = match txn_option {
+            Some(txn) => txn,
+            None => {
+                owned_read_txn = self.read_transaction();
+                &owned_read_txn
+            }
+        };
 
         // Compute inherents
         for validator_slot in validator_slots.iter() {
@@ -262,7 +270,7 @@ impl Blockchain {
 
             // Get the validator from the staking contract
             let validator = staking_contract
-                .get_validator(&data_store.read(&txn), &validator_slot.address)
+                .get_validator(&data_store.read(txn), &validator_slot.address)
                 .expect("Couldn't find validator in the accounts trie when paying rewards!");
 
             // Create inherent for the reward.
@@ -275,7 +283,7 @@ impl Blockchain {
             // Test whether account will accept inherent. If it can't then the reward will be
             // burned.
             // TODO Improve this check: it assumes that only BasicAccounts can receive transactions.
-            let account = self.state.accounts.get_complete(&tx.recipient, Some(&txn));
+            let account = self.state.accounts.get_complete(&tx.recipient, Some(txn));
             if account.account_type() == AccountType::Basic {
                 num_eligible_slots_for_accepted_tx.push(num_eligible_slots);
                 transactions.push(tx);

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -315,7 +315,7 @@ impl Blockchain {
         }
 
         let reward_transactions =
-            self.create_reward_transactions(&macro_block.header, &staking_contract);
+            self.create_reward_transactions(&macro_block.header, &staking_contract, Some(txn));
 
         let body = macro_block
             .body

--- a/blockchain/tests/inherents.rs
+++ b/blockchain/tests/inherents.rs
@@ -60,7 +60,7 @@ fn it_can_create_batch_finalization_inherents() {
     };
 
     let reward_transactions =
-        blockchain.create_reward_transactions(&macro_header, &staking_contract);
+        blockchain.create_reward_transactions(&macro_header, &staking_contract, None);
 
     let body = MacroBody {
         transactions: reward_transactions,
@@ -125,7 +125,7 @@ fn it_can_create_batch_finalization_inherents() {
 
     let staking_contract = blockchain.get_staking_contract();
     let reward_transactions =
-        blockchain.create_reward_transactions(&macro_header, &staking_contract);
+        blockchain.create_reward_transactions(&macro_header, &staking_contract, None);
     macro_header.next_batch_initial_punished_set = staking_contract
         .punished_slots
         .next_batch_initial_punished_set(macro_header.block_number, &active_validators);
@@ -241,7 +241,7 @@ fn it_can_penalize_delayed_batch() {
 
     let staking_contract = blockchain.get_staking_contract();
     let reward_transactions =
-        blockchain.create_reward_transactions(&macro_header, &staking_contract);
+        blockchain.create_reward_transactions(&macro_header, &staking_contract, None);
 
     let body = MacroBody {
         transactions: reward_transactions,
@@ -712,7 +712,7 @@ fn it_can_create_version_upgrade_inherents() {
     };
 
     let reward_transactions =
-        blockchain.create_reward_transactions(&macro_header, &staking_contract);
+        blockchain.create_reward_transactions(&macro_header, &staking_contract, None);
 
     let body = MacroBody {
         transactions: reward_transactions,
@@ -851,7 +851,7 @@ fn it_burns_all_rewards_when_all_slots_penalized() {
     // This must not panic — previously it would trigger
     // "Must have positive total probability" in DiscreteDistribution::new().
     let reward_transactions =
-        blockchain.create_reward_transactions(&macro_header, &staking_contract);
+        blockchain.create_reward_transactions(&macro_header, &staking_contract, None);
 
     // All rewards should be burned: expect exactly one burn transaction.
     assert_eq!(

--- a/blockchain/tests/rebranching.rs
+++ b/blockchain/tests/rebranching.rs
@@ -1,17 +1,103 @@
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_genesis::NetworkId;
-use nimiq_keys::{KeyPair, PrivateKey};
-use nimiq_primitives::policy::Policy;
+use nimiq_keys::{Address, KeyPair, PrivateKey};
+use nimiq_primitives::{coin::Coin, policy::Policy};
 use nimiq_serde::Deserialize;
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     block_production::TemporaryBlockProducer,
-    blockchain::{generate_transactions, REWARD_KEY},
+    blockchain::{generate_transactions, validator_key, REWARD_KEY},
 };
+use nimiq_transaction::Transaction;
+use nimiq_transaction_builder::TransactionBuilder;
 
 fn key_pair_with_funds() -> KeyPair {
     let priv_key = PrivateKey::deserialize_from_vec(&hex::decode(REWARD_KEY).unwrap()).unwrap();
     priv_key.into()
+}
+
+fn update_validator_reward_address_tx(
+    new_reward_address: Address,
+    validity_start_height: u32,
+) -> Transaction {
+    TransactionBuilder::new_update_validator(
+        &key_pair_with_funds(),
+        &validator_key(),
+        None,
+        None,
+        Some(new_reward_address),
+        None,
+        Coin::ZERO,
+        validity_start_height,
+        NetworkId::UnitAlbatross,
+    )
+}
+
+/// Regression test: `create_reward_transactions` must read reward recipients from the in-flight
+/// write txn, not a fresh committed snapshot. During a rebranch all fork blocks are applied on one
+/// uncommitted txn, so an `UpdateValidator` that changed a validator's reward_address earlier in
+/// the same batch is only visible there. Reading committed state recomputed the OLD address while
+/// the macro body (built over committed state by the producer) carries the NEW one, so the
+/// rebranching node rejected (`InvalidRewardTransactions` -> `InvalidFork`) a macro block that
+/// extending nodes accept -- a deterministic liveness split between two honest nodes.
+#[test]
+fn it_can_rebranch_with_reward_address_change() {
+    let producer1 = TemporaryBlockProducer::new(); // superior fork carrying the UpdateValidator
+    let producer2 = TemporaryBlockProducer::new(); // victim/inferior fork that rebranches
+    let new_reward_address = Address([0x11u8; 20]);
+
+    // Shared committed prefix through the first macro block (rewards empty there).
+    loop {
+        let b = producer1.next_block(vec![], false);
+        let is_macro = b.is_macro();
+        assert_eq!(producer2.push(b), Ok(PushResult::Extended));
+        if is_macro {
+            break;
+        }
+    }
+    let m1 = producer1.blockchain.read().block_number();
+    assert_eq!(Policy::batch_at(m1), 1);
+    let m2 = Policy::macro_block_after(m1 + 1);
+    assert_eq!(Policy::batch_at(m2), 2);
+
+    // Fork in batch 2: producer2 builds an inferior (skip-block) chain; producer1's second block
+    // carries the UpdateValidator that sets the NEW reward address.
+    let superior_first = producer1.next_block(vec![], false);
+    producer2.next_block(vec![], true);
+    assert_eq!(producer2.push(superior_first), Ok(PushResult::Ignored));
+
+    let update_tx = update_validator_reward_address_tx(
+        new_reward_address.clone(),
+        producer1.blockchain.read().block_number() + 1,
+    );
+    let superior_update = producer1.next_block_with_txs(vec![], false, vec![update_tx]);
+    producer2.next_block(vec![], false);
+    assert_eq!(producer2.push(superior_update), Ok(PushResult::Ignored));
+
+    while producer1.blockchain.read().block_number() < m2 - 1 {
+        let sup = producer1.next_block(vec![], false);
+        producer2.next_block(vec![], false);
+        assert_eq!(producer2.push(sup), Ok(PushResult::Ignored));
+    }
+
+    let macro_block = producer1.next_block(vec![], false);
+    assert!(macro_block.is_macro());
+    assert_eq!(producer1.blockchain.read().block_number(), m2);
+
+    // The rebranching victim must accept the same macro block extending nodes accept. Before the
+    // fix this returned `Err(InvalidFork)` because rewards were recomputed from stale committed
+    // state (OLD reward address).
+    let result = producer2.push(macro_block);
+    assert_eq!(
+        result,
+        Ok(PushResult::Rebranched),
+        "rebranching victim must accept the macro block extending nodes accept; got {result:?}"
+    );
+
+    let b1 = producer1.blockchain.read();
+    let b2 = producer2.blockchain.read();
+    assert_eq!(b1.state.head_hash, b2.state.head_hash);
+    assert_eq!(b1.state.macro_head_hash, b2.state.macro_head_hash);
 }
 
 #[test]

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -354,7 +354,8 @@ pub fn next_macro_block_proposal(
         ..Default::default()
     };
 
-    let reward_transactions = blockchain.create_reward_transactions(&header, &staking_contract);
+    let reward_transactions =
+        blockchain.create_reward_transactions(&header, &staking_contract, None);
 
     let body = MacroBody {
         transactions: reward_transactions,


### PR DESCRIPTION
## Problem

`create_reward_transactions` received the up-to-date `staking_contract`
argument but shadowed it with a fresh committed read
(`get_staking_contract()` / `read_transaction()`), looking up each validator's
`reward_address` from committed state.

During a rebranch all fork blocks are applied on one uncommitted write txn, so
an `UpdateValidator` that changed a validator's `reward_address` earlier in the
same batch is invisible to the committed read: the rebranching node recomputes
the OLD address while the macro body (built over committed state by the
producer) carries the NEW one, yielding `InvalidRewardTransactions` /
`InvalidFork`. An extending node commits each block first, sees the NEW address,
and accepts the identical block. Two honest nodes thus deterministically diverge
on a valid block (liveness/partition, not state forgery).

## Fix

Thread the caller's transaction into `create_reward_transactions` and read
validators/recipient accounts from it (and from the passed `staking_contract`),
so a rebranch sees the batch's uncommitted reward-address change. `verify.rs`
passes `Some(txn)`; block production passes its `txn_option`; committed-read
paths pass `None` (unchanged). Adds `it_can_rebranch_with_reward_address_change`
covering the rebranch split.
