### PR TITLE
fix(tendermint): align locked-round check and de-duplicate it

### DIFF
--- a/tendermint/src/states/propose.rs
+++ b/tendermint/src/states/propose.rs
@@ -20,15 +20,18 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
     /// will lead to a different proposal, but since the former proposal was not broadcast and was not acted on no harm is done, and the protocol
     /// is not breached.
     pub(crate) fn propose(&mut self) -> Result<Return<TProtocol>, ProtocolError> {
-        // Retrieve the set of proposals for the current round. Create the set if it does not exist yet.
-        let proposals = self
+        // Retrieve the first proposal for the current round, if any. Creates the set if it does not exist yet.
+        let existing_proposal = self
             .state
             .round_proposals
             .entry(self.state.current_round)
-            .or_default();
+            .or_default()
+            .iter()
+            .next()
+            .map(|(hash, (vr, signature))| (hash.clone(), *vr, signature.clone()));
 
         // At least one proposal exists. Broadcast it.
-        if let Some((proposal_hash, (vr, signature))) = proposals.iter().next() {
+        if let Some((proposal_hash, vr, signature)) = existing_proposal {
             // A proposal exist. Broadcast it and progress to prevote step.
             log::debug!(
                 current_round = self.state.current_round,
@@ -40,7 +43,7 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             let proposal = self
                 .state
                 .known_proposals
-                .get(proposal_hash)
+                .get(&proposal_hash)
                 .expect("proposal must be known")
                 .clone();
 
@@ -48,14 +51,11 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             let message = ProposalMessage {
                 proposal,
                 round: self.state.current_round,
-                valid_round: *vr,
+                valid_round: vr,
             };
 
             // Create the signed proposal message which can be broadcast.
-            let signed_proposal_message = SignedProposalMessage {
-                message,
-                signature: signature.clone(),
-            };
+            let signed_proposal_message = SignedProposalMessage { message, signature };
 
             // Broadcast the signed proposal message.
             self.protocol.broadcast_proposal(signed_proposal_message);
@@ -66,19 +66,11 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             // Store the vote for this round and step. It will always be for the proposal, except for when it is
             // locked on a value which is not the proposal.
             // Note that even though the node proposes a proposal, it might not vote for it, as valid and locked are not identical.
-            let vote = self.state.locked.as_ref().map_or(
-                // If no value is locked, the node is free to vote for `proposal_hash`.
-                Some(proposal_hash.clone()),
-                // If a locked value does exists
-                |(locked_round, locked_hash)| {
-                    // it must either be the same as `proposal_hash` or `vr` must exist and be more recent than `locked_round`.
-                    if locked_hash == proposal_hash || &Some(*locked_round) <= vr {
-                        Some(proposal_hash.clone())
-                    } else {
-                        None
-                    }
-                },
-            );
+            let vote = if self.is_allowed_to_vote_on(&proposal_hash, vr) {
+                Some(proposal_hash)
+            } else {
+                None
+            };
 
             // If a vote already existed, that is a breach of protocol.
             assert!(self
@@ -121,7 +113,11 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
             let signature = self.protocol.sign_proposal(&message);
 
             // Store the proposal for the current round.
-            proposals.insert(proposal_hash.clone(), (Some(*valid_round), signature));
+            self.state
+                .round_proposals
+                .entry(self.state.current_round)
+                .or_default()
+                .insert(proposal_hash.clone(), (Some(*valid_round), signature));
 
             // Yield the state as it has changed.
             Ok(Return::Update(self.state.clone()))
@@ -153,7 +149,11 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
                 .insert(proposal_hash.clone(), message.proposal);
 
             // Store the proposal for the current round.
-            proposals.insert(proposal_hash, (None, signature));
+            self.state
+                .round_proposals
+                .entry(self.state.current_round)
+                .or_default()
+                .insert(proposal_hash, (None, signature));
 
             // Yield the state as it has changed.
             Ok(Return::Update(self.state.clone()))

--- a/tendermint/src/tendermint.rs
+++ b/tendermint/src/tendermint.rs
@@ -175,8 +175,8 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
 
     /// Test `proposal_hash` against the locked value in state using an optional `vr`.
     ///
-    /// Returns false if locked is set and the hash is *not* equal to `proposal_hash` and `vr` is not
-    /// more recent than the round this instance is locked on.
+    /// Returns false if locked is set and the hash is *not* equal to `proposal_hash` and `vr` is
+    /// older than the round this instance is locked on (or absent).
     ///
     /// Returns true otherwise.
     pub(crate) fn is_allowed_to_vote_on(
@@ -187,9 +187,11 @@ impl<TProtocol: Protocol> Tendermint<TProtocol> {
         match &self.state.locked {
             // Always allowed to vote when not locked.
             None => true,
-            // If locked, only allowed to vote for it if it is the same hash, or vr is more recent.
+            // If locked, only allowed to vote for it if it is the same hash, or vr is at least as
+            // recent as the locked round (Tendermint paper, Algorithm 1 line 29:
+            // `lockedRound <= vr || lockedValue = v`).
             Some((locked_round, locked_hash)) => {
-                locked_hash == proposal_hash || Some(*locked_round) < vr
+                locked_hash == proposal_hash || Some(*locked_round) <= vr
             }
         }
     }


### PR DESCRIPTION
`is_allowed_to_vote_on` used a strict `locked_round < vr`, where Algorithm of the Tendermint paper specifies `lockedRound <= vr || lockedValue = v`.

The two differ only when `locked_round == vr` and the locked hash differs from the proposal. That state requires two distinct 2f+1 prevote polkas in the same round, i.e. f+1 equivocating validators — beyond the fault threshold, and rejected outright within a single aggregate (`TendermintVerifier` returns `Forged` on overlapping contributor buckets). The deviation was also conservative: it could only prevote nil where the paper prevotes for the value, so it was never a safety concern. No behaviour change under `<= f` faults.

`propose()` already implemented the same predicate correctly with `<=`, hand-copied rather than shared. It now calls `is_allowed_to_vote_on`, so the rule exists once.

No test: the only case the two operators disagree on is unreachable without `> f` Byzantine validators, so a test would have to fabricate an aggregate that real verification rejects. Existing coverage of the reachable paths (`it_locks_and_unlocks`, `it_locks_and_rebroadcasts`, `it_does_not_unlock`) is unchanged.