### PR TITLE
Fix the network unreachable test panic

### DIFF
--- a/consensus/tests/history_sync.rs
+++ b/consensus/tests/history_sync.rs
@@ -197,8 +197,8 @@ async fn sync_ingredients() {
     // Produce the blocks.
     produce_macro_blocks(&producer, &blockchain1, num_macro_blocks);
 
-    let net1: Arc<Network> =
-        TestNetwork::build_network(2, Default::default(), &mut Some(hub)).await;
+    let (net1, _): (Arc<Network>, u64) =
+        TestNetwork::build_network_with_address(0, Default::default(), &mut Some(hub)).await;
     networks.push(Arc::clone(&net1));
     let blockchain1_proxy = BlockchainProxy::from(&blockchain1);
     let syncer1 = SyncerProxy::new_history(
@@ -226,8 +226,12 @@ async fn sync_ingredients() {
         .unwrap(),
     ));
 
-    let net2: Arc<Network> =
-        TestNetwork::build_network(3, Default::default(), &mut Some(MockHub::default())).await;
+    let (net2, net2_address): (Arc<Network>, u64) = TestNetwork::build_network_with_address(
+        0,
+        Default::default(),
+        &mut Some(MockHub::default()),
+    )
+    .await;
     networks.push(Arc::clone(&net2));
     let blockchain2_proxy = BlockchainProxy::from(&blockchain2);
     let syncer2 = SyncerProxy::new_history(
@@ -244,7 +248,7 @@ async fn sync_ingredients() {
 
     // Connect the two peers.
     let mut stream = net2.subscribe_events();
-    Network::connect_networks(&networks, 3u64).await;
+    Network::connect_networks(&networks, net2_address).await;
     // Then wait for connection to be established.
     let _ = stream.next().await.unwrap();
     sleep(Duration::from_secs(1)).await; // FIXME, Prof. Berrang told me to do this

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -113,12 +113,8 @@ pub async fn sync_two_peers(
     let producer = BlockProducer::new(signing_key(), voting_key());
     produce_macro_blocks_with_txns(&producer, &blockchain1, num_batches_macro_sync, 1, 2);
 
-    let net1: Arc<Network> = TestNetwork::build_network(
-        num_batches_macro_sync as u64 * 10,
-        Default::default(),
-        &mut Some(hub),
-    )
-    .await;
+    let (net1, _): (Arc<Network>, u64) =
+        TestNetwork::build_network_with_address(0, Default::default(), &mut Some(hub)).await;
     networks.push(Arc::clone(&net1));
     let blockchain1_proxy = BlockchainProxy::from(&blockchain1);
     let syncer1 = SyncerProxy::new_history(
@@ -161,8 +157,8 @@ pub async fn sync_two_peers(
         }
     };
 
-    let net2: Arc<Network> = TestNetwork::build_network(
-        num_batches_macro_sync as u64 * 10 + 1,
+    let (net2, net2_address): (Arc<Network>, u64) = TestNetwork::build_network_with_address(
+        0,
         Default::default(),
         &mut Some(MockHub::default()),
     )
@@ -171,7 +167,7 @@ pub async fn sync_two_peers(
 
     let mut syncer2 = syncer(&sync_mode, &net2, &blockchain2_proxy).await;
 
-    Network::connect_networks(&networks, num_batches_macro_sync as u64 * 10 + 1).await;
+    Network::connect_networks(&networks, net2_address).await;
 
     let macro_sync_result = match syncer2 {
         SyncerProxy::History(ref mut syncer) => {
@@ -326,10 +322,8 @@ pub async fn sync_two_peers_across_protocol_upgrades(sync_mode: SyncMode, num_up
         expected_upgrades.push((upgrade_hash, upgrade_version));
     }
 
-    let memory_address_base = 10_000 + num_upgrades as u64 * 10;
-
-    let net1: Arc<Network> =
-        TestNetwork::build_network(memory_address_base, Default::default(), &mut Some(hub)).await;
+    let (net1, _): (Arc<Network>, u64) =
+        TestNetwork::build_network_with_address(0, Default::default(), &mut Some(hub)).await;
     networks.push(Arc::clone(&net1));
     let blockchain1_proxy = BlockchainProxy::from(&blockchain1);
     let syncer1 = SyncerProxy::new_history(
@@ -367,8 +361,8 @@ pub async fn sync_two_peers_across_protocol_upgrades(sync_mode: SyncMode, num_up
     let mut upgrade_events = events
         .filter(|event| future::ready(matches!(event, BlockchainEvent::ProtocolUpgrade(_, _))));
 
-    let net2: Arc<Network> = TestNetwork::build_network(
-        memory_address_base + 1,
+    let (net2, net2_address): (Arc<Network>, u64) = TestNetwork::build_network_with_address(
+        0,
         Default::default(),
         &mut Some(MockHub::default()),
     )
@@ -377,7 +371,7 @@ pub async fn sync_two_peers_across_protocol_upgrades(sync_mode: SyncMode, num_up
 
     let mut syncer2 = syncer(&sync_mode, &net2, &blockchain2_proxy).await;
 
-    Network::connect_networks(&networks, memory_address_base + 1).await;
+    Network::connect_networks(&networks, net2_address).await;
 
     let macro_sync_result = match syncer2 {
         SyncerProxy::History(ref mut syncer) => syncer.macro_sync.next().await,

--- a/consensus/tests/sync_utils.rs
+++ b/consensus/tests/sync_utils.rs
@@ -326,8 +326,10 @@ pub async fn sync_two_peers_across_protocol_upgrades(sync_mode: SyncMode, num_up
         expected_upgrades.push((upgrade_hash, upgrade_version));
     }
 
+    let memory_address_base = 10_000 + num_upgrades as u64 * 10;
+
     let net1: Arc<Network> =
-        TestNetwork::build_network(40, Default::default(), &mut Some(hub)).await;
+        TestNetwork::build_network(memory_address_base, Default::default(), &mut Some(hub)).await;
     networks.push(Arc::clone(&net1));
     let blockchain1_proxy = BlockchainProxy::from(&blockchain1);
     let syncer1 = SyncerProxy::new_history(
@@ -365,13 +367,17 @@ pub async fn sync_two_peers_across_protocol_upgrades(sync_mode: SyncMode, num_up
     let mut upgrade_events = events
         .filter(|event| future::ready(matches!(event, BlockchainEvent::ProtocolUpgrade(_, _))));
 
-    let net2: Arc<Network> =
-        TestNetwork::build_network(41, Default::default(), &mut Some(MockHub::default())).await;
+    let net2: Arc<Network> = TestNetwork::build_network(
+        memory_address_base + 1,
+        Default::default(),
+        &mut Some(MockHub::default()),
+    )
+    .await;
     networks.push(Arc::clone(&net2));
 
     let mut syncer2 = syncer(&sync_mode, &net2, &blockchain2_proxy).await;
 
-    Network::connect_networks(&networks, 41).await;
+    Network::connect_networks(&networks, memory_address_base + 1).await;
 
     let macro_sync_result = match syncer2 {
         SyncerProxy::History(ref mut syncer) => syncer.macro_sync.next().await,

--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -222,7 +222,10 @@ fn network(network_id: NetworkId) -> Option<&'static NetworkInfo> {
     let result = network_impl(network_id);
     if let Some(info) = result {
         assert_eq!(network_id, info.network_id);
-        assert_eq!(network_id, info.genesis_block().network());
+        // Keep the temporary block alive until the decompressed genesis keys are cached. Dropping
+        // its lazy public keys while another thread initializes `keys` can deadlock the interner.
+        let genesis_block = info.genesis_block();
+        assert_eq!(network_id, genesis_block.network());
         let keys = match network_id {
             NetworkId::DevAlbatross => &KEYS_DEV,
             NetworkId::TestAlbatross => &KEYS_TEST,

--- a/network-libp2p/src/error.rs
+++ b/network-libp2p/src/error.rs
@@ -7,6 +7,12 @@ pub enum NetworkError {
     #[error("Dial error: {0}")]
     Dial(#[from] libp2p::swarm::DialError),
 
+    #[error("Listen error: {0}")]
+    Listen(#[from] libp2p::core::transport::TransportError<std::io::Error>),
+
+    #[error("Listener closed before reporting an address")]
+    ListenerClosed,
+
     #[error("Failed to send action to swarm task")]
     Send,
 

--- a/network-libp2p/src/network.rs
+++ b/network-libp2p/src/network.rs
@@ -186,6 +186,27 @@ impl Network {
         }
     }
 
+    /// Tells the network to listen on one address and waits until the transport reports the
+    /// resolved listen address.
+    ///
+    /// This is useful for addresses such as `/memory/0`, for which the transport allocates an
+    /// available address.
+    pub async fn listen_on_address(
+        &self,
+        listen_address: Multiaddr,
+    ) -> Result<Multiaddr, NetworkError> {
+        let (output_tx, output_rx) = oneshot::channel();
+
+        self.action_tx
+            .clone()
+            .send(NetworkAction::ListenOnAddress {
+                listen_address,
+                output: output_tx,
+            })
+            .await?;
+        output_rx.await?
+    }
+
     /// Tells the network to start connecting to any available peer or seed
     /// until meeting the configured number of desired peer connections.
     /// If there are no dial attempts being made and no connections to any

--- a/network-libp2p/src/network_types.rs
+++ b/network-libp2p/src/network_types.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 #[cfg(feature = "metrics")]
 use instant::Instant;
 use libp2p::{
+    core::transport::ListenerId,
     gossipsub,
     kad::{QueryId, Record},
     request_response::{InboundRequestId, OutboundRequestId, ResponseChannel},
@@ -90,6 +91,10 @@ pub(crate) enum NetworkAction {
     },
     ListenOn {
         listen_addresses: Vec<Multiaddr>,
+    },
+    ListenOnAddress {
+        listen_address: Multiaddr,
+        output: oneshot::Sender<Result<Multiaddr, NetworkError>>,
     },
     ConnectPeersByServices {
         services: Services,
@@ -228,6 +233,9 @@ pub(crate) struct GossipsubTopicInfo {
 
 #[derive(Default)]
 pub(crate) struct TaskState {
+    /// Senders waiting for a listener to report its resolved address.
+    pub(crate) pending_listen_addresses:
+        HashMap<ListenerId, oneshot::Sender<Result<Multiaddr, NetworkError>>>,
     /// Senders for DHT (kad) put operations
     pub(crate) dht_puts: HashMap<QueryId, oneshot::Sender<Result<(), NetworkError>>>,
     /// Senders for DHT (kad) get operations

--- a/network-libp2p/src/swarm.rs
+++ b/network-libp2p/src/swarm.rs
@@ -433,7 +433,7 @@ fn handle_event(event: SwarmEvent<behaviour::BehaviourEvent>, event_info: EventI
         }
 
         SwarmEvent::NewListenAddr {
-            listener_id: _,
+            listener_id,
             address,
         } => {
             debug!(%address, "New listen address");
@@ -443,15 +443,29 @@ fn handle_event(event: SwarmEvent<behaviour::BehaviourEvent>, event_info: EventI
                 .discovery
                 .add_own_addresses([address.clone()].to_vec());
             if event_info.swarm.behaviour().is_address_dialable(&address) {
-                event_info.state.nat_status.add_address(address);
+                event_info.state.nat_status.add_address(address.clone());
+            }
+            if let Some(output) = event_info
+                .state
+                .pending_listen_addresses
+                .remove(&listener_id)
+            {
+                output.send(Ok(address)).ok();
             }
         }
 
         SwarmEvent::ListenerClosed {
-            listener_id: _,
+            listener_id,
             addresses,
             reason: _,
         } => {
+            if let Some(output) = event_info
+                .state
+                .pending_listen_addresses
+                .remove(&listener_id)
+            {
+                output.send(Err(NetworkError::ListenerClosed)).ok();
+            }
             addresses.iter().for_each(|address| {
                 event_info.state.nat_status.remove_address(address);
             });
@@ -1374,6 +1388,17 @@ fn perform_action(action: NetworkAction, swarm: &mut NimiqSwarm, state: &mut Tas
                     .expect("Failed to listen on provided address");
             }
         }
+        NetworkAction::ListenOnAddress {
+            listen_address,
+            output,
+        } => match Swarm::listen_on(swarm, listen_address) {
+            Ok(listener_id) => {
+                state.pending_listen_addresses.insert(listener_id, output);
+            }
+            Err(error) => {
+                output.send(Err(error.into())).ok();
+            }
+        },
         NetworkAction::StartConnecting => {
             swarm.behaviour_mut().pool.start_connecting();
         }

--- a/network-libp2p/tests/network.rs
+++ b/network-libp2p/tests/network.rs
@@ -5,7 +5,7 @@ use instant::SystemTime;
 use libp2p::{
     gossipsub,
     identity::Keypair,
-    multiaddr::{multiaddr, Multiaddr},
+    multiaddr::{multiaddr, Multiaddr, Protocol},
     PeerId,
 };
 use nimiq_keys::{Address, KeyPair};
@@ -401,6 +401,29 @@ async fn create_network_with_n_peers(
     }
 
     (networks, keys)
+}
+
+#[test(tokio::test)]
+async fn listening_on_memory_zero_returns_unique_allocated_addresses() {
+    let requested_address = multiaddr![Memory(0u64)];
+    let net1 = Network::new(network_config(requested_address.clone()), ()).await;
+    let net2 = Network::new(network_config(requested_address.clone()), ()).await;
+
+    let (address1, address2) = futures::try_join!(
+        net1.listen_on_address(requested_address.clone()),
+        net2.listen_on_address(requested_address),
+    )
+    .unwrap();
+
+    assert_ne!(address1, address2);
+    assert!(matches!(
+        address1.iter().next(),
+        Some(Protocol::Memory(address)) if address != 0
+    ));
+    assert!(matches!(
+        address2.iter().next(),
+        Some(Protocol::Memory(address)) if address != 0
+    ));
 }
 
 #[test(tokio::test)]

--- a/test-utils/src/test_network.rs
+++ b/test-utils/src/test_network.rs
@@ -5,8 +5,9 @@ use instant::SystemTime;
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{network::Network as NetworkInterface, peer_info::Services};
 use nimiq_network_libp2p::{
-    discovery::peer_contacts::PeerContact, libp2p::core::multiaddr::multiaddr, Config, Keypair,
-    Network,
+    discovery::peer_contacts::PeerContact,
+    libp2p::core::multiaddr::{multiaddr, Protocol},
+    Config, Keypair, Network,
 };
 use nimiq_network_mock::{MockHub, MockNetwork};
 
@@ -16,27 +17,41 @@ where
     N: NetworkInterface,
 {
     async fn build_network(
-        peer_id: u64,
+        memory_address: u64,
         genesis_hash: Blake2bHash,
         hub: &mut Option<MockHub>,
-    ) -> Arc<Self>;
-    async fn connect_networks(networks: &[Arc<N>], seed_peer_id: u64);
+    ) -> Arc<Self> {
+        Self::build_network_with_address(memory_address, genesis_hash, hub)
+            .await
+            .0
+    }
+
+    async fn build_network_with_address(
+        memory_address: u64,
+        genesis_hash: Blake2bHash,
+        hub: &mut Option<MockHub>,
+    ) -> (Arc<Self>, u64);
+
+    async fn connect_networks(networks: &[Arc<N>], seed_memory_address: u64);
 }
 
 #[async_trait]
 impl TestNetwork for MockNetwork {
-    async fn build_network(
-        peer_id: u64,
+    async fn build_network_with_address(
+        memory_address: u64,
         _genesis_hash: Blake2bHash,
         hub: &mut Option<MockHub>,
-    ) -> Arc<MockNetwork> {
+    ) -> (Arc<MockNetwork>, u64) {
         let hub = hub
             .as_mut()
             .expect("Can't build a Mock Network without a MockHub");
-        Arc::new(hub.new_network_with_address(peer_id))
+        (
+            Arc::new(hub.new_network_with_address(memory_address)),
+            memory_address,
+        )
     }
 
-    async fn connect_networks(networks: &[Arc<MockNetwork>], _seed_peer_id: u64) {
+    async fn connect_networks(networks: &[Arc<MockNetwork>], _seed_memory_address: u64) {
         // Connect validators to each other.
         for (id, network) in networks.iter().enumerate() {
             for other_id in (id + 1)..networks.len() {
@@ -49,15 +64,15 @@ impl TestNetwork for MockNetwork {
 
 #[async_trait]
 impl TestNetwork for Network {
-    async fn build_network(
-        peer_id: u64,
+    async fn build_network_with_address(
+        memory_address: u64,
         genesis_hash: Blake2bHash,
         _hub: &mut Option<MockHub>,
-    ) -> Arc<Network> {
+    ) -> (Arc<Network>, u64) {
         let peer_key = Keypair::generate_ed25519();
-        let peer_address = multiaddr![Memory(peer_id)];
+        let peer_address = multiaddr![Memory(memory_address)];
         let peer_contact = PeerContact::new(
-            vec![peer_address.clone()],
+            Vec::new(),
             peer_key.public(),
             Services::all(),
             SystemTime::now()
@@ -85,12 +100,19 @@ impl TestNetwork for Network {
             1024,
         );
         let network = Arc::new(Network::new(config, ()).await);
-        network.listen_on(vec![peer_address]).await;
-        network
+        let allocated_address = network
+            .listen_on_address(peer_address)
+            .await
+            .expect("Failed to listen on provided address");
+        let allocated_memory_address = match allocated_address.iter().next() {
+            Some(Protocol::Memory(memory_address)) => memory_address,
+            _ => panic!("Expected a memory listen address, got {allocated_address}"),
+        };
+        (network, allocated_memory_address)
     }
 
-    async fn connect_networks(networks: &[Arc<Network>], seed_peer_id: u64) {
-        let seed = multiaddr![Memory(seed_peer_id)];
+    async fn connect_networks(networks: &[Arc<Network>], seed_memory_address: u64) {
+        let seed = multiaddr![Memory(seed_memory_address)];
         // Skip the last network assuming the last one is the seed and doesn't make
         // sense for the seed to connect to itself.
         for network in &networks[0..networks.len() - 1] {


### PR DESCRIPTION
## What's in this pull request?
Some two-peer sync tests used hardcoded libp2p memory addresses. Since the memory transport registry is shared by tests running in the same binary, parallel tests could attempt to listen on the same address. This caused `Swarm::listen_on` to fail and led to subsequent network cancellation or unreachable panics before the sync assertions were reached.

This PR adds an asynchronous `Network::listen_on_address` API that waits for libp2p to report the resolved listen address. Test networks can now listen on `/memory/0`, allowing libp2p to allocate an available address, and return that address to callers for connecting peers.

The full, history, light, and pico sync tests now use these allocated addresses instead of deriving or hardcoding memory addresses. A regression test verifies that concurrent `/memory/0` listeners receive distinct, nonzero addresses.

The PR also fixes a separate deadlock exposed when history-sync tests initialize genesis data in parallel. The temporary genesis block is kept alive until the permanent decompressed BLS keys are cached, preventing its lazy public keys from being dropped while another thread is initializing the same key cache.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
