### PR TITLE
Sync the mempool's protocol version on `ProtocolUpgrade` events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "nimiq-primitives",
  "nimiq-test-log",
  "nimiq-test-utils",
+ "nimiq-time",
  "nimiq-transaction",
  "nimiq-transaction-builder",
  "nimiq-utils",

--- a/mempool/mempool-task/Cargo.toml
+++ b/mempool/mempool-task/Cargo.toml
@@ -37,6 +37,7 @@ nimiq-utils = { workspace = true, features = ["time"] }
 metrics = ["nimiq-mempool/metrics", "tokio-metrics"]
 
 [dev-dependencies]
+nimiq-time = { workspace = true }
 tokio = { version = "1.52", features = ["macros", "rt", "time"] }
 
 nimiq-database = { workspace = true }

--- a/mempool/mempool-task/src/lib.rs
+++ b/mempool/mempool-task/src/lib.rs
@@ -90,6 +90,10 @@ impl<N: Network> MempoolTask<N> {
             return;
         }
 
+        // A protocol upgrade event might have been dropped by a lagging event stream,
+        // so resynchronize the version used for transaction verification
+        self.mempool.resync_protocol_version();
+
         let mempool = Arc::clone(&self.mempool);
         let network = Arc::clone(&self.consensus.network);
         #[cfg(not(feature = "metrics"))]
@@ -152,23 +156,20 @@ impl<N: Network> MempoolTask<N> {
                         .get_block(hash, true)
                         .expect("Head block not found");
                     let is_election = block.is_election();
-                    let version = block.version();
 
                     self.mempool.update(&[(hash.clone(), block)], [].as_ref());
 
-                    // If we upgraded we must revalidate all transactions.
-                    if is_election && self.mempool.set_protocol_version(version) < version {
-                        debug!(
-                            "Revalidate mempool transactions after protocol upgrade to version {}",
-                            version
-                        );
-                        self.mempool.revalidate_transactions();
-                        debug!(
-                            "Revalidate mempool transactions after protocol upgrade to version {}",
-                            version
-                        );
+                    // Elections also repair a version whose upgrade event was dropped
+                    // by a lagging event stream while the mempool was active
+                    if is_election {
+                        self.mempool.resync_protocol_version();
                     }
                 }
+            }
+            BlockchainEvent::ProtocolUpgrade(..) => {
+                // The upgrade might have been adopted through history or macro sync while
+                // not yet synced, so this is deliberately not gated on being synced
+                self.mempool.resync_protocol_version();
             }
             // Mempool updates are only done once we are synced.
             BlockchainEvent::Rebranched(old_chain, new_chain)

--- a/mempool/mempool-task/tests/protocol_upgrade.rs
+++ b/mempool/mempool-task/tests/protocol_upgrade.rs
@@ -22,9 +22,120 @@ use nimiq_test_utils::{
     test_rng,
     test_transaction::generate_accounts,
 };
+use nimiq_time::timeout;
 use nimiq_transaction::Transaction;
 use nimiq_transaction_builder::TransactionBuilder;
