### PR TITLE
Bind skip block state_root into the aggregate proof

### DIFF
--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -4,9 +4,11 @@ use nimiq_account::{
 use nimiq_block::{Block, BlockError, SkipBlockInfo};
 use nimiq_blockchain_interface::PushError;
 use nimiq_database::{mdbx::MdbxReadTransaction, traits::Database};
+use nimiq_hash::Blake2bHash;
 use nimiq_keys::Address;
 use nimiq_primitives::{
     key_nibbles::KeyNibbles,
+    policy::Policy,
     trie::{error::IncompleteTrie, trie_diff::TrieDiff, trie_proof::TrieProof},
 };
 use nimiq_serde::Deserialize;
@@ -131,6 +133,40 @@ impl Blockchain {
                 Ok(total_tx_size)
             }
         }
+    }
+
+    /// Computes the `state_root` that a skip block on top of the current head would commit to.
+    /// Every header field of that skip block is determined by the head block (see
+    /// `Block::verify_immediate_successor`): the block number is the successor's, the timestamp is
+    /// the head's plus [`Policy::MIN_PRODUCER_TIMEOUT`], the VRF seed is carried over and the
+    /// protocol version stays unchanged. Since a skip block has an empty body and applies a
+    /// single, deterministic `Penalize` inherent, the resulting state root is fully determined by
+    /// the current (head) state.
+    ///
+    /// Validators use this to bind the `state_root` into the skip block proof before aggregating it
+    pub fn next_skip_block_state_root(&self) -> Blake2bHash {
+        let head = &self.state.main_chain.head;
+        let block_number = head.block_number() + 1;
+        let timestamp = head.timestamp() + Policy::MIN_PRODUCER_TIMEOUT;
+
+        let skip_block_info = SkipBlockInfo {
+            network_id: self.network_id,
+            block_number,
+            vrf_entropy: head.seed().entropy(),
+        };
+
+        let inherents =
+            self.create_punishment_inherents(block_number, &[], Some(skip_block_info), None);
+
+        let block_state = BlockState::new(block_number, timestamp, self.state.current_version());
+
+        let (state_root, _, _) = self
+            .state
+            .accounts
+            .exercise_transactions(&[], &inherents, &block_state, None)
+            .expect("Failed to compute skip block state root");
+
+        state_root
     }
 
     /// Reverts the accounts given a block. This only applies to micro blocks and skip blocks, since

--- a/blockchain/tests/signed.rs
+++ b/blockchain/tests/signed.rs
@@ -8,6 +8,7 @@ use nimiq_blockchain_interface::AbstractBlockchain;
 use nimiq_bls::{AggregateSignature, KeyPair, LazyPublicKey as BlsLazyPublicKey};
 use nimiq_collections::bitset::BitSet;
 use nimiq_database::mdbx::MdbxDatabase;
+use nimiq_hash::Blake2bHash;
 use nimiq_keys::{Address, Ed25519PublicKey};
 use nimiq_primitives::{
     networks::NetworkId,
@@ -61,7 +62,9 @@ fn test_skip_block_single_signature() {
         0..Policy::SLOTS,
     )]);
 
-    assert!(skip_block_proof.verify(&skip_block_info, &validators));
+    // The proof was signed over the legacy message (no state root), so it is verified against a
+    // pre-binding protocol version. The state root argument is therefore ignored.
+    assert!(skip_block_proof.verify(&skip_block_info, &Blake2bHash::default(), 1, &validators));
 }
 
 #[test]

