### PR TITLE
Staking: Account for and validate inactive stake when creating stakers

### DIFF
--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -203,6 +203,13 @@ impl StakingContract {
             });
         }
 
+        // Transaction-created stakers always use (zero, None), but genesis configurations can set
+        // these fields directly. Inactive stake and its inactivation height must either both be
+        // present or both be absent (invariants 3 and 4).
+        if inactive_balance.is_zero() != inactive_from.is_none() {
+            return Err(AccountError::InvalidForRecipient);
+        }
+
         // Check that the delegated validator exists.
         if let Some(validator_address) = &delegation {
             store.expect_validator(validator_address)?;

--- a/primitives/account/src/account/staking_contract/staker.rs
+++ b/primitives/account/src/account/staking_contract/staker.rs
@@ -228,7 +228,7 @@ impl StakingContract {
         }
 
         // Update balance.
-        self.balance += value;
+        self.balance += value + inactive_balance;
 
         // Build the return logs
         tx_logger.push_log(Log::CreateStaker {
@@ -256,7 +256,7 @@ impl StakingContract {
 
         // Update our balance.
         assert_eq!(value, staker.active_balance);
-        self.balance -= value;
+        self.balance -= value + staker.inactive_balance;
 
         // If we are delegating to a validator, we need to update it.
         if let Some(validator_address) = &staker.delegation {

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -324,6 +324,37 @@ fn create_staker_with_inactive_balance_works() {
     let inactive_balance = Coin::from_u64_unchecked(50_000_000);
     let validator_deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
 
+    // An inactive balance and its inactivation height must either both be present or both be absent.
+    for (invalid_inactive_balance, invalid_inactive_from) in
+        [(inactive_balance, None), (Coin::ZERO, Some(1))]
+    {
+        let mut tx_logger = TransactionLog::empty();
+        assert_eq!(
+            staking_contract.create_staker(
+                &mut StakingContractStoreWrite::new(&mut data_store.write(&mut db_txn)),
+                &staker_address,
+                active_balance,
+                Some(validator_address.clone()),
+                invalid_inactive_balance,
+                invalid_inactive_from,
+                &mut tx_logger,
+            ),
+            Err(AccountError::InvalidForRecipient)
+        );
+        assert!(tx_logger.logs.is_empty());
+    }
+
+    assert_eq!(staking_contract.balance, validator_deposit);
+    assert_eq!(
+        staking_contract.get_staker(&data_store.read(&db_txn), &staker_address),
+        None
+    );
+    let validator = staking_contract
+        .get_validator(&data_store.read(&db_txn), &validator_address)
+        .expect("Validator should exist");
+    assert_eq!(validator.total_stake, validator_deposit);
+    assert_eq!(validator.num_stakers, 0);
+
     staking_contract
         .create_staker(
             &mut StakingContractStoreWrite::new(&mut data_store.write(&mut db_txn)),
@@ -345,6 +376,7 @@ fn create_staker_with_inactive_balance_works() {
         .get_staker(&data_store.read(&db_txn), &staker_address)
         .expect("Staker should exist");
     assert_eq!(staker.inactive_balance, inactive_balance);
+    assert_eq!(staker.inactive_from, Some(1));
 
     let validator = staking_contract
         .get_validator(&data_store.read(&db_txn), &validator_address)

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -309,6 +309,60 @@ fn create_staker_works() {
     );
 }
 
+#[test]
+fn create_staker_with_inactive_balance_works() {
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let accounts = Accounts::new(env.clone());
+    let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+    let mut db_txn = env.write_transaction();
+    let mut db_txn = (&mut db_txn).into();
+
+    let (validator_address, _, mut staking_contract) =
+        make_sample_contract(data_store.write(&mut db_txn), None);
+    let staker_address = staker_address();
+    let active_balance = Coin::from_u64_unchecked(150_000_000);
+    let inactive_balance = Coin::from_u64_unchecked(50_000_000);
+    let validator_deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
+
+    staking_contract
+        .create_staker(
+            &mut StakingContractStoreWrite::new(&mut data_store.write(&mut db_txn)),
+            &staker_address,
+            active_balance,
+            Some(validator_address.clone()),
+            inactive_balance,
+            Some(1),
+            &mut TransactionLog::empty(),
+        )
+        .expect("Failed to create staker");
+
+    assert_eq!(
+        staking_contract.balance,
+        validator_deposit + active_balance + inactive_balance
+    );
+
+    let staker = staking_contract
+        .get_staker(&data_store.read(&db_txn), &staker_address)
+        .expect("Staker should exist");
+    assert_eq!(staker.inactive_balance, inactive_balance);
+
+    let validator = staking_contract
+        .get_validator(&data_store.read(&db_txn), &validator_address)
+        .expect("Validator should exist");
+    assert_eq!(validator.total_stake, validator_deposit + active_balance);
+
+    staking_contract
+        .revert_create_staker(
+            &mut StakingContractStoreWrite::new(&mut data_store.write(&mut db_txn)),
+            &staker_address,
+            active_balance,
+            &mut TransactionLog::empty(),
+        )
+        .expect("Failed to revert staker creation");
+
+    assert_eq!(staking_contract.balance, validator_deposit);
+}
+
 /// Updating inactive balance resets counter
 #[test]
 fn can_set_inactive_balance() {


### PR DESCRIPTION
`create_staker` and `revert_create_staker` only accounted for the staker's active balance when updating the staking contract balance. Although runtime `CreateStaker` transactions always use a zero inactive balance and no inactivation height, genesis configurations can provide both fields directly.

This PR includes the inactive balance during creation and reversion so the staking contract balance remains consistent with its stored staker balances. It also enforces the staker invariants requiring a non-zero inactive balance to have an inactivation height, while a zero inactive balance must have none. Invalid combinations are rejected with `InvalidForRecipient` before any state or log mutation.

Regression coverage verifies both invalid combinations, confirms that rejection leaves the staking contract, validator, staker store, and transaction log unchanged, and covers creating and reverting a staker with a non-zero inactive balance.

Current mainnet and testnet configurations are unaffected, but this hardens manual genesis configurations and prevents future networks or callers from creating inconsistent staking state.

Closes BUG-112 and COR-30 on linear

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
