### PR TITLE
Commit and verify the macro block diff root

### DIFF
--- a/blockchain/src/blockchain/push.rs
+++ b/blockchain/src/blockchain/push.rs
@@ -650,6 +650,7 @@ impl Blockchain {
             })?;
             if is_complete {
                 let recorded_diff = txn.stop_recording().into_forward_diff();
+                self.verify_diff_root(block, &recorded_diff)?;
                 self.chain_store
                     .put_accounts_diff(txn.raw(), &block.hash(), &recorded_diff);
             }

--- a/blockchain/src/blockchain/verify.rs
+++ b/blockchain/src/blockchain/verify.rs
@@ -6,7 +6,12 @@ use nimiq_database::{
     traits::{ReadTransaction, WriteTransaction},
 };
 use nimiq_hash::Hash;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::{
+    policy::{upgrades, Policy},
+    trie::trie_diff::TrieDiff,
+    TreeProof,
+};
+use nimiq_trie::WriteTransactionProxy as TrieMdbxWriteTransaction;
 
 use crate::{interface::HistoryInterface, BlockProducer, Blockchain};
 
@@ -120,6 +125,26 @@ impl Blockchain {
             }
         }
 
+        Ok(())
+    }
+
+    /// Verifies that the block's `diff_root` matches the forward `diff` produced by applying it.
+    /// Enforced only from `DIFF_ROOT_COMMITMENT` on; earlier blocks are not checked.
+    pub(crate) fn verify_diff_root(&self, block: &Block, diff: &TrieDiff) -> Result<(), PushError> {
+        if block.version() < upgrades::v2::DIFF_ROOT_COMMITMENT {
+            return Ok(());
+        }
+        let diff_root = TreeProof::new(diff.0.iter()).root_hash();
+        if *block.diff_root() != diff_root {
+            warn!(
+                %block,
+                header_root = %block.diff_root(),
+                computed_root = %diff_root,
+                reason = "Header diff root doesn't match real diff root",
+                "Rejecting block"
+            );
+            return Err(PushError::InvalidBlock(BlockError::DiffRootMismatch));
+        }
         Ok(())
     }
 
@@ -489,14 +514,21 @@ impl Blockchain {
             return Err(error);
         }
 
-        // Update our blockchain state using the received proposal. If we can't update the state, we
-        // return a proposal timeout.
-        if let Err(error) =
-            self.commit_accounts(block, None, &mut txn.into(), &mut BlockLogger::empty())
-        {
-            debug!(%error, %block, "Tendermint - await_proposal: Failed to commit accounts");
-            return Err(error);
-        }
+        // Update our blockchain state using the received proposal, recording the forward diff so we
+        // can verify it against the header's diff root. If we can't update the state, we return a
+        // proposal timeout.
+        let diff = {
+            let mut txn: TrieMdbxWriteTransaction = txn.into();
+            txn.start_recording();
+            if let Err(error) =
+                self.commit_accounts(block, None, &mut txn, &mut BlockLogger::empty())
+            {
+                debug!(%error, %block, "Tendermint - await_proposal: Failed to commit accounts");
+                return Err(error);
+            }
+            txn.stop_recording().into_forward_diff()
+        };
+        self.verify_diff_root(block, &diff)?;
 
         // Check the validity of the block against our state. If it is invalid, we return a proposal
         // timeout. This also returns the block body that matches the block header

