### PR TITLE
Fix panic on diffless block and chunk push

### DIFF
--- a/consensus/src/sync/live/diff_queue/mod.rs
+++ b/consensus/src/sync/live/diff_queue/mod.rs
@@ -272,6 +272,16 @@ impl<N: Network> DiffQueue<N> {
         self.block_queue.acceptance_window_size()
     }
 
+    pub(crate) fn retry_with_diff(&mut self, block: QueuedBlock<N>) {
+        let get_diff = self.diff_request_component.request_diff();
+        // Prioritize retries over existing diff work. Repeated calls are therefore
+        // scheduled in LIFO order, but Buffered blocks are independently applicable
+        // because their parents are already stored. Ordered Missing chains are retried
+        // together and preserve their order.
+        self.diffs
+            .push_front(Box::pin(augment_block(block, get_diff)));
+    }
+
     /// Ignores announced blocks whose diff requests failed and clears their pending markers.
     /// A request failure is not proof of invalidity: `remove_invalid_blocks` would also reject
     /// buffered descendants. `Ignore` closes gossipsub validation without penalizing the source,

--- a/consensus/src/sync/live/queue.rs
+++ b/consensus/src/sync/live/queue.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::{future::BoxFuture, FutureExt, Stream};
+use futures::{future::BoxFuture, Stream};
 use nimiq_block::Block;
 #[cfg(feature = "full")]
 use nimiq_blockchain::{Blockchain, PostValidationHook};
@@ -64,6 +64,29 @@ impl<N: Network> fmt::Debug for ChunkAndSource<N> {
             .field("peer_id", &self.peer_id)
             .finish()
     }
