### PR TITLE
Bound equivocation reporting window to the validity window

### DIFF
--- a/blockchain/tests/block_production.rs
+++ b/blockchain/tests/block_production.rs
@@ -1089,12 +1089,12 @@ fn it_can_consume_all_validator_deposit() {
         Ok(PushResult::Extended)
     );
 
-    let last_block_of_reporting_window = Policy::last_block_of_reporting_window(
+    let last_block_of_collateral_lockup = Policy::last_block_of_collateral_lockup(
         Policy::election_block_after(1 + Policy::genesis_block_number()),
     );
 
     // Use the genesis block number as an offset
-    let macro_blocks_to_produce = last_block_of_reporting_window - Policy::genesis_block_number();
+    let macro_blocks_to_produce = last_block_of_collateral_lockup - Policy::genesis_block_number();
 
     produce_macro_blocks(
         &producer,
@@ -1308,12 +1308,12 @@ fn it_can_revert_failed_delete_validator() {
         Ok(PushResult::Extended)
     );
 
-    let last_block_of_reporting_window = Policy::last_block_of_reporting_window(
+    let last_block_of_collateral_lockup = Policy::last_block_of_collateral_lockup(
         Policy::election_block_after(1 + Policy::genesis_block_number()),
     );
 
     // Here we need to take into consideration the genesis block number as an offset
-    let macro_blocks_to_produce = last_block_of_reporting_window - Policy::genesis_block_number();
+    let macro_blocks_to_produce = last_block_of_collateral_lockup - Policy::genesis_block_number();
 
     produce_macro_blocks(
         &producer,

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -127,7 +127,7 @@ impl Staker {
         if let Some(validator_address) = &self.delegation {
             // Funds are not released if release block height has not passed yet.
             if let Some(inactive_from) = self.inactive_from
-                && block_number < Policy::block_after_reporting_window(inactive_from)
+                && block_number < Policy::block_after_collateral_lockup(inactive_from)
             {
                 return false;
             }

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -146,7 +146,7 @@ impl Validator {
         let inactive_from = self
             .inactive_from
             .expect("Validator is retired so it must be inactive");
-        let wait_until = Policy::last_block_of_reporting_window(inactive_from);
+        let wait_until = Policy::last_block_of_collateral_lockup(inactive_from);
         if block_number <= wait_until {
             debug!(
                 ?self.address,

--- a/primitives/account/tests/accounts.rs
+++ b/primitives/account/tests/accounts.rs
@@ -903,7 +903,7 @@ fn can_revert_transactions() {
     );
 
     let block_state = BlockState::new(
-        Policy::block_after_reporting_window(Policy::election_block_after(0)),
+        Policy::block_after_collateral_lockup(Policy::election_block_after(0)),
         10,
         Policy::max_supported_version(),
     );

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -314,7 +314,7 @@ impl ValidatorSetup {
             protocol_version,
         );
         let after_cooldown =
-            Policy::block_after_reporting_window(effective_state_block_state.number);
+            Policy::block_after_collateral_lockup(effective_state_block_state.number);
         let after_cooldown = BlockState::new(after_cooldown, 1000, protocol_version);
         let before_cooldown = BlockState::new(after_cooldown.number - 1, 9000, protocol_version);
 
@@ -508,7 +508,7 @@ impl StakerSetup {
             protocol_version,
         );
         let release_block_state = BlockState::new(
-            Policy::block_after_reporting_window(effective_block_state.number),
+            Policy::block_after_collateral_lockup(effective_block_state.number),
             2,
             protocol_version,
         );

--- a/primitives/account/tests/staking_contract/punished_slots.rs
+++ b/primitives/account/tests/staking_contract/punished_slots.rs
@@ -478,11 +478,11 @@ fn jail_and_revert_twice(config: JailConfig) {
         "Can only report event after it happened"
     );
     assert!(
-        config.reporting_block <= Policy::last_block_of_reporting_window(config.event_block1),
+        config.reporting_block <= Policy::last_block_of_collateral_lockup(config.event_block1),
         "Can only report event up until reporting window"
     );
     assert!(
-        config.reporting_block <= Policy::last_block_of_reporting_window(config.event_block2),
+        config.reporting_block <= Policy::last_block_of_collateral_lockup(config.event_block2),
         "Can only report event up until reporting window"
     );
 

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -959,7 +959,7 @@ fn cannot_retire_active_stake() {
     // Cannot retire funds from active.
     let tx = make_retire_stake_transaction(Policy::MINIMUM_STAKE);
     let block_state = BlockState::new(
-        Policy::block_after_reporting_window(Policy::election_block_after(2)),
+        Policy::block_after_collateral_lockup(Policy::election_block_after(2)),
         2,
         Policy::max_supported_version(),
     );
@@ -1896,7 +1896,7 @@ fn remove_stake_works() {
     // -----------------------------------
     // Doesn't work if the value is greater than the balance.
     let block_state = BlockState::new(
-        Policy::block_after_reporting_window(Policy::election_block_after(2)),
+        Policy::block_after_collateral_lockup(Policy::election_block_after(2)),
         2,
         Policy::max_supported_version(),
     );
@@ -1930,7 +1930,7 @@ fn remove_stake_works() {
     let tx = make_remove_stake_transaction(Policy::MINIMUM_STAKE * 2);
 
     let block_state = BlockState::new(
-        Policy::block_after_reporting_window(Policy::election_block_after(2)),
+        Policy::block_after_collateral_lockup(Policy::election_block_after(2)),
         3,
         Policy::max_supported_version(),
     );

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -1165,7 +1165,7 @@ fn delete_validator_works() {
             &mut TransactionLog::empty(),
         )
         .expect("Failed to commit transaction");
-    let inactive_release = Policy::block_after_reporting_window(effective_deactivation_block);
+    let inactive_release = Policy::block_after_collateral_lockup(effective_deactivation_block);
 
     // Doesn't work if the cooldown hasn't expired.
     assert_eq!(
@@ -3230,7 +3230,7 @@ fn commit_failed_delete_validator_works() {
             &mut TransactionLog::empty(),
         )
         .expect("Failed to commit transaction");
-    let inactive_release = Policy::block_after_reporting_window(effective_deactivation_block);
+    let inactive_release = Policy::block_after_collateral_lockup(effective_deactivation_block);
 
     // Doesn't work if the cooldown hasn't expired.
     assert_eq!(

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -373,7 +373,7 @@ impl Block {
             // Perform block type specific body verification.
             if let Block::Micro(block) = self {
                 let body = block.body.as_ref().unwrap();
-                body.verify(self.is_skip(), self.block_number())?;
+                body.verify(self.is_skip(), self.block_number(), block.header.version)?;
             }
         }
 

--- a/primitives/block/src/equivocation_proof.rs
+++ b/primitives/block/src/equivocation_proof.rs
@@ -8,7 +8,7 @@ use nimiq_keys::{
 };
 use nimiq_primitives::{
     networks::NetworkId,
-    policy::Policy,
+    policy::{upgrades, Policy},
     slots_allocation::{Validator, Validators},
     TendermintIdentifier, TendermintProposal, TendermintStep, TendermintVote,
 };
@@ -121,10 +121,21 @@ impl EquivocationProof {
         }
     }
 
-    /// Check if an equivocation proof is valid at a given block height. Equivocation proofs are
-    /// valid only until the end of the reporting window.
-    pub fn is_valid_at(&self, block_number: u32) -> bool {
-        block_number <= Policy::last_block_of_reporting_window(self.block_number())
+    /// Check if an equivocation proof is valid at a given block height, given the protocol
+    /// `version` of the reporting block. From `upgrades::v2::EQUIVOCATION_REPORTING_WINDOW` onward
+    /// proofs are valid only until the end of the equivocation reporting window (bounded by the
+    /// transaction validity window) so a proof can never be re-included after it has aged out of the
+    /// validity-store dedup; before that version the legacy one-epoch window applies.
+    pub fn is_valid_at(&self, block_number: u32, version: u16) -> bool {
+        // From the v2 fork onward the equivocation reporting window is bounded by the transaction
+        // validity window; before that it was a full epoch. Gating on the reporting block's version
+        // makes the consensus change activate atomically at the upgrade.
+        let last_reportable_block = if version >= upgrades::v2::EQUIVOCATION_REPORTING_WINDOW {
+            Policy::last_block_of_equivocation_reporting_window(self.block_number())
+        } else {
+            Policy::last_block_of_collateral_lockup(self.block_number())
+        };
+        block_number <= last_reportable_block
             && Policy::batch_at(block_number) >= Policy::batch_at(self.block_number())
     }
 
@@ -727,6 +738,59 @@ mod test {
         assert_eq!(proof1.sort_key(), proof2.sort_key());
         assert_eq!(proof1.sort_key(), proof3.sort_key());
         assert_ne!(proof1.sort_key(), proof4.sort_key());
+    }
+
+    #[test]
+    fn is_valid_at_is_version_gated() {
+        let key = KeyPair::from(
+            PrivateKey::from_bytes(
+                &hex::decode("8a535c4be49186007503231c8569f873eb512eae308d9be7e7de20af1ddc1663")
+                    .unwrap(),
+            )
+            .unwrap(),
+        );
+
+        let offense_block = Policy::genesis_block_number();
+        let header1 = MicroHeader {
+            network: NetworkId::UnitAlbatross,
+            version: 1,
+            block_number: offense_block,
+            timestamp: 0,
+            parent_hash: Blake2bHash::default(),
+            seed: VrfSeed::default(),
+            extra_data: vec![],
+            state_root: Blake2bHash::default(),
+            body_root: Blake2sHash::default(),
+            diff_root: Blake2bHash::default(),
+            history_root: Blake2bHash::default(),
+            ..Default::default()
+        };
+        let mut header2 = header1.clone();
+        header2.timestamp = 1;
+
+        let justification1 = key.sign(header1.hash().as_bytes());
+        let justification2 = key.sign(header2.hash().as_bytes());
+        let proof: EquivocationProof = ForkProof::new(
+            Address::burn_address(),
+            header1,
+            justification1,
+            header2,
+            justification2,
+        )
+        .into();
+        assert_eq!(proof.block_number(), offense_block);
+
+        // A block past the (short) equivocation window but still within the legacy one-epoch window.
+        let block = Policy::last_block_of_equivocation_reporting_window(offense_block) + 1;
+        assert!(block <= Policy::last_block_of_collateral_lockup(offense_block));
+
+        // Legacy versions still accept it; from version 2 on it is rejected.
+        assert!(proof.is_valid_at(block, 1));
+        assert!(!proof.is_valid_at(block, 2));
+
+        // At the equivocation window edge it remains valid under the new rules.
+        let edge = Policy::last_block_of_equivocation_reporting_window(offense_block);
+        assert!(proof.is_valid_at(edge, 2));
     }
 
     #[test]

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -271,7 +271,12 @@ impl MicroBody {
     }
 
     /// Verifies the micro block: size, proofs, transactions, etc.
-    pub(crate) fn verify(&self, is_skip: bool, block_number: u32) -> Result<(), BlockError> {
+    pub(crate) fn verify(
+        &self,
+        is_skip: bool,
+        block_number: u32,
+        version: u16,
+    ) -> Result<(), BlockError> {
         // Check that the maximum body size is not exceeded.
         let body_size = self.serialized_size();
         if body_size > Policy::MAX_SIZE_MICRO_BODY {
@@ -299,7 +304,7 @@ impl MicroBody {
         let mut previous_proof: Option<&EquivocationProof> = None;
         for proof in &self.equivocation_proofs {
             // Check reporting window.
-            if !proof.is_valid_at(block_number) {
+            if !proof.is_valid_at(block_number, version) {
                 return Err(BlockError::InvalidForkProof);
             }
 

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -543,19 +543,57 @@ impl Policy {
         Self::epoch_index_at(block_number) < Self::blocks_per_batch()
     }
 
-    /// Returns the block height for the last block of the reporting window of a given block number.
-    /// Note: This window is meant for reporting malicious behaviour (aka `jailable` behaviour).
+    /// Returns the last block height of the collateral lock-up window of a given block number.
+    ///
+    /// This governs the collateral lock-up: a deactivated validator's funds (and its stakers')
+    /// stay locked until this block so they remain slashable while offenses could still be reported.
+    /// It is kept at one epoch and must always be `>=` the equivocation reporting window
+    /// (`last_block_of_equivocation_reporting_window`), so collateral is always present while an
+    /// offense is still reportable.
     #[inline]
-    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastBlockOfReportingWindow))]
-    pub fn last_block_of_reporting_window(block_number: u32) -> u32 {
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastBlockOfCollateralLockup))]
+    pub fn last_block_of_collateral_lockup(block_number: u32) -> u32 {
         block_number.saturating_add(Self::blocks_per_epoch())
     }
 
-    /// Returns the first block after the reporting window of a given block number has ended.
+    /// Returns the first block after the collateral lock-up window of a given block number has ended.
+    #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = blockAfterCollateralLockup))]
+    pub fn block_after_collateral_lockup(block_number: u32) -> u32 {
+        Self::last_block_of_collateral_lockup(block_number).saturating_add(1)
+    }
+
+    /// @deprecated Renamed to `lastBlockOfCollateralLockup`. This window never governed
+    /// equivocation *reporting* (that is `lastBlockOfEquivocationReportingWindow`); it has always
+    /// been the collateral lock-up window. Kept for API backwards compatibility.
+    #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastBlockOfReportingWindow))]
+    pub fn last_block_of_reporting_window(block_number: u32) -> u32 {
+        Self::last_block_of_collateral_lockup(block_number)
+    }
+
+    /// @deprecated Renamed to `blockAfterCollateralLockup`. Kept for API backwards compatibility;
+    /// see `lastBlockOfCollateralLockup`.
     #[inline]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = blockAfterReportingWindow))]
     pub fn block_after_reporting_window(block_number: u32) -> u32 {
-        Self::last_block_of_reporting_window(block_number).saturating_add(1)
+        Self::block_after_collateral_lockup(block_number)
+    }
+
+    /// Returns the last block height at which an equivocation that happened at `block_number` can
+    /// still be reported (i.e. included in a block via an equivocation proof).
+    ///
+    /// This is intentionally bounded by the transaction validity window so it stays within the
+    /// validity-store dedup retention (`transaction_validity_window_blocks + blocks_per_batch`).
+    /// Equivocation proofs are deduplicated against the validity store; if this window were longer,
+    /// a genuine proof could be re-included after the dedup forgot it, re-jailing the validator and
+    /// re-burning rewards. The collateral lock-up (`last_block_of_collateral_lockup`) is kept
+    /// longer (one epoch) and must always be `>=` this window. See the invariant test
+    /// `reporting_window_stays_within_dedup_retention`.
+    #[inline]
+    #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastBlockOfEquivocationReportingWindow))]
+    pub fn last_block_of_equivocation_reporting_window(block_number: u32) -> u32 {
+        block_number.saturating_add(Self::transaction_validity_window_blocks())
     }
 
     /// Returns the first block after the jail period of a given block number has ended.
@@ -866,6 +904,26 @@ mod tests {
         assert_eq!(
             Policy::batch_at(Policy::blocks_per_batch() + Policy::genesis_block_number() + 1),
             2
+        );
+    }
+
+    /// Invariant: the equivocation reporting window must stay within the validity-store dedup
+    /// retention (`transaction_validity_window_blocks + blocks_per_batch`). If the reporting window
+    /// were longer, a genuine equivocation proof could be re-included after the dedup store forgot
+    /// it, re-jailing the validator and re-burning rewards. Keep this satisfied if the reporting
+    /// window definition is ever changed.
+    #[test]
+    fn reporting_window_stays_within_dedup_retention() {
+        initialize_policy();
+        let block_number = Policy::genesis_block_number();
+        let reporting_window =
+            Policy::last_block_of_equivocation_reporting_window(block_number) - block_number;
+        let dedup_retention =
+            Policy::transaction_validity_window_blocks() + Policy::blocks_per_batch();
+        assert!(
+            reporting_window <= dedup_retention,
+            "equivocation reporting window ({reporting_window}) must be <= validity-store dedup \
+             retention ({dedup_retention}); a longer window would allow aged-proof replay"
         );
     }
 

--- a/primitives/src/policy/upgrades/v2.rs
+++ b/primitives/src/policy/upgrades/v2.rs
@@ -15,5 +15,7 @@ pub const VERSION: u16 = 2;
 /// via the cold-key `UpdateValidator` transaction.
 pub const WARM_KEY_SIGNALING: u16 = VERSION;
 
-// pub const HASH_CHANGE: u16 = VERSION;
-// pub const STAKING_CHANGE_XX: u16 = VERSION;
+/// Bound the equivocation reporting window to the transaction validity window
+/// so an aged proof can no longer be replayed past the validity-store dedup
+/// retention. See `EquivocationProof::is_valid_at`.
+pub const EQUIVOCATION_REPORTING_WINDOW: u16 = VERSION;

--- a/rpc-interface/src/policy.rs
+++ b/rpc-interface/src/policy.rs
@@ -74,7 +74,15 @@ pub trait PolicyInterface {
     async fn get_first_batch_of_epoch(&self, block_number: u32)
         -> RPCResult<bool, (), Self::Error>;
 
-    /// Returns the first block after the reporting window of a given block number has ended.
+    /// Returns the first block after the collateral lock-up window of a given block number has ended.
+    async fn get_block_after_collateral_lockup(
+        &self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error>;
+
+    /// **Deprecated**: renamed to `getBlockAfterCollateralLockup`. This window never governed
+    /// equivocation reporting; it has always been the collateral lock-up window. Kept for API
+    /// backwards compatibility — prefer `getBlockAfterCollateralLockup` in new clients.
     async fn get_block_after_reporting_window(
         &self,
         block_number: u32,

--- a/rpc-server/src/dispatchers/policy.rs
+++ b/rpc-server/src/dispatchers/policy.rs
@@ -137,11 +137,19 @@ impl PolicyInterface for PolicyDispatcher {
         Ok(Policy::first_batch_of_epoch(block_number).into())
     }
 
+    async fn get_block_after_collateral_lockup(
+        &self,
+        block_number: u32,
+    ) -> RPCResult<u32, (), Self::Error> {
+        Ok(Policy::block_after_collateral_lockup(block_number).into())
+    }
+
+    // Deprecated alias of `get_block_after_collateral_lockup`, kept for API backwards compatibility.
     async fn get_block_after_reporting_window(
         &self,
         block_number: u32,
     ) -> RPCResult<u32, (), Self::Error> {
-        Ok(Policy::block_after_reporting_window(block_number).into())
+        self.get_block_after_collateral_lockup(block_number).await
     }
 
     async fn get_block_after_jail(&self, block_number: u32) -> RPCResult<u32, (), Self::Error> {

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -896,7 +896,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                     &mut store,
                     &Address::from(&staker_key_pair),
                     Coin::from_u64_unchecked(Policy::MINIMUM_STAKE * 2),
-                    Policy::block_after_reporting_window(Policy::election_block_after(0)),
+                    Policy::block_after_collateral_lockup(Policy::election_block_after(0)),
                     &mut TransactionLog::empty(),
                 )
                 .expect("Failed to deactivate stake");

--- a/validator/src/jail.rs
+++ b/validator/src/jail.rs
@@ -32,13 +32,18 @@ impl EquivocationProofPool {
                 }
             }
             Block::Macro(MacroBlock {
-                header: MacroHeader { block_number, .. },
+                header:
+                    MacroHeader {
+                        block_number,
+                        version,
+                        ..
+                    },
                 ..
             }) => {
                 // After a macro block, remove all equivocation proofs that would not be valid anymore
                 // from now on.
                 self.equivocation_proofs
-                    .retain(|proof| proof.is_valid_at(*block_number + 1));
+                    .retain(|proof| proof.is_valid_at(*block_number + 1, *version));
             }
             _ => {}
         }

--- a/web-client/src/client/account.rs
+++ b/web-client/src/client/account.rs
@@ -172,7 +172,7 @@ impl From<&nimiq_account::Staker> for PlainStaker {
             inactive_from: staker.inactive_from,
             inactive_release: staker
                 .inactive_from
-                .map(Policy::block_after_reporting_window),
+                .map(Policy::block_after_collateral_lockup),
             retired_balance: staker.retired_balance.into(),
         }
     }
@@ -233,7 +233,7 @@ impl From<&nimiq_account::Validator> for PlainValidator {
             inactive_from: validator.inactive_from,
             inactive_release: validator
                 .inactive_from
-                .map(Policy::block_after_reporting_window),
+                .map(Policy::block_after_collateral_lockup),
             retired: validator.retired,
             jailed_from: validator.jailed_from,
             jailed_release: validator.jailed_from.map(Policy::block_after_jail),


### PR DESCRIPTION
A proof was reportable for a full epoch, longer than the validity-store dedup retention, so an aged proof could be replayed to re-jail a validator.

From protocol version 2 on, `is_valid_at` uses `last_block_of_equivocation_reporting_window`, which is bounded by the validity window, so replays are rejected by the existing dedup. The collateral lock-up period is unchanged.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