--- a/blockchain/tests/blockchain.rs
+++ b/blockchain/tests/blockchain.rs
@@ -4,12 +4,13 @@ use nimiq_block::{Block, BlockError};
 use nimiq_blockchain::Blockchain;
 use nimiq_blockchain_interface::{AbstractBlockchain, PushError, PushResult};
 use nimiq_hash::{Blake2bHash, Hash};
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::policy::{upgrades, Policy};
 use nimiq_tendermint::ProposalMessage;
 use nimiq_test_log::test;
 use nimiq_test_utils::{
     block_production::TemporaryBlockProducer,
     test_custom_block::{finalize_macro_block, next_macro_block_proposal},
+    versions::{assert_all_versions, bp},
 };
 
 fn produce_blocks(temp_producer: &TemporaryBlockProducer, count: u32) {
@@ -257,5 +258,42 @@ fn it_rejects_non_election_macro_block_proposals_with_superfluous_interlink() {
     assert_eq!(
         blockchain.verify_macro_block_proposal(proposal, 0, None),
         Err(PushError::InvalidBlock(BlockError::InvalidInterlink))
+    );
+}
+
+/// Seeds a chain at `version`, builds a macro block proposal whose `diff_root` does not match its
+/// real state diff, and returns the proposal verification result.
+fn verify_macro_proposal_with_wrong_diff_root(version: u16) -> Result<(), PushError> {
+    let temp_producer = TemporaryBlockProducer::new_with_protocol_version(version);
+    produce_blocks(&temp_producer, Policy::blocks_per_batch() - 1);
+
+    let blockchain = temp_producer.blockchain.upgradable_read();
+    let mut proposal = temp_producer
+        .producer
+        .next_macro_block_proposal(
+            &blockchain,
+            blockchain.timestamp() + Policy::BLOCK_SEPARATION_TIME,
+            0,
+            vec![],
+            None,
+        )
+        .unwrap();
+    proposal.header.diff_root = "invalid diff root".hash();
+
+    blockchain
+        .verify_macro_block_proposal(proposal, 0, None)
+        .map(|_| ())
+}
+
+/// When a validator verifies a macro block proposal, a wrong `diff_root` verifies before
+/// `DIFF_ROOT_COMMITMENT` and is rejected from it onward (so honest validators won't sign it).
+#[test]
+fn it_verifies_the_diff_root_in_a_macro_block_proposal_from_the_commitment_version() {
+    assert_all_versions(
+        |v| verify_macro_proposal_with_wrong_diff_root(v).is_ok(),
+        vec![bp(upgrades::v2::DIFF_ROOT_COMMITMENT, |v| {
+            verify_macro_proposal_with_wrong_diff_root(v)
+                == Err(PushError::InvalidBlock(BlockError::DiffRootMismatch))
+        })],
     );
 }

--- a/blockchain/tests/push.rs
+++ b/blockchain/tests/push.rs
@@ -9,10 +9,12 @@ use nimiq_blockchain_interface::{
     PushResult,
 };
 use nimiq_bls::AggregateSignature;
-use nimiq_hash::{Blake2bHash, Blake2sHash, HashOutput};
+use nimiq_hash::{Blake2bHash, Blake2sHash, Hash, HashOutput};
 use nimiq_keys::KeyPair;
 use nimiq_primitives::{
-    networks::NetworkId, policy::Policy, TendermintIdentifier, TendermintProposal, TendermintStep,
+    networks::NetworkId,
+    policy::{upgrades, Policy},
+    TendermintIdentifier, TendermintProposal, TendermintStep,
 };
 use nimiq_test_log::test;
 use nimiq_test_utils::{
@@ -24,6 +26,7 @@ use nimiq_test_utils::{
     blockchain_events_broadcast::{assert_events_eq_unordered, try_collect_events},
     test_custom_block::{next_macro_block, next_micro_block, next_skip_block, BlockConfig},
     test_rng,
+    versions::{assert_all_versions, bp},
 };
 use nimiq_utils::key_rng::SecureGenerate;
 use nimiq_vrf::VrfSeed;
@@ -466,7 +469,7 @@ fn it_validates_state_root() {
         ..Default::default()
     };
 
-    // This does not fail since now the state root is properly calculated from strach
+    // This does not fail since now the state root is properly calculated from scratch
     push_micro_after_micro(&config, &Ok(PushResult::Extended));
 
     push_rebranch(&config, &Err(PushError::InvalidFork));
@@ -654,4 +657,138 @@ fn it_validates_double_vote_proofs() {
             EquivocationProofError::InvalidJustification,
         )),
     )