+}
+
+pub enum BlockAndChunksPushResult<N: Network> {
+    Applied(
+        Result<PushResult, PushError>,
+        Result<ChunksPushResult, ChunksPushError>,
+        Blake2bHash,
+    ),
+    NeedsDiff(BlockAndSource<N>, Vec<ChunkAndSource<N>>, Blake2bHash),
+}
+
+pub enum MissingBlocksPushResult<N: Network> {
+    Applied(
+        Result<PushResult, PushError>,
+        Result<ChunksPushResult, ChunksPushError>,
+        Vec<Blake2bHash>,
+        HashSet<Blake2bHash>,
+    ),
+    NeedsDiff(
+        Result<ChunksPushResult, ChunksPushError>,
+        Vec<Blake2bHash>,
+        Vec<(BlockAndSource<N>, Vec<ChunkAndSource<N>>)>,
+    ),
 }
 
 impl<N: Network> ChunkAndSource<N> {
@@ -164,6 +187,7 @@ impl Default for QueueConfig {
 struct BlockchainPushResult<N: Network> {
     block_push_result: Option<Result<PushResult, PushError>>,
     push_chunks_result: Result<ChunksPushResult, ChunksPushError>,
+    retry_with_diff: Option<(BlockAndSource<N>, Vec<ChunkAndSource<N>>)>,
     #[allow(dead_code)] // TODO ban peer related
     chunk_error_peer: Option<<N as Network>::PeerId>,
     block_hash: Blake2bHash,
@@ -178,6 +202,7 @@ impl<N: Network> BlockchainPushResult<N> {
         Self {
             block_push_result: Some(push_result),
             push_chunks_result: Ok(ChunksPushResult::EmptyChunks),
+            retry_with_diff: None,
             block_hash,
             chunk_error_peer: None,
         }
@@ -204,6 +229,7 @@ impl<N: Network> BlockchainPushResult<N> {
         Self {
             block_push_result: Some(block_push_result),
             push_chunks_result,
+            retry_with_diff: None,
             block_hash,
             chunk_error_peer,
         }
@@ -226,8 +252,24 @@ impl<N: Network> BlockchainPushResult<N> {
         Self {
             block_push_result: None,
             push_chunks_result,
+            retry_with_diff: None,
             block_hash,
             chunk_error_peer: peer_id,
+        }
+    }
+
+    #[cfg(feature = "full")]
+    fn with_diff_retry(
+        block: BlockAndSource<N>,
+        chunks: Vec<ChunkAndSource<N>>,
+        block_hash: Blake2bHash,
+    ) -> Self {
+        Self {
+            block_push_result: None,
+            push_chunks_result: Ok(ChunksPushResult::EmptyChunks),
+            retry_with_diff: Some((block, chunks)),
+            block_hash,
+            chunk_error_peer: None,
         }
     }
 }
@@ -242,16 +284,12 @@ pub async fn push_block_and_chunks<N: Network>(
     block_source: BlockSource<N>,
     diff: Option<TrieDiff>,
     chunks: Vec<ChunkAndSource<N>>,
-) -> (
-    Result<PushResult, PushError>,
-    Result<ChunksPushResult, ChunksPushError>,
-    Blake2bHash,
-) {
+) -> BlockAndChunksPushResult<N> {
     let push_results = spawn_blocking(move || {
         blockchain_push(
             blockchain,
             bls_cache,
-            Some(block),
+            Some((block, block_source.clone())),
             diff,
             chunks,
             Some(MessageValidator {
@@ -263,12 +301,15 @@ pub async fn push_block_and_chunks<N: Network>(
     .await;
 
     // TODO Ban peer depending on type of chunk error?
-
-    (
-        push_results.block_push_result.unwrap(),
-        push_results.push_chunks_result,
-        push_results.block_hash,
-    )
+    if let Some((block, chunks)) = push_results.retry_with_diff {
+        BlockAndChunksPushResult::NeedsDiff(block, chunks, push_results.block_hash)
+    } else {
+        BlockAndChunksPushResult::Applied(
+            push_results.block_push_result.unwrap(),
+            push_results.push_chunks_result,
+            push_results.block_hash,
+        )
+    }
 }
 
 /// Pushes a single block into the blockchain and validates the message.
@@ -283,7 +324,7 @@ pub async fn push_block_only<N: Network>(
         blockchain_push::<N>(
             blockchain,
             bls_cache,
-            Some(block),
+            Some((block, block_source.clone())),
             None,
             vec![],
             Some(MessageValidator {
@@ -294,10 +335,16 @@ pub async fn push_block_only<N: Network>(
     })
     .await;
 
-    (
-        push_results.block_push_result.unwrap(),
-        push_results.block_hash,
-    )
+    match push_results.retry_with_diff {
+        Some(_) => (
+            Err(PushError::MissingAccountsTrieDiff),
+            push_results.block_hash,
+        ),
+        None => (
+            push_results.block_push_result.unwrap(),
+            push_results.block_hash,
+        ),
+    }
 }
 
 /// Pushes a sequence of blocks to the blockchain.
@@ -307,12 +354,7 @@ pub async fn push_multiple_blocks_impl<N: Network>(
     blockchain: BlockchainProxy,
     bls_cache: Arc<Mutex<BlsCache>>,
     blocks: Vec<(BlockAndSource<N>, Option<TrieDiff>, Vec<ChunkAndSource<N>>)>,
-) -> (
-    Result<PushResult, PushError>,
-    Result<ChunksPushResult, ChunksPushError>,
-    Vec<Blake2bHash>,
-    HashSet<Blake2bHash>,
-) {
+) -> MissingBlocksPushResult<N> {
     let mut block_iter = blocks.into_iter();
     // Hashes of adopted blocks
     let mut adopted_blocks = Vec::new();
@@ -323,7 +365,7 @@ pub async fn push_multiple_blocks_impl<N: Network>(
     let mut push_result = Err(PushError::Orphan);
     let mut push_chunk_result = Ok(ChunksPushResult::EmptyChunks);
     // Try to push blocks, until we encounter an invalid block.
-    for ((block, _), diff, mut chunks) in block_iter.by_ref() {
+    for ((block, block_source), diff, mut chunks) in block_iter.by_ref() {
         log::debug!("Pushing block {} from missing blocks response", block);
 
         let blockchain2 = blockchain.clone();
@@ -334,9 +376,30 @@ pub async fn push_multiple_blocks_impl<N: Network>(
             chunks.clear();
         }
         let push_results = spawn_blocking(move || {
-            blockchain_push::<N>(blockchain2, bls_cache2, Some(block), diff, chunks, None)
+            blockchain_push::<N>(
+                blockchain2,
+                bls_cache2,
+                Some((block, block_source)),
+                diff,
+                chunks,
+                None,
+            )
         })
         .await;
+
+        if let Some(retry_block) = push_results.retry_with_diff {
+            let mut retry_blocks = vec![retry_block];
+            retry_blocks.extend(
+                block_iter
+                    .map(|((block, block_source), _diff, chunks)| ((block, block_source), chunks)),
+            );
+
+            return MissingBlocksPushResult::NeedsDiff(
+                push_chunk_result,
+                adopted_blocks,
+                retry_blocks,
+            );
+        }
 
         push_result = push_results.block_push_result.unwrap();
         let block_hash = push_results.block_hash;
@@ -375,7 +438,7 @@ pub async fn push_multiple_blocks_impl<N: Network>(
     for ((block, _), ..) in block_iter {
         invalid_blocks.insert(block.hash());
     }
-    (
+    MissingBlocksPushResult::Applied(
         push_result,
         push_chunk_result,
         adopted_blocks,
@@ -388,12 +451,7 @@ pub async fn push_multiple_blocks_with_chunks<N: Network>(
     blockchain: BlockchainProxy,
     bls_cache: Arc<Mutex<BlsCache>>,
     blocks: Vec<(BlockAndSource<N>, Option<TrieDiff>, Vec<ChunkAndSource<N>>)>,
-) -> (
-    Result<PushResult, PushError>,
-    Result<ChunksPushResult, ChunksPushError>,
-    Vec<Blake2bHash>,
-    HashSet<Blake2bHash>,
-) {
+) -> MissingBlocksPushResult<N> {
     push_multiple_blocks_impl(blockchain, bls_cache, blocks).await
 }
 
@@ -413,11 +471,22 @@ pub async fn push_multiple_blocks<N: Network>(
         .into_iter()
         .map(|block| (block, None, vec![]))
         .collect();
-    push_multiple_blocks_impl::<N>(blockchain, bls_cache, blocks)
-        .map(|(push_result, _, adopted_blocks, invalid_blocks)| {
-            (push_result, adopted_blocks, invalid_blocks)
-        })
-        .await
+    match push_multiple_blocks_impl::<N>(blockchain, bls_cache, blocks).await {
+        MissingBlocksPushResult::Applied(
+            push_result,
+            _push_chunk_result,
+            adopted_blocks,
+            invalid_blocks,
+        ) => (push_result, adopted_blocks, invalid_blocks),
+        MissingBlocksPushResult::NeedsDiff(_push_chunk_result, adopted_blocks, retry_blocks) => (
+            Err(PushError::MissingAccountsTrieDiff),
+            adopted_blocks,
+            retry_blocks
+                .into_iter()
+                .map(|((block, _), _chunks)| block.hash())
+                .collect(),
+        ),
+    }
 }
 
 /// Pushes the chunks to the current blockchain state.
@@ -486,45 +555,58 @@ fn update_cache(block: &Block, bls_cache: &mut BlsCache) {
 fn blockchain_push<N: Network>(
     blockchain: BlockchainProxy,
     bls_cache: Arc<Mutex<BlsCache>>,
-    block: Option<Block>,
+    block: Option<BlockAndSource<N>>,
     diff: Option<TrieDiff>,
     chunks: Vec<ChunkAndSource<N>>,
     msg_validator: Option<MessageValidator<N>>,
 ) -> BlockchainPushResult<N> {
-    #[cfg(feature = "full")]
-    let (chunks, peer_ids): (Vec<_>, Vec<N::PeerId>) =
-        chunks.into_iter().map(ChunkAndSource::into_pair).unzip();
-
     // Push the block to the blockchain.
     let blockchain_push_result;
-    if let Some(block) = block {
+    if let Some((block, block_source)) = block {
         let block_hash = block.hash();
         update_cache(&block, &mut bls_cache.lock());
         match blockchain {
             #[cfg(feature = "full")]
             BlockchainProxy::Full(ref blockchain) => {
                 // We push the block and if it fails we return immediately, without committing chunks.
-                let push_result = match diff {
-                    Some(diff) => Blockchain::push_with_chunks(
-                        blockchain.upgradable_read(),
-                        block,
-                        diff,
-                        chunks,
-                        &msg_validator,
-                    ),
-                    None => {
-                        assert!(chunks.is_empty());
-                        Blockchain::push_with_hook(
+                match diff {
+                    Some(diff) => {
+                        let (chunks, peer_ids): (Vec<_>, Vec<N::PeerId>) =
+                            chunks.into_iter().map(ChunkAndSource::into_pair).unzip();
+                        let push_result = Blockchain::push_with_chunks(
                             blockchain.upgradable_read(),
                             block,
+                            diff,
+                            chunks,
                             &msg_validator,
-                        )
-                        .map(|r| (r, Ok(ChunksPushResult::EmptyChunks)))
+                        );
+                        blockchain_push_result = BlockchainPushResult::with_block_result(
+                            push_result,
+                            block_hash,
+                            &peer_ids,
+                        );
                     }
-                };
+                    None => {
+                        let blockchain = blockchain.upgradable_read();
+                        if !blockchain.accounts_complete() {
+                            return BlockchainPushResult::with_diff_retry(
+                                (block, block_source),
+                                chunks,
+                                block_hash,
+                            );
+                        }
 
-                blockchain_push_result =
-                    BlockchainPushResult::with_block_result(push_result, block_hash, &peer_ids);
+                        if !chunks.is_empty() {
+                            debug!(%block, "Discarded chunks when pushing block because accounts tree is complete.");
+                        }
+
+                        let push_result =
+                            Blockchain::push_with_hook(blockchain, block, &msg_validator)
+                                .map(|r| (r, Ok(ChunksPushResult::EmptyChunks)));
+                        blockchain_push_result =
+                            BlockchainPushResult::with_block_result(push_result, block_hash, &[]);
+                    }
+                }
             }
             BlockchainProxy::Light(ref blockchain) => {
                 let push_result = LightBlockchain::push(blockchain.upgradable_read(), block);
@@ -537,6 +619,8 @@ fn blockchain_push<N: Network>(
         match blockchain {
             #[cfg(feature = "full")]
             BlockchainProxy::Full(ref blockchain) => {
+                let (chunks, peer_ids): (Vec<_>, Vec<N::PeerId>) =
+                    chunks.into_iter().map(ChunkAndSource::into_pair).unzip();
                 let bc = blockchain.upgradable_read();
                 let block_hash = bc.head_hash();
                 // We push the chunks.
@@ -555,4 +639,60 @@ fn blockchain_push<N: Network>(
     }
 
     blockchain_push_result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nimiq_blockchain_interface::AbstractBlockchain;
+    use nimiq_network_mock::{MockHub, MockPeerId};
+    use nimiq_test_log::test;
+    use nimiq_test_utils::block_production::TemporaryBlockProducer;
+    use parking_lot::Mutex;
+
+    use super::{push_block_and_chunks, BlockAndChunksPushResult};
+    use crate::{sync::live::block_queue::BlockSource, BlsCache};
+
+    #[test(tokio::test)]
+    async fn incomplete_trie_without_diff_requests_retry() {
+        let producer = TemporaryBlockProducer::new();
+        let incomplete = TemporaryBlockProducer::new_incomplete();
+        let block = producer.next_block(vec![], false);
+        let block_hash = block.hash();
+
+        let mut hub = MockHub::new();
+        let network = Arc::new(hub.new_network());
+
+        let result = push_block_and_chunks(
+            network,
+            incomplete.blockchain.clone().into(),
+            Arc::new(Mutex::new(BlsCache::new_test())),
+            block,
+            BlockSource::requested(MockPeerId(1)),
+            None,
+            vec![],
+        )
+        .await;
+
+        match result {
+            BlockAndChunksPushResult::NeedsDiff(
+                (retry_block, block_source),
+                chunks,
+                retry_hash,
+            ) => {
+                assert_eq!(retry_hash, block_hash);
+                assert_eq!(retry_block.hash(), block_hash);
+                assert!(chunks.is_empty());
+                assert!(
+                    matches!(block_source, BlockSource::Requested { id } if id == MockPeerId(1))
+                );
+            }
+            BlockAndChunksPushResult::Applied(..) => {
+                panic!("diffless push into an incomplete trie must request a retry")
+            }
+        }
+
+        assert!(!incomplete.blockchain.read().contains(&block_hash, true));
+    }
 }

--- a/consensus/src/sync/live/state_queue/live_sync.rs
+++ b/consensus/src/sync/live/state_queue/live_sync.rs
@@ -18,8 +18,10 @@ use crate::{
     consensus::ResolveBlockRequest,
     sync::{
         live::{
-            block_queue::{live_sync::PushOpResult as BlockPushOpResult, BlockAndSource},
-            queue::{self, LiveSyncQueue},
+            block_queue::{
+                live_sync::PushOpResult as BlockPushOpResult, BlockAndSource, QueuedBlock,
+            },
+            queue::{self, BlockAndChunksPushResult, LiveSyncQueue, MissingBlocksPushResult},
         },
         sync_interface::{LiveSyncEvent, LiveSyncPeerEvent, LiveSyncPushEvent},
     },
@@ -43,6 +45,13 @@ pub enum PushOpResult<N: Network> {
         Result<ChunksPushResult, ChunksPushError>,
         Vec<Blake2bHash>,
         HashSet<Blake2bHash>,
+    ),
+    HeadNeedsDiff(BlockAndSource<N>, Vec<ChunkAndSource<N>>),
+    BufferedNeedsDiff(BlockAndSource<N>, Vec<ChunkAndSource<N>>),
+    MissingNeedsDiff(
+        Result<ChunksPushResult, ChunksPushError>,
+        Vec<Blake2bHash>,
+        Vec<(BlockAndSource<N>, Vec<ChunkAndSource<N>>)>,
     ),
     PeerEvent(LiveSyncPeerEvent<N::PeerId>),
 }
@@ -91,6 +100,9 @@ impl<N: Network> PushOpResult<N> {
             PushOpResult::Missing(push_result, _, adopted_blocks, invalid_blocks) => Some(
                 BlockPushOpResult::Missing(push_result, adopted_blocks, invalid_blocks),
             ),
+            PushOpResult::HeadNeedsDiff(..)
+            | PushOpResult::BufferedNeedsDiff(..)
+            | PushOpResult::MissingNeedsDiff(..) => None,
             PushOpResult::PeerEvent(event) => Some(BlockPushOpResult::PeerEvent(event)),
         }
     }
@@ -120,8 +132,13 @@ impl<N: Network> LiveSyncQueue<N> for StateQueue<N> {
                         diff,
                         chunks,
                     )
-                    .map(|(push_result, push_chunk_error, hash)| {
-                        PushOpResult::Head(push_result, push_chunk_error, hash)
+                    .map(|result| match result {
+                        BlockAndChunksPushResult::Applied(push_result, push_chunk_error, hash) => {
+                            PushOpResult::Head(push_result, push_chunk_error, hash)
+                        }
+                        BlockAndChunksPushResult::NeedsDiff(block, chunks, _hash) => {
+                            PushOpResult::HeadNeedsDiff(block, chunks)
+                        }
                     })
                     .boxed(),
                 );
@@ -137,8 +154,13 @@ impl<N: Network> LiveSyncQueue<N> for StateQueue<N> {
                         diff,
                         chunks,
                     )
-                    .map(|(push_result, push_chunk_error, hash)| {
-                        PushOpResult::Buffered(push_result, push_chunk_error, hash)
+                    .map(|result| match result {
+                        BlockAndChunksPushResult::Applied(push_result, push_chunk_error, hash) => {
+                            PushOpResult::Buffered(push_result, push_chunk_error, hash)
+                        }
+                        BlockAndChunksPushResult::NeedsDiff(block, chunks, _hash) => {
+                            PushOpResult::BufferedNeedsDiff(block, chunks)
+                        }
                     })
                     .boxed();
                     future_results.push_back(res);
@@ -148,16 +170,28 @@ impl<N: Network> LiveSyncQueue<N> for StateQueue<N> {
                 // Pushes multiple blocks.
                 future_results.push_back(
                     queue::push_multiple_blocks_with_chunks::<N>(blockchain, bls_cache, blocks)
-                        .map(
-                            |(push_result, push_chunk_error, adopted_blocks, invalid_blocks)| {
-                                PushOpResult::Missing(
-                                    push_result,
-                                    push_chunk_error,
-                                    adopted_blocks,
-                                    invalid_blocks,
-                                )
-                            },
-                        )
+                        .map(|result| match result {
+                            MissingBlocksPushResult::Applied(
+                                push_result,
+                                push_chunk_error,
+                                adopted_blocks,
+                                invalid_blocks,
+                            ) => PushOpResult::Missing(
+                                push_result,
+                                push_chunk_error,
+                                adopted_blocks,
+                                invalid_blocks,
+                            ),
+                            MissingBlocksPushResult::NeedsDiff(
+                                push_chunk_error,
+                                adopted_blocks,
+                                retry_blocks,
+                            ) => PushOpResult::MissingNeedsDiff(
+                                push_chunk_error,
+                                adopted_blocks,
+                                retry_blocks,
+                            ),
+                        })
                         .boxed(),
                 );
             }
@@ -206,6 +240,40 @@ impl<N: Network> LiveSyncQueue<N> for StateQueue<N> {
         }
 
         match item {
+            PushOpResult::HeadNeedsDiff(block, chunks) => {
+                self.retry_blocks_with_diff(QueuedBlock::Head(block), vec![chunks]);
+                None
+            }
+            PushOpResult::BufferedNeedsDiff(block, chunks) => {
+                self.retry_blocks_with_diff(QueuedBlock::Buffered(vec![block]), vec![chunks]);
+                None
+            }
+            PushOpResult::MissingNeedsDiff(push_chunks_result, adopted_blocks, retry_blocks) => {
+                if push_chunks_result.is_err() {
+                    self.reset_chunk_request_chain();
+                }
+
+                let queued_blocks = retry_blocks
+                    .iter()
+                    .map(|(block, _chunks)| block.clone())
+                    .collect();
+                let chunks_by_block = retry_blocks
+                    .into_iter()
+                    .map(|(_block, chunks)| chunks)
+                    .collect();
+                self.retry_blocks_with_diff(QueuedBlock::Missing(queued_blocks), chunks_by_block);
+
+                if adopted_blocks.is_empty() {
+                    None
+                } else {
+                    self.diff_queue
+                        .process_push_result(BlockPushOpResult::Missing(
+                            Ok(PushResult::Extended),
+                            adopted_blocks,
+                            HashSet::new(),
+                        ))
+                }
+            }
             PushOpResult::HeadChunk(Ok(ChunksPushResult::Chunks(committed, _)), block_hash)
                 if committed > 0 =>
             {

--- a/consensus/src/sync/live/state_queue/mod.rs
+++ b/consensus/src/sync/live/state_queue/mod.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 
 use self::chunk_request_component::ChunkRequestComponent;
 use super::{
-    block_queue::BlockAndSource,
+    block_queue::{BlockAndSource, QueuedBlock},
     queue::{ChunkAndSource, QueueConfig},
 };
 use crate::sync::live::diff_queue::{DiffQueue, QueuedDiff};
@@ -324,6 +324,60 @@ impl<N: Network> StateQueue<N> {
 
         chunks.push(ChunkAndSource::new(response.chunk, start_key, peer_id));
         self.buffer_size += 1;
+    }
+
+    pub(crate) fn retry_blocks_with_diff(
+        &mut self,
+        queued_block: QueuedBlock<N>,
+        chunks_by_block: Vec<Vec<ChunkAndSource<N>>>,
+    ) {
+        self.diff_queue.set_diff_needed(true);
+
+        match (&queued_block, chunks_by_block) {
+            (QueuedBlock::Head((block, _)), mut chunks) => {
+                if let Some(chunks) = chunks.pop() {
+                    self.restore_block_chunks(block, chunks);
+                }
+            }
+            (QueuedBlock::Buffered(blocks), chunks) | (QueuedBlock::Missing(blocks), chunks) => {
+                for ((block, _), chunks) in blocks.iter().zip(chunks) {
+                    self.restore_block_chunks(block, chunks);
+                }
+            }
+            (QueuedBlock::TooFarAhead(_), _) | (QueuedBlock::TooFarBehind(_), _) => return,
+        }
+
+        self.diff_queue.retry_with_diff(queued_block);
+    }
+
+    /// Reintroduces chunks to the buffer. This is used when we cannot yet push the block due to a missing diff.
+    ///
+    /// This intentionally bypasses `on_chunk_received`'s capacity and window checks. `LiveSyncer`
+    /// does not poll this queue while a push is pending, so no new chunks can occupy the slots
+    /// freed by `get_block_chunks` before these previously admitted chunks are restored.
+    ///
+    /// If the diff retry later returns `MaxTriesExceeded`, `DiffQueue` only clears the block's
+    /// pending marker. The chunks remain available for a later announcement of the same block;
+    /// otherwise state-sync completion, or a later chunk observing a newer macro height, removes
+    /// them.
+    fn restore_block_chunks(&mut self, block: &Block, chunks: Vec<ChunkAndSource<N>>) {
+        if chunks.is_empty() {
+            return;
+        }
+
+        let block_hash = block.hash();
+        let block_number = block.block_number();
+        for chunk in chunks {
+            self.insert_chunk_into_buffer(
+                Chunk {
+                    block_number,
+                    block_hash: block_hash.clone(),
+                    chunk: chunk.chunk,
+                },
+                chunk.start_key,
+                chunk.peer_id,
+            );
+        }
     }
 
     /// Order them inside our buffer if enough space and inside window.

--- a/consensus/tests/state_live_sync.rs
+++ b/consensus/tests/state_live_sync.rs
@@ -8,19 +8,24 @@ use futures::{join, poll, Future, Stream, StreamExt};
 use log::info;
 use nimiq_block::Block;
 use nimiq_blockchain::{BlockProducer, Blockchain, BlockchainConfig};
-use nimiq_blockchain_interface::{AbstractBlockchain, PushResult};
+use nimiq_blockchain_interface::{
+    AbstractBlockchain, BlockchainEvent, ChunksPushResult, PushResult,
+};
 use nimiq_blockchain_proxy::BlockchainProxy;
 use nimiq_consensus::{
     messages::RequestMissingBlocks,
     sync::{
         live::{
-            block_queue::BlockQueue,
+            block_queue::{BlockQueue, BlockSource},
             diff_queue::{
                 diff_request_component::{DiffRequestComponent, DiffRequestError},
                 DiffQueue, RequestTrieDiff, ResponseTrieDiff,
             },
-            queue::QueueConfig,
-            state_queue::{Chunk, ChunkRequestState, RequestChunk, ResponseChunk, StateQueue},
+            queue::{ChunkAndSource, LiveSyncQueue, QueueConfig},
+            state_queue::{
+                live_sync::PushOpResult, Chunk, ChunkRequestState, QueuedStateChunks, RequestChunk,
+                ResponseChunk, StateQueue,
+            },
             StateLiveSync,
         },
         peer_list::PeerList,
@@ -49,6 +54,7 @@ use nimiq_test_utils::{
     blockchain::{produce_macro_blocks, push_micro_block, signing_key, voting_key},
     mock_node::MockNode,
 };
+use nimiq_time::timeout;
 use nimiq_transaction::ExecutedTransaction;
 use nimiq_transaction_builder::TransactionBuilder;
 use nimiq_utils::time::OffsetTime;
@@ -56,7 +62,6 @@ use parking_lot::{Mutex, RwLock};
 use tokio::{
     sync::mpsc::{self, Sender},
     task::yield_now,
-    time::timeout,
 };
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -122,6 +127,31 @@ fn get_incomplete_live_sync(
     );
 
     (incomplete_blockchain, live_sync, network, block_tx)
+}
+
+fn get_state_queue(
+    network: Arc<MockNetwork>,
+    blockchain: Arc<RwLock<Blockchain>>,
+) -> (StateQueue<MockNetwork>, Sender<(Block, MockId<MockPeerId>)>) {
+    let blockchain_proxy = BlockchainProxy::from(&blockchain);
+    let (block_tx, block_rx) = mpsc::channel(32);
+
+    let block_queue = BlockQueue::with_gossipsub_block_stream(
+        blockchain_proxy,
+        Arc::clone(&network),
+        ReceiverStream::new(block_rx).boxed(),
+        QueueConfig::default(),
+    );
+    let diff_queue = DiffQueue::with_block_queue(Arc::clone(&network), block_queue);
+    let state_queue = StateQueue::with_diff_queue(
+        network,
+        blockchain,
+        diff_queue,
+        QueueConfig::default(),
+        Arc::new(AtomicU32::new(0)),
+    );
+
+    (state_queue, block_tx)
 }
 
 async fn gossip_head_block(
@@ -479,13 +509,10 @@ async fn gives_up_diff_request_if_only_source_knows_block_and_never_serves_diff(
     let mut get_diff = diff_request_component.request_diff();
     let source_peer_id = source_node.network.get_local_peer_id();
     // Drive the request in the background so we can observe which peers it contacts.
-    let diff_request = tokio::spawn(async move {
-        get_diff(&(
-            block,
-            nimiq_consensus::sync::live::block_queue::BlockSource::requested(source_peer_id),
-        ))
-        .await
-    });
+    let diff_request =
+        tokio::spawn(
+            async move { get_diff(&(block, BlockSource::requested(source_peer_id))).await },
+        );
 
     // The source peer is asked first.
     assert_eq!(source_node.next().await, Some(RequestTrieDiff::TYPE_ID));
@@ -506,6 +533,424 @@ async fn gives_up_diff_request_if_only_source_knows_block_and_never_serves_diff(
             .is_err(),
         "diff request should not retry once the maximum number of tries is reached"
     );
+}
+
+#[test(tokio::test)]
+async fn buffered_diffless_block_is_retried_after_state_reset() {
+    let mut hub = Some(MockHub::new());
+    let (target, mut live_sync, network, block_tx) =
+        get_incomplete_live_sync(hub.as_mut().unwrap());
+
+    let network_info = NetworkInfo::from_network_id(NetworkId::UnitAlbatross);
+    let genesis_block = network_info.genesis_block();
+    let genesis_accounts = network_info.genesis_accounts();
+    let mut source =
+        MockNode::<MockNetwork>::new(2, genesis_block, genesis_accounts, &mut hub).await;
+    let source_id = source.network.get_local_peer_id();
+    let source_mock_id = MockId::new(source_id);
+
+    network.dial_mock(&source.network);
+    live_sync.add_peer(source_id);
+
+    // Hold a diff request at the front of the ordered queue while the account state finishes
+    // syncing, so the buffered child can remain queued behind it once released.
+    source.request_partial_diff_handler.pause();
+    let blocker = TemporaryBlockProducer::new().next_block(vec![0x42], false);
+    let blocker_hash = blocker.hash();
+    block_tx
+        .send((blocker, source_mock_id.clone()))
+        .await
+        .unwrap();
+    yield_now().await;
+    assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+
+    let size = source.blockchain.read().state.accounts.size();
+    let num_chunks = size.div_ceil(Policy::state_chunks_max_size() as u64);
+    for _ in 0..num_chunks {
+        let (request, event) = timeout(Duration::from_secs(5), async {
+            join!(source.next(), live_sync.next())
+        })
+        .await
+        .expect("state chunks should continue while the front diff request is pending");
+        assert_eq!(request, Some(RequestChunk::TYPE_ID));
+        assert!(matches!(
+            event,
+            Some(LiveSyncEvent::PushEvent(LiveSyncPushEvent::AcceptedChunks(
+                _
+            )))
+        ));
+    }
+    assert!(target.read().accounts_complete());
+
+    let producer = BlockProducer::new(signing_key(), voting_key());
+    push_micro_block(&producer, &source.blockchain);
+    let applied_parent = source.blockchain.read().head().clone();
+    let applied_parent_hash = applied_parent.hash();
+    push_micro_block(&producer, &source.blockchain);
+    let retried_block = source.blockchain.read().head().clone();
+    let retried_hash = retried_block.hash();
+    assert_ne!(blocker_hash, retried_hash);
+    assert_eq!(retried_block.parent_hash(), &applied_parent_hash);
+
+    // Announce the child first so BlockQueue buffers it until the parent is applied.
+    source.request_missing_block_handler.pause();
+    block_tx
+        .send((retried_block, source_mock_id))
+        .await
+        .unwrap();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            yield_now().await;
+            assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+            if live_sync.queue().num_buffered_heights() == 1 {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("the child should be buffered while its parent is unknown");
+
+    // Applying the parent emits the real `Extended` event that marks state sync complete and
+    // releases the child as `QueuedBlock::Buffered`. Yield to BlockQueue's proxy task and then
+    // poll live sync before checking the raw buffer count; this guarantees DiffQueue classifies
+    // the child as diffless before the state reset.
+    assert_eq!(
+        Blockchain::push(target.upgradable_read(), applied_parent),
+        Ok(PushResult::Extended)
+    );
+    timeout(Duration::from_secs(5), async {
+        loop {
+            yield_now().await;
+            assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+            if live_sync.queue().num_buffered_heights() == 0 {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("the buffered child should enter DiffQueue before state is reset");
+    assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+    assert_eq!(target.read().head_hash(), applied_parent_hash);
+    assert!(live_sync.queue().chunk_request_state().is_complete());
+
+    // Notify the live-sync event handler about the reset, then let the new chunk response pair
+    // with the stale diffless block that is still waiting behind the blocker.
+    {
+        let blockchain = target.read();
+        let mut txn = blockchain.write_transaction();
+        blockchain
+            .state
+            .accounts
+            .reinitialize_as_incomplete(&mut (&mut txn).into());
+        txn.commit();
+        blockchain
+            .notifier
+            .send(BlockchainEvent::Rebranched(vec![], vec![]))
+            .unwrap();
+    }
+    assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+    assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+    assert_eq!(
+        target
+            .read()
+            .get_missing_accounts_range(None)
+            .map(|range| range.start),
+        Some(KeyNibbles::ROOT)
+    );
+
+    let expected_missing_start = source
+        .blockchain
+        .read()
+        .state
+        .accounts
+        .get_chunk(
+            KeyNibbles::ROOT,
+            Policy::state_chunks_max_size() as usize,
+            None,
+        )
+        .end_key
+        .expect("the fixture should need more than one state chunk");
+    assert_eq!(
+        timeout(Duration::from_secs(5), source.next())
+            .await
+            .expect("state reset should request a fresh chunk"),
+        Some(RequestChunk::TYPE_ID)
+    );
+    source.request_chunk_handler.pause();
+    assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+    assert_eq!(live_sync.queue().num_buffered_chunks(), 1);
+
+    // Queue a new diff request after the reset and leave it unresolved. It sits behind the stale
+    // no-diff item, but must not remain ahead of that item's retry.
+    let competing_network = Arc::new(hub.as_mut().unwrap().new_network_with_address(3_u64));
+    let mut competing_diff_requests = competing_network.receive_requests::<RequestTrieDiff>();
+    let _competing_chunk_requests = competing_network.receive_requests::<RequestChunk>();
+    network.dial_mock(&competing_network);
+    let competing_id = competing_network.get_local_peer_id();
+    live_sync.add_peer(competing_id);
+
+    let competing_block = TemporaryBlockProducer::new().next_block(vec![0x48], false);
+    let competing_hash = competing_block.hash();
+    block_tx
+        .send((competing_block, MockId::new(competing_id)))
+        .await
+        .unwrap();
+    let (competing_request, _competing_request_id, _) = timeout(Duration::from_secs(5), async {
+        loop {
+            if let Poll::Ready(request) = poll!(competing_diff_requests.next()) {
+                break request.expect("competing diff request stream should stay open");
+            }
+            assert!(matches!(poll!(live_sync.next()), Poll::Pending));
+            yield_now().await;
+        }
+    })
+    .await
+    .expect("post-reset competing diff request should be dispatched");
+    assert_eq!(competing_request.block_hash, competing_hash);
+
+    // Drop the original blocker across both peers, then serve the real diff for the stale block.
+    // With `push_back`, the unresolved competing request remains ahead and this operation times out.
+    source
+        .request_partial_diff_handler
+        .set(|_, _, _| ResponseTrieDiff::IncompleteState);
+    source.request_partial_diff_handler.unpause();
+    let source_requests = async {
+        let blocker_request = source.next().await;
+        source.request_partial_diff_handler.unset();
+        let retry_request = source.next().await;
+        (blocker_request, retry_request)
+    };
+    let competing_blocker_response = async {
+        let (request, request_id, _) = competing_diff_requests
+            .next()
+            .await
+            .expect("blocker should fall back to the competing peer");
+        assert_eq!(request.block_hash, blocker_hash);
+        competing_network
+            .respond::<RequestTrieDiff>(request_id, ResponseTrieDiff::IncompleteState)
+            .await
+            .unwrap();
+        RequestTrieDiff::TYPE_ID
+    };
+    let ((blocker_request, retry_request), fallback_request, event) =
+        timeout(Duration::from_secs(3), async {
+            join!(
+                source_requests,
+                competing_blocker_response,
+                live_sync.next()
+            )
+        })
+        .await
+        .expect("retried block should be prioritized over the unresolved diff request");
+
+    assert_eq!(blocker_request, Some(RequestTrieDiff::TYPE_ID));
+    assert_eq!(retry_request, Some(RequestTrieDiff::TYPE_ID));
+    assert_eq!(fallback_request, RequestTrieDiff::TYPE_ID);
+    assert!(matches!(
+        event,
+        Some(LiveSyncEvent::PushEvent(
+            LiveSyncPushEvent::AcceptedBufferedBlock(hash, 0)
+        )) if hash == retried_hash
+    ));
+
+    let target = target.read();
+    assert_eq!(target.head_hash(), retried_hash);
+    assert!(target.contains(&applied_parent_hash, true));
+    assert!(target.contains(&retried_hash, true));
+    assert_eq!(
+        target
+            .get_missing_accounts_range(None)
+            .map(|range| range.start),
+        Some(expected_missing_start)
+    );
+    assert_eq!(live_sync.queue().num_buffered_chunks(), 0);
+}
+
+#[test(tokio::test)]
+async fn missing_needs_diff_reports_prefix_and_retries_paired_suffix() {
+    let source_producer = TemporaryBlockProducer::new();
+    let target_producer = TemporaryBlockProducer::new_incomplete();
+
+    let first_block = source_producer.next_block(vec![], false);
+    let first_hash = first_block.hash();
+    let first_diff = source_producer
+        .blockchain
+        .read()
+        .chain_store
+        .get_accounts_diff(&first_hash, None)
+        .unwrap();
+    let first_retry_block = source_producer.next_block(vec![0x01], false);
+    let first_retry_hash = first_retry_block.hash();
+    let second_retry_block = source_producer.next_block(vec![0x02], false);
+    let second_retry_hash = second_retry_block.hash();
+    // These blocks have no transactions, so their accounts roots are identical and the chunks
+    // read at the final suffix block are also valid for the first suffix block.
+    let first_retry_chunk =
+        source_producer.get_chunk(KeyNibbles::ROOT, Policy::state_chunks_max_size() as usize);
+    let second_retry_start = first_retry_chunk
+        .chunk
+        .end_key
+        .clone()
+        .expect("the fixture should need exactly two state chunks");
+    let second_retry_chunk = source_producer.get_chunk(
+        second_retry_start.clone(),
+        Policy::state_chunks_max_size() as usize,
+    );
+    assert!(second_retry_chunk.chunk.end_key.is_none());
+    assert_eq!(second_retry_chunk.start_key, second_retry_start);
+
+    let mut hub = MockHub::new();
+    let network = Arc::new(hub.new_network());
+    let source_network = Arc::new(hub.new_network());
+    let mut source = MockNode::<MockNetwork>::with_network_and_blockchain(
+        source_network,
+        Arc::clone(&source_producer.blockchain),
+    );
+    let target = Arc::clone(&target_producer.blockchain);
+    let target_proxy = BlockchainProxy::from(&target);
+    let (mut state_queue, _block_tx) = get_state_queue(Arc::clone(&network), Arc::clone(&target));
+
+    network.dial_mock(&source.network);
+    let source_id = source.network.get_local_peer_id();
+    state_queue.add_peer(source_id);
+    source.request_chunk_handler.pause();
+
+    // Reproduce `MissingNeedsDiff`: the first block has a diff and is adopted, while the two-block
+    // suffix arrives diffless with paired chunks and must be returned for retry.
+    let initial_item = QueuedStateChunks::Missing(vec![
+        (
+            (first_block, BlockSource::requested(source_id)),
+            Some(first_diff),
+            vec![],
+        ),
+        (
+            (first_retry_block, BlockSource::requested(source_id)),
+            None,
+            vec![ChunkAndSource::new(
+                first_retry_chunk.chunk,
+                first_retry_chunk.start_key,
+                source_id,
+            )],
+        ),
+        (
+            (second_retry_block, BlockSource::requested(source_id)),
+            None,
+            vec![ChunkAndSource::new(
+                second_retry_chunk.chunk,
+                second_retry_start.clone(),
+                source_id,
+            )],
+        ),
+    ]);
+    let mut initial_push = StateQueue::push_queue_result(
+        Arc::clone(&network),
+        target_proxy.clone(),
+        Arc::new(Mutex::new(BlsCache::new_test())),
+        initial_item,
+    );
+    assert_eq!(initial_push.len(), 1);
+    let initial_result = initial_push.pop_front().unwrap().await;
+    assert!(matches!(
+        &initial_result,
+        PushOpResult::MissingNeedsDiff(
+            Ok(ChunksPushResult::EmptyChunks),
+            adopted_blocks,
+            retry_blocks,
+        ) if adopted_blocks == &vec![first_hash.clone()]
+            && retry_blocks.len() == 2
+            && retry_blocks[0].0.0.hash() == first_retry_hash
+            && retry_blocks[0].1.len() == 1
+            && retry_blocks[0].1[0].start_key == KeyNibbles::ROOT
+            && retry_blocks[1].0.0.hash() == second_retry_hash
+            && retry_blocks[1].1.len() == 1
+            && retry_blocks[1].1[0].start_key == second_retry_start
+    ));
+    assert!(target.read().contains(&first_hash, true));
+    assert_eq!(target.read().head_hash(), first_hash);
+    assert!(!target.read().contains(&first_retry_hash, true));
+    assert!(!target.read().contains(&second_retry_hash, true));
+    assert!(!target.read().accounts_complete());
+
+    // Handling the result must report only the applied prefix, restore both suffix chunks under
+    // their original block hashes, and retry only the suffix.
+    assert!(matches!(
+        state_queue.process_push_result(initial_result),
+        Some(LiveSyncEvent::PushEvent(
+            LiveSyncPushEvent::ReceivedMissingBlocks(adopted_blocks)
+        )) if adopted_blocks == vec![first_hash.clone()]
+    ));
+    assert_eq!(state_queue.num_buffered_chunks(), 2);
+
+    let (request, retried_item) = timeout(Duration::from_secs(5), async {
+        join!(next(&mut source, 2), state_queue.next())
+    })
+    .await
+    .expect("missing suffix should be retried with a diff");
+    assert_eq!(
+        request,
+        Some(vec![RequestTrieDiff::TYPE_ID, RequestTrieDiff::TYPE_ID])
+    );
+    let retried_item = retried_item.expect("retry should produce the missing suffix");
+    assert!(matches!(
+        &retried_item,
+        QueuedStateChunks::Missing(blocks)
+            if blocks.len() == 2
+                && blocks[0].0.0.hash() == first_retry_hash
+                && blocks[0].0.1.peer_id() == source_id
+                && blocks[0].1.is_some()
+                && blocks[0].2.len() == 1
+                && blocks[0].2[0].start_key == KeyNibbles::ROOT
+                && blocks[0].2[0].peer_id == source_id
+                && blocks[1].0.0.hash() == second_retry_hash
+                && blocks[1].0.1.peer_id() == source_id
+                && blocks[1].1.is_some()
+                && blocks[1].2.len() == 1
+                && blocks[1].2[0].start_key == second_retry_start
+                && blocks[1].2[0].peer_id == source_id
+    ));
+    assert_eq!(state_queue.num_buffered_chunks(), 0);
+
+    let mut retried_push = StateQueue::push_queue_result(
+        network,
+        target_proxy,
+        Arc::new(Mutex::new(BlsCache::new_test())),
+        retried_item,
+    );
+    assert_eq!(retried_push.len(), 1);
+    let final_result = retried_push.pop_front().unwrap().await;
+    assert!(matches!(
+        &final_result,
+        PushOpResult::Missing(
+            Ok(PushResult::Extended),
+            Ok(ChunksPushResult::Chunks(2, 0)),
+            adopted_blocks,
+            invalid_blocks,
+        ) if adopted_blocks == &vec![first_retry_hash.clone(), second_retry_hash.clone()]
+            && invalid_blocks.is_empty()
+    ));
+    assert!(matches!(
+        state_queue.process_push_result(final_result),
+        Some(LiveSyncEvent::PushEvent(
+            LiveSyncPushEvent::ReceivedMissingBlocks(adopted_blocks)
+        )) if adopted_blocks == vec![first_retry_hash.clone(), second_retry_hash.clone()]
+    ));
+
+    let target = target.read();
+    assert_eq!(target.head_hash(), second_retry_hash);
+    assert!(target.contains(&first_hash, true));
+    assert!(target.contains(&first_retry_hash, true));
+    assert!(target.contains(&second_retry_hash, true));
+    assert!(target.accounts_complete());
+    assert_eq!(
+        target.state.accounts.get_root_hash_assert(None),
+        source
+            .blockchain
+            .read()
+            .state
+            .accounts
+            .get_root_hash_assert(None)
+    );
+    assert_eq!(state_queue.num_buffered_chunks(), 0);
 }
 
 #[test(tokio::test)]

--- a/utils/src/stream.rs
+++ b/utils/src/stream.rs
@@ -60,6 +60,14 @@ impl<F: Future> FuturesOrdered<F> {
         self.inner.push_back(future);
         self.waker.wake();
     }
+
+    /// Push a future into the front of the queue.
+    ///
+    /// See also [`futures::stream::FuturesOrdered::push_front`].
+    pub fn push_front(&mut self, future: F) {
+        self.inner.push_front(future);
+        self.waker.wake();
+    }
 }
 
 impl<F: Future> FromIterator<F> for FuturesOrdered<F> {


### PR DESCRIPTION
### Problem description
We only need diffs while we are state syncing. There is an assertion for pushing the block and chunks, ensuring that if we push a block with chunks, we are pushing diffs as well.

This assertion can fail in the following case:
1. Node finished state sync; `diffs_needed = false` and `ChunkRequestState::Complete`
2. We are continuing following the chain via blockchain events and via the block queue
3. We have some buffered diffless blocks in the diff queue futures unordered
4. We reset live sync because we pushed a macro block far away; `diffs_needed = true` and `ChunkRequestState::Reset`
5. A peer sends chunks with a block number and hash related to one of the buffered and not yet polled diffless blocks
6. We push the pairing of the chunks with the diffless block and panic at the assertion while pushing the block to the blockchain

## What's in this pull request?
When a block without a diff reaches an incomplete accounts trie, we retry the request for diff instead of trying to push the diffless block.
Live sync does the following upon trying to push a diffless block with an incomplete state:
- Defers the block and preserves its source and associated chunks.
- Re-enables diff fetching and prioritizes the block in the diff queue.
- Requests the missing diff and retries the block through the normal block-diff-chunk path.
- Handles head, buffered, and missing-block batches while preserving any successfully adopted prefix.
- If the diff cannot be retrieved, the affected pending markers are cleared so the blocks can be announced and processed again. For multi-block batches, successfully augmented blocks are retained while the failed block and its remaining suffix are dropped from the current attempt.

The added tests cover the incomplete-trie retry path, bounded diff requests, block re-announcement after failed requests, batch prefix preservation, and continued queue processing after failures.

This PR is based on top of #3949 so that it's visible how it works in conjunction with that change.

## Pull request checklist

- [x] All tests pass. The project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have resolved all `clippy` and `rustfmt` warnings.