### PR TITLE
fix(web-client): prevent WASM panics on malformed input

### DIFF
--- a/web-client/src/common/address.rs
+++ b/web-client/src/common/address.rs
@@ -31,9 +31,17 @@ impl Address {
 
     #[wasm_bindgen(constructor)]
     pub fn new(bytes: &[u8]) -> Result<Address, JsError> {
-        Ok(Address::from(nimiq_keys::Address::from(
-            &bytes[0..nimiq_keys::Address::len()],
-        )))
+        // Require exactly the address length. Converting the slice into a fixed-size
+        // array rejects both short input and any trailing bytes, so nothing is
+        // silently dropped (and the fixed array can't panic on construction).
+        let bytes: [u8; nimiq_keys::Address::SIZE] = bytes.try_into().map_err(|_| {
+            JsError::new(&format!(
+                "Address requires exactly {} bytes, got {}",
+                nimiq_keys::Address::SIZE,
+                bytes.len()
+            ))
+        })?;
+        Ok(Address::from(nimiq_keys::Address::from(bytes)))
     }
 
     /// Deserializes an address from a byte array.

--- a/web-client/src/common/transaction.rs
+++ b/web-client/src/common/transaction.rs
@@ -485,24 +485,33 @@ impl Transaction {
                     raw: hex::encode(self.sender_data()),
                 };
 
+                // `Transaction::new` does not validate contract data, so unparseable
+                // bytes fall back to the raw representation rather than panicking.
                 if self.inner.sender_type == AccountType::Staking {
-                    let data = OutgoingStakingTransactionData::parse(&self.inner).unwrap();
-                    match data {
-                        OutgoingStakingTransactionData::DeleteValidator => {
+                    match OutgoingStakingTransactionData::parse(&self.inner) {
+                        Ok(OutgoingStakingTransactionData::DeleteValidator) => {
                             PlainTransactionSenderData::DeleteValidator(raw_data)
                         }
-                        OutgoingStakingTransactionData::RemoveStake => {
+                        Ok(OutgoingStakingTransactionData::RemoveStake) => {
                             PlainTransactionSenderData::RemoveStake(raw_data)
                         }
+                        Err(_) => PlainTransactionSenderData::Raw(raw_data),
                     }
                 } else {
-                    PlainTransactionSenderData::Raw(PlainRawData { raw: raw_data.raw })
+                    PlainTransactionSenderData::Raw(raw_data)
                 }
             },
             data: {
+                // `Transaction::new` does not validate contract data, so unparseable
+                // bytes fall back to the raw representation rather than panicking.
+                let raw_recipient_data = || {
+                    PlainTransactionRecipientData::Raw(PlainRawData {
+                        raw: hex::encode(&self.inner.recipient_data),
+                    })
+                };
                 if self.inner.recipient_type == AccountType::Staking {
-                    // Parse transaction data
-                    StakingContract::parse_data(&self.inner.recipient_data).unwrap()
+                    StakingContract::parse_data(&self.inner.recipient_data)
+                        .unwrap_or_else(|_| raw_recipient_data())
                 } else if self.inner.recipient_type == AccountType::Vesting {
                     VestingContract::parse_data(
                         &self.inner.recipient_data,
@@ -511,7 +520,7 @@ impl Transaction {
                         genesis_block_number,
                         genesis_timestamp,
                     )
-                    .unwrap()
+                    .unwrap_or_else(|_| raw_recipient_data())
                 } else if self.inner.recipient_type == AccountType::HTLC {
                     HashedTimeLockedContract::parse_data(
                         &self.inner.recipient_data,
@@ -519,14 +528,19 @@ impl Transaction {
                         genesis_block_number,
                         genesis_timestamp,
                     )
-                    .unwrap()
+                    .unwrap_or_else(|_| raw_recipient_data())
                 } else {
-                    PlainTransactionRecipientData::Raw(PlainRawData {
-                        raw: hex::encode(self.recipient_data()),
-                    })
+                    raw_recipient_data()
                 }
             },
             proof: {
+                // `Transaction::new` does not validate the proof, so unparseable
+                // bytes fall back to the raw representation rather than panicking.
+                let raw_proof = || {
+                    PlainTransactionProof::Raw(PlainRawProof {
+                        raw: hex::encode(&self.inner.proof),
+                    })
+                };
                 if self.inner.proof.is_empty() {
                     PlainTransactionProof::Raw(PlainRawProof::default())
                 } else if self.inner.sender_type == AccountType::HTLC {
@@ -534,19 +548,19 @@ impl Transaction {
                         &self.inner.proof,
                         !self.inner.network_id.is_albatross(),
                     )
-                    .unwrap()
+                    .unwrap_or_else(|_| raw_proof())
                 } else {
                     // Depending on the network the signature proofs are constructed slightly differently.
                     let proof = if self.inner.network_id.is_albatross() {
-                        SignatureProof::deserialize(&self.inner.proof).unwrap()
+                        SignatureProof::deserialize(&self.inner.proof).ok()
                     } else {
-                        SignatureProof::from(
-                            PoWSignatureProof::deserialize_all(&self.inner.proof)
-                                .unwrap()
-                                .into_pos(),
-                        )
+                        PoWSignatureProof::deserialize_all(&self.inner.proof)
+                            .ok()
+                            .map(|pow| SignatureProof::from(pow.into_pos()))
                     };
-                    proof.to_plain_transaction_proof()
+                    proof
+                        .map(|proof| proof.to_plain_transaction_proof())
+                        .unwrap_or_else(raw_proof)
                 }
             },
             size: self.serialized_size(),

--- a/web-client/src/primitives/key_pair.rs
+++ b/web-client/src/primitives/key_pair.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use nimiq_keys::SecureGenerate;
 use nimiq_serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -35,16 +33,21 @@ impl KeyPair {
 
     /// Parses a keypair from its hex representation.
     ///
-    /// Throws when the string is not valid hex format or when it represents less than 64 bytes.
+    /// Throws when the string is not valid hex or does not represent a 64-byte keypair
+    /// (optionally followed by a 1-byte lock-state flag, as produced by `toHex`).
     #[wasm_bindgen(js_name = fromHex)]
     pub fn from_hex(hex: &str) -> Result<KeyPair, JsError> {
-        if hex.len() < 128 {
+        // Decode first (safe on any &str), then reject anything that is not exactly a
+        // keypair. 64 bytes = private (32) + public (32); an optional 65th byte is the
+        // (currently unused) lock-state flag written by `serialize`/`to_hex`.
+        let bytes = hex::decode(hex)?;
+        if bytes.len() != 64 && bytes.len() != 65 {
             return Err(JsError::new(
-                "Invalid hex: expected at least 128 characters (64 bytes)",
+                "Invalid hex: expected 64 bytes (optionally + 1 lock-state byte)",
             ));
         }
-        let private = nimiq_keys::PrivateKey::from_str(&hex[0..64])?;
-        let public = nimiq_keys::Ed25519PublicKey::from_str(&hex[64..128])?;
+        let private = nimiq_keys::PrivateKey::from_bytes(&bytes[0..32])?;
+        let public = nimiq_keys::Ed25519PublicKey::from_bytes(&bytes[32..64])?;
         // TODO: Deserialize locked state if bytes remaining
         let key_pair = nimiq_keys::KeyPair { private, public };
         Ok(KeyPair::from(key_pair))


### PR DESCRIPTION
Three public web-client APIs aborted the WASM instance instead of returning a JsError / graceful value when handed malformed input:

- Address(bytes): sliced bytes[0..20] without a length check, panicking on any input shorter than 20 bytes. Now validates the length first.
- KeyPair.fromHex(hex): byte-sliced the &str after only a byte-length guard, panicking when an offset fell inside a multi-byte UTF-8 character. Now decodes the hex first and constructs the keys from the resulting bytes, rejecting any length other than 64 (optionally + the 1-byte lock-state flag that toHex appends).
- Transaction.toPlain(): unwrap()ed the parse of Staking/Vesting/HTLC data and proofs, which Transaction::new never validates, panicking on arbitrary bytes. Now falls back to the raw representation, so well-formed transactions (including all historic ones) are unaffected.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