+}
+
+/// Seeds a chain at `version`, produces a micro block whose `diff_root` does not match its real
+/// state diff, and returns the push result.
+fn push_micro_block_with_wrong_diff_root(version: u16) -> Result<PushResult, PushError> {
+    let temp_producer = TemporaryBlockProducer::new_with_protocol_version(version);
+    let block = {
+        let blockchain = temp_producer.blockchain.read();
+        next_micro_block(
+            &temp_producer.producer.signing_key,
+            &blockchain,
+            &BlockConfig {
+                diff_root: Some("invalid diff root".hash()),
+                ..Default::default()
+            },
+        )
+    };
+    temp_producer.push(Block::Micro(block))
+}
+
+/// Seeds a chain at `version`, produces a skip block whose `diff_root` does not match its real
+/// state diff, and returns the push result.
+fn push_skip_block_with_wrong_diff_root(version: u16) -> Result<PushResult, PushError> {
+    let temp_producer = TemporaryBlockProducer::new_with_protocol_version(version);
+    let block = {
+        let blockchain = temp_producer.blockchain.read();
+        next_skip_block(
+            &temp_producer.producer.voting_key,
+            &blockchain,
+            &BlockConfig {
+                diff_root: Some("invalid diff root".hash()),
+                ..Default::default()
+            },
+        )
+    };
+    temp_producer.push(Block::Micro(block))
+}
+
+/// Seeds a chain at `version`, advances to the (checkpoint) macro block and produces it with a
+/// `diff_root` that does not match its real state diff, and returns the push result.
+fn push_macro_block_with_wrong_diff_root(version: u16) -> Result<PushResult, PushError> {
+    let temp_producer = TemporaryBlockProducer::new_with_protocol_version(version);
+    for _ in 0..Policy::blocks_per_batch() - 1 {
+        let block = temp_producer.next_block(vec![], false);
+        temp_producer.push(block).unwrap();
+    }
+    let block = {
+        let blockchain = temp_producer.blockchain.read();
+        next_macro_block(
+            &temp_producer.producer.signing_key,
+            &temp_producer.producer.voting_key,
+            &blockchain,
+            &BlockConfig {
+                diff_root: Some("invalid diff root".hash()),
+                ..Default::default()
+            },
+        )
+    };
+    temp_producer.push(block)
+}
+
+/// Seeds a chain at `version`, advances to the election block and produces it with a `diff_root`
+/// that does not match its real state diff, and returns the push result.
+fn push_election_block_with_wrong_diff_root(version: u16) -> Result<PushResult, PushError> {
+    let temp_producer = TemporaryBlockProducer::new_with_protocol_version(version);
+    for _ in 0..Policy::blocks_per_epoch() - 1 {
+        let block = temp_producer.next_block(vec![], false);
+        temp_producer.push(block).unwrap();
+    }
+    let block = {
+        let blockchain = temp_producer.blockchain.read();
+        next_macro_block(
+            &temp_producer.producer.signing_key,
+            &temp_producer.producer.voting_key,
+            &blockchain,
+            &BlockConfig {
+                diff_root: Some("invalid diff root".hash()),
+                ..Default::default()
+            },
+        )
+    };
+    temp_producer.push(block)
+}
+
+/// On push, a micro block carrying a wrong `diff_root` is accepted before
+/// `DIFF_ROOT_COMMITMENT` and rejected from it onward.
+#[test]
+fn it_verifies_the_micro_block_diff_root_from_the_commitment_version() {
+    assert_all_versions(
+        |v| push_micro_block_with_wrong_diff_root(v) == Ok(PushResult::Extended),
+        vec![bp(upgrades::v2::DIFF_ROOT_COMMITMENT, |v| {
+            push_micro_block_with_wrong_diff_root(v)
+                == Err(InvalidBlock(BlockError::DiffRootMismatch))
+        })],
+    );
+}
+
+/// On push, a skip block carrying a wrong `diff_root` is accepted before
+/// `DIFF_ROOT_COMMITMENT` and rejected from it onward.
+#[test]
+fn it_verifies_the_skip_block_diff_root_from_the_commitment_version() {
+    assert_all_versions(
+        |v| push_skip_block_with_wrong_diff_root(v) == Ok(PushResult::Extended),
+        vec![bp(upgrades::v2::DIFF_ROOT_COMMITMENT, |v| {
+            push_skip_block_with_wrong_diff_root(v)
+                == Err(InvalidBlock(BlockError::DiffRootMismatch))
+        })],
+    );
+}
+
+/// On push, a macro block carrying a wrong `diff_root` is accepted before
+/// `DIFF_ROOT_COMMITMENT` and rejected from it onward.
+#[test]
+fn it_verifies_the_macro_block_diff_root_from_the_commitment_version() {
+    assert_all_versions(
+        |v| push_macro_block_with_wrong_diff_root(v) == Ok(PushResult::Extended),
+        vec![bp(upgrades::v2::DIFF_ROOT_COMMITMENT, |v| {
+            push_macro_block_with_wrong_diff_root(v)
+                == Err(InvalidBlock(BlockError::DiffRootMismatch))
+        })],
+    );
+}
+
+/// On push, an election block carrying a wrong `diff_root` is accepted before
+/// `DIFF_ROOT_COMMITMENT` and rejected from it onward.
+#[test]
+fn it_verifies_the_election_block_diff_root_from_the_commitment_version() {
+    assert_all_versions(
+        |v| push_election_block_with_wrong_diff_root(v) == Ok(PushResult::Extended),
+        vec![bp(upgrades::v2::DIFF_ROOT_COMMITMENT, |v| {
+            push_election_block_with_wrong_diff_root(v)
+                == Err(InvalidBlock(BlockError::DiffRootMismatch))
+        })],
+    );
 }

