### PR TITLE
genesis: refresh MainAlbatross checkpoint election block

### DIFF
--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -114,10 +114,10 @@ impl NetworkInfo {
 /// yet return `None`, in which case clients behave exactly as without checkpoints.
 fn checkpoint_for_network(network_id: NetworkId) -> Option<HardcodedElection> {
     match network_id {
-        // Election block #52401600 (2026-06-01), refreshed per release from a trusted node.
+        // Election block #53611200 (2026-06-15), refreshed per release from a trusted node.
         NetworkId::MainAlbatross => Some(HardcodedElection {
-            block_number: 52_401_600,
-            hash: "70fb730260deea0950e3f0f448d5eaadb252e36fe808ab2782dddaabdd3e6de5"
+            block_number: 53_611_200,
+            hash: "f2953c1a7597422587f76dff07fd5786e41425a2c51d4837ebc3691f05eb5b43"
                 .parse()
                 .expect("valid checkpoint hash"),
         }),


### PR DESCRIPTION
Refresh the hardcoded MainAlbatross checkpoint from election block 52401600 (2026-06-01) to 53611200 (2026-06-15), the latest election macro block at least two weeks old, taken from a trusted, fully-synced node.