### PR TITLE
light-blockchain: reject election blocks with an undecodable VRF seed in pico sync

### DIFF
--- a/light-blockchain/src/sync.rs
+++ b/light-blockchain/src/sync.rs
@@ -1,4 +1,4 @@
-use nimiq_block::Block;
+use nimiq_block::{Block, BlockError};
 use nimiq_blockchain_interface::{
     AbstractBlockchain, BlockchainEvent, ChainInfo, PushError, PushResult,
 };
@@ -142,6 +142,12 @@ impl LightBlockchain {
         // Perform block intrinsic checks.
         let max_timestamp = this.now().saturating_add(Policy::TIMESTAMP_MAX_DRIFT);
         block.verify(this.network_id, max_timestamp)?;
+
+        // The pico path never checks the VRF seed (it skips `verify_proposer`); an
+        // undecodable seed would otherwise panic in `VrfSeed::entropy` at proposer selection.
+        if block.unwrap_macro_ref().header.seed.try_entropy().is_none() {
+            return Err(PushError::InvalidBlock(BlockError::InvalidSeed));
+        }
 
         // Upgrade the blockchain lock
         let mut this = RwLockUpgradableReadGuard::upgrade(this);


### PR DESCRIPTION
`push_pico_election` adopts a peer-supplied election block after only `block.verify`, which does not validate the VRF seed, and the pico sync path skips `verify_proposer` (the only seed-signature check). An election block whose seed does not decompress to a valid point is therefore stored and later panics in `VrfSeed::entropy` during proposer selection, crashing the client.

Reject such blocks up front. Honest seeds always decompress (`sign_next` stores a compressed point), so valid blocks are never rejected.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
