### PR TITLE
Enable websocket support on the RPC server

### DIFF
--- a/lib/src/extras/rpc_server.rs
+++ b/lib/src/extras/rpc_server.rs
@@ -78,7 +78,9 @@ pub fn initialize_rpc_server(
     Ok(Server::new(
         Config {
             bind_to: (config.bind_to.unwrap_or_else(default_bind), config.port).into(),
-            enable_websocket: false,
+            // The RPC client connects over `/ws` and the subscription methods are only available
+            // there, so websocket support must stay enabled
+            enable_websocket: true,
             ip_whitelist: config.allow_ips.map(|ips| ips.into_iter().collect()),
             basic_auth,
             cors: Some(cors_config),


### PR DESCRIPTION
`enable_websocket` was hardcoded to `false`, which is wrong: the RPC client and all subscription methods use `/ws`.

This is now important since `nimiq-jsonrpc` was ignoring that configuration option but now it is going to be read when [this PR](https://github.com/nimiq/jsonrpc/pull/69) is merged and then we update the dependency.

## Pull request checklist

- [X] All tests pass. The project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have resolved all `clippy` and `rustfmt` warnings.
