### PR TITLE
Filter expired equivocation proofs at block production

### DIFF
--- a/primitives/account/tests/staking_contract/punished_slots.rs
+++ b/primitives/account/tests/staking_contract/punished_slots.rs
@@ -734,7 +734,7 @@ fn jail_not_reelected_and_revert(
         "Reporting block must be in a later epoch than the offense"
     );
     assert!(
-        reporting_block <= Policy::last_block_of_reporting_window(offense_event_block),
+        reporting_block <= Policy::last_block_of_collateral_lockup(offense_event_block),
         "Can only report event up until the reporting window"
     );
 

--- a/primitives/src/policy.rs
+++ b/primitives/src/policy.rs
@@ -567,6 +567,9 @@ impl Policy {
     /// equivocation *reporting* (that is `lastBlockOfEquivocationReportingWindow`); it has always
     /// been the collateral lock-up window. Kept for API backwards compatibility.
     #[inline]
+    #[deprecated(since = "2.0.0", note = "renamed to `last_block_of_collateral_lockup`")]
+    // The generated wasm shim calls this deprecated function; callers still get the warning
+    #[cfg_attr(feature = "ts-types", allow(deprecated))]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = lastBlockOfReportingWindow))]
     pub fn last_block_of_reporting_window(block_number: u32) -> u32 {
         Self::last_block_of_collateral_lockup(block_number)
@@ -575,6 +578,9 @@ impl Policy {
     /// @deprecated Renamed to `blockAfterCollateralLockup`. Kept for API backwards compatibility;
     /// see `lastBlockOfCollateralLockup`.
     #[inline]
+    #[deprecated(since = "2.0.0", note = "renamed to `block_after_collateral_lockup`")]
+    // The generated wasm shim calls this deprecated function; callers still get the warning
+    #[cfg_attr(feature = "ts-types", allow(deprecated))]
     #[cfg_attr(feature = "ts-types", wasm_bindgen(js_name = blockAfterReportingWindow))]
     pub fn block_after_reporting_window(block_number: u32) -> u32 {
         Self::block_after_collateral_lockup(block_number)

--- a/rpc-client/src/subcommands/policy_subcommands.rs
+++ b/rpc-client/src/subcommands/policy_subcommands.rs
@@ -127,7 +127,14 @@ pub enum PolicyCommand {
         block_number: u32,
     },
 
-    /// Returns the first block after the reporting window of a given block number has ended.
+    /// Returns the first block after the collateral lock-up window of a given block number has ended.
+    BlockAfterCollateralLockup {
+        /// The block number.
+        block_number: u32,
+    },
+
+    /// **Deprecated**: use `block-after-collateral-lockup`. This window never governed equivocation
+    /// reporting; it has always been the collateral lock-up window.
     BlockAfterReportingWindow {
         /// The block number.
         block_number: u32,
@@ -259,12 +266,25 @@ impl HandleSubcommand for PolicyCommand {
                     client.policy.get_first_batch_of_epoch(block_number).await?
                 );
             }
-            PolicyCommand::BlockAfterReportingWindow { block_number } => {
+            PolicyCommand::BlockAfterCollateralLockup { block_number } => {
                 println!(
                     "{:#?}",
                     client
                         .policy
-                        .get_block_after_reporting_window(block_number)
+                        .get_block_after_collateral_lockup(block_number)
+                        .await?
+                );
+            }
+            PolicyCommand::BlockAfterReportingWindow { block_number } => {
+                eprintln!(
+                    "warning: `block-after-reporting-window` is deprecated and will be removed; \
+                     use `block-after-collateral-lockup` instead"
+                );
+                println!(
+                    "{:#?}",
+                    client
+                        .policy
+                        .get_block_after_collateral_lockup(block_number)
                         .await?
                 );
             }

--- a/validator/src/jail.rs
+++ b/validator/src/jail.rs
@@ -62,11 +62,24 @@ impl EquivocationProofPool {
         }
     }
 
-    /// Returns a list of current equivocation proofs.
-    pub fn get_equivocation_proofs_for_block(&self, max_size: usize) -> Vec<EquivocationProof> {
+    /// Returns a list of equivocation proofs that are valid for inclusion in a block
+    /// with the given block number and version.
+    pub fn get_equivocation_proofs_for_block(
+        &self,
+        block_number: u32,
+        version: u16,
+        max_size: usize,
+    ) -> Vec<EquivocationProof> {
         let mut proofs = Vec::new();
         let mut size = 0;
         for proof in self.equivocation_proofs.iter() {
+            // The pool is only pruned at macro blocks and proofs are re-added on reverts
+            // unconditionally, so proofs can expire mid-batch. Mirror the check done by
+            // `MicroBlock` body verification to never produce a block that includes an
+            // expired proof, which the network would reject
+            if !proof.is_valid_at(block_number, version) {
+                continue;
+            }
             let proof_len = proof.serialized_size();
             if size + proof_len < max_size {
                 proofs.push(proof.clone());
@@ -74,5 +87,82 @@ impl EquivocationProofPool {
             }
         }
         proofs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nimiq_block::{ForkProof, MicroHeader};
+    use nimiq_hash::HashOutput;
+    use nimiq_keys::{Address, KeyPair, PrivateKey};
+    use nimiq_primitives::policy::Policy;
+
+    use super::*;
+
+    fn equivocation_proof(offense_block: u32) -> EquivocationProof {
+        // The pool never verifies signatures, so any key works here.
+        let key = KeyPair::from(PrivateKey::from_bytes(&[1u8; 32]).unwrap());
+        let header1 = MicroHeader {
+            version: 1,
+            block_number: offense_block,
+            timestamp: 0,
+            ..Default::default()
+        };
+        let mut header2 = header1.clone();
+        header2.timestamp = 1;
+        let justification1 = key.sign(header1.hash().as_bytes());
+        let justification2 = key.sign(header2.hash().as_bytes());
+        ForkProof::new(
+            Address::burn_address(),
+            header1,
+            justification1,
+            header2,
+            justification2,
+        )
+        .into()
+    }
+
+    #[test]
+    fn get_equivocation_proofs_for_block_filters_expired_proofs() {
+        let offense_block = Policy::genesis_block_number();
+        let mut pool = EquivocationProofPool::new();
+        assert!(pool.insert(equivocation_proof(offense_block)));
+
+        let last_reportable = Policy::last_block_of_equivocation_reporting_window(offense_block);
+        assert!(last_reportable < Policy::last_block_of_collateral_lockup(offense_block));
+
+        // Within the reporting window the proof is returned.
+        assert_eq!(
+            pool.get_equivocation_proofs_for_block(last_reportable, 2, usize::MAX)
+                .len(),
+            1
+        );
+        // Past the window it is filtered out from version 2 on.
+        assert!(pool
+            .get_equivocation_proofs_for_block(last_reportable + 1, 2, usize::MAX)
+            .is_empty());
+        // Legacy versions still use the longer window.
+        assert_eq!(
+            pool.get_equivocation_proofs_for_block(last_reportable + 1, 1, usize::MAX)
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn get_equivocation_proofs_for_block_keeps_valid_drops_expired_together() {
+        let older = Policy::genesis_block_number();
+        // An offense one block later has a reporting window that ends one block later.
+        let newer = older + 1;
+        let mut pool = EquivocationProofPool::new();
+        assert!(pool.insert(equivocation_proof(older)));
+        assert!(pool.insert(equivocation_proof(newer)));
+
+        // A block past `older`'s window but still within `newer`'s window: the two proofs
+        // must be filtered independently, not all-or-nothing.
+        let at = Policy::last_block_of_equivocation_reporting_window(older) + 1;
+        let returned = pool.get_equivocation_proofs_for_block(at, 2, usize::MAX);
+        assert_eq!(returned.len(), 1);
+        assert_eq!(returned[0].block_number(), newer);
     }
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -455,7 +455,11 @@ where
                 let equivocation_proofs = state
                     .consensus
                     .equivocation_proofs
-                    .get_equivocation_proofs_for_block(Self::EQUIVOCATION_PROOFS_MAX_SIZE);
+                    .get_equivocation_proofs_for_block(
+                        next_block_number,
+                        blockchain.protocol_version(),
+                        Self::EQUIVOCATION_PROOFS_MAX_SIZE,
+                    );
                 let prev_seed = head.seed().clone();
 
                 self.micro_producer = Some(ProduceMicroBlock::new(


### PR DESCRIPTION
- `get_equivocation_proofs_for_block` now checks `is_valid_at` for the block being produced, mirroring `MicroBody` verification. The pool is only pruned at macro blocks and reverts re-add proofs unconditionally, so proofs could expire mid-batch under the shorter v2 reporting window and get the produced block rejected network-wide.
- Expose the renamed policy endpoint as the `block-after-collateral-lockup` CLI subcommand, re-point the deprecated `block-after-reporting-window` alias at it with a runtime notice, and mark the `last_block_of_reporting_window` and `block_after_reporting_window` policy aliases `#[deprecated]`.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