--- a/blockchain/tests/skip_block_state_root_binding.rs
+++ b/blockchain/tests/skip_block_state_root_binding.rs
@@ -1,0 +1,91 @@
+//! Regression tests for the forged skip block `state_root` vulnerability.
+//!
+//! Validators only sign the reduced `SkipBlockInfo` (network id, block number, VRF entropy) of a
+//! skip block, not its full header. Before `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` this let
+//! a public attacker replay a valid skip block proof onto a header carrying a forged `state_root`.
+//! An incomplete (state live syncing) node could not recompute the state root and adopted the
+//! forged head, stalling further state synchronization.
+//!
+//! From the binding version on, the proof additionally commits to the `state_root`, so such a
+//! replay invalidates the proof. The binding is gated by the block's protocol version (which cannot
+//! be decreased, see `Block::verify_immediate_successor`) so historical proofs remain verifiable.
+
+use nimiq_block::{Block, BlockError};
+use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_hash::Blake2bHash;
+use nimiq_primitives::{policy::upgrades, slots_allocation::Validators};
+use nimiq_test_log::test;
+use nimiq_test_utils::{
+    block_production::TemporaryBlockProducer,
+    test_custom_block::{next_skip_block, BlockConfig},
+};
+
+/// A `state_root` that differs from any real (deterministic) skip block state root.
+fn forged_state_root() -> Blake2bHash {
+    Blake2bHash::from([0xABu8; 32])
+}
+
+/// Builds the next skip block on top of the (complete) producer's head with the given protocol
+/// `version`. If `forged_state_root` is `Some`, it overrides the header's `state_root` to model an
+/// attacker replaying an honest proof onto a forged header. Returns the block together with the
+/// validators it must be verified against.
+fn next_skip_block_for(
+    producer: &TemporaryBlockProducer,
+    version: u16,
+    forged_state_root: Option<Blake2bHash>,
+) -> (Block, Validators) {
+    let blockchain = producer.blockchain.read();
+    let config = BlockConfig {
+        version: Some(version),
+        // The proof is always signed over the real state root; this only rewrites the header.
+        state_root: forged_state_root,
+        ..Default::default()
+    };
+    let skip_block = next_skip_block(&producer.producer.voting_key, &blockchain, &config);
+    let validators = blockchain.current_validators().unwrap().clone();
+    (Block::Micro(skip_block), validators)
+}
+
+#[test]
+fn it_accepts_a_correctly_bound_skip_block_proof() {
+    let producer = TemporaryBlockProducer::new();
+
+    // A genuine skip block at the binding version: the proof commits to the real state root, which
+    // matches the header.
+    let (block, validators) =
+        next_skip_block_for(&producer, upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING, None);
+
+    assert_eq!(block.verify_validators(&validators), Ok(()));
+}
+
+#[test]
+fn it_rejects_a_forged_state_root_skip_block_proof() {
+    let producer = TemporaryBlockProducer::new();
+
+    // The same proof replayed onto a header with a forged state root. From the binding version on,
+    // the forged state root is part of the verified message and no longer matches the signature.
+    let (block, validators) = next_skip_block_for(
+        &producer,
+        upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING,
+        Some(forged_state_root()),
+    );
+
+    assert_eq!(
+        block.verify_validators(&validators),
+        Err(BlockError::InvalidSkipBlockProof)
+    );
+}
+
+#[test]
+fn it_does_not_bind_state_root_before_the_upgrade_version() {
+    let producer = TemporaryBlockProducer::new();
+
+    // Below the binding version the state root is not part of the signed message, so a forged state
+    // root still produces a valid proof. This is the pre-fork behaviour, kept so that historical
+    // version 1 skip block proofs remain verifiable.
+    let legacy_version = upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING - 1;
+    let (block, validators) =
+        next_skip_block_for(&producer, legacy_version, Some(forged_state_root()));
+
+    assert_eq!(block.verify_validators(&validators), Ok(()));
+}

--- a/primitives/block/src/micro_block.rs
+++ b/primitives/block/src/micro_block.rs
@@ -106,7 +106,16 @@ impl MicroBlock {
                     vrf_entropy: self.header.seed.entropy(),
                 };
 
