### PR TITLE
Remove dead `tree_from_chunks`

### DIFF
--- a/blockchain/src/history/history_store.rs
+++ b/blockchain/src/history/history_store.rs
@@ -13,12 +13,7 @@ use nimiq_genesis::NetworkId;
 use nimiq_hash::{Blake2bHash, Hash};
 use nimiq_mmr::{
     error::Error as MMRError,
-    mmr::{
-        partial::PartialMerkleMountainRange,
-        position::leaf_number_to_index,
-        proof::{RangeProof, SizeProof},
-        MerkleMountainRange,
-    },
+    mmr::{position::leaf_number_to_index, proof::SizeProof, MerkleMountainRange},
     store::memory::MemoryStore,
 };
 use nimiq_primitives::policy::Policy;
@@ -733,59 +728,6 @@ impl HistoryInterface for HistoryStore {
             proof,
             history: hist_txs,
         })
-    }
-
-    /// Creates a new history tree from chunks and returns the root hash.
-    fn tree_from_chunks(
-        &self,
-        epoch_number: u32,
-        chunks: Vec<(Vec<HistoricTransaction>, RangeProof<Blake2bHash>)>,
-        txn: &mut MdbxWriteTransaction,
-    ) -> Result<Blake2bHash, MMRError> {
-        // Get partial history tree for given epoch.
-        let mut tree = PartialMerkleMountainRange::new(MMRStore::with_write_transaction(
-            &self.hist_tree_table,
-            txn,
-            epoch_number,
-        ));
-
-        // Push all proofs into the history tree and remember all leaves.
-        let mut all_leaves = Vec::with_capacity(
-            chunks.len() * chunks.first().map(|(leaves, _)| leaves.len()).unwrap_or(0),
-        );
-        for (mut leaves, proof) in chunks {
-            tree.push_proof(proof, &leaves)?;
-            all_leaves.append(&mut leaves);
-        }
-
-        // Calculate the root once the tree is complete.
-        if !tree.is_finished() {
-            return Err(MMRError::IncompleteProof);
-        }
-
-        let root = tree.get_root()?;
-
-        let mut cursor = WriteTransaction::dup_cursor(txn, &self.hist_tx_table);
-        // Then add all transactions to the database as the tree is finished.
-        for (leaf_index, hist_tx) in all_leaves.iter().enumerate() {
-            let value = IndexedTransaction {
-                index: leaf_index as u32,
-                value: hist_tx.clone(),
-            };
-            cursor.append(&epoch_number, &value);
-
-            if let Some(ref validity_store) = self.validity_store {
-                validity_store.add_transaction(txn, hist_tx.block_number, hist_tx.tx_hash());
-            }
-
-            txn.put(
-                &self.last_leaf_table,
-                &hist_tx.block_number,
-                &(leaf_index as u32),
-            );
-        }
-
-        Ok(root)
     }
 
     /// Returns the block number of the last leaf in the history store

--- a/blockchain/src/history/history_store_index.rs
+++ b/blockchain/src/history/history_store_index.rs
@@ -11,10 +11,7 @@ use nimiq_database::{
 use nimiq_genesis::NetworkId;
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_mmr::{
-    error::Error as MMRError,
-    mmr::proof::{RangeProof, SizeProof},
-};
+use nimiq_mmr::{error::Error as MMRError, mmr::proof::SizeProof};
 use nimiq_primitives::policy::Policy;
 use nimiq_transaction::{
     historic_transaction::{HistoricTransaction, HistoricTransactionData, RawTransactionHash},
@@ -451,16 +448,6 @@ impl HistoryInterface for HistoryStoreIndex {
             chunk_index,
             txn_option,
         )
-    }
-
-    fn tree_from_chunks(
-        &self,
-        epoch_number: u32,
-        chunks: Vec<(Vec<HistoricTransaction>, RangeProof<Blake2bHash>)>,
-        txn: &mut MdbxWriteTransaction,
-    ) -> Result<Blake2bHash, MMRError> {
-        self.history_store
-            .tree_from_chunks(epoch_number, chunks, txn)
     }
 
     fn get_last_leaf_block_number(&self, txn_option: Option<&MdbxReadTransaction>) -> Option<u32> {

--- a/blockchain/src/history/history_store_proxy.rs
+++ b/blockchain/src/history/history_store_proxy.rs
@@ -2,10 +2,7 @@ use nimiq_block::{Block, MicroBlock};
 use nimiq_database::mdbx::{MdbxDatabase, MdbxReadTransaction, MdbxWriteTransaction};
 use nimiq_genesis::NetworkId;
 use nimiq_hash::Blake2bHash;
-use nimiq_mmr::{
-    error::Error as MMRError,
-    mmr::proof::{RangeProof, SizeProof},
-};
+use nimiq_mmr::{error::Error as MMRError, mmr::proof::SizeProof};
 use nimiq_transaction::{
     historic_transaction::{HistoricTransaction, RawTransactionHash},
     inherent::Inherent,
@@ -362,23 +359,6 @@ impl<S: HistoryInterface, I: HistoryIndexInterface> HistoryInterface for History
                 chunk_index,
                 txn_option,
             ),
-        }
-    }
-
-    /// Creates a new history tree from chunks and returns the root hash.
-    fn tree_from_chunks(
-        &self,
-        epoch_number: u32,
-        chunks: Vec<(Vec<HistoricTransaction>, RangeProof<Blake2bHash>)>,
-        txn: &mut MdbxWriteTransaction,
-    ) -> Result<Blake2bHash, MMRError> {
-        match self {
-            HistoryStoreProxy::WithIndex(index) => {
-                index.tree_from_chunks(epoch_number, chunks, txn)
-            }
-            HistoryStoreProxy::WithoutIndex(store) => {
-                store.tree_from_chunks(epoch_number, chunks, txn)
-            }
         }
     }
 

