### PR TITLE
Bind validator signing keys into election header hash (v2+)

### DIFF
--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -7,7 +7,7 @@ use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput, Hasher, SerializeCo
 use nimiq_keys::{Address, Ed25519PublicKey as SchnorrPublicKey};
 use nimiq_primitives::{
     networks::NetworkId,
-    policy::Policy,
+    policy::{upgrades, Policy},
     slots_allocation::{Validators, ValidatorsBuilder},
     Message, PREFIX_TENDERMINT_PROPOSAL,
 };
@@ -264,16 +264,33 @@ impl MacroHeader {
         Ok(())
     }
 
-    fn zkp_body_root(&self) -> Blake2sHash {
+    /// Blake2s root over the payload, folded into the header hash by `serialize_content`.
+    /// See `serialize_payload_commitment` for the contents.
+    fn payload_commitment_root(&self) -> Blake2sHash {
         let mut h = <Blake2sHash as HashOutput>::Builder::default();
-        self.zkp_body_serialize_content(&mut h).unwrap();
+        self.serialize_payload_commitment(&mut h).unwrap();
         h.finish()
     }
 
-    pub fn zkp_body_serialize_content<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    /// Serializes the payload commitment embedded in the header hash: the elected
+    /// validator set (election blocks only), the next batch's initial punished set, and
+    /// the body root.
+    ///
+    /// The validator set uses `Validators::hash` (voting keys only) before v2, and
+    /// `Validators::commitment_hash` (full set) from v2 on, which additionally binds the
+    /// signing keys, addresses and slot ranges so they can't be swapped under an
+    /// unchanged hash.
+    pub fn serialize_payload_commitment<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         if let Some(ref validators) = self.validators {
-            let pk_tree_root = validators.hash::<Blake2sHash>();
-            pk_tree_root.serialize_to_writer(writer)?;
+            // v1 hashing is left untouched so mainnet/testnet header hashes stay
+            // byte-identical until the v2 upgrade activates.
+            let validators_root =
+                if self.version >= upgrades::v2::ELECTION_VALIDATOR_METADATA_COMMITMENT {
+                    validators.commitment_hash::<Blake2sHash>()
+                } else {
+                    validators.hash::<Blake2sHash>()
+                };
+            validators_root.serialize_to_writer(writer)?;
         } else {
             0u8.serialize_to_writer(writer)?;
         }
@@ -374,8 +391,8 @@ impl SerializeContent for MacroHeader {
         extra_data_hash.serialize_to_writer(writer)?;
 
         self.state_root.serialize_to_writer(writer)?;
-        // This includes validators and next_batch_punished_set.
-        self.zkp_body_root().serialize_to_writer(writer)?;
+        // Binds the validator set, the next batch's initial punished set and the body root.
+        self.payload_commitment_root().serialize_to_writer(writer)?;
         self.history_root.serialize_to_writer(writer)?;
 
         Ok(())
@@ -411,7 +428,7 @@ mod test {
     use nimiq_bls::CompressedPublicKey as BlsCompressedPublicKey;
     use nimiq_keys::Ed25519PublicKey as SchnorrPublicKey;
     use nimiq_primitives::{
-        policy::Policy,
+        policy::{upgrades, Policy},
         slots_allocation::{Validator, Validators},
     };
 
@@ -424,6 +441,95 @@ mod test {
             2 * dbg!(MacroBlock::MAX_SIZE) + 16384
                 <= dbg!(nimiq_network_interface::network::MIN_SUPPORTED_MSG_SIZE)
         );
+    }
+
+    /// Builds a single-band election header carrying `validators`, at the given protocol
+    /// version. Only the fields that influence the header hash are set.
+    fn election_header(validators: Validators, version: u16) -> MacroHeader {
+        MacroHeader {
+            version,
+            validators: Some(validators),
+            ..Default::default()
+        }
+    }
+
+    /// Builds a valid single-band validator set owning all slots, with the given Ed25519
+    /// signing key and a matching reward address. The BLS voting key is the same for every
+    /// set so that only the metadata (signing key / address) differs between them.
+    fn validators_with_signing_key(signing_key: SchnorrPublicKey) -> Validators {
+        let validator = Validator::new(
+            nimiq_keys::Address::from(&signing_key),
+            BlsCompressedPublicKey::default(),
+            signing_key,
+            0..Policy::SLOTS,
+        );
+        Validators::new(vec![validator])
+    }
+
+    /// From protocol version 2 on, the macro-header hash must bind the validators'
+    /// Ed25519 signing keys and reward addresses, so a peer cannot swap them on an
+    /// election block while keeping the same hash (and a valid justification).
+    /// Before version 2 the binding is dormant and the hash is unchanged.
+    ///
+    /// Regression test for the validator-metadata poisoning issue: the BLS voting-key
+    /// tree (`Validators::hash`) does not commit signing keys or addresses.
+    #[test]
+    fn election_hash_binds_signing_key_from_version_2() {
+        use nimiq_hash::{Blake2sHash, Hash};
+
+        let honest = validators_with_signing_key(SchnorrPublicKey::from([0x11; 32]));
+        let forged = validators_with_signing_key(SchnorrPublicKey::from([0x22; 32]));
+
+        // The forge keeps the BLS voting-key tree identical; only the metadata differs.
+        assert_eq!(
+            honest.hash::<Blake2sHash>(),
+            forged.hash::<Blake2sHash>(),
+            "voting-key tree must be unaffected by the signing-key swap"
+        );
+        assert_ne!(
+            honest.commitment_hash::<Blake2sHash>(),
+            forged.commitment_hash::<Blake2sHash>(),
+            "v2 commitment must distinguish the swapped signing key"
+        );
+
+        let activation = upgrades::v2::ELECTION_VALIDATOR_METADATA_COMMITMENT;
+
+        // Before activation: binding dormant, the swap is invisible to the header hash (the bug).
+        assert_eq!(
+            election_header(honest.clone(), activation - 1).hash(),
+            election_header(forged.clone(), activation - 1).hash(),
+            "pre-activation the header hash must be unchanged (legacy hashing)"
+        );
+
+        // From activation on: the swap changes the authenticated header hash (the fix).
+        assert_ne!(
+            election_header(honest, activation).hash(),
+            election_header(forged, activation).hash(),
+            "from activation the header hash must bind the signing key / address"
+        );
+    }
+
+    /// Validator sets with non-contiguous or overlapping slot bands are rejected, so the
+    /// `get_band_from_slot` lookup can never panic on a crafted set (which would otherwise
+    /// crash light nodes that adopt the set verbatim).
+    #[test]
+    fn non_contiguous_slot_bands_rejected() {
+        let band = |start, end| {
+            Validator::new(
+                nimiq_keys::Address::default(),
+                BlsCompressedPublicKey::default(),
+                SchnorrPublicKey::default(),
+                start..end,
+            )
+        };
+
+        // Gap between the two bands (0..1 then 2..Policy::SLOTS leaves slot 1 uncovered).
+        let gapped = Validators::new(vec![band(0, 1), band(2, Policy::SLOTS)]);
+        assert!(gapped.validate_keys().is_err());
+
+        // Overlapping bands.
+        let overlapping = Validators::new(vec![band(0, 2), band(1, Policy::SLOTS)]);
+        assert!(overlapping.validate_keys().is_err());
     }
 
     /// Verifies that invalid BLS voting keys are caught by verify() and

--- a/primitives/src/policy/upgrades/v2.rs
+++ b/primitives/src/policy/upgrades/v2.rs
@@ -19,3 +19,9 @@ pub const WARM_KEY_SIGNALING: u16 = VERSION;
 /// so an aged proof can no longer be replayed past the validity-store dedup
 /// retention. See `EquivocationProof::is_valid_at`.
 pub const EQUIVOCATION_REPORTING_WINDOW: u16 = VERSION;
+
+/// The election macro-header hash commits to the full validator set — signing keys,
+/// reward addresses and slot ranges in addition to the voting keys (via
+/// `Validators::commitment_hash`) — so a peer cannot swap them on an election block
+/// under an unchanged hash. Gated in `MacroHeader::serialize_payload_commitment`.
+pub const ELECTION_VALIDATOR_METADATA_COMMITMENT: u16 = VERSION;

--- a/primitives/src/slots_allocation.rs
+++ b/primitives/src/slots_allocation.rs
@@ -17,7 +17,7 @@
 use std::{cmp::Ordering, collections::BTreeMap, fmt, ops::Range, slice::Iter};
 
 use nimiq_bls::{G2Projective, LazyPublicKey as LazyBlsPublicKey, PublicKey as BlsPublicKey};
-use nimiq_hash::{Hash, HashOutput};
+use nimiq_hash::{Hash, HashOutput, Hasher};
 use nimiq_keys::{Address, Ed25519PublicKey as SchnorrPublicKey};
 #[cfg(feature = "parallel")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -224,6 +224,15 @@ impl Validators {
                 .voting_key
                 .uncompress()
                 .ok_or(InvalidValidatorsError)?;
+            // The slot bands must be contiguous and start at 0, in band order. The
+            // honest chain always builds them this way (see `ValidatorsBuilder::build`),
+            // but a crafted set with gaps or overlaps would otherwise make
+            // `get_band_from_slot` land on a slot that no band covers and panic on
+            // light nodes that adopt the set verbatim. Reject such sets here so the lookup
+            // can never panic
+            if validator.slots.start != total_slots || validator.slots.end < validator.slots.start {
+                return Err(InvalidValidatorsError);
+            }
             // Use `checked_add` so a crafted validator set cannot silently wrap the
             // running total around `u16` (overflow checks are disabled in the release
             // profile). Any overflow implies far more than `Policy::SLOTS` slots, so the
@@ -253,6 +262,27 @@ impl Validators {
     /// Iterates over the validators.
     pub fn iter(&self) -> Iter<'_, Validator> {
         self.validators.iter()
+    }
+
+    /// Hashes the full validator set used in the macro header hash from v2 on: per band,
+    /// in band order, the `address`, `signing_key`, `voting_key` and slot range.
+    ///
+    /// Unlike `Validators::hash`, which commits only the voting keys (leaving the signing
+    /// keys, addresses and slot ranges swappable under an unchanged hash), this binds all
+    /// of them. It is a plain hash rather than a Merkle tree — the tree only existed for a
+    /// circuit that no longer exists.
+    pub fn commitment_hash<H: HashOutput>(&self) -> H {
+        let mut bytes = Vec::new();
+        for validator in self.iter() {
+            bytes.extend_from_slice(validator.address.as_bytes());
+            bytes.extend_from_slice(validator.signing_key.as_bytes());
+            // Raw compressed BLS bytes (like `Validators::hash`) so an invalid key can't panic
+            bytes.extend_from_slice(validator.voting_key.compressed().as_ref());
+            bytes.extend_from_slice(&validator.slots.start.to_be_bytes());
+            bytes.extend_from_slice(&validator.slots.end.to_be_bytes());
+        }
+
+        H::Builder::default().chain(&bytes).finish()
     }
 }
 


### PR DESCRIPTION
The macro header hash committed only the BLS voting-key tree, leaving each validator band's `signing_key`, `address` and slot range unauthenticated. A peer could swap them on an election block without changing the hash or its justification, poisoning the validator set on light and pico clients.

- From protocol version 2 on, commit the full validator set via `Validators::commitment_hash()` in `MacroHeader::serialize_payload_commitment`, gated through the `upgrades::v2` registry. v1 hashing is unchanged, so mainnet and testnet are unaffected until the v2 upgrade.
- Reject non-contiguous slot bands in `validate_keys`, which also prevents a `get_band_from_slot` panic.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
