### PR TITLE
Update tooling for signal upgrade with the warm key

### DIFF
--- a/rpc-client/src/subcommands/validator_subcommands.rs
+++ b/rpc-client/src/subcommands/validator_subcommands.rs
@@ -86,7 +86,9 @@ pub enum ValidatorCommand {
         #[clap(long)]
         new_reward_address: Option<Address>,
 
-        /// The new signal data showed by the validator.
+        /// The new signal data showed by the validator. For upgrade signaling prefer
+        /// `signal-version`, which is signed with the warm key and so does not need the
+        /// validator (cold) wallet unlocked.
         #[clap(short = 'd', long)]
         new_signal_data: Option<String>,
 
@@ -137,8 +139,7 @@ pub enum ValidatorCommand {
     /// Sends a transaction that sets the full `signal_data` of this validator, signed with the
     /// validator's signing (warm) key (so the cold key is not required). This replaces the entire
     /// signal data field, overwriting any signaled protocol version; use `signal-version` to
-    /// update only the version while preserving the rest. Omit the data to clear the signal. Only
-    /// valid once the chain has reached the protocol version that introduces this transaction.
+    /// update only the version while preserving the rest. Omit the data to clear the signal.
     /// The sender wallet must be unlocked prior to this command.
     SetSignalData {
         /// The fee will be paid from this address. This wallet must be already unlocked.
@@ -157,8 +158,7 @@ pub enum ValidatorCommand {
 
     /// Sends a transaction signalling support for a protocol upgrade `version`, signed with the
     /// validator's signing (warm) key (so the cold key is not required). This only updates the
-    /// version bytes; to clear the signal data use the `set-signal-data` command. Only valid once
-    /// the chain has reached the protocol version that introduces this transaction.
+    /// version bytes; to clear the signal data use the `set-signal-data` command.
     /// The sender wallet must be unlocked prior to this command.
     SignalVersion {
         /// The fee will be paid from this address. This wallet must be already unlocked.

--- a/tools/src/mktx/README.md
+++ b/tools/src/mktx/README.md
@@ -24,6 +24,14 @@ so that no combination can be misread:
 - `--clear-signal-data` → clear it
 - `--new-signal-data <hex>` → set it
 
+`validator set-signal-data` always writes the field, so it has no "leave unchanged" case:
+
+- `--signal-data <hex>` → set it
+- `--clear-signal-data` → clear it
+
+Exactly one of the two is required. Omitting both is an error rather than an implicit clear,
+so a forgotten value can never silently wipe the field.
+
 ## Global options
 
 - `-f`, `--fee <Lunas>` defaults to `0`; ensure the sender balance covers value plus fee.
@@ -39,6 +47,20 @@ so that no combination can be misread:
 - `vesting`: create vesting contracts or redeem vesting payouts with schedule parameters.
 
 Successful commands print a hex string → broadcast transactions through RPC or custom tooling.
+
+## Upgrade signaling
+
+Validators signal support for a chain (hard-fork) upgrade through their `signal_data` field.
+Since protocol version 2 this is done with the validator's signing (warm) key, so the cold key
+stays offline:
+
+- `validator signal-version` — rewrites only the version bytes and preserves the rest of the
+  field. This is the command to use for upgrade signaling.
+- `validator set-signal-data` — sets or clears the whole field, overwriting any signaled
+  version along with it.
+
+Setting the field with the cold key is still possible through `validator update
+--new-signal-data`, but it overwrites the whole field and is no longer needed for signaling.
 
 ## Security and troubleshooting
 

--- a/tools/src/mktx/commands/mod.rs
+++ b/tools/src/mktx/commands/mod.rs
@@ -69,12 +69,6 @@ pub fn hex_to_signal_data(
     })
 }
 
-pub fn version_to_signal_data(supported_version: u16) -> Result<Blake2bHash, DeserializeError> {
-    let mut data = [0u8; 32];
-    data[..2].copy_from_slice(&supported_version.to_be_bytes());
-    Blake2bHash::deserialize_from_vec(&data)
-}
-
 #[derive(Debug, Error)]
 pub enum CommandError {
     #[error("Deserialize")]

--- a/tools/src/mktx/commands/validator.rs
+++ b/tools/src/mktx/commands/validator.rs
@@ -7,7 +7,6 @@ use super::{
     hex_secret_key_to_bls_pair, hex_secret_key_to_pair, hex_secret_key_to_public,
     hex_to_signal_data, CommandError, TransactionOrProof,
 };
-use crate::commands::version_to_signal_data;
 
 #[derive(Debug, Subcommand)]
 /// Builds validator-related transactions that move a validator through its lifecycle: created, active, inactive, retired, deleted
@@ -44,21 +43,49 @@ pub enum ValidatorCommands {
         #[arg(long)]
         new_reward_address: Option<Address>,
         /// Optional hex-encoded replacement of the validator's signal data; omit both this
-        /// and `--clear-signal-data` to leave the signal data unchanged
+        /// and `--clear-signal-data` to leave the signal data unchanged. For upgrade signaling
+        /// prefer `signal-version`, which does not need the cold key
         #[arg(long, conflicts_with = "clear_signal_data")]
         new_signal_data: Option<String>,
         /// Clear the validator's signal data; mutually exclusive with `--new-signal-data`
         #[arg(long)]
         clear_signal_data: bool,
     },
-    /// Creates a transaction that signals the validator's support for a new block version
-    SignalUpgrade {
-        /// Version this transaction will signal support for
-        version: u16,
+    /// Creates a transaction that sets the validator's signal data, signed with the validator's
+    /// signing (warm) key so that the cold key is not needed. This replaces the entire field,
+    /// overwriting any signaled protocol version; use `signal-version` to update only the version
+    /// and preserve the rest
+    SetSignalData {
         /// Hex-encoded private key of the account paying the fee
         secret_key: String,
-        /// Hex-encoded private key of the validator's cold key; this key proves ownership of the validator
-        secret_cold_key: String,
+        /// NQ address of the validator whose signal data is being set
+        validator_address: Address,
+        /// Hex-encoded private key of the validator's signing key to authorize the update
+        secret_signing_key: String,
+        /// Hex-encoded signal data to set; mutually exclusive with `--clear-signal-data`
+        #[arg(
+            long,
+            conflicts_with = "clear_signal_data",
+            required_unless_present = "clear_signal_data"
+        )]
+        signal_data: Option<String>,
+        /// Clear the validator's signal data; mutually exclusive with `--signal-data`
+        #[arg(long)]
+        clear_signal_data: bool,
+    },
+    /// Creates a transaction that signals the validator's support for a new block version, signed
+    /// with the validator's signing (warm) key so that the cold key is not needed. This rewrites
+    /// only the version bytes and preserves the rest of the signal data; clearing the field
+    /// entirely is a `set-signal-data --clear-signal-data`
+    SignalVersion {
+        /// Hex-encoded private key of the account paying the fee
+        secret_key: String,
+        /// NQ address of the validator signaling the support
+        validator_address: Address,
+        /// Hex-encoded private key of the validator's signing key to authorize the signaling
+        secret_signing_key: String,
+        /// Version this transaction will signal support for
+        version: u16,
     },
     /// Creates a transaction to deactivate an active validator; moves it to the inactive set
     Deactivate {
@@ -165,27 +192,42 @@ pub fn get_tx(
                 ),
             ))
         }
-        ValidatorCommands::SignalUpgrade {
-            version,
+        ValidatorCommands::SetSignalData {
             secret_key,
-            secret_cold_key,
-        } => {
-            let new_signal_data = Some(Some(version_to_signal_data(version)?));
-
-            Ok(TransactionOrProof::Transaction(
-                TransactionBuilder::new_update_validator(
-                    &hex_secret_key_to_pair(secret_key)?,
-                    &hex_secret_key_to_pair(secret_cold_key)?,
-                    None,
-                    None,
-                    None,
-                    new_signal_data,
-                    fee,
-                    validity_start_height,
-                    network_id,
-                ),
-            ))
-        }
+            validator_address,
+            secret_signing_key,
+            signal_data,
+            // Clap guarantees exactly one of `--signal-data` / `--clear-signal-data` is given, so
+            // an absent `signal_data` already means "clear"; the flag only makes that explicit
+            // rather than letting a forgotten value silently wipe the field.
+            clear_signal_data: _,
+        } => Ok(TransactionOrProof::Transaction(
+            TransactionBuilder::new_set_signal_data(
+                &hex_secret_key_to_pair(secret_key)?,
+                validator_address,
+                &hex_secret_key_to_pair(secret_signing_key)?,
+                hex_to_signal_data(signal_data)?,
+                fee,
+                validity_start_height,
+                network_id,
+            ),
+        )),
+        ValidatorCommands::SignalVersion {
+            secret_key,
+            validator_address,
+            secret_signing_key,
+            version,
+        } => Ok(TransactionOrProof::Transaction(
+            TransactionBuilder::new_signal_version(
+                &hex_secret_key_to_pair(secret_key)?,
+                validator_address,
+                &hex_secret_key_to_pair(secret_signing_key)?,
+                version,
+                fee,
+                validity_start_height,
+                network_id,
+            ),
+        )),
         ValidatorCommands::Deactivate {
             secret_key,
             validator_address,


### PR DESCRIPTION
- mktx: Add `validator set-signal-data` and `validator signal-version`, the warm-key `SetSignalData` commands every other client surface already has.
  Drop `validator signal-upgrade`: it built a cold-key `UpdateValidator` and zeroed the non-version bytes of `signal_data`. The chain is on protocol version 2, so the warm key suffices; `validator update --new-signal-data` still covers the cold-key case.
  With it gone, `version_to_signal_data` has no callers. It duplicated `Policy::signal_data_for_version`, so remove it.

- `set-signal-data` and `signal-version` warned that they are only valid once the chain reaches the protocol version that introduces them. The chain is on version 2, so the warning is noise at the point of use.
  Point `update-validator --new-signal-data` at `signal-version` instead, since it needs the validator (cold) wallet unlocked and signaling no longer does.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
