### PR TITLE
Collapse the signal-data no-signal ambiguity on the v2 signaling paths

### DIFF
--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -374,13 +374,15 @@ impl StakingContract {
 
         // Resolve the update mode into the new signal data value.
         let new_signal_data = match update {
-            // Full mode replaces the entire field (and thus any previously signaled version).
+            // Full mode replaces the entire field (and thus any previously signaled version); it is
+            // the only mode that can clear the field to `None`.
             SignalDataUpdate::Full(signal_data) => signal_data,
-            // Version mode is a non-destructive partial update: it only touches the version bytes
-            // and preserves the rest of the existing signal data.
-            SignalDataUpdate::Version(version) => {
-                Policy::signal_data_with_version(validator.signal_data.clone(), version)
-            }
+            // Version mode is a non-destructive partial update: it only sets the version bytes and
+            // preserves the rest, so it always yields a present value.
+            SignalDataUpdate::Version(version) => Some(Policy::signal_data_with_version(
+                validator.signal_data.clone(),
+                version,
+            )),
         };
 
         // Update the validator's signal data.

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -843,7 +843,7 @@ fn signal_version_partial_update_works() {
     let tx_version = make_signed_incoming_transaction(
         IncomingStakingTransactionData::SetSignalData {
             validator_address: validator_address.clone(),
-            update: SignalDataUpdate::Version(Some(2)),
+            update: SignalDataUpdate::Version(2),
             proof: SignatureProof::default(),
         },
         0,
@@ -884,6 +884,39 @@ fn signal_version_partial_update_works() {
         .get_validator(&data_store.read(&db_txn), &validator_address)
         .expect("Validator should exist");
     assert_eq!(validator.signal_data, Some(full_signal_data));
+
+    // Withdrawing the signal uses `Version(0)` (there is no `Version(None)`): it zeroes the
+    // version bytes but keeps the field present with the rest preserved, so the validator no
+    // longer supports an upgrade.
+    let tx_withdraw = make_signed_incoming_transaction(
+        IncomingStakingTransactionData::SetSignalData {
+            validator_address: validator_address.clone(),
+            update: SignalDataUpdate::Version(0),
+            proof: SignatureProof::default(),
+        },
+        0,
+        &signing_keypair,
+    );
+    validator_setup
+        .staking_contract
+        .commit_incoming_transaction(
+            &tx_withdraw,
+            &block_state,
+            data_store.write(&mut db_txn),
+            &mut TransactionLog::empty(),
+        )
+        .expect("Failed to commit signal withdrawal transaction");
+
+    let validator = validator_setup
+        .staking_contract
+        .get_validator(&data_store.read(&db_txn), &validator_address)
+        .expect("Validator should exist");
+    let signal_data = validator
+        .signal_data
+        .expect("Signal data should still be present");
+    assert_eq!(&signal_data.as_slice()[..2], &[0u8, 0u8]);
+    assert_eq!(signal_data.as_slice()[10], 0xCD);
+    assert!(!Policy::supports_upgrade(Some(signal_data), 2));
 }
 
 #[test]

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -177,18 +177,17 @@ impl Policy {
         Blake2bHash(signal_data)
     }
 
-    /// Applies a protocol-version update to an existing `signal_data` value: the `version` is
-    /// encoded into the first two bytes (big-endian) while the remaining bytes are preserved.
-    /// `version == None` clears the version bytes (sets them to zero). Returns `None` if the
-    /// resulting value is all-zero, so that "no signal" has a single canonical representation.
+    /// Applies a protocol-version update to an existing `signal_data` value: `version` is encoded
+    /// into the first two bytes (big-endian) while the remaining bytes are preserved. This is a
+    /// partial update, so it always yields a present value (clearing the whole field is a separate
+    /// operation). `version == 0` zeroes the version bytes. An all-zero result and a `None` signal
+    /// data are equivalent for upgrade signaling at every real version (>= 2) — both make
+    /// [`Policy::supports_upgrade`] return `false`; they differ only at version 0.
     /// This is the partial-update counterpart to [`Policy::signal_data_for_version`].
-    pub fn signal_data_with_version(
-        current: Option<Blake2bHash>,
-        version: Option<u16>,
-    ) -> Option<Blake2bHash> {
+    pub fn signal_data_with_version(current: Option<Blake2bHash>, version: u16) -> Blake2bHash {
         let mut bytes: [u8; 32] = current.map(Into::into).unwrap_or([0u8; 32]);
-        bytes[..2].copy_from_slice(&version.unwrap_or(0).to_be_bytes());
-        (bytes != [0u8; 32]).then_some(Blake2bHash(bytes))
+        bytes[..2].copy_from_slice(&version.to_be_bytes());
+        Blake2bHash(bytes)
     }
 
     /// This function is used to determine if a validator signalled for a specific upgrade.
@@ -778,38 +777,45 @@ mod tests {
 
         // Setting a version on empty signal data encodes it in the first two bytes and matches
         // the canonical encoding.
-        let v2 = Policy::signal_data_with_version(None, Some(2)).unwrap();
+        let v2 = Policy::signal_data_with_version(None, 2);
         assert_eq!(&v2.as_slice()[..2], &2u16.to_be_bytes());
         assert!(v2.as_slice()[2..].iter().all(|&b| b == 0));
         assert!(Policy::supports_upgrade(Some(v2), 2));
         assert_eq!(
-            Policy::signal_data_with_version(None, Some(2)),
-            Some(Policy::signal_data_for_version(2))
+            Policy::signal_data_with_version(None, 2),
+            Policy::signal_data_for_version(2)
         );
 
         // Updating the version preserves the remaining bytes (non-destructive partial update).
         let mut bytes = [0u8; 32];
         bytes[5] = 0xAB;
-        let updated = Policy::signal_data_with_version(Some(Blake2bHash(bytes)), Some(7)).unwrap();
+        let updated = Policy::signal_data_with_version(Some(Blake2bHash(bytes)), 7);
         assert_eq!(&updated.as_slice()[..2], &7u16.to_be_bytes());
         assert_eq!(updated.as_slice()[5], 0xAB);
         assert!(Policy::supports_upgrade(Some(updated), 7));
 
-        // Clearing the version (None) zeroes only the version bytes, preserving the rest.
+        // Zeroing the version (version 0) zeroes only the version bytes, preserving the rest.
         let mut bytes = [0u8; 32];
         bytes[..2].copy_from_slice(&9u16.to_be_bytes());
         bytes[5] = 0xAB;
-        let cleared = Policy::signal_data_with_version(Some(Blake2bHash(bytes)), None).unwrap();
+        let cleared = Policy::signal_data_with_version(Some(Blake2bHash(bytes)), 0);
         assert_eq!(&cleared.as_slice()[..2], &[0u8, 0u8]);
         assert_eq!(cleared.as_slice()[5], 0xAB);
 
-        // The result canonicalizes to `None` when everything becomes zero.
+        // A version update always yields a present value — it never clears the field to `None`.
+        // An all-zero result is a valid value, equivalent to `None` for upgrade signaling.
         assert_eq!(
-            Policy::signal_data_with_version(Some(Policy::signal_data_for_version(3)), None),
-            None
+            Policy::signal_data_with_version(Some(Policy::signal_data_for_version(3)), 0),
+            Blake2bHash::default()
         );
-        assert_eq!(Policy::signal_data_with_version(None, None), None);
-        assert_eq!(Policy::signal_data_with_version(None, Some(0)), None);
+        assert_eq!(
+            Policy::signal_data_with_version(None, 0),
+            Blake2bHash::default()
+        );
+        assert!(!Policy::supports_upgrade(
+            Some(Policy::signal_data_with_version(None, 0)),
+            2
+        ));
     }
 
     #[test]

--- a/primitives/transaction/src/account/staking_contract/structs.rs
+++ b/primitives/transaction/src/account/staking_contract/structs.rs
@@ -101,13 +101,14 @@ pub enum IncomingStakingTransactionData {
 #[derive(Clone, Debug, Serialize, Deserialize, SerializedMaxSize)]
 #[repr(u8)]
 pub enum SignalDataUpdate {
-    /// Replaces the *entire* `signal_data` field (`None` clears it). This overwrites any
-    /// previously signaled protocol version.
+    /// Replaces the *entire* `signal_data` field. `None` clears it (the only way to reach a `None`
+    /// signal data); `Some(hash)` sets it verbatim. This overwrites any previously signaled version.
     Full(Option<Blake2bHash>),
-    /// Updates *only* the protocol-version bytes (the first two bytes, big-endian), preserving
-    /// the rest of `signal_data`. `None` clears the version bytes (sets them to zero). In
-    /// contrast to [`SignalDataUpdate::Full`], this is a non-destructive partial update.
-    Version(Option<u16>),
+    /// Sets *only* the protocol-version bytes (the first two bytes, big-endian) to `version`,
+    /// preserving the rest of `signal_data`. Unlike [`SignalDataUpdate::Full`], this is a
+    /// non-destructive partial update and always yields a present (`Some`) value — clearing the
+    /// whole field is a `Full` operation. Pass `0` to zero the version bytes.
+    Version(u16),
 }
 
 impl IncomingStakingTransactionData {

--- a/primitives/transaction/tests/staking_contract_verify.rs
+++ b/primitives/transaction/tests/staking_contract_verify.rs
@@ -439,6 +439,23 @@ fn set_signal_data() {
         Ok(())
     );
 
+    // A `Full` update with an all-zero hash is a valid value of the `Option<Blake2bHash>` field
+    // (equivalent to `None` for upgrade signaling), so it is accepted.
+    let tx_zero = make_signed_incoming_tx(
+        IncomingStakingTransactionData::SetSignalData {
+            validator_address: VALIDATOR_ADDRESS.parse().unwrap(),
+            update: SignalDataUpdate::Full(Some(Blake2bHash::default())),
+            proof: SignatureProof::default(),
+        },
+        0,
+        &signing_keypair,
+        None,
+    );
+    assert_eq!(
+        AccountType::verify_incoming_transaction(&tx_zero, upgrades::v2::WARM_KEY_SIGNALING),
+        Ok(())
+    );
+
     // Signaling transaction with a non-zero value is rejected.
     let mut tx_value = tx.clone();
     tx_value.value = Coin::from_u64_unchecked(1);

--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -156,9 +156,9 @@ pub enum ValidatorCommand {
     },
 
     /// Sends a transaction signalling support for a protocol upgrade `version`, signed with the
-    /// validator's signing (warm) key (so the cold key is not required). Omit the version to clear
-    /// the current signal. Only valid once the chain has reached the protocol version that
-    /// introduces this transaction.
+    /// validator's signing (warm) key (so the cold key is not required). This only updates the
+    /// version bytes; to clear the signal data use the `set-signal-data` command. Only valid once
+    /// the chain has reached the protocol version that introduces this transaction.
     /// The sender wallet must be unlocked prior to this command.
     SignalVersion {
         /// The fee will be paid from this address. This wallet must be already unlocked.
@@ -167,9 +167,9 @@ pub enum ValidatorCommand {
         /// The Schnorr signing secret key used by the validator.
         signing_secret_key: String,
 
-        /// The protocol version to signal support for. Omit to clear the signal.
+        /// The protocol version to signal support for.
         #[clap(long)]
-        version: Option<u16>,
+        version: u16,
 
         #[clap(flatten)]
         tx_commons: TxCommon,

--- a/rpc-interface/src/consensus.rs
+++ b/rpc-interface/src/consensus.rs
@@ -532,18 +532,18 @@ pub trait ConsensusInterface {
     ) -> RPCResult<Blake2bHash, (), Self::Error>;
 
     /// Returns a serialized `signal_version` transaction that signals support for the given
-    /// protocol `version` (or clears the signaled version if null), signed with the validator's
-    /// signing (warm) key. You need to provide the address of a basic account (the sender wallet)
-    /// to pay the transaction fee.
+    /// protocol `version`, signed with the validator's signing (warm) key. You need to provide the
+    /// address of a basic account (the sender wallet) to pay the transaction fee.
     /// Note: this only updates the protocol-version bytes of the signal data and preserves the
-    /// rest of the field. To replace the entire signal data, use `create_set_signal_data_transaction`.
+    /// rest of the field; it cannot clear the field. To replace the entire signal data (including
+    /// clearing it), use `create_set_signal_data_transaction`.
     /// This transaction is only valid from protocol version `upgrades::v2::WARM_KEY_SIGNALING` onwards.
     async fn create_signal_version_transaction(
         &self,
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
-        version: Option<u16>,
+        version: u16,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error>;
@@ -555,7 +555,7 @@ pub trait ConsensusInterface {
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
-        version: Option<u16>,
+        version: u16,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error>;

--- a/rpc-server/src/dispatchers/consensus.rs
+++ b/rpc-server/src/dispatchers/consensus.rs
@@ -1133,7 +1133,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
-        version: Option<u16>,
+        version: u16,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<String, (), Self::Error> {
@@ -1159,7 +1159,7 @@ impl ConsensusInterface for ConsensusDispatcher {
         sender_wallet: Address,
         validator_address: Address,
         signing_secret_key: String,
-        version: Option<u16>,
+        version: u16,
         fee: Coin,
         validity_start_height: ValidityStartHeight,
     ) -> RPCResult<Blake2bHash, (), Self::Error> {

--- a/transaction-builder/src/lib.rs
+++ b/transaction-builder/src/lib.rs
@@ -1492,8 +1492,10 @@ impl TransactionBuilder {
         )
     }
 
-    /// Creates a `SetSignalData` transaction that signals support for the given protocol `version`
-    /// (or clears the signal if `None`), signed with the validator's signing (warm) key.
+    /// Creates a `SetSignalData` transaction that signals support for the given protocol `version`,
+    /// signed with the validator's signing (warm) key. This only updates the version bytes and
+    /// preserves the rest; to clear the signal data use [`new_set_signal_data`](Self::new_set_signal_data)
+    /// with `None`.
     ///
     /// In contrast to [`new_set_signal_data`](Self::new_set_signal_data), this only updates the
     /// version bytes of the signal data and preserves the rest of the field.
@@ -1506,7 +1508,7 @@ impl TransactionBuilder {
         key_pair: &KeyPair,
         validator_address: Address,
         signing_key_pair: &KeyPair,
-        version: Option<u16>,
+        version: u16,
         fee: Coin,
         validity_start_height: u32,
         network_id: NetworkId,

--- a/transaction-builder/src/recipient/staking_contract.rs
+++ b/transaction-builder/src/recipient/staking_contract.rs
@@ -136,17 +136,14 @@ impl StakingRecipientBuilder {
         self
     }
 
-    /// This method signals support for the given protocol `version` (or clears the signal if
-    /// `None`). Like [`set_signal_data`](Self::set_signal_data), it needs to be signed by the
-    /// validator's signing (warm) key.
+    /// This method signals support for the given protocol `version`. Like
+    /// [`set_signal_data`](Self::set_signal_data), it needs to be signed by the validator's signing
+    /// (warm) key.
     ///
     /// In contrast to [`set_signal_data`](Self::set_signal_data), this only updates the version
-    /// bytes of the signal data and preserves the rest.
-    pub fn signal_version(
-        &mut self,
-        validator_address: Address,
-        version: Option<u16>,
-    ) -> &mut Self {
+    /// bytes of the signal data and preserves the rest; it cannot clear the field (use
+    /// [`set_signal_data`](Self::set_signal_data) with `None` for that).
+    pub fn signal_version(&mut self, validator_address: Address, version: u16) -> &mut Self {
         self.data = Some(IncomingStakingTransactionData::SetSignalData {
             validator_address,
             update: SignalDataUpdate::Version(version),

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -296,7 +296,7 @@ fn create_validator(temp_producer: &TemporaryBlockProducer) -> Address {
 fn signal_support(
     temp_producer: &TemporaryBlockProducer,
     validator_address: &Address,
-    version: Option<u16>,
+    version: u16,
 ) {
     let blockchain = Arc::clone(&temp_producer.blockchain);
 
@@ -403,14 +403,14 @@ async fn it_triggers_version_upgrades() {
 
     // Case 2: The elected slots support the upgrade (validator1 holds them all), but only half of
     // the active stake does, so the stake threshold is not reached.
-    signal_support(&temp_producer, &validator1, Some(next_version));
+    signal_support(&temp_producer, &validator1, next_version);
     let proposal = interface
         .create_proposal(0)
         .expect("Should have created proposal");
     assert_eq!(proposal.0.proposal.0.version, initial_version);
 
     // Case 3: Both the elected slots and the active stake support the upgrade.
-    signal_support(&temp_producer, &validator2, Some(next_version));
+    signal_support(&temp_producer, &validator2, next_version);
 
     let proposal = interface
         .create_proposal(0)
@@ -518,8 +518,8 @@ async fn it_does_not_trigger_version_upgrades_on_checkpoint_blocks() {
 
     // Setup second validator with same stake and signal full support from both
     let validator2 = create_validator(&temp_producer);
-    signal_support(&temp_producer, &validator1, Some(next_version));
-    signal_support(&temp_producer, &validator2, Some(next_version));
+    signal_support(&temp_producer, &validator1, next_version);
+    signal_support(&temp_producer, &validator2, next_version);
 
     // Even with both thresholds reached, a checkpoint block must keep the current version,
     // since the network only accepts version increases on election blocks
@@ -555,7 +555,7 @@ async fn it_rejects_unsupported_version_upgrade_blocks() {
     // support. This yields full slot support but only half of the active stake, below the
     // `UPGRADE_MIN_SUPPORT` threshold, so the upgrade is not supported.
     let _validator2 = create_validator(&temp_producer);
-    signal_support(&temp_producer, &validator1, Some(next_version));
+    signal_support(&temp_producer, &validator1, next_version);
 
     // Forcefully craft an election block that bumps the version despite the missing support.
     let proposal = {

--- a/web-client/src/common/staking_contract.rs
+++ b/web-client/src/common/staking_contract.rs
@@ -141,7 +141,7 @@ impl StakingContract {
                         None,
                     ),
                     SignalDataUpdate::Version(version) => {
-                        (PlainSignalDataUpdateMode::Version, None, version)
+                        (PlainSignalDataUpdateMode::Version, None, Some(version))
                     }
                 };
                 PlainTransactionRecipientData::SetSignalData(PlainSetSignalDataData {

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -804,8 +804,7 @@ pub struct PlainSetSignalDataData {
     /// For `full` mode: the new signal data as a hex string, or `null` to clear it. Always `null`
     /// in `version` mode.
     pub new_signal_data: Option<String>,
-    /// For `version` mode: the signaled protocol version, or `null` to clear it. Always `null` in
-    /// `full` mode.
+    /// For `version` mode: the signaled protocol version; `null` in `full` mode.
     pub version: Option<u16>,
 }
 

--- a/web-client/src/primitives/transaction_builder.rs
+++ b/web-client/src/primitives/transaction_builder.rs
@@ -458,7 +458,7 @@ impl TransactionBuilder {
     /// Signals support for the given protocol `version` with the validator's *signing (warm) key*
     /// by updating the validator's signal data in the staking contract. In contrast to
     /// `newSetSignalData`, this only updates the protocol-version bytes of the signal data and
-    /// preserves the rest. Pass `undefined` as `version` to clear the signaled version.
+    /// preserves the rest. To clear the signal data entirely, use `newSetSignalData` with `null`.
     ///
     /// The returned transaction is not yet signed. You can sign it e.g. with `tx.sign(keyPair)`.
     ///
@@ -467,7 +467,7 @@ impl TransactionBuilder {
     pub fn new_signal_version(
         sender: &Address,
         validator: &Address,
-        version: Option<u16>,
+        version: u16,
         fee: Option<u64>,
         validity_start_height: u32,
         network_id: u8,


### PR DESCRIPTION
`signal_data` on a validator is `Option<Blake2bHash>`, so "no signal" had two encodings: `None` and `Some([0;32])`. The two are equivalent for upgrade signaling — `Policy::supports_upgrade` returns `false` for both at every real version (≥ 2) — but the code was internally inconsistent: `SignalDataUpdate::Version` collapsed an all-zero result to `None` while `Full` stored it verbatim.

Rather than enforce a single on-chain representation (which isn't consensus-relevant, and can't be done globally since the live v1 `CreateValidator`/`UpdateValidator` wire formats can't change), this removes the *type-level* ambiguity on the v2-gated `SetSignalData` paths only:

- `SignalDataUpdate::Version(Option<u16>)` → `Version(u16)`. A version update only touches the version bytes and always yields a present value, so `Version(None)` is now unrepresentable and `Full(None)` is the single way to clear the field.
- `Policy::signal_data_with_version` drops its `Option<u16>` parameter and the all-zero → `None` canonicalization; it always returns the raw bytes.
- The all-zero rejection introduced earlier is removed — `Full(Some([0;32]))` is a valid value of the field, equivalent to `None`.
- `version: u16` is threaded through the transaction builder, RPC (interface/server/CLI) and web-client; clearing now routes through `set_signal_data(None)`.

`SetSignalData` is gated on `upgrades::v2::WARM_KEY_SIGNALING` and is not yet deployed, so changing its serialization is safe. The v1 `CreateValidator`/`UpdateValidator` transactions and the `Validator` state struct are deliberately untouched — they can still hold `Some([0;32])`, which is harmless since consensus treats it identically to `None`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