--- a/blockchain/src/history/interface.rs
+++ b/blockchain/src/history/interface.rs
@@ -4,10 +4,7 @@ use nimiq_block::{Block, MicroBlock};
 use nimiq_database::mdbx::{MdbxReadTransaction, MdbxWriteTransaction};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_mmr::{
-    error::Error as MMRError,
-    mmr::proof::{RangeProof, SizeProof},
-};
+use nimiq_mmr::{error::Error as MMRError, mmr::proof::SizeProof};
 use nimiq_transaction::{
     historic_transaction::{HistoricTransaction, RawTransactionHash},
     history_proof::HistoryTreeProof,
@@ -158,14 +155,6 @@ pub trait HistoryInterface: Debug {
         chunk_index: usize,
         txn_option: Option<&MdbxReadTransaction>,
     ) -> Option<HistoryTreeChunk>;
-
-    /// Creates a new history tree from chunks and returns the root hash.
-    fn tree_from_chunks(
-        &self,
-        epoch_number: u32,
-        chunks: Vec<(Vec<HistoricTransaction>, RangeProof<Blake2bHash>)>,
-        txn: &mut MdbxWriteTransaction,
-    ) -> Result<Blake2bHash, MMRError>;
 
     /// Returns the block number of the last leaf in the history store
     fn get_last_leaf_block_number(&self, txn_option: Option<&MdbxReadTransaction>) -> Option<u32>;

--- a/blockchain/src/history/merged_history_store.rs
+++ b/blockchain/src/history/merged_history_store.rs
@@ -4,10 +4,7 @@ use nimiq_block::{Block, MicroBlock};
 use nimiq_database::mdbx::{MdbxReadTransaction, MdbxWriteTransaction};
 use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
-use nimiq_mmr::{
-    error::Error,
-    mmr::proof::{RangeProof, SizeProof},
-};
+use nimiq_mmr::{error::Error, mmr::proof::SizeProof};
 use nimiq_primitives::policy::Policy;
 use nimiq_transaction::{
     historic_transaction::{HistoricTransaction, RawTransactionHash},
@@ -288,16 +285,6 @@ impl<S: HistoryInterface> HistoryInterface for HistoryStoreMerger<S> {
                 txn_option,
             )
         }
-    }
-
-    fn tree_from_chunks(
-        &self,
-        epoch_number: u32,
-        chunks: Vec<(Vec<HistoricTransaction>, RangeProof<Blake2bHash>)>,
-        txn: &mut MdbxWriteTransaction,
-    ) -> Result<Blake2bHash, Error> {
-        assert_ne!(epoch_number, 0, "Epoch 0 is pre-genesis");
-        self.main.tree_from_chunks(epoch_number, chunks, txn)
     }
 
     fn get_last_leaf_block_number(&self, txn_option: Option<&MdbxReadTransaction>) -> Option<u32> {


### PR DESCRIPTION
`HistoryInterface::tree_from_chunks` builds a history tree from range-proof chunks, but it has no production caller — and never had one (it has never been referenced anywhere in `consensus/` in the git history). History sync adopts epochs incrementally via `add_to_history` (`blockchain/src/blockchain/history_sync.rs`), not `tree_from_chunks`. Its prover counterpart `prove_chunk` *is* live (the `RequestHistoryChunk` handler), which is likely why the unused adopter method went unnoticed. It's a blockchain-internal trait method with no web-client/RPC/wasm exposure.

This removes it: the `HistoryInterface` trait method and all four implementations (`HistoryStore` — the real logic, and the `HistoryStoreIndex` / `HistoryStoreProxy` / `HistoryStoreMerger` delegations), plus the now-unused `RangeProof` / `PartialMerkleMountainRange` imports. Pure deletion, no behaviour change; the live history-chunk-serving path (`prove_chunk`) is untouched.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
