### PR TITLE
Live sync can hang indefinitely while retrying block diff requests

### DIFF
--- a/consensus/src/sync/live/diff_queue/diff_request_component.rs
+++ b/consensus/src/sync/live/diff_queue/diff_request_component.rs
@@ -1,9 +1,8 @@
-use std::{sync::Arc, time::Duration};
+use std::{cmp::min, sync::Arc};
 
 use futures::future::BoxFuture;
 use nimiq_network_interface::network::Network;
 use nimiq_primitives::{trie::trie_diff::TrieDiff, TreeProof};
-use nimiq_time::sleep;
 use parking_lot::RwLock;
 use tokio::sync::Semaphore;
 
@@ -13,11 +12,24 @@ use crate::sync::{
     peer_list::{PeerList, PeerListIndex},
 };
 
+/// Errors that can occur while requesting a trie diff from peers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DiffRequestError {
+    /// The maximum number of diff request attempts was reached.
+    MaxTriesExceeded,
+}
+
+/// Maximum total number of request attempts per diff request. Peer-list changes may cause the same
+/// peer to be selected more than once.
+const MAX_TRIES: usize = 15;
+
 /// Handles requesting `TrieDiff` for blocks from peers during live sync.
 pub struct DiffRequestComponent<N: Network> {
     network: Arc<N>,
     peers: Arc<RwLock<PeerList<N>>>,
     current_peer_index: PeerListIndex,
+    /// Bounds locally active request futures. Dropping a future releases its permit, but cannot
+    /// withdraw a request that has already been handed to the network.
     concurrent_requests: Arc<Semaphore>,
 }
 