--- a/primitives/block/src/lib.rs
+++ b/primitives/block/src/lib.rs
@@ -49,6 +49,8 @@ pub enum BlockError {
     BodyHashMismatch,
     #[error("Accounts hash mismatch")]
     AccountsHashMismatch,
+    #[error("Diff root mismatch")]
+    DiffRootMismatch,
     #[error("Invalid history root")]
     InvalidHistoryRoot,
 

--- a/primitives/block/src/macro_block.rs
+++ b/primitives/block/src/macro_block.rs
@@ -395,6 +395,11 @@ impl SerializeContent for MacroHeader {
         self.payload_commitment_root().serialize_to_writer(writer)?;
         self.history_root.serialize_to_writer(writer)?;
 
+        // From `DIFF_ROOT_COMMITMENT` on, the diff root is part of the (signed) header hash.
+        if self.version >= upgrades::v2::DIFF_ROOT_COMMITMENT {
+            self.diff_root.serialize_to_writer(writer)?;
+        }
+
         Ok(())
     }
 }

--- a/primitives/block/tests/verify.rs
+++ b/primitives/block/tests/verify.rs
@@ -10,15 +10,25 @@ use nimiq_keys::{Address, Ed25519PublicKey as SchnorrPublicKey, Ed25519Signature
 use nimiq_primitives::{
     coin::Coin,
     networks::NetworkId,
-    policy::Policy,
+    policy::{upgrades, Policy},
     slots_allocation::{Validator, Validators, ValidatorsBuilder},
 };
+use nimiq_serde::Deserialize;
 use nimiq_test_log::test;
-use nimiq_test_utils::blockchain::{generate_transactions, validator_address};
+use nimiq_test_utils::{
+    blockchain::{generate_transactions, validator_address},
+    versions::{assert_all_versions, bp},
+};
 use nimiq_transaction::{ExecutedTransaction, Transaction};
 
 /// Test blocks use timestamp 0; this allows up to 1 second into the future.
 const TEST_MAX_TIMESTAMP: u64 = 1000;
+
+/// A real micro block produced under a protocol version below `DIFF_ROOT_COMMITMENT`.
+const PRE_COMMITMENT_VERSION_MICRO_BLOCK: &str = "010701c90188cfe981cd2f4f8f18fcfe98ccacee0745b6aa69365cd28c836f962d577de57f04aa17fe54a18bb8c886fe96c5cff2a6a2f5e5587779c2a08b3bdccb68923aa30879b5169b238a0a6251c5a0e64a0809bd296d1bf1e9f9c75f07d546ce5b6f511d5da932e301a48c1c89b89fb46ac24d3e190fb72bd17d268407d36a48cd73ced4e870402e07006dd08f34183d089f3e95917e05ebdc11983aa6f433d99332af0cb74b0e299da2774f9018b4b2cdc08f8928e89b0d963ac388e537b003492c69aafeeab976e55303170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131481e47a19e6b29b0a65b9591762ce5143ed30d0261e5d24a3201752506b20f15c0100e873f12b712f8fe1c337fefb0bacd37dc9257846878386e71e15e05ce4f6fbc31b414ce0887c6a03dd34a36a40993c44aa11878883c0df683a1b415f47fa7a02010000";
+
+/// A real macro block produced under a protocol version below `DIFF_ROOT_COMMITMENT`.
+const PRE_COMMITMENT_VERSION_MACRO_BLOCK: &str = "000701e80100b8b9eb81cd2f2a59f22014aa9b1bf739abf71dbdb02eaa954e4febbc8fd4ffc43356e531e3804f8f18fcfe98ccacee0745b6aa69365cd28c836f962d577de57f04aa17fe54a1008090c81856fb3385f88ab330fbb222a1f776186011eab09980705585271ea04571c4042a747bfb7e3b4f089b0109968c9a2359abf18d8aa31258b9d8af68bf0f2aa3ae2fb99b75e24684d336cf50371888556cac228ec10c1ab32499df0b3505006dd08f34183d089f3e95917e05ebdc11983aa6f433d99332af0cb74b0e299da24f3ac8d1e747d2f46da2fef81f51cad8be2664acec4b30926083d11b7c811c6c03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131481e47a19e6b29b0a65b9591762ce5143ed30d0261e5d24a3201752506b20f15c000001000100a0caba01ff7b00f356b6e20ba6a297f2d7901042c460b4cb2502bb3478fcd8397ca6fc5fb28361938021b5fe69412074e646f17853dec44a17fb245c82f016f46c6068886a16fcf6e9da19280db7ed3d4632271ce4983970ec376ddd04258008ffffffffffffffffff01ffffffffffffffffff01ffffffffffffffffff01ffffffffffffffffff01ffffffffffffffffff01ffffffffffffffffff01ffffffffffffffffff01ffffffffffffffffff01";
 
 #[test]
 fn test_verify_header_network() {
@@ -819,5 +829,83 @@ fn test_verify_rejects_out_of_range_punished_set() {
     assert_eq!(
         block.verify(NetworkId::UnitAlbatross, TEST_MAX_TIMESTAMP),
         Ok(())
+    );
+}
+
+/// Builds a header at `version` and reports whether changing only `diff_root` changes the header
+/// hash, i.e. whether the hash commits to `diff_root`.
+fn micro_header_hash_commits_to_diff_root(version: u16) -> bool {
+    let mut header = MicroHeader {
+        network: NetworkId::UnitAlbatross,
+        version,
+        block_number: 1,
+        timestamp: 0,
+        ..Default::default()
+    };
+    let header_hash = header.hash();
+    header.diff_root = "a different diff root".hash();
+    header_hash != header.hash()
+}
+
+fn macro_header_hash_commits_to_diff_root(version: u16) -> bool {
+    let mut header = MacroHeader {
+        network: NetworkId::UnitAlbatross,
+        version,
+        block_number: Policy::macro_block_after(1),
+        round: 0,
+        timestamp: 0,
+        ..Default::default()
+    };
+    let header_hash = header.hash();
+    header.diff_root = "a different diff root".hash();
+    header_hash != header.hash()
+}
+
+/// Micro block header hashes are not gated: they commit to `diff_root` in every version.
+#[test]
+fn it_commits_to_the_diff_root_in_the_micro_header_hash() {
+    assert_all_versions(micro_header_hash_commits_to_diff_root, vec![]);
+}
+
+/// The macro block header hash commits to `diff_root` from `DIFF_ROOT_COMMITMENT` onward;
+/// before that version it does not (so pre-commitment-version hashes stay unchanged).
+#[test]
+fn it_commits_to_the_diff_root_in_the_macro_header_hash_from_the_commitment_version() {
+    assert_all_versions(
+        |v| !macro_header_hash_commits_to_diff_root(v),
+        vec![bp(
+            upgrades::v2::DIFF_ROOT_COMMITMENT,
+            macro_header_hash_commits_to_diff_root,
+        )],
+    );
+}
+
+/// A real micro block from before `DIFF_ROOT_COMMITMENT` must keep its original hash: the
+/// gating must not retroactively change the hash of pre-commitment-version blocks.
+#[test]
+fn it_preserves_the_hash_of_a_pre_commitment_version_micro_block() {
+    let block =
+        Block::deserialize_from_vec(&hex::decode(PRE_COMMITMENT_VERSION_MICRO_BLOCK).unwrap())
+            .unwrap();
+
+    assert!(block.version() < upgrades::v2::DIFF_ROOT_COMMITMENT);
+    assert_eq!(
+        block.hash().to_string(),
+        "79ec03e9fc624a9ebffe66bc724349cf993104a24d6296bb13240174488046cb",
+    );
+}
+
+/// A real macro block from before `DIFF_ROOT_COMMITMENT` must keep its original hash: the
+/// gating must not retroactively change the hash of pre-commitment-version blocks.
+#[test]
+fn it_preserves_the_hash_of_a_pre_commitment_version_macro_block() {
+    let block =
+        Block::deserialize_from_vec(&hex::decode(PRE_COMMITMENT_VERSION_MACRO_BLOCK).unwrap())
+            .unwrap();
+
+    assert!(block.version() < upgrades::v2::DIFF_ROOT_COMMITMENT);
+    assert_eq!(
+        block.hash().to_string(),
+        "4aa3e0d454336e6dd28656318fd3290a62f91b5c66b4e5c5cc05646c9f58eb39",
     );
 }

--- a/primitives/src/policy/upgrades/v2.rs
+++ b/primitives/src/policy/upgrades/v2.rs
@@ -25,3 +25,7 @@ pub const EQUIVOCATION_REPORTING_WINDOW: u16 = VERSION;
 /// `Validators::commitment_hash`) — so a peer cannot swap them on an election block
 /// under an unchanged hash. Gated in `MacroHeader::serialize_payload_commitment`.
 pub const ELECTION_VALIDATOR_METADATA_COMMITMENT: u16 = VERSION;
+
+/// The `diff_root` is committed to the block header hash and verified against the block's actual
+/// state diff. Before this version the `diff_root` is neither hashed nor checked.
+pub const DIFF_ROOT_COMMITMENT: u16 = VERSION;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -10,6 +10,7 @@ pub mod test_network;
 pub mod test_transaction;
 pub mod transactions;
 pub mod validator;
+pub mod versions;
 
 pub use self::test_rng::test_rng;
 

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -124,6 +124,9 @@ pub fn next_micro_block(
         .exercise_transactions(&transactions, &inherents, &block_state, None)
         .expect("Failed to compute accounts hash during block production");
 
+    // Allow tests to inject a specific diff root (e.g. an incorrect one).
+    let diff_root = config.diff_root.clone().unwrap_or(diff_root);
+
     let hist_txs = HistoricTransaction::from(
         blockchain.network_id,
         block_number,
@@ -386,7 +389,8 @@ pub fn next_macro_block_proposal(
     };
 
     macro_block.header.state_root = state_root;
-    macro_block.header.diff_root = diff_root;
+    // Allow tests to inject a specific diff root (e.g. an incorrect one).
+    macro_block.header.diff_root = config.diff_root.clone().unwrap_or(diff_root);
 
     let hist_txs = HistoricTransaction::from(
         blockchain.network_id,

--- a/test-utils/src/versions.rs
+++ b/test-utils/src/versions.rs
@@ -1,0 +1,268 @@
+//! Version-dependent test helper.
+//!
+//! [`assert_all_versions`] sweeps every protocol version from `1` up to
+//! [`Policy::max_supported_version()`] (inclusive) and asserts a property that
+//! may change at one or more *breakpoints*. This mirrors the version-gating
+//! pattern used throughout the codebase, where behaviour flips on
+//! `block.version() >= upgrades::vN::SOME_CHANGE` (see
+//! [`nimiq_primitives::policy::upgrades`]).
+//!
+//! A *breakpoint* `(b, pred)` switches the active predicate to `pred` from
+//! version `b` onward (inclusive). Before the first breakpoint, the
+//! `before_breakpoint` predicate is active. Every version is evaluated with its
+//! active predicate, which must return `true`.
+//!
+//! The helper is intentionally self-contained: apart from reading the
+//! [`Policy`] constant for the upper bound it has no dependency on the rest of
+//! the workspace, so the same pattern can be lifted into other projects.
+//!
+//! # Examples
+//!
+//! A property that flips once, at version 2 (predicates are pure functions of
+//! `v`, so closures here capture nothing):
+//!
+//! ```ignore
+//! use nimiq_test_utils::versions::{assert_all_versions, bp};
+//!
+//! assert_all_versions(
+//!     |v| reward_curve(v) == Curve::Legacy,           // v == 1
+//!     vec![bp(2, |v| reward_curve(v) == Curve::New)], // v == 2..=max
+//! );
+//! ```
+//!
+//! Several breakpoints produce several segments:
+//!
+//! ```ignore
+//! assert_all_versions(
+//!     |v| hash_algo(v) == Hash::Blake2b,           // v == 1
+//!     vec![
+//!         bp(2, |v| hash_algo(v) == Hash::Blake2s), // v == 2
+//!         bp(3, |v| hash_algo(v) == Hash::Blake3),  // v == 3..=max
+//!     ],
+//! );
+//! ```
+//!
+//! Bigger predicates may borrow a shared fixture (enabled by the lifetime on
+//! [`VersionPredicate`]) and fold several checks into the returned `bool`:
+//!
+//! ```ignore
+//! let blockchain = temporary_blockchain(NetworkId::UnitAlbatross);
+//! let producer = BlockProducer::new(/* … */);
+//!
+//! assert_all_versions(
+//!     |v| {
+//!         let block = producer.next_macro_block(&blockchain, v, None);
+//!         block.verify(&blockchain).is_ok() && block.diff_root() == Blake2bHash::default()
+//!     },
+//!     vec![bp(upgrades::v2::VERSION, |v| {
+//!         let diff = compute_diff(&blockchain);
+//!         let block = producer.next_macro_block(&blockchain, v, Some(diff.root()));
+//!         block.verify(&blockchain).is_ok() && block.diff_root() == diff.root()
+//!     })],
+//! );
+//! ```
+//!
+//! When a property is uniform across versions, omit the breakpoints entirely:
+//!
+//! ```ignore
+//! assert_all_versions(|v| supports_upgrade_for(v), vec![]);
+//! ```
+
+use nimiq_primitives::policy::Policy;
+
+/// A predicate evaluated for a single protocol version. It receives the version
+/// `v` and must return `true`; returning `false` fails the assertion.
+///
+/// The `'a` lifetime allows boxed predicates to borrow test-local fixtures
+/// rather than forcing every captured value to be `'static`.
+pub type VersionPredicate<'a> = Box<dyn Fn(u16) -> bool + 'a>;
+
+/// Convenience constructor for a breakpoint entry, avoiding the `Box::new`
+/// boilerplate at call sites: `bp(2, |v| ...)` instead of
+/// `(2, Box::new(|v| ...))`.
+pub fn bp<'a>(version: u16, pred: impl Fn(u16) -> bool + 'a) -> (u16, VersionPredicate<'a>) {
+    (version, Box::new(pred))
+}
+
+/// Asserts a version-gated property across every protocol version from `1` up
+/// to [`Policy::max_supported_version()`] (inclusive).
+///
+/// `before_breakpoint` is the active predicate until the first breakpoint. Each
+/// `(b, pred)` in `breakpoints` switches the active predicate to `pred` from
+/// version `b` onward. `breakpoints` is sorted ascending internally, so the
+/// caller need not pre-sort it.
+///
+/// # Panics
+///
+/// - if two breakpoints share the same version, or
+/// - if any breakpoint `b` does not satisfy `1 < b <= max_version`, or
+/// - if any version's active predicate returns `false` (the panic message lists
+///   every failing version together with its active segment).
+pub fn assert_all_versions<'a>(
+    before_breakpoint: impl Fn(u16) -> bool,
+    breakpoints: Vec<(u16, VersionPredicate<'a>)>,
+) {
+    assert_all_versions_with_max(
+        Policy::max_supported_version(),
+        before_breakpoint,
+        breakpoints,
+    );
+}
+
+/// Core of [`assert_all_versions`] with an explicit `max_version`, so the logic
+/// can be exercised deterministically without touching the global [`Policy`].
+fn assert_all_versions_with_max<'a>(
+    max_version: u16,
+    before_breakpoint: impl Fn(u16) -> bool,
+    mut breakpoints: Vec<(u16, VersionPredicate<'a>)>,
+) {
+    assert!(max_version >= 1, "max_version must be at least 1");
+
+    // Sort ascending by version so segment selection and the duplicate check
+    // below can rely on order.
+    breakpoints.sort_by_key(|(version, _)| *version);
+
+    // Validate: breakpoints must be unique and in range.
+    for pair in breakpoints.windows(2) {
+        assert_ne!(
+            pair[0].0, pair[1].0,
+            "duplicate breakpoint at version {}",
+            pair[0].0
+        );
+    }
+    for (version, _) in &breakpoints {
+        assert!(
+            *version > 1 && *version <= max_version,
+            "breakpoint {version} out of range; must satisfy 1 < breakpoint <= {max_version}"
+        );
+    }
+
+    // Evaluate every version with its active predicate, collecting all failures
+    // so the panic reports them together rather than stopping at the first.
+    let mut failures = Vec::new();
+    for v in 1..=max_version {
+        // The active predicate is the one of the highest breakpoint <= v, or
+        // `before_breakpoint` if no breakpoint has been reached yet.
+        match breakpoints.iter().rev().find(|(b, _)| *b <= v) {
+            Some((b, pred)) => {
+                if !pred(v) {
+                    failures.push(format!("version {v} (breakpoint at version {b})"));
+                }
+            }
+            None => {
+                if !before_breakpoint(v) {
+                    failures.push(format!("version {v} (before first breakpoint)"));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "version assertion failed for: {}",
+        failures.join(", ")
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[test]
+    fn selects_correct_segment_and_sorts_input() {
+        // max = 5, segments: before -> {1}, bp(2) -> {2, 3}, bp(4) -> {4, 5}.
+        // Each predicate returns true only for versions in its own segment, so
+        // a wrong segment selection (or a failure to sort) would fail.
+        assert_all_versions_with_max(
+            5,
+            |v| v == 1,
+            // Passed out of order on purpose to exercise the internal sort.
+            vec![
+                bp(4, |v| (4..=5).contains(&v)),
+                bp(2, |v| (2..=3).contains(&v)),
+            ],
+        );
+    }
+
+    #[test]
+    fn breakpoint_equal_to_max_version_is_inclusive() {
+        // bp(3) is active only for the final version.
+        assert_all_versions_with_max(3, |v| v < 3, vec![bp(3, |v| v == 3)]);
+    }
+
+    #[test]
+    fn empty_breakpoints_cover_all_versions() {
+        assert_all_versions_with_max(4, |v| (1..=4).contains(&v), vec![]);
+    }
+
+    #[test]
+    fn max_version_of_one() {
+        assert_all_versions_with_max(1, |v| v == 1, vec![]);
+    }
+
+    #[test]
+    fn every_version_is_visited_exactly_once() {
+        let visited = RefCell::new(Vec::new());
+        assert_all_versions_with_max(
+            4,
+            |v| {
+                visited.borrow_mut().push(v);
+                true
+            },
+            vec![bp(3, |v| {
+                visited.borrow_mut().push(v);
+                true
+            })],
+        );
+        assert_eq!(*visited.borrow(), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate breakpoint at version 2")]
+    fn duplicate_breakpoint_panics() {
+        assert_all_versions_with_max(3, |_| true, vec![bp(2, |_| true), bp(2, |_| true)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn breakpoint_above_max_panics() {
+        assert_all_versions_with_max(3, |_| true, vec![bp(5, |_| true)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn breakpoint_at_one_panics() {
+        assert_all_versions_with_max(3, |_| true, vec![bp(1, |_| true)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn breakpoint_at_zero_panics() {
+        assert_all_versions_with_max(3, |_| true, vec![bp(0, |_| true)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "version 2 (before first breakpoint)")]
+    fn failing_before_breakpoint_names_version_and_segment() {
+        assert_all_versions_with_max(3, |v| v != 2, vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "version 2 (breakpoint at version 2)")]
+    fn failing_breakpoint_segment_names_breakpoint() {
+        assert_all_versions_with_max(3, |_| true, vec![bp(2, |_| false)]);
+    }
+
+    #[test]
+    fn predicates_can_borrow_a_shared_fixture() {
+        // Demonstrates the `'a` lifetime: both predicates borrow `fixture`.
+        let fixture = [10u16, 20, 30];
+        assert_all_versions_with_max(
+            3,
+            |v| fixture[(v - 1) as usize] == v * 10,
+            vec![bp(2, |v| fixture[(v - 1) as usize] == v * 10)],
+        );
+    }
+}


### PR DESCRIPTION
The macro block header hash excluded `diff_root`, so the Tendermint signature never committed to it and it was never verified against the block's real state diff. A malicious proposer could forge `diff_root` and mislead diff-syncing nodes.

- Include `diff_root` in `MacroHeader::serialize_content` (micro headers already did).
- Verify `diff_root` against the recomputed forward diff on complete nodes, both on import (`push`) and during macro proposal verification, before validators vote.

Both are gated on `upgrades::v2::DIFF_ROOT_COMMITMENT`: non-retroactive, activating with the v2 hard fork and a no-op for v1, so existing behaviour is unchanged.

The first commit adds an `assert_all_versions` test helper that asserts version-gated behaviour across every supported protocol version.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
