### PR TITLE
build(deps): Upgrade to ark-* 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -194,8 +194,8 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
@@ -205,29 +205,26 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "arrayvec 0.7.6",
  "digest 0.10.7",
  "educe",
- "itertools 0.13.0",
  "num-bigint 0.4.8",
  "num-traits",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -235,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint 0.4.8",
  "num-traits",
@@ -248,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "ark-mnt4-753"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e33982ce85d021036f94e47847f127697552b0f65431daa5d36acb57be2d5c4"
+checksum = "181ff0fdd66c25f74a9cb810b3fc7240608fec61656df26baf14dcacb9a183dd"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -259,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "ark-mnt6-753"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c59ccd175dae4e117d11bf282263bd1d9d2393ee1e8754b516a3c452a0320cf"
+checksum = "356fe2899fb78ad59ba3d86b5ec664bdcd9ef874e5bc3336d0c40755d9f60db1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -271,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -281,28 +278,28 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "arrayvec 0.7.6",
  "digest 0.10.7",
  "num-bigint 0.4.8",
  "rayon",
+ "serde_with",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -311,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -2229,6 +2226,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.2.0",
 ]
 
@@ -2866,6 +2864,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -23,11 +23,11 @@ rand_core_compat = { version = "0.1", features = ["rand_core_0_6", "rand_core_0_
 serde = { version = "1.0", optional = true }
 thiserror = "2.0"
 
-ark-std = "0.5"
-ark-ff = "0.5"
-ark-ec = "0.5"
-ark-mnt6-753 = "0.5"
-ark-serialize = "0.5"
+ark-std = "0.6"
+ark-ff = "0.6"
+ark-ec = "0.6"
+ark-mnt6-753 = "0.6"
+ark-serialize = "0.6"
 
 nimiq-hash = { workspace = true }
 nimiq-hash_derive = { workspace = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,9 +20,9 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-ark-ec = "0.5"
-ark-mnt6-753 = "0.5"
-ark-serialize = "0.5"
+ark-ec = "0.6"
+ark-mnt6-753 = "0.6"
+ark-serialize = "0.6"
 byteorder = "1.5"
 cfg_eval = "0.1"
 hex = { version = "0.4", optional = true }

--- a/primitives/block/Cargo.toml
+++ b/primitives/block/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "nimiq/core-rs", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-ark-ec = "0.5"
+ark-ec = "0.6"
 bitflags = { version = "2.12", features = ["serde"] }
 byteorder = "1.5"
 hex = "0.4"
@@ -43,6 +43,6 @@ nimiq-utils = { workspace = true, features = ["merkle"] }
 nimiq-vrf = { workspace = true, features = ["serde-derive"] }
 
 [dev-dependencies]
-ark-serialize = "0.5"
+ark-serialize = "0.6"
 nimiq-test-log = { workspace = true }
 nimiq-test-utils = { workspace = true }

--- a/rpc-interface/Cargo.toml
+++ b/rpc-interface/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 workspace = true
 
 [dependencies]
-ark-mnt6-753 = "0.5"
+ark-mnt6-753 = "0.6"
 async-trait = "0.1"
 clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }


### PR DESCRIPTION
Upgrade all ark dependencies to 0.6.0.

This closed #3879 and closes #3880.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
