### PR TITLE
Rename `num_buffered_blocks` to `num_buffered_heights`

### DIFF
--- a/consensus/src/sync/live/block_queue/live_sync.rs
+++ b/consensus/src/sync/live/block_queue/live_sync.rs
@@ -120,7 +120,7 @@ impl<N: Network> LiveSyncQueue<N> for BlockQueue<N> {
                 self.on_block_processed(&hash);
                 if result == PushResult::Extended || result == PushResult::Rebranched {
                     return Some(LiveSyncEvent::PushEvent(
-                        LiveSyncPushEvent::AcceptedBufferedBlock(hash, self.num_buffered_blocks()),
+                        LiveSyncPushEvent::AcceptedBufferedBlock(hash, self.num_buffered_heights()),
                     ));
                 }
             }

--- a/consensus/src/sync/live/block_queue/proxy.rs
+++ b/consensus/src/sync/live/block_queue/proxy.rs
@@ -101,9 +101,9 @@ impl<N: Network> BlockQueueProxy<N> {
         self.queue.lock().buffered_blocks()
     }
 
-    /// Returns the total number of buffered blocks.
-    pub fn num_buffered_blocks(&self) -> usize {
-        self.queue.lock().num_buffered_blocks()
+    /// Returns the number of buffered block heights.
+    pub fn num_buffered_heights(&self) -> usize {
+        self.queue.lock().num_buffered_heights()
     }
 
     /// Returns the peer list used by the queue

--- a/consensus/src/sync/live/block_queue/queue.rs
+++ b/consensus/src/sync/live/block_queue/queue.rs
@@ -780,8 +780,10 @@ impl<N: Network> BlockQueue<N> {
             .collect()
     }
 
-    /// Returns the number of buffered blocks.
-    pub(crate) fn num_buffered_blocks(&self) -> usize {
+    /// Returns the number of block heights with buffered blocks. Each height contributes at most
+    /// one block to the chain, so this is the number of blocks still missing to reach the tip of
+    /// the buffer.
+    pub(crate) fn num_buffered_heights(&self) -> usize {
         self.buffer.len()
     }
 

--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -210,8 +210,8 @@ impl<N: Network> DiffQueue<N> {
         self.block_queue.add_block_stream(block_stream)
     }
 
-    pub(crate) fn num_buffered_blocks(&self) -> usize {
-        self.block_queue.num_buffered_blocks()
+    pub(crate) fn num_buffered_heights(&self) -> usize {
+        self.block_queue.num_buffered_heights()
     }
 
     /// Sets whether diffs should be fetched for incoming blocks.

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -496,8 +496,8 @@ impl<N: Network> StateQueue<N> {
         self.buffer_size
     }
 
-    pub fn num_buffered_blocks(&self) -> usize {
-        self.diff_queue.num_buffered_blocks()
+    pub fn num_buffered_heights(&self) -> usize {
+        self.diff_queue.num_buffered_heights()
     }
 
     pub fn chunk_request_state(&self) -> &ChunkRequestState {

--- a/consensus/tests/history.rs
+++ b/consensus/tests/history.rs
@@ -142,7 +142,7 @@ async fn send_single_micro_block_to_block_queue() {
         blockchain2.read().block_number(),
         1 + Policy::genesis_block_number()
     );
-    assert_eq!(syncer.live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(syncer.live_sync.queue().num_buffered_heights(), 0);
 }
 
 #[test(tokio::test)]
@@ -233,7 +233,7 @@ async fn send_two_micro_blocks_out_of_order() {
         blockchain1.read().block_number(),
         2 + Policy::genesis_block_number()
     );
-    assert_eq!(syncer.live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(syncer.live_sync.queue().num_buffered_heights(), 0);
     assert_eq!(
         blockchain1
             .read()
@@ -320,7 +320,7 @@ async fn send_micro_blocks_out_of_order() {
 
     // Obtain the buffered blocks
     assert_eq!(
-        syncer.live_sync.queue().num_buffered_blocks() as u64,
+        syncer.live_sync.queue().num_buffered_heights() as u64,
         n_blocks - 1
     );
 
@@ -343,7 +343,7 @@ async fn send_micro_blocks_out_of_order() {
     }
 
     // No blocks buffered
-    assert_eq!(syncer.live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(syncer.live_sync.queue().num_buffered_heights(), 0);
 }
 
 #[test(tokio::test)]
@@ -439,7 +439,7 @@ async fn send_invalid_block() {
         blockchain1.read().block_number(),
         1 + Policy::genesis_block_number()
     );
-    assert_eq!(syncer.live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(syncer.live_sync.queue().num_buffered_heights(), 0);
     assert_eq!(
         blockchain1
             .read()
@@ -529,7 +529,7 @@ async fn send_block_with_gap_and_respond_to_missing_request() {
 
     // Now both blocks should've been pushed to the blockchain
     assert_eq!(blockchain1.read().block_number(), 2 + genesis_block_number);
-    assert_eq!(syncer.live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(syncer.live_sync.queue().num_buffered_heights(), 0);
     assert_eq!(
         blockchain1
             .read()
@@ -666,7 +666,7 @@ async fn request_missing_blocks_across_macro_block() {
 
     // Now all blocks should've been pushed to the blockchain.
     assert_eq!(blockchain1.read().block_number(), block2.block_number());
-    assert_eq!(syncer.live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(syncer.live_sync.queue().num_buffered_heights(), 0);
     assert_eq!(
         blockchain1
             .read()

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -331,7 +331,7 @@ async fn can_sync_state() {
     yield_now().await;
 
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     let size = mock_node.blockchain.read().state.accounts.size();
     let num_chunks = size.div_ceil(Policy::state_chunks_max_size() as u64);
@@ -352,7 +352,7 @@ async fn can_sync_state() {
         yield_now().await;
 
         assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-        assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+        assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
         let blockchain_rg = incomplete_blockchain.read();
         log::info!(
@@ -390,7 +390,7 @@ async fn can_sync_state() {
     yield_now().await;
 
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     // Will apply the buffered block.
     assert!(
@@ -405,7 +405,7 @@ async fn can_sync_state() {
     yield_now().await;
 
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     push_micro_block(&producer, &mock_node.blockchain);
     gossip_head_block(&block_tx, mock_id.clone(), &mock_node.blockchain).await;
@@ -423,7 +423,7 @@ async fn can_sync_state() {
     yield_now().await;
 
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     let blockchain_rg = incomplete_blockchain.read();
     assert!(blockchain_rg.accounts_complete());
@@ -487,7 +487,7 @@ async fn revert_chunks_for_state_live_sync() {
         "Should immediately receive block"
     );
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     info!("Applying chunk #{}", 0);
     assert!(
@@ -503,7 +503,7 @@ async fn revert_chunks_for_state_live_sync() {
         "Should receive and accept chunks"
     );
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     let blockchain_rg = incomplete_blockchain.read();
     log::info!(
@@ -547,7 +547,7 @@ async fn revert_chunks_for_state_live_sync() {
         "Should immediately receive block"
     );
     assert_eq!(live_sync.queue().num_buffered_chunks(), 1);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     info!("Applying chunk #{}", 2);
     assert!(
@@ -563,7 +563,7 @@ async fn revert_chunks_for_state_live_sync() {
         "Should receive and accept chunks"
     );
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     info!("Applying chunk #{}", 3);
     assert!(
@@ -811,7 +811,7 @@ async fn can_remove_chunks_related_to_invalid_blocks() {
 
     // Check buffer cleared.
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 }
 
 // Buffer clearing after macro blocks
@@ -899,7 +899,7 @@ async fn clears_buffer_after_macro_block() {
 
     // Check buffer.
     assert_eq!(live_sync.queue().num_buffered_chunks(), 1);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     produce_macro_blocks(&producer, &mock_node.blockchain, 1);
     gossip_head_block(&block_tx, mock_id.clone(), &mock_node.blockchain).await;
@@ -923,7 +923,7 @@ async fn clears_buffer_after_macro_block() {
 
     // Check buffer.
     assert_eq!(live_sync.queue().num_buffered_chunks(), 1);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 
     assert!(
         matches!(
@@ -957,7 +957,7 @@ async fn clears_buffer_after_macro_block() {
 
     // Check buffer.
     assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
-    assert_eq!(live_sync.queue().num_buffered_blocks(), 0);
+    assert_eq!(live_sync.queue().num_buffered_heights(), 0);
 }
 
 // Check correct reply for incomplete nodes


### PR DESCRIPTION
`BlockQueue`'s buffer is keyed by block height (`BTreeMap<u32, HashMap<Blake2bHash, _>>`), so `self.buffer.len()` returns the number of buffered *heights*, not blocks — yet the method was named `num_buffered_blocks` and documented as returning a block count.

Since each height contributes at most one block to the canonical chain, the height count is exactly what the sole consumer wants: the catch-up log (`"… {} blocks remaining"`), which reports how many blocks are still missing to reach the tip of the buffer. So rather than change the value, this renames the method to `num_buffered_heights` and documents it. No behavior change; the rename is threaded through the delegating layers (`BlockQueueProxy`, `DiffQueue`, `StateQueue`) and the `AcceptedBufferedBlock` event's producer.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
