### PR TITLE
Abstain from skip block aggregation on an incomplete accounts state

### DIFF
--- a/blockchain/src/blockchain/accounts.rs
+++ b/blockchain/src/blockchain/accounts.rs
@@ -143,8 +143,15 @@ impl Blockchain {
     /// single, deterministic `Penalize` inherent, the resulting state root is fully determined by
     /// the current (head) state.
     ///
-    /// Validators use this to bind the `state_root` into the skip block proof before aggregating it
-    pub fn next_skip_block_state_root(&self) -> Blake2bHash {
+    /// Validators use this to bind the `state_root` into the skip block proof before aggregating it.
+    ///
+    /// Returns `None` if the accounts trie is incomplete, in which case the state root cannot be
+    /// computed and the caller must not participate in the skip block aggregation.
+    pub fn next_skip_block_state_root(&self) -> Option<Blake2bHash> {
+        if !self.state.accounts.is_complete(None) {
+            return None;
+        }
+
         let head = &self.state.main_chain.head;
         let block_number = head.block_number() + 1;
         let timestamp = head.timestamp() + Policy::MIN_PRODUCER_TIMEOUT;
@@ -166,7 +173,7 @@ impl Blockchain {
             .exercise_transactions(&[], &inherents, &block_state, None)
             .expect("Failed to compute skip block state root");
 
-        state_root
+        Some(state_root)
     }
 
     /// Reverts the accounts given a block. This only applies to micro blocks and skip blocks, since

--- a/blockchain/tests/block_production.rs
+++ b/blockchain/tests/block_production.rs
@@ -1526,6 +1526,25 @@ fn it_aborts_macro_block_proposal_with_incomplete_accounts() {
     ));
 }
 
+#[test]
+fn it_requires_complete_accounts_for_the_skip_block_state_root() {
+    // With a complete accounts trie the deterministic skip block state root is available.
+    let temp_producer = TemporaryBlockProducer::new();
+    assert!(temp_producer
+        .blockchain
+        .read()
+        .next_skip_block_state_root()
+        .is_some());
+
+    // On an incomplete trie it must be unavailable instead of panicking.
+    let temp_producer = TemporaryBlockProducer::new_incomplete();
+    assert!(temp_producer
+        .blockchain
+        .read()
+        .next_skip_block_state_root()
+        .is_none());
+}
+
 fn ed25519_key_pair(secret_key: &str) -> SchnorrKeyPair {
     let priv_key =
         SchnorrPrivateKey::deserialize_from_vec(&hex::decode(secret_key).unwrap()).unwrap();

--- a/test-utils/src/block_production.rs
+++ b/test-utils/src/block_production.rs
@@ -330,7 +330,9 @@ impl TemporaryBlockProducer {
             };
             (
                 skip_block_info,
-                blockchain.next_skip_block_state_root(),
+                blockchain
+                    .next_skip_block_state_root()
+                    .expect("Accounts trie must be complete to compute the skip block state root"),
                 blockchain.state().current_version(),
             )
         };

--- a/test-utils/src/blockchain.rs
+++ b/test-utils/src/blockchain.rs
@@ -1,10 +1,7 @@
 use std::{str::FromStr, sync::Arc, time::Instant};
 
 use nimiq_account::{Account, StakingContractStoreWrite, TransactionLog};
-use nimiq_block::{
-    Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, SignedSkipBlockInfo, SkipBlockInfo,
-    SkipBlockProof, TendermintProof,
-};
+use nimiq_block::{Block, MacroBlock, MacroBody, MacroHeader, MultiSignature, TendermintProof};
 use nimiq_blockchain::{BlockProducer, Blockchain};
 use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
 use nimiq_bls::{AggregateSignature, KeyPair as BlsKeyPair, SecretKey as BlsSecretKey};
@@ -236,25 +233,6 @@ pub fn sign_macro_block(
     block.justification = Some(tendermint_proof);
 
     block
-}
-
-pub fn sign_skip_block_info(
-    voting_key_pair: &BlsKeyPair,
-    skip_block_info: &SkipBlockInfo,
-) -> SkipBlockProof {
-    let skip_block_info =
-        SignedSkipBlockInfo::from_message(skip_block_info.clone(), &voting_key_pair.secret_key, 0);
-
-    let signature =
-        AggregateSignature::from_signatures(&[skip_block_info.signature.multiply(Policy::SLOTS)]);
-    let mut signers = BitSet::new();
-    for i in 0..Policy::SLOTS {
-        signers.insert(i as usize);
-    }
-
-    SkipBlockProof {
-        sig: MultiSignature::new(signature, signers),
-    }
 }
 
 pub fn validator_key() -> SchnorrKeyPair {

--- a/validator/src/micro.rs
+++ b/validator/src/micro.rs
@@ -10,8 +10,9 @@ use futures::{future::BoxFuture, ready, FutureExt, Stream};
 use nimiq_block::{Block, EquivocationProof, MicroBlock, SkipBlockInfo};
 use nimiq_blockchain::{BlockProducer, BlockProducerError, Blockchain};
 use nimiq_blockchain_interface::AbstractBlockchain;
+use nimiq_hash::Blake2bHash;
 use nimiq_mempool::mempool::Mempool;
-use nimiq_primitives::policy::Policy;
+use nimiq_primitives::policy::{upgrades, Policy};
 use nimiq_time::sleep;
 use nimiq_utils::time::systemtime_to_timestamp;
 use nimiq_validator_network::ValidatorNetwork;
@@ -225,11 +226,31 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> NextProduceMicroBlockEvent<T
         let skip_block_inputs = {
             let blockchain = self.blockchain.read();
             if in_current_state(blockchain.head()) {
-                Some((
-                    blockchain.current_validators().unwrap().clone(),
-                    blockchain.next_skip_block_state_root(),
-                    blockchain.state().current_version(),
-                ))
+                let protocol_version = blockchain.state().current_version();
+                let state_root = match blockchain.next_skip_block_state_root() {
+                    Some(state_root) => Some(state_root),
+                    // Before the state root binding it is not part of the signed message
+                    // (see `SkipBlockInfo::signing_hash`), so any value works and a
+                    // validator with an incomplete accounts state can still participate
+                    None if protocol_version < upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING => {
+                        Some(Blake2bHash::default())
+                    }
+                    None => {
+                        warn!(
+                            block_number = self.block_number,
+                            "Cannot participate in the skip block aggregation, accounts state \
+                             is incomplete"
+                        );
+                        None
+                    }
+                };
+                state_root.map(|state_root| {
+                    (
+                        blockchain.current_validators().unwrap().clone(),
+                        state_root,
+                        protocol_version,
+                    )
+                })
             } else {
                 None
             }
@@ -458,5 +479,74 @@ impl<TValidatorNetwork: ValidatorNetwork + 'static> Stream
             ProduceMicroBlockEvent::MicroBlock => None,
         };
         Poll::Ready(Some(event))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nimiq_database::traits::WriteTransaction;
+    use nimiq_mempool::config::MempoolConfig;
+    use nimiq_network_mock::MockHub;
+    use nimiq_test_log::test;
+    use nimiq_test_utils::block_production::TemporaryBlockProducer;
+    use nimiq_time::timeout;
+    use nimiq_validator_network::network_impl::ValidatorNetworkImpl;
+
+    use super::*;
+
+    #[test(tokio::test)]
+    async fn it_abstains_from_skip_block_aggregation_on_incomplete_accounts() {
+        let temp_producer = TemporaryBlockProducer::new_with_protocol_version(
+            upgrades::v2::SKIP_BLOCK_STATE_ROOT_BINDING,
+        );
+
+        // Make the accounts trie incomplete.
+        {
+            let blockchain = temp_producer.blockchain.read();
+            let mut txn = blockchain.write_transaction();
+            blockchain
+                .state
+                .accounts
+                .reinitialize_as_incomplete(&mut (&mut txn).into());
+            txn.commit();
+        }
+
+        let blockchain = Arc::clone(&temp_producer.blockchain);
+        let mempool = Arc::new(Mempool::new(
+            Arc::clone(&blockchain),
+            MempoolConfig::default(),
+        ));
+        let mut hub = MockHub::default();
+        let network = Arc::new(ValidatorNetworkImpl::new(Arc::new(hub.new_network())));
+
+        let (prev_seed, block_number) = {
+            let blockchain = blockchain.read();
+            (
+                blockchain.head().seed().clone(),
+                blockchain.block_number() + 1,
+            )
+        };
+
+        // Slot band 1 never matches the single genesis validator's band, so this node is
+        // not the proposer and takes the skip block path as soon as the timeout elapses.
+        let event = NextProduceMicroBlockEvent::new(
+            blockchain,
+            mempool,
+            network,
+            temp_producer.producer.clone(),
+            1,
+            vec![],
+            prev_seed,
+            block_number,
+            Duration::ZERO,
+            Duration::ZERO,
+        );
+
+        // With an incomplete accounts state, from the state root binding on the validator
+        // must abstain from the aggregation instead of panicking.
+        let (produced, _) = timeout(Duration::from_secs(10), event.next())
+            .await
+            .expect("Producer must abstain instead of aggregating");
+        assert!(produced.is_none());
     }
 }


### PR DESCRIPTION
`next_skip_block_state_root` now returns `None` instead of panicking when the accounts trie is incomplete. Before the state root binding the validator still participates, since the state root is not part of the signed message; from v2 on it abstains for that height.

Also removes the unused legacy `sign_skip_block_info` helper, which signed the unbound message.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