-use tokio::time::timeout;
+
+#[test(tokio::test)]
+async fn mempool_task_syncs_protocol_version_while_unsynced() {
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let mut genesis_builder = GenesisBuilder::default();
+    genesis_builder.with_network(NetworkId::UnitAlbatross);
+    genesis_builder.with_genesis_block_number(Policy::genesis_block_number());
+
+    genesis_builder.with_genesis_validator(
+        validator_address(),
+        signing_key().public,
+        voting_key().public_key,
+        Address::default(),
+        None,
+        None,
+        false,
+    );
+
+    let genesis_info = genesis_builder.generate(env).unwrap();
+    let mut hub = Some(MockHub::default());
+    let mut node = Node::<MockNetwork>::history_with_genesis_info(0, genesis_info, &mut hub).await;
+
+    let blockchain = Arc::clone(&node.blockchain);
+    let consensus = node.consensus.take().unwrap();
+    let producer = BlockProducer::new(signing_key(), voting_key());
+
+    // Advance to the last batch of the epoch and signal the protocol upgrade.
+    produce_macro_blocks_with_txns(
+        &producer,
+        &blockchain,
+        (Policy::batches_per_epoch() - 1) as usize,
+        0,
+        0,
+    );
+    let upgrade_version = signal_next_protocol_version_via_tx(&producer, &blockchain);
+    fill_micro_blocks_with_txns(&producer, &blockchain, 0, 0);
+
+    // The task caches the pre-upgrade version at construction. Consensus is deliberately
+    // not established: the upgrade is observed while the node is still syncing.
+    let mut mempool_task = MempoolTask::new(
+        &consensus,
+        Arc::clone(&blockchain),
+        MempoolConfig::default(),
+    );
+    assert!(mempool_task.mempool.protocol_version() < upgrade_version);
+
+    let upgrade_block = next_election_block_with_version(&producer, &blockchain, upgrade_version);
+    assert_eq!(
+        Blockchain::push(blockchain.upgradable_read(), upgrade_block),
+        Ok(PushResult::Extended)
+    );
+
+    // Process events until the protocol upgrade is seen.
+    loop {
+        let event = timeout(Duration::from_secs(5), mempool_task.next())
+            .await
+            .unwrap()
+            .unwrap();
+        if matches!(
+            BlockchainEvent::from(event),
+            BlockchainEvent::ProtocolUpgrade(..)
+        ) {
+            break;
+        }
+    }
+    assert_eq!(mempool_task.mempool.protocol_version(), upgrade_version);
+}
+
+#[test(tokio::test)]
+async fn mempool_task_resyncs_protocol_version_on_activation() {
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let mut genesis_builder = GenesisBuilder::default();
+    genesis_builder.with_network(NetworkId::UnitAlbatross);
+    genesis_builder.with_genesis_block_number(Policy::genesis_block_number());
+
+    genesis_builder.with_genesis_validator(
+        validator_address(),
+        signing_key().public,
+        voting_key().public_key,
+        Address::default(),
+        None,
+        None,
+        false,
+    );
+
+    let genesis_info = genesis_builder.generate(env).unwrap();
+    let mut hub = Some(MockHub::default());
+    let mut node = Node::<MockNetwork>::history_with_genesis_info(0, genesis_info, &mut hub).await;
+
+    let blockchain = Arc::clone(&node.blockchain);
+    let mut consensus = node.consensus.take().unwrap();
+
+    let mut mempool_task = MempoolTask::new(
+        &consensus,
+        Arc::clone(&blockchain),
+        MempoolConfig::default(),
+    );
+
+    // Simulate a stale cached version, e.g. from upgrade events that were dropped
+    // by a lagging blockchain event stream.
+    let current_version = blockchain.read().protocol_version();
+    mempool_task
+        .mempool
+        .set_protocol_version(current_version - 1);
+
+    // Establishing consensus starts the mempool, which must resync the version.
+    consensus.force_established();
+    let _ = timeout(Duration::from_millis(100), mempool_task.next()).await;
+
+    assert_eq!(mempool_task.mempool.protocol_version(), current_version);
+}
 
 #[test(tokio::test)]
 #[ignore = "Enable once a protocol-gated transaction verification rule exists"]

--- a/mempool/src/mempool.rs
+++ b/mempool/src/mempool.rs
@@ -691,6 +691,20 @@ impl Mempool {
         old_protocol_version
     }
 
+    /// Synchronizes the protocol version used for transaction verification with the
+    /// current blockchain state. If the protocol version increased, all mempool
+    /// contents are revalidated under the new version's rules.
+    pub fn resync_protocol_version(&self) {
+        let protocol_version = self.blockchain.read().protocol_version();
+        if self.set_protocol_version(protocol_version) < protocol_version {
+            debug!(
+                version = protocol_version,
+                "Revalidating mempool transactions after protocol upgrade"
+            );
+            self.revalidate_transactions();
+        }
+    }
+
     /// Checks whether a transaction has been filtered
     pub fn is_filtered(&self, hash: &Blake2bHash) -> bool {
         self.filter.read().blacklisted(hash)


### PR DESCRIPTION
The version was only bumped on live election `Extended` events, so a node crossing an upgrade via history or macro sync kept verifying transactions with the pre-fork version until the next live election. Also resync on mempool activation and at elections as a backstop for dropped events

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
