### PR TITLE
genesis: refresh MainAlbatross checkpoint election block

### DIFF
--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -116,10 +116,10 @@ impl NetworkInfo {
 /// yet return `None`, in which case clients behave exactly as without checkpoints.
 fn checkpoint_for_network(network_id: NetworkId) -> Option<HardcodedElection> {
     match network_id {
-        // Election block #53611200 (2026-06-15), refreshed per release from a trusted node.
+        // Election block #57240000 (2026-07-27), refreshed per release from a trusted node.
         NetworkId::MainAlbatross => Some(HardcodedElection {
-            block_number: 53_611_200,
-            hash: "f2953c1a7597422587f76dff07fd5786e41425a2c51d4837ebc3691f05eb5b43"
+            block_number: 57_240_000,
+            hash: "e7a649c932f023a327192a8b9ded65f8ea4ff4989c4516a1191eaf7ac9f26ad7"
                 .parse()
                 .expect("valid checkpoint hash"),
         }),


### PR DESCRIPTION
Update the hardcoded checkpoint to election block 57240000 (2026-07-27), taken from a trusted, fully-synced node.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