@@ -36,7 +48,8 @@ impl<N: Network> DiffRequestComponent<N> {
 
     pub fn request_diff(
         &mut self,
-    ) -> impl FnMut(&BlockAndSource<N>) -> BoxFuture<'static, Result<TrieDiff, ()>> + use<N> {
+    ) -> impl FnMut(&BlockAndSource<N>) -> BoxFuture<'static, Result<TrieDiff, DiffRequestError>> + use<N>
+    {
         let mut starting_peer_index = self.current_peer_index.clone();
         self.current_peer_index.increment();
 
@@ -61,13 +74,11 @@ impl<N: Network> DiffRequestComponent<N> {
             let block_desc = format!("{block}");
             let block_hash = block.hash();
             let block_diff_root = block.diff_root().clone();
-            let max_backoff = Duration::from_secs(30);
 
             Box::pin(async move {
                 // Controls the number of concurrent diff requests.
                 let _request_permit = concurrent_requests.acquire().await.unwrap();
                 let mut num_tries = 0;
-                let mut backoff_delay = Duration::from_secs(1);
 
                 loop {
                     // Get the current peer based on the index.
@@ -75,9 +86,18 @@ impl<N: Network> DiffRequestComponent<N> {
                     let peer_id = match peer_id {
                         Some(peer_id) => peer_id,
                         None => {
-                            // If no peer is available, wait and retry.
-                            error!("couldn't fetch diff: no peers");
-                            sleep(Duration::from_secs(5)).await;
+                            // No request can be sent in this iteration, so wait for a peer. A peer
+                            // removed after an invalid response is handled by the post-attempt
+                            // retry check below before the loop can reach this branch again.
+                            let peers_became_nonempty = peers.read().wait_for_peers();
+                            if let Some(peers_became_nonempty) = peers_became_nonempty {
+                                debug!(block = %block_desc, "couldn't fetch diff: waiting for peers");
+
+                                // This wait is intentionally unbounded: having no peers is not a
+                                // failed request attempt. Keep the semaphore permit while parked so
+                                // at most `NUM_PENDING_DIFFS` diff requests wait for peers.
+                                peers_became_nonempty.await;
+                            }
                             continue;
                         }
                     };
@@ -94,7 +114,6 @@ impl<N: Network> DiffRequestComponent<N> {
                         .await;
 
                     num_tries += 1;
-                    let max_tries = peers.read().len();
 
                     match result {
                         // If the peer returns a partial diff, validate it.
@@ -106,26 +125,28 @@ impl<N: Network> DiffRequestComponent<N> {
                             }
                             // A tree-proof mismatch is cryptographically tied to the response
                             // contents; an honest peer cannot produce it by accident.
-                            warn!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: invalid diff, removing peer");
+                            warn!(%peer_id, block = %block_desc, %num_tries, "couldn't fetch diff: invalid diff, removing peer");
                             peers.write().remove_peer(&peer_id);
                         }
                         Ok(ResponseTrieDiff::IncompleteState) => {
-                            debug!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: incomplete state")
+                            debug!(%peer_id, block = %block_desc, %num_tries, "couldn't fetch diff: incomplete state")
                         }
                         Ok(ResponseTrieDiff::UnknownBlockHash) => {
-                            debug!(%peer_id, block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: unknown block hash")
+                            debug!(%peer_id, block = %block_desc, %num_tries, "couldn't fetch diff: unknown block hash")
                         }
                         Err(error) => {
-                            debug!(%peer_id, block = %block_desc, %num_tries, %max_tries, ?error, "couldn't fetch diff: {}", error)
+                            debug!(%peer_id, block = %block_desc, %num_tries, ?error, "couldn't fetch diff: {}", error)
                         }
                     }
 
+                    // Recompute the limit after processing the response because an invalid diff
+                    // may have removed the selected peer. If it was the last peer, `max_tries`
+                    // becomes zero and this completed attempt terminates instead of entering the
+                    // no-peer waiting branch on the next iteration.
+                    let max_tries = min(MAX_TRIES, peers.read().len());
                     if num_tries >= max_tries {
-                        error!(%num_tries, %max_tries, ?backoff_delay, "couldn't fetch diff: maximum tries reached");
-
-                        sleep(backoff_delay).await;
-                        backoff_delay = Duration::min(backoff_delay * 2, max_backoff);
-                        num_tries = 0;
+                        debug!(block = %block_desc, %num_tries, %max_tries, "couldn't fetch diff: giving up after maximum tries");
+                        return Err(DiffRequestError::MaxTriesExceeded);
                     }
                 }
             })

--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -1,14 +1,14 @@
 //! Provides a queuing component that augments blocks with state trie diffs during live sync.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     future,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
 };
 
-use futures::{future::BoxFuture, Stream, StreamExt, TryStreamExt};
+use futures::{future::BoxFuture, Stream, StreamExt};
 use nimiq_hash::Blake2bHash;
 use nimiq_network_interface::{
     network::Network,
@@ -16,11 +16,11 @@ use nimiq_network_interface::{
 };
 use nimiq_primitives::trie::trie_diff::TrieDiff;
 use nimiq_serde::{Deserialize, Serialize};
-use nimiq_utils::stream::{FuturesOrdered, FuturesUnordered};
+use nimiq_utils::stream::FuturesOrdered;
 use parking_lot::RwLock;
 
-use self::diff_request_component::DiffRequestComponent;
-use super::block_queue::{BlockAndSource, BlockQueue, QueuedBlock};
+use self::diff_request_component::{DiffRequestComponent, DiffRequestError};
+use super::block_queue::{BlockAndSource, BlockQueue, BlockSource, QueuedBlock};
 use crate::{
     consensus::ResolveBlockRequest,
     sync::{
@@ -84,68 +84,112 @@ impl<N: Network> QueuedDiff<N> {
     }
 }
 
+struct AugmentedDiff<N: Network> {
+    queued_diff: Option<QueuedDiff<N>>,
+    dropped_blocks: HashMap<Blake2bHash, BlockSource<N>>,
+}
+
+/// Fetches a batch concurrently while consuming its results in block order.
+///
+/// Requests after the first failing block are speculative: they may already have started or even
+/// completed before the ordered failure is observed. Only the successful prefix is retained.
 async fn get_multiple_diffs<N: Network>(
-    blocks: &[BlockAndSource<N>],
-    mut get_diff: impl FnMut(&BlockAndSource<N>) -> BoxFuture<'static, Result<TrieDiff, ()>>,
-) -> Result<Vec<TrieDiff>, ()> {
-    // This is just a fancy way to collect all the diffs simultaneously.
-    let diffs: FuturesUnordered<_> = blocks
+    blocks: Vec<BlockAndSource<N>>,
+    mut get_diff: impl FnMut(
+        &BlockAndSource<N>,
+    ) -> BoxFuture<'static, Result<TrieDiff, DiffRequestError>>,
+) -> (
+    Vec<(BlockAndSource<N>, Option<TrieDiff>)>,
+    HashMap<Blake2bHash, BlockSource<N>>,
+) {
+    let mut blocks_with_diffs = Vec::with_capacity(blocks.len());
+    // `FuturesOrdered` polls all requests concurrently, but only yields them in insertion order.
+    // Indexing the results makes the prefix invariant explicit and avoids sorting after retrieval.
+    let mut diff_futures: FuturesOrdered<_> = blocks
         .iter()
         .enumerate()
-        .map(|(i, block)| {
-            // Get each diff.
+        .map(|(index, block)| {
             let diff = get_diff(block);
-            async move {
-                // Annotate it with its index.
-                diff.await.map(|d| (i, d))
-            }
+            async move { (index, diff.await) }
         })
         .collect();
+    let mut remaining_blocks = blocks.into_iter();
 
-    // Collect all diffs, returning an error if any failed.
-    let mut diffs = diffs.try_collect::<Vec<_>>().await?;
+    while let Some((index, result)) = diff_futures.next().await {
+        let block = remaining_blocks
+            .next()
+            .expect("one diff future is created per block");
+        debug_assert_eq!(index, blocks_with_diffs.len());
 
-    // Sort the diffs by index again.
-    diffs.sort_unstable_by_key(|&(i, _)| i);
-    assert_eq!(blocks.len(), diffs.len());
+        match result {
+            Ok(diff) => blocks_with_diffs.push((block, Some(diff))),
+            Err(DiffRequestError::MaxTriesExceeded) => {
+                let dropped_blocks = std::iter::once(block)
+                    .chain(remaining_blocks)
+                    .map(|(block, block_source)| (block.hash(), block_source))
+                    .collect();
+                // Returning drops the speculative suffix futures, stopping their local retry loops
+                // and releasing their semaphore permits. Requests already handed to the network
+                // cannot be withdrawn and may still complete; their responses are ignored.
+                return (blocks_with_diffs, dropped_blocks);
+            }
+        }
+    }
 
-    // Strip index before returning.
-    Ok(diffs.into_iter().map(|(_, diff)| diff).collect())
+    (blocks_with_diffs, HashMap::default())
 }
 
 async fn augment_block<N: Network>(
     block: QueuedBlock<N>,
-    mut get_diff: impl FnMut(&BlockAndSource<N>) -> BoxFuture<'static, Result<TrieDiff, ()>>,
-) -> Result<QueuedDiff<N>, ()> {
-    Ok(match block {
-        QueuedBlock::Head(block) => {
-            let diff = get_diff(&block).await?;
-            QueuedDiff::Head(block, Some(diff))
-        }
+    mut get_diff: impl FnMut(
+        &BlockAndSource<N>,
+    ) -> BoxFuture<'static, Result<TrieDiff, DiffRequestError>>,
+) -> AugmentedDiff<N> {
+    match block {
+        QueuedBlock::Head(block) => match get_diff(&block).await {
+            Ok(diff) => AugmentedDiff {
+                queued_diff: Some(QueuedDiff::Head(block, Some(diff))),
+                dropped_blocks: HashMap::default(),
+            },
+            Err(DiffRequestError::MaxTriesExceeded) => {
+                let (block, block_source) = block;
+                AugmentedDiff {
+                    queued_diff: None,
+                    dropped_blocks: HashMap::from([(block.hash(), block_source)]),
+                }
+            }
+        },
         QueuedBlock::Buffered(blocks) => {
-            let diffs = get_multiple_diffs::<N>(&blocks[..], get_diff).await?;
-            QueuedDiff::Buffered(
-                blocks
-                    .into_iter()
-                    .zip(diffs.into_iter().map(Some))
-                    .collect(),
-            )
+            let (blocks_with_diffs, dropped_blocks) = get_multiple_diffs(blocks, get_diff).await;
+            AugmentedDiff {
+                queued_diff: (!blocks_with_diffs.is_empty())
+                    .then_some(QueuedDiff::Buffered(blocks_with_diffs)),
+                dropped_blocks,
+            }
         }
         QueuedBlock::Missing(blocks) => {
-            let diffs = get_multiple_diffs::<N>(&blocks[..], get_diff).await?;
-            QueuedDiff::Missing(
-                blocks
-                    .into_iter()
-                    .zip(diffs.into_iter().map(Some))
-                    .collect(),
-            )
+            let (blocks_with_diffs, dropped_blocks) = get_multiple_diffs(blocks, get_diff).await;
+            AugmentedDiff {
+                queued_diff: (!blocks_with_diffs.is_empty())
+                    .then_some(QueuedDiff::Missing(blocks_with_diffs)),
+                dropped_blocks,
+            }
         }
-        QueuedBlock::TooFarAhead(peer_id) => QueuedDiff::TooFarAhead(peer_id),
-        QueuedBlock::TooFarBehind(peer_id) => QueuedDiff::TooFarBehind(peer_id),
-    })
+        QueuedBlock::TooFarAhead(peer_id) => AugmentedDiff {
+            queued_diff: Some(QueuedDiff::TooFarAhead(peer_id)),
+            dropped_blocks: HashMap::default(),
+        },
+        QueuedBlock::TooFarBehind(peer_id) => AugmentedDiff {
+            queued_diff: Some(QueuedDiff::TooFarBehind(peer_id)),
+            dropped_blocks: HashMap::default(),
+        },
+    }
 }
 
 pub struct DiffQueue<N: Network> {
+    /// Reference to the network used to close validation of dropped gossip messages.
+    network: Arc<N>,
+
     /// The BlockQueue component.
     block_queue: BlockQueue<N>,
 
@@ -154,7 +198,7 @@ pub struct DiffQueue<N: Network> {
     diff_request_component: DiffRequestComponent<N>,
 
     /// The pending TreeDiff requests to peers.
-    diffs: FuturesOrdered<BoxFuture<'static, Result<QueuedDiff<N>, ()>>>,
+    diffs: FuturesOrdered<BoxFuture<'static, AugmentedDiff<N>>>,
 
     /// Flag indicating if diffs should be requested.
     diff_needed: bool,
@@ -166,6 +210,7 @@ impl<N: Network> DiffQueue<N> {
         let diff_request_component =
             DiffRequestComponent::new(Arc::clone(&network), block_queue.peer_list());
         Self {
+            network,
             block_queue,
             diff_request_component,
             diffs: FuturesOrdered::new(),
@@ -226,6 +271,20 @@ impl<N: Network> DiffQueue<N> {
     pub(crate) fn acceptance_window_size(&self) -> u32 {
         self.block_queue.acceptance_window_size()
     }
+
+    /// Ignores announced blocks whose diff requests failed and clears their pending markers.
+    /// A request failure is not proof of invalidity: `remove_invalid_blocks` would also reject
+    /// buffered descendants. `Ignore` closes gossipsub validation without penalizing the source,
+    /// while clearing `blocks_pending_push` allows a later announcement to enqueue the block again.
+    fn clear_pending_diff_requests(
+        &mut self,
+        dropped_blocks: HashMap<Blake2bHash, BlockSource<N>>,
+    ) {
+        for (block_hash, block_source) in dropped_blocks {
+            block_source.ignore_block(&self.network);
+            self.block_queue.on_block_processed(&block_hash);
+        }
+    }
 }
 
 impl<N: Network> Stream for DiffQueue<N> {
@@ -241,9 +300,10 @@ impl<N: Network> Stream for DiffQueue<N> {
                         .push_back(Box::pin(augment_block(block, get_diff)));
                 }
                 (Some(block), false) => {
-                    self.diffs.push_back(Box::pin(future::ready(Ok(
-                        QueuedDiff::from_block_no_diff(block),
-                    ))));
+                    self.diffs.push_back(Box::pin(future::ready(AugmentedDiff {
+                        queued_diff: Some(QueuedDiff::from_block_no_diff(block)),
+                        dropped_blocks: HashMap::default(),
+                    })));
                 }
                 // The block queue only ends when something bad happens.
                 // Thus we immediately quit and do not wait for any pending diffs.
@@ -253,14 +313,378 @@ impl<N: Network> Stream for DiffQueue<N> {
 
         // Check for blocks augmented with diffs.
         while let Poll::Ready(Some(diff)) = self.diffs.poll_next_unpin(cx) {
-            match diff {
-                Ok(diff) => return Poll::Ready(Some(diff)),
-                Err(()) => {
-                    error!("couldn't fetch diff");
-                }
+            if !diff.dropped_blocks.is_empty() {
+                debug!(
+                    dropped_block_hashes = ?diff.dropped_blocks.keys(),
+                    "dropping blocks after diff request failed"
+                );
+                self.clear_pending_diff_requests(diff.dropped_blocks);
+            }
+
+            if let Some(queued_diff) = diff.queued_diff {
+                return Poll::Ready(Some(queued_diff));
             }
         }
 
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        future::{pending, ready},
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use futures::{join, StreamExt};
+    use nimiq_blockchain_proxy::BlockchainProxy;
+    use nimiq_network_interface::network::{MsgAcceptance, Network, PubsubId};
+    use nimiq_network_mock::{MockHub, MockId, MockNetwork, MockPeerId};
+    use nimiq_primitives::trie::trie_diff::TrieDiff;
+    use nimiq_test_log::test;
+    use nimiq_test_utils::block_production::TemporaryBlockProducer;
+    use tokio::{
+        sync::{mpsc, Notify},
+        time::timeout,
+    };
+    use tokio_stream::wrappers::ReceiverStream;
+
+    use super::{
+        augment_block, diff_request_component::DiffRequestError, AugmentedDiff, DiffQueue,
+        QueuedDiff, RequestTrieDiff, ResponseTrieDiff,
+    };
+    use crate::sync::live::{
+        block_queue::{BlockQueue, BlockSource, QueuedBlock},
+        queue::QueueConfig,
+    };
+
+    #[test(tokio::test)]
+    async fn failed_head_diff_request_ignores_message_and_allows_reannouncement() {
+        let mut hub = MockHub::new();
+        let local = TemporaryBlockProducer::new();
+        let local_blockchain = Arc::clone(&local.blockchain);
+        let network = Arc::new(hub.new_network());
+        let (block_tx, block_rx) = mpsc::channel(8);
+
+        let block_queue = BlockQueue::with_gossipsub_block_stream(
+            BlockchainProxy::from(&local_blockchain),
+            Arc::clone(&network),
+            ReceiverStream::new(block_rx).boxed(),
+            QueueConfig::default(),
+        );
+        let mut diff_queue = DiffQueue::with_block_queue(Arc::clone(&network), block_queue);
+
+        let source = TemporaryBlockProducer::new();
+        let source_network = Arc::new(hub.new_network());
+        let other_network = Arc::new(hub.new_network());
+        let mut source_requests = source_network.receive_requests::<RequestTrieDiff>();
+        let mut other_requests = other_network.receive_requests::<RequestTrieDiff>();
+
+        network.dial_mock(&source_network);
+        network.dial_mock(&other_network);
+        diff_queue.add_peer(source_network.get_local_peer_id());
+        diff_queue.add_peer(other_network.get_local_peer_id());
+
+        let block = source.next_block(vec![], false);
+        let source_id = MockId::new(source_network.get_local_peer_id());
+        block_tx
+            .send((block.clone(), source_id.clone()))
+            .await
+            .unwrap();
+
+        let (_, first_attempt) = join!(
+            async {
+                let (_, request_id, _) = source_requests.next().await.unwrap();
+                source_network
+                    .respond::<RequestTrieDiff>(request_id, ResponseTrieDiff::IncompleteState)
+                    .await
+                    .unwrap();
+
+                let (_, request_id, _) = other_requests.next().await.unwrap();
+                other_network
+                    .respond::<RequestTrieDiff>(request_id, ResponseTrieDiff::UnknownBlockHash)
+                    .await
+                    .unwrap();
+            },
+            async { timeout(Duration::from_millis(100), diff_queue.next()).await },
+        );
+        assert!(
+            first_attempt.is_err(),
+            "diff request failure should not emit an augmented block"
+        );
+        let validation_results = network.take_validation_results();
+        assert!(
+            matches!(
+                validation_results.as_slice(),
+                [(_, pubsub_id, MsgAcceptance::Ignore)]
+                    if pubsub_id.propagation_source() == source_id.propagation_source()
+            ),
+            "the dropped block announcement should be ignored without penalizing its source"
+        );
+
+        block_tx.send((block, source_id)).await.unwrap();
+
+        let (retry_request, retry_attempt) = join!(
+            async { timeout(Duration::from_millis(100), source_requests.next()).await },
+            async { timeout(Duration::from_millis(100), diff_queue.next()).await },
+        );
+        assert!(
+            matches!(retry_request, Ok(Some(_))),
+            "the same head block should be accepted again after the previous diff request was dropped"
+        );
+        assert!(
+            retry_attempt.is_err(),
+            "reannouncing the head block should still wait on the next diff request"
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn dropped_diff_does_not_block_follow_up_items() {
+        let mut hub = MockHub::new();
+        let local = TemporaryBlockProducer::new();
+        let local_blockchain = Arc::clone(&local.blockchain);
+        let network = Arc::new(hub.new_network());
+        let (_block_tx, block_rx) = mpsc::channel(8);
+
+        let block_queue = BlockQueue::with_gossipsub_block_stream(
+            BlockchainProxy::from(&local_blockchain),
+            Arc::clone(&network),
+            ReceiverStream::new(block_rx).boxed(),
+            QueueConfig::default(),
+        );
+        let mut diff_queue = DiffQueue::with_block_queue(Arc::clone(&network), block_queue);
+
+        let peer_id = network.get_local_peer_id();
+        diff_queue.diffs.push_back(Box::pin(ready(AugmentedDiff {
+            queued_diff: None,
+            dropped_blocks: HashMap::default(),
+        })));
+        diff_queue.diffs.push_back(Box::pin(ready(AugmentedDiff {
+            queued_diff: Some(QueuedDiff::TooFarAhead(peer_id)),
+            dropped_blocks: HashMap::default(),
+        })));
+
+        let next_item = timeout(Duration::from_millis(100), diff_queue.next()).await;
+        assert!(
+            matches!(next_item, Ok(Some(QueuedDiff::TooFarAhead(id))) if id == peer_id),
+            "dropping a diff request failure must not block later queued items"
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn buffered_diff_failure_keeps_prefix_and_reports_remaining_hashes() {
+        let source = TemporaryBlockProducer::new();
+        let first_block = source.next_block(vec![], false);
+        let second_block = source.next_block(vec![], false);
+        let third_block = source.next_block(vec![], false);
+        let first_block_hash = first_block.hash();
+        let second_block_hash = second_block.hash();
+        let third_block_hash = third_block.hash();
+        let failing_block_hash = second_block_hash.clone();
+
+        let result = augment_block(
+            QueuedBlock::<MockNetwork>::Buffered(vec![
+                (
+                    first_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+                (
+                    second_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+                (
+                    third_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+            ]),
+            move |(block, _)| {
+                let block_hash = block.hash();
+                Box::pin(ready(if block_hash == failing_block_hash {
+                    Err(DiffRequestError::MaxTriesExceeded)
+                } else {
+                    Ok(TrieDiff::default())
+                }))
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                AugmentedDiff {
+                    queued_diff: Some(QueuedDiff::Buffered(blocks_with_diffs)),
+                    dropped_blocks,
+                }
+                    if blocks_with_diffs.len() == 1
+                        && blocks_with_diffs[0].0.0.hash() == first_block_hash
+                        && blocks_with_diffs[0].1.is_some()
+                        && dropped_blocks.keys().cloned().collect::<HashSet<_>>()
+                            == HashSet::from([second_block_hash, third_block_hash])
+            ),
+            "buffered diff failures should keep the successful prefix and drop the failed suffix"
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn missing_diff_failure_keeps_prefix_and_reports_remaining_hashes() {
+        let source = TemporaryBlockProducer::new();
+        let first_block = source.next_block(vec![], false);
+        let second_block = source.next_block(vec![], false);
+        let third_block = source.next_block(vec![], false);
+        let first_block_hash = first_block.hash();
+        let second_block_hash = second_block.hash();
+        let third_block_hash = third_block.hash();
+        let failing_block_hash = second_block_hash.clone();
+
+        let result = augment_block(
+            QueuedBlock::<MockNetwork>::Missing(vec![
+                (
+                    first_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+                (
+                    second_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+                (
+                    third_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+            ]),
+            move |(block, _)| {
+                let block_hash = block.hash();
+                Box::pin(ready(if block_hash == failing_block_hash {
+                    Err(DiffRequestError::MaxTriesExceeded)
+                } else {
+                    Ok(TrieDiff::default())
+                }))
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                AugmentedDiff {
+                    queued_diff: Some(QueuedDiff::Missing(blocks_with_diffs)),
+                    dropped_blocks,
+                }
+                    if blocks_with_diffs.len() == 1
+                        && blocks_with_diffs[0].0.0.hash() == first_block_hash
+                        && blocks_with_diffs[0].1.is_some()
+                        && dropped_blocks.keys().cloned().collect::<HashSet<_>>()
+                            == HashSet::from([second_block_hash, third_block_hash])
+            ),
+            "missing diff failures should keep the successful prefix and drop the failed suffix"
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn missing_diff_requests_are_concurrent_but_stop_at_first_ordered_failure() {
+        struct SetOnDrop(Arc<AtomicBool>);
+
+        impl Drop for SetOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let source = TemporaryBlockProducer::new();
+        let first_block = source.next_block(vec![], false);
+        let second_block = source.next_block(vec![], false);
+        let third_block = source.next_block(vec![], false);
+        let first_block_hash = first_block.hash();
+        let second_block_hash = second_block.hash();
+        let third_block_hash = third_block.hash();
+
+        let started_requests = Arc::new(AtomicUsize::new(0));
+        let started_requests_for_diff = Arc::clone(&started_requests);
+        let release_first = Arc::new(Notify::new());
+        let release_first_for_diff = Arc::clone(&release_first);
+        let suffix_cancelled = Arc::new(AtomicBool::new(false));
+        let suffix_cancelled_for_diff = Arc::clone(&suffix_cancelled);
+        let first_request_hash = first_block_hash.clone();
+        let second_request_hash = second_block_hash.clone();
+
+        let request = augment_block(
+            QueuedBlock::<MockNetwork>::Missing(vec![
+                (
+                    first_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+                (
+                    second_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+                (
+                    third_block,
+                    BlockSource::<MockNetwork>::requested(MockPeerId(0)),
+                ),
+            ]),
+            move |(block, _)| {
+                let block_hash = block.hash();
+                let started_requests = Arc::clone(&started_requests_for_diff);
+                let release_first = Arc::clone(&release_first_for_diff);
+                let suffix_cancelled = Arc::clone(&suffix_cancelled_for_diff);
+                let first_request_hash = first_request_hash.clone();
+                let second_request_hash = second_request_hash.clone();
+
+                Box::pin(async move {
+                    started_requests.fetch_add(1, Ordering::SeqCst);
+
+                    if block_hash == first_request_hash {
+                        // Hold the first result so that the ordered stream must poll the suffix.
+                        release_first.notified().await;
+                        Ok(TrieDiff::default())
+                    } else if block_hash == second_request_hash {
+                        Err(DiffRequestError::MaxTriesExceeded)
+                    } else {
+                        // This future must be dropped once the preceding error is consumed.
+                        let _set_on_drop = SetOnDrop(suffix_cancelled);
+                        pending().await
+                    }
+                })
+            },
+        );
+
+        let observe_concurrency = async {
+            timeout(Duration::from_secs(1), async {
+                while started_requests.load(Ordering::SeqCst) != 3 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("all diff futures should be polled concurrently");
+            release_first.notify_one();
+        };
+
+        let (result, ()) = join!(request, observe_concurrency);
+
+        assert!(
+            matches!(
+                result,
+                AugmentedDiff {
+                    queued_diff: Some(QueuedDiff::Missing(blocks_with_diffs)),
+                    dropped_blocks,
+                }
+                    if blocks_with_diffs.len() == 1
+                        && blocks_with_diffs[0].0.0.hash() == first_block_hash
+                        && blocks_with_diffs[0].1.is_some()
+                        && dropped_blocks.keys().cloned().collect::<HashSet<_>>()
+                            == HashSet::from([second_block_hash, third_block_hash])
+            ),
+            "ordered retrieval should retain the prefix and drop the failed suffix"
+        );
+        assert_eq!(started_requests.load(Ordering::SeqCst), 3);
+        assert!(
+            suffix_cancelled.load(Ordering::SeqCst),
+            "the unconsumed local suffix future should be cancelled"
+        );
     }
 }

--- a/consensus/src/sync/peer_list.rs
+++ b/consensus/src/sync/peer_list.rs
@@ -147,12 +147,10 @@ impl<N: Network> PeerList<N> {
 
     /// Returns a future that resolves when the list becomes nonempty.
     ///
-    /// Returns `None` is the list has peers already.
+    /// Returns `None` if the list has peers already.
     pub fn wait_for_peers(&self) -> Option<BoxFuture<'static, ()>> {
-        self.is_empty().then(|| {
-            let notify = self.notify_nonempty.clone();
-            Box::pin(async move { notify.notified().await }) as _
-        })
+        self.is_empty()
+            .then(|| Box::pin(self.notify_nonempty.clone().notified_owned()) as _)
     }
 }
 
@@ -161,5 +159,32 @@ impl<N: Network, I: SliceIndex<[N::PeerId]>> Index<I> for PeerList<N> {
 
     fn index(&self, index: I) -> &Self::Output {
         self.peers.index(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use nimiq_network_mock::{MockNetwork, MockPeerId};
+    use nimiq_test_log::test;
+    use tokio::time::timeout;
+
+    use super::PeerList;
+
+    #[test(tokio::test)]
+    async fn wait_for_peers_observes_notification_before_first_poll() {
+        let mut peers = PeerList::<MockNetwork>::default();
+        let peers_became_nonempty = peers
+            .wait_for_peers()
+            .expect("an empty peer list should return a wait future");
+
+        // Notify before polling the future to cover the handoff from the peer-list read lock to
+        // the asynchronous wait. The notification must not be lost during that window.
+        assert!(peers.add_peer(MockPeerId(0)));
+
+        timeout(Duration::from_secs(1), peers_became_nonempty)
+            .await
+            .expect("the pre-poll notification should resolve the wait future");
     }
 }

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -1,6 +1,7 @@
 use std::{
     sync::{atomic::AtomicU32, Arc},
     task::Poll,
+    time::Duration,
 };
 
 use futures::{join, poll, Future, Stream, StreamExt};
@@ -14,11 +15,15 @@ use nimiq_consensus::{
     sync::{
         live::{
             block_queue::BlockQueue,
-            diff_queue::{DiffQueue, RequestTrieDiff, ResponseTrieDiff},
+            diff_queue::{
+                diff_request_component::{DiffRequestComponent, DiffRequestError},
+                DiffQueue, RequestTrieDiff, ResponseTrieDiff,
+            },
             queue::QueueConfig,
             state_queue::{Chunk, ChunkRequestState, RequestChunk, ResponseChunk, StateQueue},
             StateLiveSync,
         },
+        peer_list::PeerList,
         sync_interface::{LiveSync, LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
     },
     BlsCache,
@@ -51,6 +56,7 @@ use parking_lot::{Mutex, RwLock};
 use tokio::{
     sync::mpsc::{self, Sender},
     task::yield_now,
+    time::timeout,
 };
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -429,6 +435,77 @@ async fn can_sync_state() {
     assert!(blockchain_rg.accounts_complete());
     assert!(live_sync.queue().chunk_request_state().is_complete());
     drop(blockchain_rg);
+}
+
+#[test(tokio::test)]
+async fn gives_up_diff_request_if_only_source_knows_block_and_never_serves_diff() {
+    let mut hub = Some(MockHub::new());
+    let network = Arc::new(hub.as_mut().unwrap().new_network());
+
+    let network_info = NetworkInfo::from_network_id(NetworkId::UnitAlbatross);
+    let genesis_block = network_info.genesis_block();
+    let genesis_accounts = network_info.genesis_accounts();
+
+    let mut source_node =
+        MockNode::<MockNetwork>::new(2, genesis_block.clone(), genesis_accounts.clone(), &mut hub)
+            .await;
+    let mut other_node =
+        MockNode::<MockNetwork>::new(3, genesis_block, genesis_accounts, &mut hub).await;
+
+    network.dial_mock(&source_node.network);
+    network.dial_mock(&other_node.network);
+
+    // Only the source node has the block whose diff we are going to request.
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    push_micro_block(&producer, &source_node.blockchain);
+    let block = source_node.blockchain.read().state.main_chain.head.clone();
+
+    // The source peer knows the block but never serves a usable diff for it.
+    source_node
+        .request_partial_diff_handler
+        .set(|_, _, _| ResponseTrieDiff::IncompleteState);
+
+    let peers = Arc::new(RwLock::new(PeerList::default()));
+    // Insert a different peer first to prove that the request logic still prioritizes
+    // the original sender before falling back to the rest of the peer set.
+    peers
+        .write()
+        .add_peer(other_node.network.get_local_peer_id());
+    peers
+        .write()
+        .add_peer(source_node.network.get_local_peer_id());
+
+    let mut diff_request_component = DiffRequestComponent::new(Arc::clone(&network), peers);
+    let mut get_diff = diff_request_component.request_diff();
+    let source_peer_id = source_node.network.get_local_peer_id();
+    // Drive the request in the background so we can observe which peers it contacts.
+    let diff_request = tokio::spawn(async move {
+        get_diff(&(
+            block,
+            nimiq_consensus::sync::live::block_queue::BlockSource::requested(source_peer_id),
+        ))
+        .await
+    });
+
+    // The source peer is asked first.
+    assert_eq!(source_node.next().await, Some(RequestTrieDiff::TYPE_ID));
+    // Once that fails, the requester falls back to the next peer, which does not know the block.
+    assert_eq!(other_node.next().await, Some(RequestTrieDiff::TYPE_ID));
+    // After all peers fail to provide a valid diff, the request gives up instead of starting another pass.
+    assert!(
+        matches!(
+            diff_request.await.unwrap(),
+            Err(DiffRequestError::MaxTriesExceeded)
+        ),
+        "diff request should fail after exhausting the peer set"
+    );
+    // No new request should be sent to the source peer after the request gives up.
+    assert!(
+        timeout(Duration::from_millis(100), source_node.next())
+            .await
+            .is_err(),
+        "diff request should not retry once the maximum number of tries is reached"
+    );
 }
 
 #[test(tokio::test)]

--- a/network-mock/src/network.rs
+++ b/network-mock/src/network.rs
@@ -77,6 +77,7 @@ pub struct MockNetwork {
     peers: Arc<RwLock<ObservableHashMap<MockPeerId, PeerInfo>>>,
     hub: Arc<Mutex<MockHubInner>>,
     is_connected: Arc<AtomicBool>,
+    validation_results: Mutex<Vec<(&'static str, MockId<MockPeerId>, MsgAcceptance)>>,
 }
 
 impl MockNetwork {
@@ -105,6 +106,7 @@ impl MockNetwork {
             peers,
             hub,
             is_connected,
+            validation_results: Mutex::new(Vec::new()),
         }
     }
 
@@ -114,6 +116,13 @@ impl MockNetwork {
 
     pub fn peer_id(&self) -> MockPeerId {
         self.address.into()
+    }
+
+    /// Returns and clears all reported gossipsub validation results.
+    pub fn take_validation_results(
+        &self,
+    ) -> Vec<(&'static str, MockId<MockPeerId>, MsgAcceptance)> {
+        std::mem::take(&mut self.validation_results.lock())
     }
 
     fn dial_mock_address(&self, address: MockAddress) -> Result<(), MockNetworkError> {
@@ -527,11 +536,13 @@ impl Network for MockNetwork {
         self.publish_with_name::<T>(topic_name, item).await
     }
 
-    fn validate_message<TTopic>(&self, _id: Self::PubsubId, _acceptance: MsgAcceptance)
+    fn validate_message<TTopic>(&self, id: Self::PubsubId, acceptance: MsgAcceptance)
     where
         TTopic: Topic + Sync,
     {
-        // TODO implement
+        self.validation_results
+            .lock()
+            .push((TTopic::NAME, id, acceptance));
     }
 
     async fn dht_get<K, V, T>(&self, k: &K) -> Result<Option<V>, Self::Error>


### PR DESCRIPTION
## What's in this pull request?

This change prevents live-sync diff requests from retrying indefinitely after unsuccessful requests have been made. It addresses a liveness issue where a node could remain stuck waiting for a block diff that none of its available peers could provide.

Previously, `DiffRequestComponent::request_diff()` repeatedly cycled through peers using a backoff-and-reset loop, without a terminal failure condition. With this change, every completed unsuccessful request counts toward a bounded retry limit. Once that limit is reached, the request terminates with a typed error instead of restarting the retry loop.

If an invalid diff causes the last peer to be removed, `peers.len()` becomes 0. The post-attempt retry check therefore terminates the request immediately with `MaxTriesExceeded`. This differs from finding an empty peer list at the start of an iteration, which waits for a peer to become available.

The retry limit is calculated after each attempt as:

`min(MAX_TRIES, peers.len())`

`MAX_TRIES` is currently set to `15`. Because the peer count is read after processing the response, removing a peer can reduce the remaining retry allowance.

#### What changed

- Added a dedicated `DiffRequestError` enum instead of using `Result<_, ()>`.
- Introduced a `MAX_TRIES` constant to cap diff-request attempts.
- Return `DiffRequestError::MaxTriesExceeded` when the current retry limit is reached without obtaining a valid diff.
- Continue waiting when peer selection finds no available peer.
- Recalculate the retry limit after processing each response, including any invalid-peer removal.
- Threaded the new error type through the diff-queue helpers and logging.
- Removed the previous backoff-and-reset behavior, so unsuccessful requests can terminate instead of restarting indefinitely.
- Added regression coverage confirming that a request terminates after the available attempts fail.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.