### PR TITLE
Fix clippy warnings after the release of rust 1.97.0

### DIFF
--- a/blockchain/src/blockchain/history_sync.rs
+++ b/blockchain/src/blockchain/history_sync.rs
@@ -651,8 +651,8 @@ impl Blockchain {
                 *prev_info.head.state_root(),
                 accounts_hash,
                 "Inconsistent state after reverting block {} - {:?}",
-                &current_info.head,
-                &current_info.head,
+                current_info.head,
+                current_info.head,
             );
 
             // Move on to the next block.

--- a/bls/src/types/compressed_public_key.rs
+++ b/bls/src/types/compressed_public_key.rs
@@ -77,13 +77,13 @@ impl AsRef<[u8]> for CompressedPublicKey {
 
 impl fmt::Display for CompressedPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{}", &self.to_hex())
+        write!(f, "{}", self.to_hex())
     }
 }
 
 impl fmt::Debug for CompressedPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "CompressedPublicKey({})", &self.to_hex())
+        write!(f, "CompressedPublicKey({})", self.to_hex())
     }
 }
 

--- a/bls/src/types/signature.rs
+++ b/bls/src/types/signature.rs
@@ -119,7 +119,7 @@ impl fmt::Display for Signature {
 
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "Signature({})", &::hex::encode(self.compress().as_ref()))
+        write!(f, "Signature({})", ::hex::encode(self.compress().as_ref()))
     }
 }
 

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -330,7 +330,7 @@ impl<N: Network> BlockQueue<N> {
         // Enforce a maximum number of announced blocks per peer per block number.
         let peer_id = block_source.peer_id();
         let mut num_buffered_blocks = 0;
-        for (_, (_, block_source)) in map.iter() {
+        for (_, block_source) in map.values() {
             // Don't count blocks that we requested.
             if block_source.is_requested() {
                 continue;

--- a/mnemonic/src/lib.rs
+++ b/mnemonic/src/lib.rs
@@ -417,10 +417,7 @@ impl Mnemonic {
             .iter()
             .map(|word| wordlist.binary_search(&word.to_lowercase().as_ref()).ok())
         {
-            match index {
-                Some(i) => push_usize(&mut bit_vec, i, Self::NUM_BITS_PER_WORD),
-                None => return None,
-            }
+            push_usize(&mut bit_vec, index?, Self::NUM_BITS_PER_WORD)
         }
         Some(bit_vec)
     }


### PR DESCRIPTION
Fix clippy warnings after the stable release of rust 1.97.0.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
