### PR TITLE
Reset the proposal timeout on Tendermint skip-ahead

### DIFF
--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -490,6 +490,8 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                             // Skip to that round
                             self.state.current_round = round;
                             self.state.current_step = Step::Propose;
+                            // Drop the abandoned round's timeout so the skipped-to round arms a fresh one.
+                            self.timeout = None;
                             self.future_contributions
                                 .retain(|&round, _contributors| round > self.state.current_round);
                             self.future_round_messages

--- a/tendermint/tests/detailed.rs
+++ b/tendermint/tests/detailed.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use futures::stream::{self, StreamExt};
 use nimiq_collections::BitSet;
@@ -971,6 +971,51 @@ async fn it_skips_ahead() {
     let update = await_state(&mut tendermint).await;
     expect_nothing_observed(&mut observe_receiver);
     assert_eq!(update.current_round, 2);
+}
+
+// A skip ahead must start a fresh proposal timeout for the round it jumps to,
+// not reuse the (elapsed) timeout of the round it left.
+#[test(tokio::test)]
+async fn skip_ahead_restarts_proposal_timeout() {
+    let (proposer, mut observe_receiver) = create_validator(vec![false, false, false], vec![]);
+    let (sender, receiver) = mpsc::channel(10);
+
+    let mut tendermint = Tendermint::new(
+        proposer.clone(),
+        None,
+        stream::iter(vec![]).boxed(),
+        ReceiverStream::new(receiver).boxed(),
+    );
+
+    // First poll arms the round 0 proposal timeout and then waits.
+    assert_poll_pending(&mut tendermint);
+
+    // Let the round 0 timeout elapse.
+    nimiq_time::sleep(Duration::from_millis(150)).await;
+
+    // f+1 votes for round 2 trigger a skip ahead.
+    let mut bs = BitSet::default();
+    for index in 0..Validator::F_PLUS_ONE {
+        bs.insert(index);
+    }
+    let mut contributions = BTreeMap::default();
+    contributions.insert(None, bs);
+    sender
+        .try_send(TaggedAggregationMessage {
+            tag: (2, Step::Prevote),
+            aggregation: Agg { contributions },
+        })
+        .expect("try_send must not fail");
+
+    // Skip ahead to round 2.
+    let update = expect_state(&mut tendermint);
+    assert_eq!(update.current_round, 2);
+
+    // The node must still await the round 2 proposal on a fresh timeout, not have
+    // prematurely voted nil by reusing the elapsed round 0 one.
+    assert_eq!(update.current_step, Step::Propose);
+    assert!(!update.votes.contains_key(&(2, Step::Prevote)));
+    expect_nothing_observed(&mut observe_receiver);
 }
 
 // // We don't have enough prevotes for the first proposal we create.


### PR DESCRIPTION
When a skip-ahead to a future round is triggered in dispatch_messages, the round was advanced without clearing self.timeout. Since start_timeout() is a no-op while a timer is already set and the timeout duration scales with the round, the skipped-to round reused the abandoned round's timer — which is shorter and usually already elapsed — causing the node to prematurely vote nil instead of awaiting the proposal. Skip-ahead was the only round transition that didn't clear the timer.

Fix: clear self.timeout at the skip-ahead so the new round arms a fresh timeout.

Adds a regression test (skip_ahead_restarts_proposal_timeout) that arms round 0's timeout, lets it elapse, then skips to round 2 and asserts the node still awaits the proposal on a fresh timeout rather than voting nil.