### PR TITLE
Abort macro block proposal creation on an incomplete accounts state

### DIFF
--- a/blockchain/src/block_production/mod.rs
+++ b/blockchain/src/block_production/mod.rs
@@ -303,6 +303,13 @@ impl BlockProducer {
         // The rng seed. We need this parameterized in order to have determinism when running unit tests.
         rng: &mut R,
     ) -> Result<MacroBlock, BlockProducerError> {
+        // The complete accounts state is needed to produce a macro block proposal. Abort
+        // gracefully otherwise, mirroring `Blockchain::verify_macro_block_proposal` on the
+        // verifying side
+        if !blockchain.accounts_complete() {
+            return Err(BlockProducerError::AccountsIncomplete);
+        }
+
         // The network ID stays unchanged for the whole blockchain.
         let network = blockchain.head().network();
 
@@ -336,7 +343,7 @@ impl BlockProducer {
         // Get the staking contract PRIOR to any state changes.
         let staking_contract = blockchain
             .get_staking_contract_if_complete(None)
-            .expect("Staking Contract must be complete to create a macro body");
+            .ok_or(BlockProducerError::AccountsIncomplete)?;
 
         // Calculate the punished set for the next batch.
         let next_batch_initial_punished_set = staking_contract

--- a/blockchain/tests/block_production.rs
+++ b/blockchain/tests/block_production.rs
@@ -1,7 +1,9 @@
 use std::{convert::TryInto, sync::Arc};
 
 use nimiq_block::{Block, EquivocationProof, ForkProof, MicroHeader, MicroJustification};
-use nimiq_blockchain::{interface::HistoryInterface, BlockProducer, Blockchain, BlockchainConfig};
+use nimiq_blockchain::{
+    interface::HistoryInterface, BlockProducer, BlockProducerError, Blockchain, BlockchainConfig,
+};
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_bls::KeyPair as BlsKeyPair;
 use nimiq_database::{mdbx::MdbxDatabase, traits::WriteTransaction};
@@ -1502,6 +1504,26 @@ fn it_can_revert_basic_and_create_contracts_txns() {
     let result = bc.revert_blocks(1, &mut txn);
 
     assert!(result.is_ok());
+}
+
+#[test]
+fn it_aborts_macro_block_proposal_with_incomplete_accounts() {
+    let temp_producer = TemporaryBlockProducer::new_incomplete();
+    let bc = temp_producer.blockchain.read();
+
+    // Producing a macro block proposal on an incomplete accounts trie must fail
+    // gracefully instead of panicking
+    let result = temp_producer.producer.next_macro_block_proposal(
+        &bc,
+        bc.timestamp() + Policy::BLOCK_SEPARATION_TIME,
+        0u32,
+        vec![],
+        None,
+    );
+    assert!(matches!(
+        result,
+        Err(BlockProducerError::AccountsIncomplete)
+    ));
 }
 
 fn ed25519_key_pair(secret_key: &str) -> SchnorrKeyPair {

--- a/validator/src/tendermint.rs
+++ b/validator/src/tendermint.rs
@@ -238,9 +238,17 @@ where
             && blockchain.state().current_version() + 1 == Policy::max_supported_version()
         {
             let new_version = blockchain.state().current_version() + 1;
-            let staking_contract = blockchain
-                .get_staking_contract_if_complete(None)
-                .expect("Staking Contract must be complete to create a macro proposal");
+            // The complete accounts state is needed to determine the upgrade support, as the
+            // support check below reads the individual validator entries of the staking
+            // contract. Abort instead of panicking, mirroring the stale-blockchain abort above
+            if !blockchain.accounts_complete() {
+                warn!("Cannot create macro proposal, accounts state is incomplete");
+                return Err(ProtocolError::Abort);
+            }
+            let Some(staking_contract) = blockchain.get_staking_contract_if_complete(None) else {
+                // Unreachable: the accounts state was just checked to be complete
+                return Err(ProtocolError::Abort);
+            };
             let data_store = blockchain.get_staking_contract_store();
             let txn = blockchain.read_transaction();
             let data_store_read = &data_store.read(&txn);

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -10,7 +10,7 @@ use nimiq_keys::{Address, KeyPair, SecureGenerate};
 use nimiq_network_libp2p::Network;
 use nimiq_network_mock::MockHub;
 use nimiq_primitives::{coin::Coin, key_nibbles::KeyNibbles, networks::NetworkId, policy::Policy};
-use nimiq_tendermint::{ProposalMessage, Protocol, SignedProposalMessage};
+use nimiq_tendermint::{ProposalMessage, Protocol, ProtocolError, SignedProposalMessage};
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     block_production::TemporaryBlockProducer, test_network::TestNetwork, test_rng,
@@ -411,6 +411,52 @@ async fn it_triggers_version_upgrades() {
         .create_proposal(0)
         .expect("Should have created proposal");
     assert_eq!(proposal.0.proposal.0.version, next_version);
+}
+
+#[test(tokio::test)]
+async fn it_aborts_proposal_creation_with_incomplete_accounts() {
+    // Move to before the next election block, with an upgrade to the next version pending.
+    let initial_version = Policy::max_supported_version() - 1;
+    let temp_producer = TemporaryBlockProducer::new_with_protocol_version(initial_version);
+    for _ in 0..Policy::blocks_per_epoch() - 1 {
+        let block = temp_producer.next_block(vec![], false);
+        temp_producer
+            .push(block)
+            .expect("Should be able to push block");
+    }
+
+    // Initialize a TendermintProtocol.
+    let blockchain = Arc::clone(&temp_producer.blockchain);
+    let current_validators = blockchain.read().current_validators().unwrap().clone();
+    let hub = MockHub::default();
+    let nw: Arc<Network> = TestNetwork::build_network(0, Default::default(), &mut Some(hub)).await;
+    let val_net = Arc::new(ValidatorNetworkImpl::new(nw));
+    let interface = TendermintProtocol::new(
+        Arc::clone(&blockchain),
+        val_net,
+        temp_producer.producer.clone(),
+        current_validators,
+        0,
+        NetworkId::UnitAlbatross,
+        blockchain.read().head().block_number() + 1,
+    );
+
+    // Make the accounts trie incomplete.
+    {
+        let blockchain_rg = blockchain.read();
+        let mut raw_txn = blockchain_rg.write_transaction();
+        blockchain_rg
+            .state()
+            .accounts
+            .reinitialize_as_incomplete(&mut (&mut raw_txn).into());
+        raw_txn.commit();
+    }
+
+    // The version-upgrade support check must abort the proposal instead of panicking.
+    assert!(matches!(
+        interface.create_proposal(0),
+        Err(ProtocolError::Abort)
+    ));
 }
 
 #[test(tokio::test)]


### PR DESCRIPTION
Replace the `.expect` panics in `create_proposal` and `next_macro_block_proposal_with_rng` with graceful failures guarded by `accounts_complete()`, mirroring `verify_macro_block_proposal` on the verifying side. Add regression tests for both paths

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