-                if !proof.verify(&skip_block, validators) {
+                // From `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` on, the proof also commits to
+                // the header `state_root`, so a forged `state_root` invalidates the proof. The header
+                // version cannot be decreased below the predecessor's (checked in
+                // `verify_immediate_successor`), preventing a downgrade to the legacy message.
+                if !proof.verify(
+                    &skip_block,
+                    &self.header.state_root,
+                    self.header.version,
+                    validators,
+                ) {
                     debug!(
                         block = %self,
                         reason = "Bad skip block proof",

--- a/primitives/block/src/skip_block.rs
+++ b/primitives/block/src/skip_block.rs
@@ -1,10 +1,13 @@
 use std::fmt::Debug;
 
-use nimiq_bls::AggregatePublicKey;
+use nimiq_bls::{AggregatePublicKey, SigHash};
+use nimiq_hash::Blake2bHash;
 use nimiq_hash_derive::SerializeContent;
 use nimiq_primitives::{
-    networks::NetworkId, policy::Policy, slots_allocation::Validators, Message, SignedMessage,
-    PREFIX_SKIP_BLOCK_INFO,
+    networks::NetworkId,
+    policy::{upgrades, Policy},
+    slots_allocation::Validators,
+    Message, SignedMessage, PREFIX_SKIP_BLOCK_INFO, PREFIX_SKIP_BLOCK_WITH_STATE_ROOT_INFO,
 };
 use nimiq_serde::{Deserialize, Serialize, SerializedMaxSize};
 use nimiq_vrf::VrfEntropy;
@@ -43,10 +46,45 @@ impl SkipBlockInfo {
             None
         }
     }
+
+    /// Computes the message hash that the validators sign when attesting to a skip block.
+    ///
+    /// From `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` onwards the signed message is a
+    /// [`SkipBlockWithStateRootInfo`], which additionally commits to the skip block's
+    /// `state_root`. This binds the otherwise unauthenticated header commitment to the aggregate
+    /// proof, so a valid proof can no longer be replayed onto a header carrying a forged
+    /// `state_root`. For earlier protocol versions the legacy hash (over the reduced
+    /// `SkipBlockInfo` only) is returned unchanged, keeping historical proofs verifiable.
+    pub fn signing_hash(&self, state_root: &Blake2bHash, protocol_version: u16) -> SigHash {
+        if protocol_version < upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING {
+            self.hash_with_prefix()
+        } else {
+            SkipBlockWithStateRootInfo {
+                info: self.clone(),
+                state_root: state_root.clone(),
+            }
+            .hash_with_prefix()
+        }
+    }
 }
 
 impl Message for SkipBlockInfo {
     const PREFIX: u8 = PREFIX_SKIP_BLOCK_INFO;
+}
+
+/// The skip block message that validators sign from
+/// `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` on: the reduced [`SkipBlockInfo`] together with
+/// the deterministic `state_root` the skip block commits to. Signing this as its own prefixed
+/// [`Message`] (instead of re-hashing the `SkipBlockInfo` hash with the `state_root` appended)
+/// keeps the domain separation between validator-signed messages explicit.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, SerializeContent)]
+pub struct SkipBlockWithStateRootInfo {
+    pub info: SkipBlockInfo,
+    pub state_root: Blake2bHash,
+}
+
+impl Message for SkipBlockWithStateRootInfo {
+    const PREFIX: u8 = PREFIX_SKIP_BLOCK_WITH_STATE_ROOT_INFO;
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedMaxSize)]
@@ -58,7 +96,17 @@ pub struct SkipBlockProof {
 impl SkipBlockProof {
     /// Verifies the proof. This only checks that the proof is valid for this skip block, not that
     /// the skip block itself is valid.
-    pub fn verify(&self, skip_block: &SkipBlockInfo, validators: &Validators) -> bool {
+    ///
+    /// `state_root` and `protocol_version` are those of the block the proof is attached to. From
+    /// `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` onwards the `state_root` is part of the
+    /// signed message (see [`SkipBlockInfo::signing_hash`]).
+    pub fn verify(
+        &self,
+        skip_block: &SkipBlockInfo,
+        state_root: &Blake2bHash,
+        protocol_version: u16,
+        validators: &Validators,
+    ) -> bool {
         let signer_slots = match checked_signer_slots(&self.sig.signers) {
             Some(slots) => slots,
             None => {
@@ -92,6 +140,9 @@ impl SkipBlockProof {
         }
 
         // Verify the aggregated signature against our aggregated public key.
-        agg_pk.verify_hash(skip_block.hash_with_prefix(), &self.sig.signature)
+        agg_pk.verify_hash(
+            skip_block.signing_hash(state_root, protocol_version),
+            &self.sig.signature,
+        )
     }
 }

--- a/primitives/src/policy/upgrades/v2.rs
+++ b/primitives/src/policy/upgrades/v2.rs
@@ -29,3 +29,8 @@ pub const ELECTION_VALIDATOR_METADATA_COMMITMENT: u16 = VERSION;
 /// The `diff_root` is committed to the block header hash and verified against the block's actual
 /// state diff. Before this version the `diff_root` is neither hashed nor checked.
 pub const DIFF_ROOT_COMMITMENT: u16 = VERSION;
+
+/// A skip block's aggregate proof commits to the block's `state_root`. This binds the otherwise
+/// unauthenticated header commitment to the proof, so a valid proof can no longer be replayed onto
+/// a header carrying a forged `state_root`. See `nimiq_block::SkipBlockInfo::signing_hash`.
+pub const SKIP_BLOCK_STATE_ROOT_BINDING: u16 = VERSION;

--- a/primitives/src/signed.rs
+++ b/primitives/src/signed.rs
@@ -54,6 +54,9 @@ pub const PREFIX_TENDERMINT_COMMIT: u8 = 0x04;
 pub const PREFIX_POKOSK: u8 = 0x05;
 /// prefix to sign a validator info
 pub const PREFIX_VALIDATOR_INFO: u8 = 0x06;
+/// prefix to sign skip block info messages that also bind the skip block's state root
+/// (used from `policy::upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` on)
+pub const PREFIX_SKIP_BLOCK_WITH_STATE_ROOT_INFO: u8 = 0x07;
 
 pub trait Message:
     Clone

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use nimiq_block::{
-    Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo,
-    SkipBlockProof, TendermintProof,
+    Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SkipBlockInfo, SkipBlockProof,
+    TendermintProof,
 };
 use nimiq_blockchain::{BlockProducer, Blockchain, BlockchainConfig};
 use nimiq_blockchain_interface::{
@@ -321,21 +321,24 @@ impl TemporaryBlockProducer {
             BlsSecretKey::deserialize_from_vec(&hex::decode(VOTING_KEY).unwrap()).unwrap(),
         );
 
-        let skip_block_info = {
+        let (skip_block_info, state_root, protocol_version) = {
             let blockchain = self.blockchain.read();
-            SkipBlockInfo {
+            let skip_block_info = SkipBlockInfo {
                 network_id: blockchain.network_id,
                 block_number: blockchain.block_number() + 1,
                 vrf_entropy: blockchain.head().seed().entropy(),
-            }
+            };
+            (
+                skip_block_info,
+                blockchain.next_skip_block_state_root(),
+                blockchain.state().current_version(),
+            )
         };
 
-        // create signed skip block information
-        let skip_block_info =
-            SignedSkipBlockInfo::from_message(skip_block_info, &keypair.secret_key, 0);
-
-        let signature = AggregateSignature::from_signatures(&[skip_block_info
-            .signature
+        // Sign the (possibly state-root bound) skip block message.
+        let signature = AggregateSignature::from_signatures(&[keypair
+            .secret_key
+            .sign_hash(skip_block_info.signing_hash(&state_root, protocol_version))
             .multiply(Policy::SLOTS)]);
         let mut signers = BitSet::new();
         for i in 0..Policy::SLOTS {

--- a/test-utils/src/test_custom_block.rs
+++ b/test-utils/src/test_custom_block.rs
@@ -1,8 +1,8 @@
 use nimiq_account::BlockState;
 use nimiq_block::{
     Block, EquivocationProof, MacroBlock, MacroBody, MacroHeader, MicroBlock, MicroBody,
-    MicroHeader, MicroJustification, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo,
-    SkipBlockProof, TendermintProof,
+    MicroHeader, MicroJustification, MultiSignature, SkipBlockInfo, SkipBlockProof,
+    TendermintProof,
 };
 use nimiq_blockchain::{interface::HistoryInterface, Blockchain};
 use nimiq_blockchain_interface::AbstractBlockchain;
@@ -231,7 +231,13 @@ pub fn next_skip_block(
         .exercise_transactions(&[], &inherents, &block_state, None)
         .expect("Failed to compute accounts hash during block production");
 
-    let state_root = config.state_root.clone().unwrap_or(real_state_root);
+    // The proof is signed over the real (deterministic) state root, mirroring honest validators.
+    // `config.state_root` may override the header's state root to model a forgery; from
+    // `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` on, such a mismatch invalidates the proof.
+    let state_root = config
+        .state_root
+        .clone()
+        .unwrap_or_else(|| real_state_root.clone());
     let diff_root = config.diff_root.clone().unwrap_or(real_diff_root);
 
     let hist_txs = HistoricTransaction::from(
@@ -260,11 +266,13 @@ pub fn next_skip_block(
         transactions: vec![],
     };
 
+    let version = config
+        .version
+        .unwrap_or(blockchain.state().current_version());
+
     let header = MicroHeader {
         network,
-        version: config
-            .version
-            .unwrap_or(blockchain.state().current_version()),
+        version,
         block_number,
         timestamp,
         parent_hash,
@@ -277,7 +285,8 @@ pub fn next_skip_block(
         ..Default::default()
     };
 
-    let skip_block_proof = create_skip_block_proof(voting_key, blockchain, config);
+    let skip_block_proof =
+        create_skip_block_proof(voting_key, blockchain, config, &real_state_root, version);
 
     MicroBlock {
         header,
@@ -493,6 +502,8 @@ fn create_skip_block_proof(
     voting_key_pair: &BlsKeyPair,
     blockchain: &Blockchain,
     config: &BlockConfig,
+    state_root: &Blake2bHash,
+    protocol_version: u16,
 ) -> SkipBlockProof {
     let seed = config
         .seed
@@ -505,11 +516,10 @@ fn create_skip_block_proof(
         vrf_entropy: seed.entropy(),
     };
 
-    let skip_block_info =
-        SignedSkipBlockInfo::from_message(skip_block_info, &voting_key_pair.secret_key, 0);
-
-    let signature =
-        AggregateSignature::from_signatures(&[skip_block_info.signature.multiply(Policy::SLOTS)]);
+    let signature = AggregateSignature::from_signatures(&[voting_key_pair
+        .secret_key
+        .sign_hash(skip_block_info.signing_hash(state_root, protocol_version))
+        .multiply(Policy::SLOTS)]);
     let mut signers = BitSet::new();
     for i in 0..Policy::SLOTS {
         signers.insert(i as usize);

--- a/validator/src/aggregation/skip_block.rs
+++ b/validator/src/aggregation/skip_block.rs
@@ -1,7 +1,7 @@
 use std::{fmt, future::Future, sync::Arc, time::Duration};
 
 use futures::{future, stream::StreamExt};
-use nimiq_block::{MultiSignature, SignedSkipBlockInfo, SkipBlockInfo, SkipBlockProof};
+use nimiq_block::{MultiSignature, SkipBlockInfo, SkipBlockProof};
 use nimiq_bls::{AggregateSignature, KeyPair};
 use nimiq_collections::BitSet;
 use nimiq_handel::{
@@ -15,12 +15,12 @@ use nimiq_handel::{
     store::ReplaceStore,
     update::LevelUpdate,
 };
-use nimiq_hash::Blake2sHash;
+use nimiq_hash::{Blake2bHash, Blake2sHash};
 use nimiq_network_interface::{
     network::CloseReason,
     request::{MessageMarker, RequestCommon},
 };
-use nimiq_primitives::{policy::Policy, slots_allocation::Validators, Message};
+use nimiq_primitives::{policy::Policy, slots_allocation::Validators};
 use nimiq_validator_network::ValidatorNetwork;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -206,6 +206,11 @@ pub struct SkipBlockAggregation {}
 impl SkipBlockAggregation {
     pub async fn start<N: ValidatorNetwork + 'static>(
         skip_block_info: SkipBlockInfo,
+        // The deterministic `state_root` of the skip block to be produced. It is bound into the
+        // signed message from `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` on.
+        state_root: Blake2bHash,
+        // The protocol version of the skip block to be produced.
+        protocol_version: u16,
         voting_key: KeyPair,
         // TODO: This seems to be a SlotBand. Change this to a proper Validator ID.
         validator_id: u16,
@@ -219,20 +224,18 @@ impl SkipBlockAggregation {
             .slots
             .clone();
 
-        let message_hash = skip_block_info.hash_with_prefix();
+        let message_hash = skip_block_info.signing_hash(&state_root, protocol_version);
         trace!(
             %message_hash,
             ?skip_block_info,
+            %state_root,
+            protocol_version,
             "Starting skip block aggregation",
         );
-        let signed_skip_block_info = SignedSkipBlockInfo::from_message(
-            skip_block_info.clone(),
-            &voting_key.secret_key,
-            validator_id,
-        );
 
-        let signature = AggregateSignature::from_signatures(&[signed_skip_block_info
-            .signature
+        let signature = AggregateSignature::from_signatures(&[voting_key
+            .secret_key
+            .sign_hash(message_hash.clone())
             .multiply(slots.len() as u16)]);
 
         let mut signers = BitSet::new();

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -218,18 +218,25 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
             "No micro block received within timeout, producing skip block"
         );
 
-        // Acquire a blockchain read lock and check if the state still matches to fetch active validators.
-        let active_validators = {
+        // Acquire a blockchain read lock and check if the state still matches to fetch the active
+        // validators as well as the deterministic state root and protocol version of the skip
+        // block we are about to produce. From `upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING` on, the state
+        // root is part of the signed skip block message, so it must be known before aggregating.
+        let skip_block_inputs = {
             let blockchain = self.blockchain.read();
             if in_current_state(blockchain.head()) {
-                Some(blockchain.current_validators().unwrap().clone())
+                Some((
+                    blockchain.current_validators().unwrap().clone(),
+                    blockchain.next_skip_block_state_root(),
+                    blockchain.state().current_version(),
+                ))
             } else {
                 None
             }
         };
-        if active_validators.is_none() {
+        let Some((active_validators, state_root, protocol_version)) = skip_block_inputs else {
             return (None, self);
-        }
+        };
 
         let skip_block_info = SkipBlockInfo {
             network_id: self.blockchain.read().network_id,
@@ -239,9 +246,11 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
 
         let (_, skip_block_proof) = SkipBlockAggregation::start(
             skip_block_info.clone(),
+            state_root,
+            protocol_version,
             self.block_producer.voting_key.clone(),
             self.validator_slot_band,
-            active_validators.unwrap(),
+            active_validators,
             Arc::clone(&self.network),
         )
         .await;


### PR DESCRIPTION
Validators only sign the reduced `SkipBlockInfo` (network id, block number, VRF entropy), not the skip block header. An attacker could therefore replay a valid skip block proof onto a header with a forged `state_root`.

From protocol version 2 on, the skip block proof additionally commits to the `state_root` via `SkipBlockInfo::signing_hash`. The binding is gated by the block's protocol version, which cannot be decreased (`Block::verify_immediate_successor`), so historical version 1 proofs remain verifiable and the change only takes effect once a network upgrades.

- Register the change in the `policy::upgrades::v2` activation registry as `SKIP_BLOCK_STATE_ROOT_BINDING` (replacing the standalone `Policy` constant).
- Add `SkipBlockInfo::signing_hash` and thread `state_root` and `protocol_version` through `SkipBlockProof::verify` and `MicroBlock::verify_validators`.
- Compute the deterministic skip block state root before aggregating (`Blockchain::skip_block_state_root`) and bind it in the validator producer.
- Update the skip-block test helpers and add regression tests.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
