### PR TITLE
Bounds check slot numbers in ValidatorRegistry

### DIFF
--- a/validator/src/aggregation/registry.rs
+++ b/validator/src/aggregation/registry.rs
@@ -25,11 +25,18 @@ impl ValidatorRegistry {
     }
 }
 
+/// Narrows a slot number to the `u16` the `Validators` accessors take, rejecting slots that do not
+/// exist. The bound must be checked before the cast, as truncating first maps out of range slots
+/// onto existing ones. `Validators::get_band_from_slot` panics on anything this rejects.
+fn checked_slot(slot: usize) -> Option<u16> {
+    (slot < Policy::SLOTS as usize).then_some(slot as u16)
+}
+
 impl IdentityRegistry for ValidatorRegistry {
     fn public_key(&self, slot_number: usize) -> Option<PublicKey> {
         self.validators
-            // Get the validator for with id
-            .get_validator_by_slot_number(slot_number as u16)
+            // Get the validator owning the slot, if the slot exists
+            .get_validator_by_slot_number(checked_slot(slot_number)?)
             // Get the public key for this validator
             .voting_key
             // and uncompress it
@@ -46,8 +53,12 @@ impl IdentityRegistry for ValidatorRegistry {
         // Create a set of validator ids corresponding to the slots
         let mut ids: HashSet<u16> = HashSet::new();
         for slot in slots.iter() {
+            // Reject the whole set if it references a slot that does not exist.
+            let Some(slot) = checked_slot(slot) else {
+                return Identity::new(BitSet::default());
+            };
             // Insert each validator_address if there is one.
-            let _ = ids.insert(self.validators.get_band_from_slot(slot as u16));
+            let _ = ids.insert(self.validators.get_band_from_slot(slot));
         }
 
         // If there is no signer it needs to be rejected.
@@ -78,11 +89,8 @@ impl IdentityRegistry for ValidatorRegistry {
 
 impl WeightRegistry for ValidatorRegistry {
     fn weight(&self, id: usize) -> Option<usize> {
-        if (0..Policy::SLOTS).contains(&(id as u16)) {
-            Some(1)
-        } else {
-            None
-        }
+        // Every existing slot carries a single vote.
+        checked_slot(id).map(|_| 1)
     }
 }
 

--- a/validator/src/aggregation/registry.rs
+++ b/validator/src/aggregation/registry.rs
@@ -85,3 +85,216 @@ impl WeightRegistry for ValidatorRegistry {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use nimiq_bls::KeyPair as BlsKeyPair;
+    use nimiq_collections::BitSet;
+    use nimiq_handel::identity::{IdentityRegistry, WeightRegistry};
+    use nimiq_keys::{Address, Ed25519PublicKey};
+    use nimiq_primitives::{policy::Policy, slots_allocation::ValidatorsBuilder};
+    use nimiq_utils::key_rng::SecureGenerate;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::ValidatorRegistry;
+
+    /// The test set splits `Policy::SLOTS` evenly, so the whole slot range is allocated.
+    const NUM_VALIDATORS: u16 = 4;
+    const SLOTS_PER_VALIDATOR: u16 = Policy::SLOTS / NUM_VALIDATORS;
+
+    /// First id above the valid range that truncates back into it when cast to `u16`.
+    const WRAPPED: usize = u16::MAX as usize + 1;
+
+    /// Registry covering the entire slot range, plus the voting keys in slot band order.
+    fn setup() -> (ValidatorRegistry, Vec<BlsKeyPair>) {
+        let mut rng = StdRng::from_rng(&mut rand::rng());
+        let mut key_pairs = Vec::new();
+        let mut builder = ValidatorsBuilder::new();
+
+        // `ValidatorsBuilder` orders validators by address, so band `i` owns address `[i; 20]`.
+        for band in 0..NUM_VALIDATORS {
+            let key_pair = BlsKeyPair::generate(&mut rng);
+            for _ in 0..SLOTS_PER_VALIDATOR {
+                builder.push(
+                    Address::from([band as u8; 20]),
+                    key_pair.public_key,
+                    Ed25519PublicKey::default(),
+                );
+            }
+            key_pairs.push(key_pair);
+        }
+
+        (ValidatorRegistry::new(builder.build()), key_pairs)
+    }
+
+    /// The slots of the validator owning `band`.
+    fn band_slots(band: u16) -> std::ops::Range<usize> {
+        let start = band as usize * SLOTS_PER_VALIDATOR as usize;
+        start..start + SLOTS_PER_VALIDATOR as usize
+    }
+
+    fn bitset(slots: impl IntoIterator<Item = usize>) -> BitSet {
+        BitSet::from_iter(slots)
+    }
+
+    /// Only slots below `Policy::SLOTS` exist, so only those may carry weight.
+    #[test]
+    fn weight_accepts_only_slots_below_slot_count() {
+        let (registry, _) = setup();
+        let slots = Policy::SLOTS as usize;
+
+        assert_eq!(registry.weight(0), Some(1));
+        assert_eq!(registry.weight(slots - 1), Some(1));
+
+        assert_eq!(registry.weight(slots), None);
+        assert_eq!(registry.weight(slots + 1), None);
+        assert_eq!(registry.weight(u16::MAX as usize), None);
+    }
+
+    /// Ids congruent to a valid slot modulo 2^16 truncate into range when cast to `u16`. No such
+    /// slot exists, so none may carry weight.
+    #[test]
+    fn weight_rejects_ids_that_truncate_into_slot_range() {
+        let (registry, _) = setup();
+        let slots = Policy::SLOTS as usize;
+
+        for id in [
+            WRAPPED,
+            WRAPPED + 1,
+            WRAPPED + slots - 1,
+            2 * WRAPPED,
+            2 * WRAPPED + 100,
+        ] {
+            assert_eq!(
+                registry.weight(id),
+                None,
+                "phantom slot {id} truncates to {} and must not carry weight",
+                id as u16,
+            );
+        }
+    }
+
+    /// The skip block aggregation compares `signers_weight` against `TWO_F_PLUS_ONE`, so a single
+    /// non existent slot must make the set unweighable rather than inflate its weight.
+    #[test]
+    fn signers_weight_rejects_sets_containing_phantom_slots() {
+        let (registry, _) = setup();
+
+        let signers = bitset(band_slots(0));
+        assert_eq!(
+            registry.signers_weight(&signers),
+            Some(SLOTS_PER_VALIDATOR as usize),
+        );
+
+        for phantom in [Policy::SLOTS as usize, WRAPPED, WRAPPED + 1] {
+            let mut polluted = signers.clone();
+            polluted.insert(phantom);
+            assert_eq!(
+                registry.signers_weight(&polluted),
+                None,
+                "set containing phantom slot {phantom} must not be weighable",
+            );
+        }
+    }
+
+    /// Every existing slot resolves to the voting key of the validator owning it.
+    #[test]
+    fn public_key_resolves_every_valid_slot() {
+        let (registry, key_pairs) = setup();
+
+        for (band, key_pair) in key_pairs.iter().enumerate() {
+            for slot in band_slots(band as u16) {
+                assert_eq!(
+                    registry.public_key(slot),
+                    Some(key_pair.public_key),
+                    "slot {slot} must resolve to the key of band {band}",
+                );
+            }
+        }
+    }
+
+    /// Out of range slots must resolve to `None`, not panic in `Validators::get_band_from_slot`.
+    #[test]
+    fn public_key_rejects_out_of_range_slots() {
+        let (registry, _) = setup();
+
+        for slot in [
+            Policy::SLOTS as usize,
+            Policy::SLOTS as usize + 1,
+            u16::MAX as usize,
+        ] {
+            assert_eq!(
+                registry.public_key(slot),
+                None,
+                "out of range slot {slot} must not resolve to a key",
+            );
+        }
+    }
+
+    /// Truncating ids must not resolve either: a real key here verifies a forged signer index
+    /// against an unrelated validator's key instead of rejecting it.
+    #[test]
+    fn public_key_rejects_slots_that_truncate_into_range() {
+        let (registry, _) = setup();
+
+        for slot in [
+            WRAPPED,
+            WRAPPED + 1,
+            2 * WRAPPED,
+            WRAPPED + Policy::SLOTS as usize,
+        ] {
+            assert_eq!(
+                registry.public_key(slot),
+                None,
+                "phantom slot {slot} truncates to {} and must not resolve to a key",
+                slot as u16,
+            );
+        }
+    }
+
+    /// A set of slots exactly covering one validator's band resolves to that validator.
+    #[test]
+    fn signers_identity_maps_full_slot_bands() {
+        let (registry, _) = setup();
+
+        for band in 0..NUM_VALIDATORS {
+            let identity = registry.signers_identity(&bitset(band_slots(band)));
+            assert_eq!(identity.as_vec(), vec![band]);
+        }
+    }
+
+    /// Out of range slots belong to no validator, so they yield an empty identity rather than
+    /// panicking in `Validators::get_band_from_slot`.
+    #[test]
+    fn signers_identity_rejects_out_of_range_slots() {
+        let (registry, _) = setup();
+
+        for slot in [
+            Policy::SLOTS as usize,
+            u16::MAX as usize,
+            WRAPPED,
+            WRAPPED + Policy::SLOTS as usize,
+        ] {
+            assert!(
+                registry.signers_identity(&bitset([slot])).is_empty(),
+                "out of range slot {slot} must not resolve to an identity",
+            );
+        }
+    }
+
+    /// The same when mixed into a valid band: the set is malformed as a whole and must not resolve
+    /// to the validator owning its valid part.
+    #[test]
+    fn signers_identity_rejects_valid_band_polluted_with_out_of_range_slot() {
+        let (registry, _) = setup();
+
+        for phantom in [Policy::SLOTS as usize, WRAPPED, WRAPPED + 1] {
+            let mut signers = bitset(band_slots(0));
+            signers.insert(phantom);
+            assert!(
+                registry.signers_identity(&signers).is_empty(),
+                "band polluted with phantom slot {phantom} must not resolve to an identity",
+            );
+        }
+    }
+}

--- a/validator/tests/updates.rs
+++ b/validator/tests/updates.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use nimiq_block::MultiSignature;
 use nimiq_bls::{AggregateSignature, KeyPair};
 use nimiq_collections::BitSet;
@@ -5,8 +7,12 @@ use nimiq_handel::{
     contribution::{AggregatableContribution, ContributionError},
     update::LevelUpdate,
 };
+use nimiq_hash::Blake2sHash;
+use nimiq_primitives::policy::Policy;
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_validator::aggregation::update::SerializableLevelUpdate;
+use nimiq_validator::aggregation::{
+    tendermint::contribution::TendermintContribution, update::SerializableLevelUpdate,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct WrappedMultiSignature(pub MultiSignature);
@@ -59,4 +65,162 @@ fn test_serialize_deserialize_with_message() {
     let update: SerializableLevelUpdate<WrappedMultiSignature> =
         LevelUpdate::new(create_multisig(), None, 2, 3).into();
     assert_eq!(update.serialized_size(), 99);
+}
+
+// The tests below cover the `Checked` bound on `SerializableLevelUpdate`. It is the only bounds
+// check between a peer supplied bitset and `ValidatorRegistry`, which indexes slots into the
+// validator set without re-checking them.
+//
+// The payloads are built as a `LevelUpdate` and serialized: `Checked` only runs on deserialization
+// and `From<LevelUpdate>` does not inspect its input, so this is what a peer can put on the wire.
+
+/// Contribution whose contributor bitset is exactly `signers`. The signature is irrelevant,
+/// `Checked` runs before any signature is looked at.
+fn multisig_with_signers(signers: impl IntoIterator<Item = usize>) -> WrappedMultiSignature {
+    let mut multisig = create_multisig();
+    multisig.0.signers = BitSet::from_iter(signers);
+    multisig
+}
+
+fn roundtrip(
+    update: SerializableLevelUpdate<WrappedMultiSignature>,
+) -> Result<SerializableLevelUpdate<WrappedMultiSignature>, nimiq_serde::DeserializeError> {
+    Deserialize::deserialize_from_vec(&update.serialize_to_vec())
+}
+
+/// Control: the highest existing slot is accepted, so the rejections below are not an off by one.
+#[test]
+fn accepts_highest_valid_slot() {
+    let update: SerializableLevelUpdate<WrappedMultiSignature> = LevelUpdate::new(
+        multisig_with_signers([Policy::SLOTS as usize - 1]),
+        None,
+        2,
+        3,
+    )
+    .into();
+
+    assert!(roundtrip(update).is_ok());
+}
+
+/// The first non existent slot. Unchecked it reaches `get_band_from_slot` untruncated and trips
+/// its assertion, crashing the node.
+#[test]
+fn rejects_aggregate_with_slot_at_slot_count() {
+    let update: SerializableLevelUpdate<WrappedMultiSignature> =
+        LevelUpdate::new(multisig_with_signers([Policy::SLOTS as usize]), None, 2, 3).into();
+
+    assert!(roundtrip(update).is_err());
+}
+
+/// Slots at or above 2^16 truncate back into range when cast to `u16`, which is what makes
+/// `WeightRegistry::weight` hand out weight for slots that do not exist.
+#[test]
+fn rejects_aggregate_with_slots_beyond_u16() {
+    let wrapped = u16::MAX as usize + 1;
+
+    for slot in [
+        wrapped,
+        wrapped + 1,
+        2 * wrapped,
+        wrapped + Policy::SLOTS as usize,
+    ] {
+        let update: SerializableLevelUpdate<WrappedMultiSignature> =
+            LevelUpdate::new(multisig_with_signers([slot]), None, 2, 3).into();
+
+        assert!(
+            roundtrip(update).is_err(),
+            "slot {slot} truncates to {} and must be rejected",
+            slot as u16,
+        );
+    }
+}
+
+/// `WeightedVote::verify` feeds both fields to the registry, so a valid aggregate does not excuse
+/// an out of range individual contribution.
+#[test]
+fn rejects_individual_with_out_of_range_slot() {
+    let update: SerializableLevelUpdate<WrappedMultiSignature> = LevelUpdate::new(
+        multisig_with_signers([0]),
+        Some(multisig_with_signers([Policy::SLOTS as usize])),
+        2,
+        3,
+    )
+    .into();
+
+    assert!(roundtrip(update).is_err());
+}
+
+/// The registry walks every bit, so a bad slot hidden among valid ones must reject the whole
+/// update rather than be silently dropped.
+#[test]
+fn rejects_aggregate_mixing_valid_and_out_of_range_slots() {
+    let update: SerializableLevelUpdate<WrappedMultiSignature> = LevelUpdate::new(
+        multisig_with_signers([0, 1, 2, Policy::SLOTS as usize, u16::MAX as usize + 1]),
+        None,
+        2,
+        3,
+    )
+    .into();
+
+    assert!(roundtrip(update).is_err());
+}
+
+fn tendermint_contribution(
+    buckets: impl IntoIterator<Item = (Option<Blake2sHash>, Vec<usize>)>,
+) -> TendermintContribution {
+    let signature = create_multisig().0.signature;
+    let contributions = buckets
+        .into_iter()
+        .map(|(hash, signers)| {
+            (
+                hash,
+                MultiSignature::new(signature, BitSet::from_iter(signers)),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    TendermintContribution { contributions }
+}
+
+/// `TendermintContribution` splits its signers into one bucket per proposal hash. The check must
+/// see every bucket, otherwise a bad slot can hide behind a well formed leading one.
+#[test]
+fn rejects_tendermint_contribution_with_out_of_range_slot_in_any_bucket() {
+    let proposal = Some(Blake2sHash::from([1u8; 32]));
+    let out_of_range = vec![Policy::SLOTS as usize];
+    let valid = vec![0];
+
+    // `None` sorts before `Some`, so these put the offending bucket first and last respectively.
+    let cases = [
+        vec![
+            (None, out_of_range.clone()),
+            (proposal.clone(), valid.clone()),
+        ],
+        vec![
+            (None, valid.clone()),
+            (proposal.clone(), out_of_range.clone()),
+        ],
+    ];
+
+    for buckets in cases {
+        let update: SerializableLevelUpdate<TendermintContribution> =
+            LevelUpdate::new(tendermint_contribution(buckets), None, 2, 3).into();
+        let data = update.serialize_to_vec();
+
+        assert!(
+            SerializableLevelUpdate::<TendermintContribution>::deserialize_from_vec(&data).is_err(),
+        );
+    }
+
+    // Control: the same shape with only valid slots.
+    let update: SerializableLevelUpdate<TendermintContribution> = LevelUpdate::new(
+        tendermint_contribution([(None, valid), (proposal, vec![1])]),
+        None,
+        2,
+        3,
+    )
+    .into();
+    let data = update.serialize_to_vec();
+
+    assert!(SerializableLevelUpdate::<TendermintContribution>::deserialize_from_vec(&data).is_ok());
 }


### PR DESCRIPTION
ValidatorRegistry narrowed slot numbers to u16 before checking them against Policy::SLOTS. Out of range slots therefore either truncated onto an existing slot or reached Validators::get_band_from_slot untruncated and tripped its assert!:

weight returned Some(1) for any id congruent to a valid slot mod 2¹⁶, inflating the weight compared against TWO_F_PLUS_ONE.
public_key returned a real validator's voting key for a slot that does not exist, folding a non-signing validator into the aggregate public key instead of failing as UnknownSigner. public_key and signers_identity panicked on slots in 512..=65535.

All three now go through a checked_slot helper that checks the bound in usize before narrowing, the same shape as checked_signer_slots in the block crate.

Not reachable from the network today: the Checked wrapper on SerializableLevelUpdate rejects contributor bits >= Policy::SLOTS at deserialization, and both entry points (SkipBlockUpdate, TendermintUpdate) go through it. This is defense in depth for the case where a contribution reaches the registry without that check.

Tests were added in a preceding commit and cover both layers: the registry functions at the range boundaries and at truncating ids, and the Checked wrapper itself, which had no coverage.