### PR TITLE
Update the max supported version from `1` to `2`

### DIFF
--- a/genesis/src/networks.rs
+++ b/genesis/src/networks.rs
@@ -259,7 +259,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                         name: "dev-albatross",
                         genesis: read_genesis_config(Path::new(&p))
                             .expect("failure reading provided NIMIQ_OVERRIDE_DEVNET_CONFIG"),
-                        max_supported_version: 1, // This should only be increased when a new hard fork code is released
+                        max_supported_version: 2, // This should only be increased when a new hard fork code is released
                                                   // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
                     })
                 }) {
@@ -273,7 +273,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                     env!("OUT_DIR"),
                     "/genesis/dev-albatross/genesis.rs",
                 )),
-                max_supported_version: 1,
+                max_supported_version: 2,
             };
             &INFO
         }
@@ -289,7 +289,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                         name: "test-albatross",
                         genesis: read_genesis_config(Path::new(&p))
                             .expect("failure reading provided NIMIQ_OVERRIDE_TESTNET_CONFIG"),
-                        max_supported_version: 1, // This should only be increased when a new hard fork code is released
+                        max_supported_version: 2, // This should only be increased when a new hard fork code is released
                                                   // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
                     })
                 }) {
@@ -303,7 +303,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                     env!("OUT_DIR"),
                     "/genesis/test-albatross/genesis.rs"
                 )),
-                max_supported_version: 1, // This should only be increased when a new hard fork code is released
+                max_supported_version: 2, // This should only be increased when a new hard fork code is released
                                           // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
             };
             &INFO
@@ -333,7 +333,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                         name: "main-albatross",
                         genesis: read_genesis_config(Path::new(&p))
                             .expect("failure reading provided NIMIQ_OVERRIDE_MAINNET_CONFIG"),
-                        max_supported_version: 1, // This should only be increased when a new hard fork code is released
+                        max_supported_version: 2, // This should only be increased when a new hard fork code is released
                                                   // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
                     })
                 }) {
@@ -347,7 +347,7 @@ fn network_impl(network_id: NetworkId) -> Option<&'static NetworkInfo> {
                     env!("OUT_DIR"),
                     "/genesis/main-albatross/genesis.rs"
                 )),
-                max_supported_version: 1, // This should only be increased when a new hard fork code is released
+                max_supported_version: 2, // This should only be increased when a new hard fork code is released
                                           // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
             };
             &INFO

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -770,7 +770,7 @@ pub const MAINNET_POLICY: Policy = Policy {
     genesis_block_number: 3456000,
     // This should only be increased when a new hard fork code is released.
     // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
-    max_supported_version: 1,
+    max_supported_version: 2,
 };
 
 /// Policy constants for TestNet
@@ -783,7 +783,7 @@ pub const TESTNET_POLICY: Policy = Policy {
     genesis_block_number: 3032010,
     // This should only be increased when a new hard fork code is released.
     // VERY IMPORTANT: This should be changed accordingly in `NetworkInfo`.
-    max_supported_version: 1,
+    max_supported_version: 2,
 };
 
 /// Policy constants used for testing purposes


### PR DESCRIPTION
Bump `max_supported_version` from `1` to `2` in the policy constants and in the network info, in preparation for the next hard fork.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
