### PR TITLE
Staking: Enforce validator status invariants on creation

### DIFF
--- a/genesis-builder/src/lib.rs
+++ b/genesis-builder/src/lib.rs
@@ -494,7 +494,8 @@ impl GenesisBuilder {
 
                 debug!("Staking contract");
                 // First generate the Staking contract in the Accounts.
-                let staking_contract = full.generate_staking_contract(&accounts, &mut txn)?;
+                let staking_contract =
+                    full.generate_staking_contract(&accounts, &mut txn, self.block_number)?;
 
                 // Update hashes in tree.
                 accounts
@@ -586,6 +587,7 @@ impl GenesisBuilderFullAccounts {
         &self,
         accounts: &Accounts,
         txn: &mut WriteTransactionProxy,
+        block_number: u32,
     ) -> Result<StakingContract, GenesisBuilderError> {
         let mut staking_contract = StakingContract::default();
 
@@ -608,6 +610,7 @@ impl GenesisBuilderFullAccounts {
                 validator.inactive_from,
                 validator.jailed_from,
                 validator.retired,
+                block_number,
                 &mut TransactionLog::empty(),
             )?;
         }
@@ -682,5 +685,47 @@ impl GenesisBuilder {
         }
 
         Ok((hash, have_accounts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nimiq_bls::KeyPair as BlsKeyPair;
+    use nimiq_utils::key_rng::SecureGenerate;
+
+    use super::*;
+
+    fn genesis_with_jailed_validator(block_number: u32, jailed_from: u32) -> GenesisBuilder {
+        let mut builder = GenesisBuilder::default();
+        builder.with_genesis_block_number(block_number);
+        builder.with_genesis_validator(
+            Address::from([1u8; 20]),
+            SchnorrPublicKey::default(),
+            BlsKeyPair::generate_default_csprng().public_key,
+            Address::default(),
+            None,
+            Some(jailed_from),
+            false,
+        );
+        builder
+    }
+
+    #[test]
+    fn genesis_validator_jail_boundary_is_enforced() {
+        let jailed_from = 1;
+        let release_block = Policy::block_after_jail(jailed_from);
+
+        let still_jailed = genesis_with_jailed_validator(release_block - 1, jailed_from);
+        assert!(matches!(
+            still_jailed.generate(MdbxDatabase::new_volatile(Default::default()).unwrap()),
+            Err(GenesisBuilderError::StakingError(
+                AccountError::InvalidForRecipient
+            ))
+        ));
+
+        let released = genesis_with_jailed_validator(release_block, jailed_from);
+        released
+            .generate(MdbxDatabase::new_volatile(Default::default()).unwrap())
+            .expect("Validator should be active once its jail period is over");
     }
 }

--- a/primitives/account/src/account/staking_contract/traits.rs
+++ b/primitives/account/src/account/staking_contract/traits.rs
@@ -83,6 +83,7 @@ impl AccountTransactionInteraction for StakingContract {
                     None,
                     None,
                     false,
+                    block_state.number,
                     tx_logger,
                 )
                 .map(|_| None)

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -170,6 +170,7 @@ pub struct Tombstone {
 impl StakingContract {
     /// Creates a new validator. The initial stake is always equal to the validator deposit
     /// and can only be retrieved by deleting the validator.
+    /// `block_number` is the height at which the supplied validator state is evaluated.
     /// This function is public to fill the genesis staking contract.
     pub fn create_validator(
         &mut self,
@@ -183,6 +184,7 @@ impl StakingContract {
         inactive_from: Option<u32>,
         jailed_from: Option<u32>,
         retired: bool,
+        block_number: u32,
         tx_logger: &mut TransactionLog,
     ) -> Result<(), AccountError> {
         // Fail if the validator already exists.
@@ -190,6 +192,14 @@ impl StakingContract {
             return Err(AccountError::AlreadyExistentAddress {
                 address: validator_address.clone(),
             });
+        }
+        // A retired validator must be inactive because validator deletion relies on
+        // `inactive_from`. A validator whose jail is still active must also be inactive so
+        // that it is not included in `active_validators` below.
+        let is_currently_jailed = jailed_from
+            .is_some_and(|jailed_from| block_number < Policy::block_after_jail(jailed_from));
+        if inactive_from.is_none() && (retired || is_currently_jailed) {
+            return Err(AccountError::InvalidForRecipient);
         }
         // Fail if validator existed already.
         let tombstone = store.get_tombstone(validator_address);
@@ -217,7 +227,7 @@ impl StakingContract {
         // Update our balance.
         self.balance += deposit;
 
-        if !retired && inactive_from.is_none() {
+        if validator.is_active() {
             self.active_validators
                 .insert(validator_address.clone(), validator.total_stake);
         }

--- a/primitives/account/src/account/staking_contract/validator.rs
+++ b/primitives/account/src/account/staking_contract/validator.rs
@@ -49,6 +49,14 @@ use crate::{
 ///      in the first place.
 /// (**) The validator may be set to automatically reactivate itself upon inactivation.
 ///      If this setting is not enabled the state change can only be triggered manually.
+/// (***) The validator has a set of status invariants:
+///             (invariant 1) Retired validators are marked inactive:
+///                           `retired` implies `inactive_from.is_some()`
+///             (invariant 2) Validators whose jail period is still active are marked inactive:
+///                           `is_jailed(block_number)` implies `inactive_from.is_some()`
+///
+/// `jailed_from.is_some()` alone does not mean that a validator is currently jailed.
+/// The field is retained after the jail period and may coexist with an active validator.
 ///
 /// Create, Update, Deactivate, Retire and Re-activate are incoming transactions to the staking contract.
 /// Delete is an outgoing transaction from the staking contract.
@@ -193,8 +201,9 @@ impl StakingContract {
                 address: validator_address.clone(),
             });
         }
-        // A retired validator must be inactive because validator deletion relies on
-        // `inactive_from`. A validator whose jail is still active must also be inactive so
+        // Enforce invariant 1: a retired validator must be inactive because validator
+        // deletion relies on `inactive_from`.
+        // Enforce invariant 2: a validator whose jail is still active must be inactive so
         // that it is not included in `active_validators` below.
         let is_currently_jailed = jailed_from
             .is_some_and(|jailed_from| block_number < Policy::block_after_jail(jailed_from));
@@ -530,7 +539,7 @@ impl StakingContract {
 
         let next_election_block = Policy::election_block_after(block_number);
 
-        // Mark validator as inactive.
+        // Mark validator as inactive to preserve invariant 2.
         // A validator can only effectively become inactive on the next election block.
         if newly_deactivated {
             validator.inactive_from = Some(next_election_block);
@@ -629,13 +638,13 @@ impl StakingContract {
             return Err(AccountError::InvalidForRecipient);
         }
 
-        // Check that the validator is not retired.
+        // Check that reactivation would not violate invariant 1.
         if validator.retired {
             debug!(?validator_address, "Validator is retired");
             return Err(AccountError::InvalidForRecipient);
         }
 
-        // Check that the validator is not jailed.
+        // Check that reactivation would not violate invariant 2.
         if validator.is_jailed(block_number) {
             debug!(
                 ?validator_address,
@@ -728,7 +737,7 @@ impl StakingContract {
             validator_address: validator_address.clone(),
         });
 
-        // Mark validator as inactive if it is still active.
+        // Mark validator as inactive if it is still active to preserve invariant 1.
         let was_active = validator.is_active();
         if was_active {
             // A validator can only effectively become inactive on the next election block.

--- a/primitives/account/tests/staking_contract/mod.rs
+++ b/primitives/account/tests/staking_contract/mod.rs
@@ -200,6 +200,7 @@ fn make_sample_contract_with_protocol_version(
             None,
             None,
             false,
+            Policy::genesis_block_number(),
             &mut TransactionLog::empty(),
         )
         .unwrap();

--- a/primitives/account/tests/staking_contract/staker.rs
+++ b/primitives/account/tests/staking_contract/staker.rs
@@ -114,6 +114,7 @@ pub(crate) fn prepare_second_validator_for_redelegation(
             None,
             None,
             false,
+            Policy::genesis_block_number(),
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");
@@ -1418,6 +1419,7 @@ fn update_staker_with_stake_reactivation_works() {
             None,
             None,
             false,
+            Policy::genesis_block_number(),
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");

--- a/primitives/account/tests/staking_contract/validator.rs
+++ b/primitives/account/tests/staking_contract/validator.rs
@@ -184,6 +184,33 @@ fn can_get_validator() {
     );
 }
 
+fn create_validator_with_status(
+    staking_contract: &mut StakingContract,
+    mut data_store: DataStoreWrite,
+    validator_address: &Address,
+    inactive_from: Option<u32>,
+    jailed_from: Option<u32>,
+    retired: bool,
+    block_number: u32,
+    tx_logger: &mut TransactionLog,
+) -> Result<(), AccountError> {
+    let mut store = StakingContractStoreWrite::new(&mut data_store);
+    staking_contract.create_validator(
+        &mut store,
+        validator_address,
+        ed25519_public_key(VALIDATOR_SIGNING_KEY),
+        bls_public_key(VALIDATOR_VOTING_KEY),
+        Address::from([3u8; 20]),
+        None,
+        Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT),
+        inactive_from,
+        jailed_from,
+        retired,
+        block_number,
+        tx_logger,
+    )
+}
+
 #[test]
 fn create_validator_works() {
     let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
@@ -309,6 +336,184 @@ fn create_validator_works() {
         staking_contract.active_validators.get(&validator_address),
         None
     );
+}
+
+#[test]
+fn create_validator_rejects_active_retired_validator() {
+    let block_number = Policy::block_after_jail(1);
+
+    for jailed_from in [None, Some(1)] {
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let accounts = Accounts::new(env.clone());
+        let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+        let mut db_txn = env.write_transaction();
+        let mut db_txn = (&mut db_txn).into();
+        let validator_address = validator_address();
+        let mut staking_contract = StakingContract::default();
+        let mut tx_logger = TransactionLog::empty();
+
+        assert_eq!(
+            create_validator_with_status(
+                &mut staking_contract,
+                data_store.write(&mut db_txn),
+                &validator_address,
+                None,
+                jailed_from,
+                true,
+                block_number,
+                &mut tx_logger,
+            ),
+            Err(AccountError::InvalidForRecipient)
+        );
+
+        assert_eq!(staking_contract.balance, Coin::ZERO);
+        assert!(staking_contract.active_validators.is_empty());
+        assert_eq!(
+            staking_contract.get_validator(&data_store.read(&db_txn), &validator_address),
+            None
+        );
+        assert!(tx_logger.logs.is_empty());
+    }
+}
+
+#[test]
+fn create_validator_rejects_active_validator_during_jail() {
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let accounts = Accounts::new(env.clone());
+    let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+    let mut db_txn = env.write_transaction();
+    let mut db_txn = (&mut db_txn).into();
+    let validator_address = validator_address();
+    let mut staking_contract = StakingContract::default();
+    let mut tx_logger = TransactionLog::empty();
+    let jailed_from = 1;
+    let block_number = Policy::block_after_jail(jailed_from) - 1;
+
+    assert_eq!(
+        create_validator_with_status(
+            &mut staking_contract,
+            data_store.write(&mut db_txn),
+            &validator_address,
+            None,
+            Some(jailed_from),
+            false,
+            block_number,
+            &mut tx_logger,
+        ),
+        Err(AccountError::InvalidForRecipient)
+    );
+
+    assert_eq!(staking_contract.balance, Coin::ZERO);
+    assert!(staking_contract.active_validators.is_empty());
+    assert_eq!(
+        staking_contract.get_validator(&data_store.read(&db_txn), &validator_address),
+        None
+    );
+    assert!(tx_logger.logs.is_empty());
+}
+
+#[test]
+fn create_validator_accepts_active_validator_after_jail() {
+    let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+    let accounts = Accounts::new(env.clone());
+    let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+    let mut db_txn = env.write_transaction();
+    let mut db_txn = (&mut db_txn).into();
+    let validator_address = validator_address();
+    let mut staking_contract = StakingContract::default();
+    let mut tx_logger = TransactionLog::empty();
+    let jailed_from = 1;
+    let block_number = Policy::block_after_jail(jailed_from);
+    let deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
+
+    create_validator_with_status(
+        &mut staking_contract,
+        data_store.write(&mut db_txn),
+        &validator_address,
+        None,
+        Some(jailed_from),
+        false,
+        block_number,
+        &mut tx_logger,
+    )
+    .unwrap();
+
+    let validator = staking_contract
+        .get_validator(&data_store.read(&db_txn), &validator_address)
+        .expect("Validator should exist");
+    assert_eq!(validator.inactive_from, None);
+    assert_eq!(validator.jailed_from, Some(jailed_from));
+    assert!(!validator.retired);
+    assert_eq!(validator.deposit, deposit);
+    assert_eq!(validator.total_stake, deposit);
+    assert_eq!(staking_contract.balance, deposit);
+    assert_eq!(
+        staking_contract.active_validators.get(&validator_address),
+        Some(&deposit)
+    );
+    assert_eq!(
+        tx_logger.logs,
+        vec![Log::CreateValidator {
+            validator_address,
+            reward_address: Address::from([3u8; 20]),
+        }]
+    );
+}
+
+#[test]
+fn create_validator_accepts_inactive_status_combinations() {
+    let inactive_from = Policy::election_block_after(Policy::genesis_block_number());
+    let jailed_from = 1;
+    let block_number = Policy::block_after_jail(jailed_from) - 1;
+
+    for (jailed_from, retired) in [
+        (None, false),
+        (Some(jailed_from), false),
+        (None, true),
+        (Some(jailed_from), true),
+    ] {
+        let env = MdbxDatabase::new_volatile(Default::default()).unwrap();
+        let accounts = Accounts::new(env.clone());
+        let data_store = accounts.data_store(&Policy::STAKING_CONTRACT_ADDRESS);
+        let mut db_txn = env.write_transaction();
+        let mut db_txn = (&mut db_txn).into();
+        let validator_address = validator_address();
+        let mut staking_contract = StakingContract::default();
+        let mut tx_logger = TransactionLog::empty();
+        let deposit = Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
+
+        create_validator_with_status(
+            &mut staking_contract,
+            data_store.write(&mut db_txn),
+            &validator_address,
+            Some(inactive_from),
+            jailed_from,
+            retired,
+            block_number,
+            &mut tx_logger,
+        )
+        .unwrap();
+
+        let validator = staking_contract
+            .get_validator(&data_store.read(&db_txn), &validator_address)
+            .expect("Validator should exist");
+        assert_eq!(validator.inactive_from, Some(inactive_from));
+        assert_eq!(validator.jailed_from, jailed_from);
+        assert_eq!(validator.retired, retired);
+        assert_eq!(validator.deposit, deposit);
+        assert_eq!(validator.total_stake, deposit);
+        assert_eq!(staking_contract.balance, deposit);
+        assert!(!staking_contract
+            .active_validators
+            .contains_key(&validator_address));
+        assert_eq!(
+            tx_logger.logs,
+            vec![Log::CreateValidator {
+                validator_address,
+                reward_address: Address::from([3u8; 20]),
+            }]
+        );
+    }
 }
 
 #[test]
@@ -3626,6 +3831,7 @@ fn version_upgrade_works() {
             None,
             None,
             false,
+            block_state.number,
             &mut TransactionLog::empty(),
         )
         .unwrap();

--- a/test-utils/src/transactions.rs
+++ b/test-utils/src/transactions.rs
@@ -836,6 +836,7 @@ impl<R: Rng + CryptoRng> TransactionsGenerator<R> {
                 None,
                 None,
                 false,
+                Policy::genesis_block_number(),
                 &mut TransactionLog::empty(),
             )
             .expect("Failed to create validator");

--- a/validator/tests/tendermint.rs
+++ b/validator/tests/tendermint.rs
@@ -220,6 +220,7 @@ fn create_validator(temp_producer: &TemporaryBlockProducer) -> Address {
 
     let blockchain_rg = blockchain.read();
     let mut staking_contract = blockchain_rg.get_staking_contract();
+    let block_number = blockchain_rg.head().block_number();
     let total_stake = staking_contract.balance;
     let current_stake =
         staking_contract.balance - Coin::from_u64_unchecked(Policy::VALIDATOR_DEPOSIT);
@@ -254,6 +255,7 @@ fn create_validator(temp_producer: &TemporaryBlockProducer) -> Address {
             None,
             None,
             false,
+            block_number,
             &mut TransactionLog::empty(),
         )
         .expect("Failed to create validator");


### PR DESCRIPTION
This hardens validator creation by rejecting states where a validator is active while retired or while its jail period is still in effect.

`create_validator` now evaluates validator status at an explicit block height. Runtime transactions provide the current block height, while genesis generation provides its configured genesis height. This preserves valid active validators with expired jail history and keeps `active_validators` consistent with `Validator::is_active()`.

Tests cover:

- Atomic rejection of active retired or currently jailed validators.
- Acceptance at the exact jail-release boundary.
- Valid inactive, jailed, and retired status combinations.
- Propagation of the configured genesis block height.

Current mainnet and testnet configurations are unaffected, but this prevents future networks or callers from accidentally creating an inconsistent genesis state.

Closes COR-29 on linear

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.
